### PR TITLE
feat: Slack Bolt 앱 초기화 및 채널 라우터 구현

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,2 +1,23 @@
-// Entry point — will be implemented in Phase 1a
-export {};
+import { App } from '@slack/bolt';
+import { CONFIG } from './shared/config.js';
+import { registerMessageHandler } from './router.js';
+
+const app = new App({
+  token: CONFIG.slack.botToken,
+  signingSecret: CONFIG.slack.signingSecret,
+  appToken: CONFIG.slack.appToken,
+  socketMode: true,
+});
+
+registerMessageHandler(app);
+
+const startApp = async (): Promise<void> => {
+  await app.start();
+  // eslint-disable-next-line no-console
+  console.log('[App] Slack bot is running in Socket Mode');
+};
+
+startApp().catch((error: unknown) => {
+  console.error('[App] Failed to start:', error);
+  process.exit(1);
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,2 +1,30 @@
-// Channel routing — will be implemented in Phase 1a
-export {};
+import type { App, KnownEventFromType, SayFn } from '@slack/bolt';
+
+type MessageEvent = KnownEventFromType<'message'>;
+
+export type AgentHandler = (
+  message: MessageEvent,
+  say: SayFn,
+) => Promise<void>;
+
+const channelAgentMap = new Map<string, AgentHandler>();
+
+export const registerAgent = (
+  channelId: string,
+  handler: AgentHandler,
+): void => {
+  channelAgentMap.set(channelId, handler);
+};
+
+export const registerMessageHandler = (app: App): void => {
+  app.message(async ({ message, say }) => {
+    if ('bot_id' in message) return;
+    if (message.subtype) return;
+
+    const handler = channelAgentMap.get(message.channel);
+
+    if (handler) {
+      await handler(message as MessageEvent, say);
+    }
+  });
+};

--- a/src/shared/slack.ts
+++ b/src/shared/slack.ts
@@ -1,2 +1,16 @@
-// Slack utilities — will be implemented in Phase 1a
-export {};
+import type { SayFn } from '@slack/bolt';
+
+export const sendMessage = async (
+  say: SayFn,
+  text: string,
+): Promise<void> => {
+  await say(text);
+};
+
+export const sendThreadReply = async (
+  say: SayFn,
+  text: string,
+  threadTs: string,
+): Promise<void> => {
+  await say({ text, thread_ts: threadTs });
+};


### PR DESCRIPTION
## Summary
- Socket Mode 기반 Slack Bolt 앱 초기화
- 채널 ID → 에이전트 매핑 라우터 (`Map<channelId, AgentHandler>`)
- 봇 메시지 / subtype 필터링 (무한루프 방지)
- Slack 메시지 유틸리티 (sendMessage, sendThreadReply)

## Test plan
- [x] `yarn build` 성공
- [x] `yarn lint` 통과
- [x] `yarn dev`로 Slack 연결 확인 (Slack App 생성 후)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)