### PR TITLE
feat: 일정 카테고리별 그룹핑 표시

### DIFF
--- a/src/agents/schedule/__tests__/actions.test.ts
+++ b/src/agents/schedule/__tests__/actions.test.ts
@@ -7,6 +7,7 @@ import { registerScheduleActions } from '../actions.js';
 vi.mock('../../../shared/notion.js', () => ({
   updatePageProperties: vi.fn(),
   queryTodaySchedules: vi.fn(async () => []),
+  getCategoryOrder: vi.fn(async () => ['약속']),
 }));
 
 vi.mock('../../../shared/slack.js', () => ({

--- a/src/agents/schedule/__tests__/blocks.test.ts
+++ b/src/agents/schedule/__tests__/blocks.test.ts
@@ -39,7 +39,7 @@ describe('encodeOverflowValue / parseOverflowValue', () => {
 describe('buildScheduleBlocks', () => {
   it('할일 항목에 overflow 메뉴가 포함된다', () => {
     const items = [createItem({ status: 'todo' })];
-    const { blocks } = buildScheduleBlocks(items, '2026-03-07');
+    const { blocks } = buildScheduleBlocks(items, '2026-03-07', ['약속']);
 
     const sectionWithAccessory = blocks.find(
       (b) => b.type === 'section' && 'accessory' in b,
@@ -49,7 +49,7 @@ describe('buildScheduleBlocks', () => {
 
   it('약속 항목에는 overflow 메뉴가 없다', () => {
     const items = [createItem({ category: ['약속'] })];
-    const { blocks } = buildScheduleBlocks(items, '2026-03-07');
+    const { blocks } = buildScheduleBlocks(items, '2026-03-07', ['약속']);
 
     const sectionWithAccessory = blocks.find(
       (b) => b.type === 'section' && 'accessory' in b,
@@ -59,7 +59,7 @@ describe('buildScheduleBlocks', () => {
 
   it('todo 항목에 "내일로 미루기" 옵션이 포함된다', () => {
     const items = [createItem({ status: 'todo' })];
-    const { blocks } = buildScheduleBlocks(items, '2026-03-07');
+    const { blocks } = buildScheduleBlocks(items, '2026-03-07', ['약속']);
 
     const sectionWithAccessory = blocks.find(
       (b) => b.type === 'section' && 'accessory' in b,
@@ -73,7 +73,7 @@ describe('buildScheduleBlocks', () => {
 
   it('done 항목에는 "내일로 미루기" 옵션이 없다', () => {
     const items = [createItem({ status: 'done' })];
-    const { blocks } = buildScheduleBlocks(items, '2026-03-07');
+    const { blocks } = buildScheduleBlocks(items, '2026-03-07', ['약속']);
 
     const sectionWithAccessory = blocks.find(
       (b) => b.type === 'section' && 'accessory' in b,
@@ -86,7 +86,7 @@ describe('buildScheduleBlocks', () => {
 
   it('in-progress 항목에 "내일로 미루기" 옵션이 포함된다', () => {
     const items = [createItem({ status: 'in-progress' })];
-    const { blocks } = buildScheduleBlocks(items, '2026-03-07');
+    const { blocks } = buildScheduleBlocks(items, '2026-03-07', ['약속']);
 
     const sectionWithAccessory = blocks.find(
       (b) => b.type === 'section' && 'accessory' in b,
@@ -102,7 +102,7 @@ describe('buildScheduleBlocks', () => {
       createItem({ id: 'p1', status: 'done' }),
       createItem({ id: 'p2', status: 'todo' }),
     ];
-    const { blocks } = buildScheduleBlocks(items, '2026-03-07');
+    const { blocks } = buildScheduleBlocks(items, '2026-03-07', ['약속']);
 
     const context = blocks.find((b) => b.type === 'context') as {
       elements?: Array<{ text: string }>;

--- a/src/agents/schedule/__tests__/index.test.ts
+++ b/src/agents/schedule/__tests__/index.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../../shared/notion.js', async (importOriginal) => {
     ...original,
     queryTodaySchedules: vi.fn(async () => []),
     queryBacklogItems: vi.fn(async () => []),
+    getCategoryOrder: vi.fn(async () => ['약속']),
   };
 });
 

--- a/src/agents/schedule/actions.ts
+++ b/src/agents/schedule/actions.ts
@@ -1,6 +1,6 @@
 import type { App } from '@slack/bolt';
 import type { Client as NotionClient } from '@notionhq/client';
-import { updatePageProperties, queryTodaySchedules } from '../../shared/notion.js';
+import { updatePageProperties, queryTodaySchedules, getCategoryOrder } from '../../shared/notion.js';
 import { updateMessage } from '../../shared/slack.js';
 import { ACTION_ID, POSTPONE_ACTION, parseOverflowValue, buildScheduleBlocks } from './blocks.js';
 
@@ -49,8 +49,9 @@ export const registerScheduleActions = (
       }
 
       // 해당 날짜 일정 재조회 → 블록 재빌드 + 인플레이스 업데이트
+      const catOrder = await getCategoryOrder(notionClient, dbId);
       const items = await queryTodaySchedules(notionClient, dbId, targetDate);
-      const { text, blocks } = buildScheduleBlocks(items, targetDate);
+      const { text, blocks } = buildScheduleBlocks(items, targetDate, catOrder);
 
       const channelId =
         'channel' in body && body.channel ? body.channel.id : undefined;

--- a/src/agents/schedule/blocks.ts
+++ b/src/agents/schedule/blocks.ts
@@ -1,6 +1,6 @@
 import type { KnownBlock } from '@slack/types';
 import type { ScheduleItem } from '../../shared/notion.js';
-import { sortItems, formatItem, formatDateShort } from '../../cron/schedule-reminder.js';
+import { groupItemsByCategory, formatItem, formatDateShort } from '../../cron/schedule-reminder.js';
 
 export const ACTION_ID = 'schedule_status';
 
@@ -61,10 +61,11 @@ const buildOverflowOptions = (
 
 // --- 블록 빌드 ---
 
-/** 일정 목록을 Block Kit으로 빌드 (overflow 메뉴 포함) */
+/** 일정 목록을 Block Kit으로 빌드 (카테고리별 그룹핑 + overflow 메뉴) */
 export const buildScheduleBlocks = (
   items: ScheduleItem[],
   targetDate: string,
+  categoryOrder: string[],
   headerText?: string,
 ): { text: string; blocks: KnownBlock[] } => {
   const blocks: KnownBlock[] = [];
@@ -76,45 +77,50 @@ export const buildScheduleBlocks = (
     text: { type: 'mrkdwn', text: `*${headerText ?? `${formatted} 일정`}*` },
   });
 
-  const sorted = sortItems(items);
+  const groups = groupItemsByCategory(items, categoryOrder);
 
-  // overflow 없는 항목(약속)은 한 블록에 모아서 표시
-  // overflow 있는 항목은 개별 section (accessory 필요)
-  const noOverflowLines: string[] = [];
-
-  const flushNoOverflow = (): void => {
-    if (noOverflowLines.length === 0) return;
+  for (const group of groups) {
+    // 카테고리 서브 헤더
     blocks.push({
       type: 'section',
-      text: { type: 'mrkdwn', text: noOverflowLines.join('\n') },
+      text: { type: 'mrkdwn', text: `*[${group.category}]*` },
     });
-    noOverflowLines.length = 0;
-  };
 
-  for (const item of sorted) {
-    const isAppointment = item.category.includes('약속');
-    const itemText = formatItem(item);
+    // overflow 없는 항목(약속)은 한 블록에 모아서 표시
+    // overflow 있는 항목은 개별 section (accessory 필요)
+    const noOverflowLines: string[] = [];
 
-    if (isAppointment || !item.status) {
-      // 약속: overflow 불필요 → 버퍼에 모음
-      noOverflowLines.push(itemText);
-    } else {
-      // overflow 필요한 항목 앞에 버퍼 비우기
-      flushNoOverflow();
+    const flushNoOverflow = (): void => {
+      if (noOverflowLines.length === 0) return;
       blocks.push({
         type: 'section',
-        text: { type: 'mrkdwn', text: itemText },
-        accessory: {
-          type: 'overflow',
-          action_id: ACTION_ID,
-          options: buildOverflowOptions(item, targetDate),
-        },
+        text: { type: 'mrkdwn', text: noOverflowLines.join('\n') },
       });
-    }
-  }
+      noOverflowLines.length = 0;
+    };
 
-  // 남은 약속 항목 비우기
-  flushNoOverflow();
+    for (const item of group.items) {
+      const isAppointment = item.category.includes('약속');
+      const itemText = formatItem(item);
+
+      if (isAppointment || !item.status) {
+        noOverflowLines.push(itemText);
+      } else {
+        flushNoOverflow();
+        blocks.push({
+          type: 'section',
+          text: { type: 'mrkdwn', text: itemText },
+          accessory: {
+            type: 'overflow',
+            action_id: ACTION_ID,
+            options: buildOverflowOptions(item, targetDate),
+          },
+        });
+      }
+    }
+
+    flushNoOverflow();
+  }
 
   // 하단 통계 — 약속 제외, 할일만 카운트
   const tasks = items.filter((i) => !i.category.includes('약속'));

--- a/src/agents/schedule/index.ts
+++ b/src/agents/schedule/index.ts
@@ -4,7 +4,7 @@ import type { NotionClient } from '../../shared/notion.js';
 import { runAgentLoopWithAck, getAckMessage } from '../../shared/agent-loop.js';
 import type { AgentLoopResult } from '../../shared/agent-loop.js';
 import { sendMessage, sendBlockMessage } from '../../shared/slack.js';
-import { queryTodaySchedules, queryBacklogItems } from '../../shared/notion.js';
+import { queryTodaySchedules, queryBacklogItems, getCategoryOrder } from '../../shared/notion.js';
 import { buildReminderMessage, formatDateShort, formatScheduleList } from '../../cron/schedule-reminder.js';
 import { buildSystemPrompt, getTodayString } from './prompt.js';
 import { getScheduleTools } from './tools.js';
@@ -127,12 +127,13 @@ const buildPostMutationList = async (
   notionClient: NotionClient,
   dbId: string,
   targetDate: string,
+  categoryOrder: string[],
 ): Promise<string | null> => {
   try {
     const items = await queryTodaySchedules(notionClient, dbId, targetDate);
     if (items.length === 0) return null;
     const formatted = formatDateShort(targetDate);
-    return `\n\n${formatted} 일정이야.\n\n${formatScheduleList(items)}`;
+    return `\n\n${formatted} 일정이야.\n\n${formatScheduleList(items, categoryOrder)}`;
   } catch (error: unknown) {
     console.error('[Schedule Agent] post-mutation 조회 오류:', error instanceof Error ? error.message : error);
     return null;
@@ -213,12 +214,13 @@ const buildQueryResponse = (
   target: QueryTarget,
   targetDate: string,
   items: import('../../shared/notion.js').ScheduleItem[],
+  categoryOrder: string[],
 ): string => {
   const formatted = formatDateShort(targetDate);
 
   // 오늘은 기존 크론 메시지 포맷 재사용
   if (target === 'today') {
-    return buildReminderMessage(items, targetDate, formatted, false);
+    return buildReminderMessage(items, targetDate, formatted, false, categoryOrder);
   }
 
   const dateLabels: Record<Exclude<QueryTarget, 'today'>, string> = {
@@ -232,7 +234,7 @@ const buildQueryResponse = (
     return `${label} ${formatted}은 일정 없어.`;
   }
 
-  const list = formatScheduleList(items);
+  const list = formatScheduleList(items, categoryOrder);
   return `${label} ${formatted} 일정이야.\n\n${list}`;
 };
 
@@ -309,6 +311,7 @@ export const createScheduleAgent = (
       const text = message.text.trim();
       const channelId = 'channel' in message ? (message.channel as string) : 'default';
       const ctx = history.toContext(channelId);
+      const catOrder = await getCategoryOrder(notionClient, dbId);
 
       // 0. "체크" 단축어 → 오늘 일정 Block Kit (overflow 메뉴 포함)
       if (text === '체크') {
@@ -319,7 +322,7 @@ export const createScheduleAgent = (
           history.add(channelId, text, '오늘 일정 없어.');
           return;
         }
-        const { text: msgText, blocks } = buildScheduleBlocks(items, today);
+        const { text: msgText, blocks } = buildScheduleBlocks(items, today, catOrder);
         await sendBlockMessage(say, msgText, blocks);
         history.add(channelId, text, msgText);
         return;
@@ -333,7 +336,7 @@ export const createScheduleAgent = (
         const today = getTodayISO();
         const targetDate = getTargetDate(queryTarget, today);
         const items = await queryTodaySchedules(notionClient, dbId, targetDate);
-        const reply = buildQueryResponse(queryTarget, targetDate, items);
+        const reply = buildQueryResponse(queryTarget, targetDate, items, catOrder);
         await sendMessage(say, reply);
         history.add(channelId, text, reply);
         return;
@@ -356,7 +359,7 @@ export const createScheduleAgent = (
 
       const loopResult = await runAgentLoopWithAck(
         llmClient, text,
-        { label: 'Schedule Agent', buildSystemPrompt: () => buildSystemPrompt(dbId, getTodayString()) + ctx, getTools: getScheduleTools },
+        { label: 'Schedule Agent', buildSystemPrompt: () => buildSystemPrompt(dbId, getTodayString(), catOrder) + ctx, getTools: getScheduleTools },
         () => sendMessage(say, getAckMessage()),
       );
 
@@ -385,7 +388,7 @@ export const createScheduleAgent = (
           if (targetDate) {
             // eslint-disable-next-line no-console
             console.log(`[Schedule Agent] post-mutation 조회: ${targetDate}`);
-            const postList = await buildPostMutationList(notionClient, dbId, targetDate);
+            const postList = await buildPostMutationList(notionClient, dbId, targetDate, catOrder);
             if (postList) {
               reply += postList;
             }

--- a/src/agents/schedule/prompt.ts
+++ b/src/agents/schedule/prompt.ts
@@ -19,8 +19,11 @@ export const getTodayString = (): string => {
   return `${yyyy}-${mm}-${dd} (${day})`;
 };
 
-export const buildSystemPrompt = (dbId: string, today: string): string => {
+export const buildSystemPrompt = (dbId: string, today: string, categoryOrder: string[]): string => {
   const uuid = toUUID(dbId);
+  const categoryList = categoryOrder.length > 0
+    ? categoryOrder.join(', ')
+    : '(없음)';
 
   return `너는 내 일정 관리를 도와주는 친구야. 반말로 대화해.
 ${CHARACTER_PROMPT}
@@ -50,30 +53,42 @@ ${CHARACTER_PROMPT}
 ## 응답 포맷
 - 날짜 형식: 3/5(수). 기간: 3/10(월)~3/16(일).
 - 할일 표시: done → ~취소선~ / in-progress → ► 제목 / todo → 제목
-- 약속 표시: 제목 시간 [약속]
+- 약속 표시: 제목 시간 (약속 카테고리 항목에 [약속] 붙이지 마 — 카테고리 헤더로 구분됨)
 - 중요 일정: 줄 끝에 ★
-- 정렬: 약속 → done → in-progress → todo
+- 카테고리별로 *[카테고리명]* 헤더로 묶어서 표시. 카테고리 순서: ${categoryList}. 카테고리 없으면 *[미분류]* 맨 끝.
+- 각 카테고리 안에서 상태별 정렬: done → in-progress → todo
 - 하루 조회: 각 항목 옆에 날짜 절대 붙이지 마. 기간 일정만 범위(3/5~3/14) 표시.
   잘못된 예: "빨래 개기 - 3/7(금)" ← 날짜 금지
   올바른 예: "빨래 개기"
-- 여러 날 조회: 날짜별 *볼드 헤더*로 묶기. 항목 옆 날짜 생략.
+- 여러 날 조회: 날짜별 *볼드 헤더*로 묶기. 각 날짜 안에서 카테고리별로 *[카테고리]* 헤더로 묶기.
 - 하루 예시:
   "오늘 3/6(금) 일정이야.
 
-  친구랑 저녁 19:00 [약속]
+  *[약속]*
+  친구랑 저녁 19:00
+
+  *[개인]*
   ~블로그 글 작성~
-  ► 리뷰 작성
   빨래 개기
-  슬랙 에이전트 개발 - 3/5(목)~3/14(금)
-  병원 예약 ★"
+  병원 예약 ★
+
+  *[사업]*
+  ► 리뷰 작성
+  슬랙 에이전트 개발 - 3/5(목)~3/14(금)"
 - 여러 날 예시:
   "이번 주 일정이야.
 
   *3/10(월)*
-  팀 미팅 14:00 [약속]
+
+  *[약속]*
+  팀 미팅 14:00
+
+  *[개인]*
   코드 리뷰
 
   *3/11(화)*
+
+  *[개인]*
   ► 블로그 글 작성
   빨래 개기"
 

--- a/src/cron/__tests__/schedule-reminder.test.ts
+++ b/src/cron/__tests__/schedule-reminder.test.ts
@@ -31,13 +31,13 @@ describe('buildReminderMessage', () => {
 
   describe('일정 없을 때', () => {
     it('일반 시간대: 일정 없음 메시지', () => {
-      const msg = buildReminderMessage([], today, todayFormatted, false);
+      const msg = buildReminderMessage([], today, todayFormatted, false, ['약속']);
       expect(msg).toContain(todayFormatted);
       expect(msg).toContain('일정');
     });
 
     it('밤 시간대: 마무리 일정 없음 메시지', () => {
-      const msg = buildReminderMessage([], today, todayFormatted, true);
+      const msg = buildReminderMessage([], today, todayFormatted, true, ['약속']);
       expect(msg).toContain('푹 쉬어');
     });
   });
@@ -45,13 +45,13 @@ describe('buildReminderMessage', () => {
   describe('일반 시간대 (isNight=false)', () => {
     it('인사 + 일정 리스트를 포함한다', () => {
       const items = [makeItem({ title: '블로그 작성' })];
-      const msg = buildReminderMessage(items, today, todayFormatted, false);
+      const msg = buildReminderMessage(items, today, todayFormatted, false, ['약속']);
 
       expect(msg).toContain(todayFormatted);
       expect(msg).toContain('블로그 작성');
     });
 
-    it('약속을 [약속] 태그로 표시한다', () => {
+    it('약속은 카테고리 헤더 아래에 시간과 함께 표시한다', () => {
       const items = [
         makeItem({
           title: '친구 만남',
@@ -60,9 +60,12 @@ describe('buildReminderMessage', () => {
           date: { start: '2026-03-07T19:00:00+09:00', end: null },
         }),
       ];
-      const msg = buildReminderMessage(items, today, todayFormatted, false);
+      const msg = buildReminderMessage(items, today, todayFormatted, false, ['약속']);
 
-      expect(msg).toContain('친구 만남 19:00 [약속]');
+      expect(msg).toContain('*[약속]*');
+      expect(msg).toContain('친구 만남 19:00');
+      // [약속] 서픽스는 카테고리 헤더로 대체됨
+      expect(msg).not.toContain('19:00 [약속]');
     });
 
     it('done은 취소선, in-progress는 ► 표시', () => {
@@ -71,7 +74,7 @@ describe('buildReminderMessage', () => {
         makeItem({ title: '진행중 작업', status: 'in-progress' }),
         makeItem({ title: '할일 작업', status: 'todo' }),
       ];
-      const msg = buildReminderMessage(items, today, todayFormatted, false);
+      const msg = buildReminderMessage(items, today, todayFormatted, false, ['약속']);
 
       expect(msg).toContain('~완료 작업~');
       expect(msg).toContain('► 진행중 작업');
@@ -80,7 +83,7 @@ describe('buildReminderMessage', () => {
 
     it('중요 일정은 ★ 표시', () => {
       const items = [makeItem({ title: '중요한 일', hasStarIcon: true })];
-      const msg = buildReminderMessage(items, today, todayFormatted, false);
+      const msg = buildReminderMessage(items, today, todayFormatted, false, ['약속']);
 
       expect(msg).toContain('중요한 일 ★');
     });
@@ -92,33 +95,41 @@ describe('buildReminderMessage', () => {
           date: { start: '2026-03-05', end: '2026-03-10' },
         }),
       ];
-      const msg = buildReminderMessage(items, today, todayFormatted, false);
+      const msg = buildReminderMessage(items, today, todayFormatted, false, ['약속']);
 
       expect(msg).toContain('인스타 포스팅 3/5(목)~3/10(화)');
     });
 
-    it('정렬: 약속 → done → in-progress → todo', () => {
+    it('카테고리별로 그룹핑 후 상태 순서로 정렬한다', () => {
       const items = [
-        makeItem({ title: 'C-todo', status: 'todo' }),
+        makeItem({ title: 'C-todo', status: 'todo', category: ['개인'] }),
         makeItem({ title: 'A-약속', category: ['약속'], status: null }),
-        makeItem({ title: 'B-done', status: 'done' }),
-        makeItem({ title: 'D-진행중', status: 'in-progress' }),
+        makeItem({ title: 'B-done', status: 'done', category: ['개인'] }),
+        makeItem({ title: 'D-진행중', status: 'in-progress', category: ['개인'] }),
       ];
-      const msg = buildReminderMessage(items, today, todayFormatted, false);
+      const msg = buildReminderMessage(items, today, todayFormatted, false, ['약속', '개인']);
 
-      const lines = msg.split('\n').filter((l) => l.trim());
-      const itemLines = lines.slice(1); // 첫 줄은 인사
+      // 카테고리 헤더 포함
+      expect(msg).toContain('*[약속]*');
+      expect(msg).toContain('*[개인]*');
 
-      expect(itemLines[0]).toContain('A-약속');
-      expect(itemLines[1]).toContain('B-done');
-      expect(itemLines[2]).toContain('D-진행중');
-      expect(itemLines[3]).toContain('C-todo');
+      // 약속 그룹이 개인 그룹보다 먼저
+      const appointmentIdx = msg.indexOf('*[약속]*');
+      const personalIdx = msg.indexOf('*[개인]*');
+      expect(appointmentIdx).toBeLessThan(personalIdx);
+
+      // 개인 그룹 내 상태 순서: done → in-progress → todo
+      const doneIdx = msg.indexOf('B-done');
+      const progressIdx = msg.indexOf('D-진행중');
+      const todoIdx = msg.indexOf('C-todo');
+      expect(doneIdx).toBeLessThan(progressIdx);
+      expect(progressIdx).toBeLessThan(todoIdx);
     });
 
     it('남은 일정 있으면 상황에 맞는 코멘트를 붙인다', () => {
       // Math.random = 0 → 0 < 0.4 이므로 코멘트 추가됨
       const items = [makeItem({ title: '할일', status: 'todo' })];
-      const msg = buildReminderMessage(items, today, todayFormatted, false);
+      const msg = buildReminderMessage(items, today, todayFormatted, false, ['약속']);
 
       expect(msg).toContain('해야 할 일이 남아있네');
     });
@@ -130,7 +141,7 @@ describe('buildReminderMessage', () => {
         makeItem({ title: '작업1', status: 'done' }),
         makeItem({ title: '작업2', status: 'done' }),
       ];
-      const msg = buildReminderMessage(items, today, todayFormatted, true);
+      const msg = buildReminderMessage(items, today, todayFormatted, true, ['약속']);
 
       expect(msg).toContain('완료했네');
       expect(msg).toContain('고생했어');
@@ -142,7 +153,7 @@ describe('buildReminderMessage', () => {
         makeItem({ title: '완료', status: 'done' }),
         makeItem({ title: '미완료', status: 'todo' }),
       ];
-      const msg = buildReminderMessage(items, today, todayFormatted, true);
+      const msg = buildReminderMessage(items, today, todayFormatted, true, ['약속']);
 
       expect(msg).toContain('할 일이 남았네');
       expect(msg).toContain('미완료');
@@ -153,7 +164,7 @@ describe('buildReminderMessage', () => {
         makeItem({ title: '완료', status: 'done' }),
         makeItem({ title: '약속', category: ['약속'], status: null }),
       ];
-      const msg = buildReminderMessage(items, today, todayFormatted, true);
+      const msg = buildReminderMessage(items, today, todayFormatted, true, ['약속']);
 
       expect(msg).toContain('고생했어');
     });
@@ -167,7 +178,7 @@ describe('buildReminderMessage', () => {
           date: { start: '2026-03-05', end: '2026-03-10' },
         }),
       ];
-      const msg = buildReminderMessage(items, today, todayFormatted, true);
+      const msg = buildReminderMessage(items, today, todayFormatted, true, ['약속']);
 
       expect(msg).toContain('고생했어');
     });
@@ -180,7 +191,7 @@ describe('buildReminderMessage', () => {
           date: { start: '2026-03-05', end: '2026-03-07' },
         }),
       ];
-      const msg = buildReminderMessage(items, today, todayFormatted, true);
+      const msg = buildReminderMessage(items, today, todayFormatted, true, ['약속']);
 
       expect(msg).toContain('할 일이 남았네');
     });

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -2,7 +2,7 @@ import cron from 'node-cron';
 import type { App } from '@slack/bolt';
 import type { LLMClient } from '../shared/llm.js';
 import type { NotionClient } from '../shared/notion.js';
-import { queryTodaySchedules } from '../shared/notion.js';
+import { queryTodaySchedules, getCategoryOrder } from '../shared/notion.js';
 import { postToChannel, postBlockMessage } from '../shared/slack.js';
 import {
   formatDateShort,
@@ -48,6 +48,7 @@ const createReminderTask = (
     try {
       const today = getTodayISO();
       const formatted = formatDateShort(today);
+      const catOrder = await getCategoryOrder(notionClient, config.dbId);
       const items = await queryTodaySchedules(notionClient, config.dbId, today);
 
       // 인사 생성 (LLM 또는 하드코딩 폴백)
@@ -60,7 +61,7 @@ const createReminderTask = (
         await postToChannel(app.client, config.channelId, greeting);
       } else {
         // 일정 있으면 Block Kit + overflow 메뉴
-        const { text, blocks } = buildScheduleBlocks(items, today, greeting);
+        const { text, blocks } = buildScheduleBlocks(items, today, catOrder, greeting);
         await postBlockMessage(app.client, config.channelId, text, blocks);
       }
       // eslint-disable-next-line no-console

--- a/src/cron/schedule-reminder.ts
+++ b/src/cron/schedule-reminder.ts
@@ -50,7 +50,7 @@ export const formatItem = (item: ScheduleItem): string => {
   if (isAppointment) {
     const time = item.date ? formatTime(item.date.start) : null;
     const timePart = time ? ` ${time}` : '';
-    return `${item.title}${timePart}${rangePart} [약속]${star}`;
+    return `${item.title}${timePart}${rangePart}${star}`;
   }
 
   if (item.status === 'done') return `~${item.title}~${rangePart}${star}`;
@@ -58,13 +58,23 @@ export const formatItem = (item: ScheduleItem): string => {
   return `${item.title}${rangePart}${star}`;
 };
 
-export const sortItems = (items: ScheduleItem[]): ScheduleItem[] => {
-  const statusOrder: Record<string, number> = {
-    done: 0,
-    'in-progress': 1,
-    todo: 2,
-  };
+const STATUS_ORDER: Record<string, number> = {
+  done: 0,
+  'in-progress': 1,
+  todo: 2,
+};
 
+/** 상태 순서로만 정렬 (카테고리 그룹 내부용) */
+export const sortByStatus = (items: ScheduleItem[]): ScheduleItem[] => {
+  return [...items].sort((a, b) => {
+    const aOrder = STATUS_ORDER[a.status ?? 'todo'] ?? 2;
+    const bOrder = STATUS_ORDER[b.status ?? 'todo'] ?? 2;
+    return aOrder - bOrder;
+  });
+};
+
+/** @deprecated groupItemsByCategory 사용 권장 */
+export const sortItems = (items: ScheduleItem[]): ScheduleItem[] => {
   return [...items].sort((a, b) => {
     const aIsAppointment = a.category.includes('약속');
     const bIsAppointment = b.category.includes('약속');
@@ -73,8 +83,8 @@ export const sortItems = (items: ScheduleItem[]): ScheduleItem[] => {
     if (!aIsAppointment && bIsAppointment) return 1;
 
     if (!aIsAppointment && !bIsAppointment) {
-      const aOrder = statusOrder[a.status ?? 'todo'] ?? 2;
-      const bOrder = statusOrder[b.status ?? 'todo'] ?? 2;
+      const aOrder = STATUS_ORDER[a.status ?? 'todo'] ?? 2;
+      const bOrder = STATUS_ORDER[b.status ?? 'todo'] ?? 2;
       return aOrder - bOrder;
     }
 
@@ -82,9 +92,85 @@ export const sortItems = (items: ScheduleItem[]): ScheduleItem[] => {
   });
 };
 
-export const formatScheduleList = (items: ScheduleItem[]): string => {
-  const sorted = sortItems(items);
-  return sorted.map(formatItem).join('\n');
+// --- 카테고리별 그룹핑 ---
+
+export interface CategoryGroup {
+  category: string;
+  items: ScheduleItem[];
+}
+
+/** 아이템의 대표 카테고리 결정 (복수 → categoryOrder 기준 가장 아래) */
+const assignCategory = (item: ScheduleItem, categoryOrder: string[]): string => {
+  if (item.category.length === 0) return '미분류';
+  if (item.category.length === 1) return item.category[0]!;
+
+  // 복수 카테고리 → categoryOrder에서 인덱스가 가장 큰 것 선택
+  let bestIndex = -1;
+  let bestCategory = item.category[item.category.length - 1]!;
+  for (const cat of item.category) {
+    const idx = categoryOrder.indexOf(cat);
+    if (idx > bestIndex) {
+      bestIndex = idx;
+      bestCategory = cat;
+    }
+  }
+  return bestCategory;
+};
+
+/** 아이템을 카테고리별로 그룹핑 (카테고리 순서: Notion DB 순서, 미분류 맨 끝) */
+export const groupItemsByCategory = (
+  items: ScheduleItem[],
+  categoryOrder: string[],
+): CategoryGroup[] => {
+  const categoryMap = new Map<string, ScheduleItem[]>();
+
+  for (const item of items) {
+    const cat = assignCategory(item, categoryOrder);
+    if (!categoryMap.has(cat)) {
+      categoryMap.set(cat, []);
+    }
+    categoryMap.get(cat)!.push(item);
+  }
+
+  const result: CategoryGroup[] = [];
+
+  // categoryOrder 순서대로 그룹 추가
+  for (const cat of categoryOrder) {
+    const groupItems = categoryMap.get(cat);
+    if (groupItems && groupItems.length > 0) {
+      result.push({ category: cat, items: sortByStatus(groupItems) });
+      categoryMap.delete(cat);
+    }
+  }
+
+  // categoryOrder에 없는 카테고리 (미분류 제외)
+  for (const [cat, groupItems] of categoryMap) {
+    if (cat !== '미분류' && groupItems.length > 0) {
+      result.push({ category: cat, items: sortByStatus(groupItems) });
+    }
+  }
+
+  // 미분류 맨 끝
+  const uncategorized = categoryMap.get('미분류');
+  if (uncategorized && uncategorized.length > 0) {
+    result.push({ category: '미분류', items: sortByStatus(uncategorized) });
+  }
+
+  return result;
+};
+
+export const formatScheduleList = (
+  items: ScheduleItem[],
+  categoryOrder: string[],
+): string => {
+  const groups = groupItemsByCategory(items, categoryOrder);
+  return groups
+    .map((g) => {
+      const header = `*[${g.category}]*`;
+      const list = g.items.map(formatItem).join('\n');
+      return `${header}\n${list}`;
+    })
+    .join('\n\n');
 };
 
 // --- 문구 ---
@@ -161,6 +247,7 @@ export const buildReminderMessage = (
   today: string,
   todayFormatted: string,
   isNight: boolean,
+  categoryOrder: string[],
 ): string => {
   if (items.length === 0) {
     if (isNight) {
@@ -169,7 +256,7 @@ export const buildReminderMessage = (
     return pickRandom(NO_SCHEDULE_MESSAGES).replace('{date}', todayFormatted);
   }
 
-  const list = formatScheduleList(items);
+  const list = formatScheduleList(items, categoryOrder);
 
   if (!isNight) {
     const greeting = pickRandom(GREETING_MESSAGES).replace('{date}', todayFormatted);
@@ -303,8 +390,9 @@ export const generateScheduleGreeting = async (
 export const buildReminderWithGreeting = (
   greeting: string,
   items: ScheduleItem[],
+  categoryOrder: string[],
 ): string => {
   if (items.length === 0) return greeting;
-  const list = formatScheduleList(items);
+  const list = formatScheduleList(items, categoryOrder);
   return `${greeting}\n\n${list}`;
 };

--- a/src/shared/notion.ts
+++ b/src/shared/notion.ts
@@ -206,3 +206,42 @@ export const toUUID = (id: string): string => {
   if (hex.length !== 32) return id;
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 };
+
+// --- 카테고리 순서 조회 ---
+
+interface DatabaseProperty {
+  type: string;
+  multi_select?: { options: Array<{ name: string }> };
+}
+
+interface DatabaseResponse {
+  properties: Record<string, DatabaseProperty>;
+}
+
+let cachedCategoryOrder: string[] | null = null;
+
+/** Notion DB 스키마에서 카테고리 multi_select 옵션 순서 조회 (캐싱) */
+export const getCategoryOrder = async (
+  client: NotionClient,
+  dbId: string,
+): Promise<string[]> => {
+  if (cachedCategoryOrder) return cachedCategoryOrder;
+
+  const uuid = toUUID(dbId);
+  const response = await (client.request as (args: {
+    path: string;
+    method: string;
+  }) => Promise<unknown>)({
+    path: `databases/${uuid}`,
+    method: 'get',
+  }) as DatabaseResponse;
+
+  const categoryProp = response.properties['카테고리'];
+  if (categoryProp?.type === 'multi_select' && categoryProp.multi_select) {
+    cachedCategoryOrder = categoryProp.multi_select.options.map((o) => o.name);
+  } else {
+    cachedCategoryOrder = [];
+  }
+
+  return cachedCategoryOrder;
+};


### PR DESCRIPTION
## Summary
- 일정을 카테고리별로 묶어서 `*[카테고리]*` 헤더 아래 리스트로 표시
- 카테고리 순서는 Notion DB `multi_select` 옵션 순서를 따름
- 카테고리 없는 항목은 `*[미분류]*` 그룹으로 맨 아래 배치
- 복수 카테고리 항목은 Notion 순서 기준 더 아래(세부적인) 카테고리에 배치
- 각 그룹 내에서 상태별 정렬(done → in-progress → todo) 유지
- `[약속]` 서픽스 제거 (카테고리 헤더로 구분되므로 중복)

## 변경 파일 (11개)
- `src/shared/notion.ts` — `getCategoryOrder()` 추가 (DB 스키마에서 카테고리 순서 조회 + 캐싱)
- `src/cron/schedule-reminder.ts` — `groupItemsByCategory()`, `formatScheduleList()` 그룹핑 로직
- `src/agents/schedule/blocks.ts` — Block Kit 카테고리 섹션 빌드
- `src/agents/schedule/prompt.ts` — LLM 시스템 프롬프트에 카테고리 순서 주입
- `src/agents/schedule/index.ts` — 모든 호출부에 `categoryOrder` 전달
- `src/cron/index.ts` — 크론 알림에 `categoryOrder` 전달
- `src/agents/schedule/actions.ts` — overflow 액션 후 재빌드 시 `categoryOrder` 전달
- 테스트 4개 파일 업데이트

## Test plan
- [x] `yarn build` 타입 체크 통과
- [x] `yarn test` 통과 (기존 루틴 테스트 3개 실패는 pre-existing)
- [x] Slack에서 "체크" 명령 → 카테고리 그룹핑 확인
- [x] 크론 알림 → 카테고리 그룹핑 확인
- [x] LLM 응답 → 카테고리 그룹핑 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)