### PR TITLE
feat: LLM 추상화 레이어 구현 (Groq)

### DIFF
--- a/src/shared/__tests__/llm.test.ts
+++ b/src/shared/__tests__/llm.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest';
+import type { ChatCompletion } from 'groq-sdk/resources/chat/completions';
+import {
+  toGroqMessages,
+  toGroqTools,
+  fromGroqResponse,
+} from '../llm.js';
+import type { LLMMessage, LLMToolDefinition } from '../llm.js';
+
+describe('toGroqMessages', () => {
+  it('system/user/assistant 메시지를 올바르게 변환한다', () => {
+    const messages: LLMMessage[] = [
+      { role: 'system', content: '시스템 프롬프트' },
+      { role: 'user', content: '안녕' },
+      { role: 'assistant', content: '반가워요' },
+    ];
+
+    const result = toGroqMessages(messages);
+
+    expect(result).toEqual([
+      { role: 'system', content: '시스템 프롬프트' },
+      { role: 'user', content: '안녕' },
+      { role: 'assistant', content: '반가워요' },
+    ]);
+  });
+
+  it('tool 메시지를 tool_call_id와 함께 변환한다', () => {
+    const messages: LLMMessage[] = [
+      { role: 'tool', content: '도구 결과', toolCallId: 'call_123' },
+    ];
+
+    const result = toGroqMessages(messages);
+
+    expect(result).toEqual([
+      { role: 'tool', content: '도구 결과', tool_call_id: 'call_123' },
+    ]);
+  });
+
+  it('assistant 메시지의 toolCalls를 Groq 형식으로 변환한다', () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            id: 'call_456',
+            name: 'create_page',
+            arguments: { title: '테스트' },
+          },
+        ],
+      },
+    ];
+
+    const result = toGroqMessages(messages);
+
+    expect(result).toEqual([
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_456',
+            type: 'function',
+            function: {
+              name: 'create_page',
+              arguments: '{"title":"테스트"}',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('toGroqTools', () => {
+  it('LLMToolDefinition을 Groq ChatCompletionTool 형식으로 변환한다', () => {
+    const tools: LLMToolDefinition[] = [
+      {
+        name: 'create_page',
+        description: '페이지 생성',
+        inputSchema: {
+          type: 'object',
+          properties: { title: { type: 'string' } },
+          required: ['title'],
+        },
+      },
+    ];
+
+    const result = toGroqTools(tools);
+
+    expect(result).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'create_page',
+          description: '페이지 생성',
+          parameters: {
+            type: 'object',
+            properties: { title: { type: 'string' } },
+            required: ['title'],
+          },
+        },
+      },
+    ]);
+  });
+});
+
+describe('fromGroqResponse', () => {
+  it('텍스트 응답을 올바르게 변환한다', () => {
+    const response = {
+      id: 'chatcmpl-123',
+      object: 'chat.completion',
+      created: 1234567890,
+      model: 'llama-3.3-70b-versatile',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: '안녕하세요!' },
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+    } as ChatCompletion;
+
+    const result = fromGroqResponse(response);
+
+    expect(result).toEqual({
+      text: '안녕하세요!',
+      toolCalls: [],
+      finishReason: 'stop',
+    });
+  });
+
+  it('tool_calls 응답을 파싱하여 변환한다', () => {
+    const response = {
+      id: 'chatcmpl-456',
+      object: 'chat.completion',
+      created: 1234567890,
+      model: 'llama-3.3-70b-versatile',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_789',
+                type: 'function',
+                function: {
+                  name: 'create_page',
+                  arguments: '{"title":"이력서 수정"}',
+                },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+          logprobs: null,
+        },
+      ],
+    } as ChatCompletion;
+
+    const result = fromGroqResponse(response);
+
+    expect(result).toEqual({
+      text: null,
+      toolCalls: [
+        {
+          id: 'call_789',
+          name: 'create_page',
+          arguments: { title: '이력서 수정' },
+        },
+      ],
+      finishReason: 'tool_calls',
+    });
+  });
+
+  it('choices가 비어있으면 error finishReason을 반환한다', () => {
+    const response = {
+      id: 'chatcmpl-empty',
+      object: 'chat.completion',
+      created: 1234567890,
+      model: 'llama-3.3-70b-versatile',
+      choices: [],
+    } as ChatCompletion;
+
+    const result = fromGroqResponse(response);
+
+    expect(result).toEqual({
+      text: null,
+      toolCalls: [],
+      finishReason: 'error',
+    });
+  });
+
+  it('finish_reason이 length이면 length를 반환한다', () => {
+    const response = {
+      id: 'chatcmpl-len',
+      object: 'chat.completion',
+      created: 1234567890,
+      model: 'llama-3.3-70b-versatile',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: '잘린 텍스트...' },
+          finish_reason: 'length',
+          logprobs: null,
+        },
+      ],
+    } as ChatCompletion;
+
+    const result = fromGroqResponse(response);
+
+    expect(result.finishReason).toBe('length');
+  });
+});

--- a/src/shared/llm.ts
+++ b/src/shared/llm.ts
@@ -1,2 +1,167 @@
-// LLM abstraction layer — will be implemented in Phase 1b
-export {};
+import Groq from 'groq-sdk';
+import type {
+  ChatCompletion,
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+  ChatCompletionMessageToolCall,
+} from 'groq-sdk/resources/chat/completions';
+// ---- 공통 인터페이스 (Provider 독립) ----
+
+export interface LLMMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  toolCallId?: string;
+  toolCalls?: LLMToolCall[];
+}
+
+export interface LLMToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface LLMToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface LLMResponse {
+  text: string | null;
+  toolCalls: LLMToolCall[];
+  finishReason: 'stop' | 'tool_calls' | 'length' | 'error';
+}
+
+export interface LLMClient {
+  chat(
+    messages: LLMMessage[],
+    tools?: LLMToolDefinition[],
+  ): Promise<LLMResponse>;
+}
+
+// ---- Groq 구현체 ----
+
+export class GroqLLMClient implements LLMClient {
+  private client: Groq;
+  private model: string;
+
+  constructor(apiKey: string, model = 'llama-3.3-70b-versatile') {
+    this.client = new Groq({ apiKey });
+    this.model = model;
+  }
+
+  async chat(
+    messages: LLMMessage[],
+    tools?: LLMToolDefinition[],
+  ): Promise<LLMResponse> {
+    const groqMessages = toGroqMessages(messages);
+    const groqTools = tools?.length ? toGroqTools(tools) : undefined;
+
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      messages: groqMessages,
+      tools: groqTools,
+      tool_choice: groqTools ? 'auto' : undefined,
+    });
+
+    return fromGroqResponse(response);
+  }
+}
+
+// ---- 팩토리 ----
+
+export const createLLMClient = async (): Promise<LLMClient> => {
+  const { CONFIG } = await import('./config.js');
+
+  if (CONFIG.llm.provider === 'groq') {
+    return new GroqLLMClient(CONFIG.llm.groqApiKey);
+  }
+  throw new Error(`지원하지 않는 LLM provider: ${CONFIG.llm.provider}`);
+};
+
+// ---- 변환 함수 (테스트 가능하도록 export) ----
+
+export function toGroqMessages(
+  messages: LLMMessage[],
+): ChatCompletionMessageParam[] {
+  return messages.map((msg): ChatCompletionMessageParam => {
+    if (msg.role === 'tool') {
+      if (!msg.toolCallId) {
+        throw new Error('tool 메시지에는 toolCallId가 필요합니다');
+      }
+      return {
+        role: 'tool',
+        content: msg.content,
+        tool_call_id: msg.toolCallId,
+      };
+    }
+
+    if (msg.role === 'assistant' && msg.toolCalls?.length) {
+      return {
+        role: 'assistant',
+        content: msg.content || null,
+        tool_calls: msg.toolCalls.map(
+          (tc): ChatCompletionMessageToolCall => ({
+            id: tc.id,
+            type: 'function',
+            function: {
+              name: tc.name,
+              arguments: JSON.stringify(tc.arguments),
+            },
+          }),
+        ),
+      };
+    }
+
+    return {
+      role: msg.role,
+      content: msg.content,
+    };
+  });
+}
+
+export function toGroqTools(
+  tools: LLMToolDefinition[],
+): ChatCompletionTool[] {
+  return tools.map((tool) => ({
+    type: 'function' as const,
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema,
+    },
+  }));
+}
+
+export function fromGroqResponse(response: ChatCompletion): LLMResponse {
+  const choice = response.choices[0];
+  if (!choice) {
+    return { text: null, toolCalls: [], finishReason: 'error' };
+  }
+
+  const message = choice.message;
+
+  const toolCalls: LLMToolCall[] = (message.tool_calls ?? []).map((tc) => ({
+    id: tc.id,
+    name: tc.function.name,
+    arguments: JSON.parse(tc.function.arguments) as Record<string, unknown>,
+  }));
+
+  let finishReason: LLMResponse['finishReason'];
+  switch (choice.finish_reason) {
+    case 'tool_calls':
+      finishReason = 'tool_calls';
+      break;
+    case 'length':
+      finishReason = 'length';
+      break;
+    default:
+      finishReason = 'stop';
+  }
+
+  return {
+    text: message.content,
+    toolCalls,
+    finishReason,
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['node_modules', 'dist'],
+  },
+});


### PR DESCRIPTION
## Summary
- `LLMClient` 인터페이스 정의 (Groq↔Claude 교체 가능)
- `GroqLLMClient` 구현 (llama-3.3-70b-versatile, tool calling 지원)
- `createLLMClient()` 팩토리 함수 (환경변수 기반 Provider 선택)
- 메시지/도구/응답 변환 함수 (toGroqMessages, toGroqTools, fromGroqResponse)
- 단위 테스트 8개 (변환 로직 검증, mock 기반)
- vitest.config.ts 추가 (dist 디렉토리 테스트 제외)

## Test plan
- [x] `yarn build` 성공
- [x] `yarn lint` 통과
- [x] `yarn test` 통과 (8 tests passed)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)