### PR TITLE
feat: MCP 클라이언트 구현 (Notion MCP 서버 연결)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import { App } from '@slack/bolt';
 import { CONFIG } from './shared/config.js';
 import { registerMessageHandler } from './router.js';
+import { connectMCP, disconnectMCP } from './shared/mcp-client.js';
 
 const app = new App({
   token: CONFIG.slack.botToken,
@@ -12,12 +13,23 @@ const app = new App({
 registerMessageHandler(app);
 
 const startApp = async (): Promise<void> => {
+  await connectMCP(CONFIG.notion.apiKey);
   await app.start();
   // eslint-disable-next-line no-console
-  console.log('[App] Slack bot is running in Socket Mode');
+  console.log('[App] Slack 봇이 Socket Mode로 실행 중입니다');
 };
 
+const shutdown = async (): Promise<void> => {
+  // eslint-disable-next-line no-console
+  console.log('[App] 종료 중...');
+  await disconnectMCP();
+  process.exit(0);
+};
+
+process.on('SIGINT', () => void shutdown());
+process.on('SIGTERM', () => void shutdown());
+
 startApp().catch((error: unknown) => {
-  console.error('[App] Failed to start:', error);
+  console.error('[App] 시작 실패:', error);
   process.exit(1);
 });

--- a/src/shared/mcp-client.ts
+++ b/src/shared/mcp-client.ts
@@ -1,2 +1,84 @@
-// MCP client — will be implemented in Phase 1c
-export {};
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { LLMToolDefinition } from './llm.js';
+
+interface MCPClientState {
+  client: Client;
+  transport: StdioClientTransport;
+  tools: LLMToolDefinition[];
+}
+
+let state: MCPClientState | null = null;
+
+export const connectMCP = async (notionApiKey: string): Promise<void> => {
+  if (state) {
+    console.warn('[MCP] 이미 연결되어 있습니다');
+    return;
+  }
+
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: ['-y', '@notionhq/notion-mcp-server'],
+    env: {
+      ...process.env as Record<string, string>,
+      OPENAPI_MCP_HEADERS: JSON.stringify({
+        Authorization: `Bearer ${notionApiKey}`,
+        'Notion-Version': '2022-06-28',
+      }),
+    },
+  });
+
+  const client = new Client(
+    { name: 'slack-ai-agents', version: '1.0.0' },
+  );
+
+  await client.connect(transport);
+
+  const toolsResult = await client.listTools();
+  const tools: LLMToolDefinition[] = toolsResult.tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description ?? '',
+    inputSchema: tool.inputSchema as Record<string, unknown>,
+  }));
+
+  state = { client, transport, tools };
+
+  // eslint-disable-next-line no-console
+  console.log(
+    '[MCP] Notion MCP 서버 연결 완료. 사용 가능한 도구:',
+    tools.map((t) => t.name),
+  );
+};
+
+export const getMCPTools = (): LLMToolDefinition[] => {
+  if (!state) {
+    throw new Error('[MCP] 연결되지 않음. connectMCP()를 먼저 호출하세요.');
+  }
+  return state.tools;
+};
+
+export const callMCPTool = async (
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> => {
+  if (!state) {
+    throw new Error('[MCP] 연결되지 않음. connectMCP()를 먼저 호출하세요.');
+  }
+
+  const result = await state.client.callTool({ name, arguments: args });
+
+  const textContent = (result.content as Array<{ type: string; text?: string }>)
+    .filter((c) => c.type === 'text')
+    .map((c) => c.text ?? '')
+    .join('\n');
+
+  return textContent;
+};
+
+export const disconnectMCP = async (): Promise<void> => {
+  if (!state) return;
+  await state.transport.close();
+  state = null;
+  // eslint-disable-next-line no-console
+  console.log('[MCP] Notion MCP 서버 연결 해제');
+};

--- a/src/shared/notion.ts
+++ b/src/shared/notion.ts
@@ -1,2 +1,7 @@
-// Notion SDK client (for Cron) — will be implemented in Phase 1c
-export {};
+import { Client as NotionClient } from '@notionhq/client';
+
+export const createNotionClient = (apiKey: string): NotionClient => {
+  return new NotionClient({ auth: apiKey });
+};
+
+// Cron 조회용 함수들은 Phase 3에서 추가


### PR DESCRIPTION
## Summary
- Notion MCP 서버 연결 (StdioClientTransport, `npx @notionhq/notion-mcp-server`)
- 도구 목록 캐싱 (`getMCPTools()`) — LLM에 전달할 도구 목록 제공
- 도구 실행 (`callMCPTool()`) — 결과 텍스트 추출하여 LLM tool result로 사용
- 서버 종료 시 MCP 연결 해제 (SIGINT/SIGTERM)
- Notion SDK 클라이언트 초기화 (Cron 조회용 placeholder)
- `app.ts`에서 MCP 연결 → Slack 시작 순서 보장

## Test plan
- [x] `yarn build` 성공
- [x] `yarn lint` 통과
- [x] `yarn test` 통과 (기존 8 tests)
- [x] Notion API 키 + DB 설정 후 MCP 연결 테스트 (수동)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)