### PR TITLE
feat: PostgreSQL 세팅 + 스키마 설계 (#34)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ docs/
 .claude/
 .vscode/
 src/**/__tests__/
+db/test-connection.ts

--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,8 @@ CRON_ROUTINE_MORNING=0 9 * * *
 CRON_ROUTINE_LUNCH=0 13 * * *
 CRON_ROUTINE_EVENING=0 18 * * *
 CRON_ROUTINE_NIGHT=0 22 * * *
+
+# Database (PostgreSQL)
+# Docker: postgresql://agent:agent_password@db:5432/slack_ai_agents
+# Local:  postgresql://agent:agent_password@localhost:5432/slack_ai_agents
+DATABASE_URL=postgresql://agent:agent_password@db:5432/slack_ai_agents

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --production && yarn cache clean
 
 COPY --from=builder /app/dist ./dist
+COPY db/ ./db/
 
 USER node
 

--- a/db/migrations/001_initial_schema.sql
+++ b/db/migrations/001_initial_schema.sql
@@ -1,0 +1,30 @@
+-- 일정
+CREATE TABLE IF NOT EXISTS schedules (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  date DATE,
+  end_date DATE,
+  status TEXT DEFAULT 'todo',
+  category TEXT,
+  memo TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 루틴 템플릿
+CREATE TABLE IF NOT EXISTS routine_templates (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  time_slot TEXT,
+  frequency TEXT,
+  active BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 루틴 일별 기록
+CREATE TABLE IF NOT EXISTS routine_records (
+  id SERIAL PRIMARY KEY,
+  template_id INTEGER REFERENCES routine_templates(id),
+  date DATE NOT NULL,
+  completed BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/db/test-connection.ts
+++ b/db/test-connection.ts
@@ -1,0 +1,37 @@
+// 수동 접속 테스트: npx tsx db/test-connection.ts
+import 'dotenv/config';
+import pg from 'pg';
+
+const { Pool } = pg;
+
+const main = async (): Promise<void> => {
+  const pool = new Pool({
+    connectionString: process.env['DATABASE_URL'],
+  });
+
+  try {
+    const result = await pool.query<{ now: Date; db: string }>(
+      'SELECT NOW() AS now, current_database() AS db',
+    );
+    console.log('Connection successful!');
+    console.log('Time:', result.rows[0].now);
+    console.log('Database:', result.rows[0].db);
+
+    const tables = await pool.query<{ tablename: string }>(`
+      SELECT tablename FROM pg_tables
+      WHERE schemaname = 'public'
+      ORDER BY tablename
+    `);
+    console.log(
+      'Tables:',
+      tables.rows.map((r) => r.tablename),
+    );
+  } catch (err) {
+    console.error('Connection failed:', err);
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+};
+
+void main();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,36 @@
 services:
+  db:
+    image: postgres:17-alpine
+    container_name: slack-ai-agents-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-agent}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-agent_password}
+      POSTGRES_DB: ${POSTGRES_DB:-slack_ai_agents}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-agent}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   app:
     build: .
     container_name: slack-ai-agents
     restart: unless-stopped
     env_file:
       - .env
+    depends_on:
+      db:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "node", "-e", "process.exit(0)"]
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 10s
+
+volumes:
+  pgdata:

--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
     "dotenv": "^17.3.1",
     "groq-sdk": "^0.37.0",
     "node-cron": "^4.2.1",
+    "pg": "^8.20.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.3.3",
     "@types/node-cron": "^3.0.11",
+    "@types/pg": "^8.18.0",
     "eslint": "^10.0.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,8 @@ import { App } from '@slack/bolt';
 import { CONFIG } from './shared/config.js';
 import { registerMessageHandler, registerAgent } from './router.js';
 import { connectMCP, disconnectMCP } from './shared/mcp-client.js';
+import { connectDB, disconnectDB } from './shared/db.js';
+import { runMigrations } from './shared/migrate.js';
 import { createLLMClient } from './shared/llm.js';
 import { createScheduleAgent } from './agents/schedule/index.js';
 import { createRoutineAgent } from './agents/routine/index.js';
@@ -21,6 +23,10 @@ const app = new App({
 registerMessageHandler(app);
 
 const startApp = async (): Promise<void> => {
+  // DB 연결 + 마이그레이션 (가장 먼저)
+  await connectDB(CONFIG.db.url);
+  await runMigrations();
+
   await connectMCP(CONFIG.notion.apiKey);
 
   const llmClient = await createLLMClient();
@@ -64,6 +70,7 @@ const shutdown = async (): Promise<void> => {
   // eslint-disable-next-line no-console
   console.log('[App] 종료 중...');
   await disconnectMCP();
+  await disconnectDB();
   process.exit(0);
 };
 

--- a/src/shared/__tests__/db.test.ts
+++ b/src/shared/__tests__/db.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockRelease = vi.fn();
+const mockEnd = vi.fn();
+
+vi.mock('pg', () => {
+  const MockPool = vi.fn(function (this: Record<string, unknown>) {
+    this.query = mockQuery;
+    this.connect = mockConnect;
+    this.end = mockEnd;
+  });
+  return { default: { Pool: MockPool } };
+});
+
+const { connectDB, query, queryOne, disconnectDB } = await import('../db.js');
+
+describe('db', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue({ release: mockRelease });
+    mockEnd.mockResolvedValue(undefined);
+    // pool 상태 초기화
+    await disconnectDB();
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue({ release: mockRelease });
+    mockEnd.mockResolvedValue(undefined);
+  });
+
+  describe('connectDB', () => {
+    it('풀을 생성하고 연결을 확인한다', async () => {
+      await connectDB('postgresql://test@localhost/test');
+      expect(mockConnect).toHaveBeenCalled();
+      expect(mockRelease).toHaveBeenCalled();
+    });
+  });
+
+  describe('query', () => {
+    it('pool.query에 위임한다', async () => {
+      await connectDB('postgresql://test@localhost/test');
+      const mockResult = { rows: [{ id: 1 }], rowCount: 1 };
+      mockQuery.mockResolvedValue(mockResult);
+
+      const result = await query('SELECT 1');
+      expect(result).toEqual(mockResult);
+      expect(mockQuery).toHaveBeenCalledWith('SELECT 1', undefined);
+    });
+
+    it('파라미터 바인딩을 전달한다', async () => {
+      await connectDB('postgresql://test@localhost/test');
+      mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      await query('SELECT * FROM schedules WHERE id = $1', [42]);
+      expect(mockQuery).toHaveBeenCalledWith(
+        'SELECT * FROM schedules WHERE id = $1',
+        [42],
+      );
+    });
+  });
+
+  describe('queryOne', () => {
+    it('첫 번째 행을 반환한다', async () => {
+      await connectDB('postgresql://test@localhost/test');
+      mockQuery.mockResolvedValue({ rows: [{ id: 1, title: 'test' }] });
+      const result = await queryOne('SELECT * FROM schedules LIMIT 1');
+      expect(result).toEqual({ id: 1, title: 'test' });
+    });
+
+    it('결과가 없으면 null을 반환한다', async () => {
+      await connectDB('postgresql://test@localhost/test');
+      mockQuery.mockResolvedValue({ rows: [] });
+      const result = await queryOne('SELECT * FROM schedules WHERE id = $1', [999]);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('disconnectDB', () => {
+    it('pool.end()를 호출한다', async () => {
+      await connectDB('postgresql://test@localhost/test');
+      await disconnectDB();
+      expect(mockEnd).toHaveBeenCalled();
+    });
+
+    it('미연결 상태에서는 아무 동작 안 한다', async () => {
+      await disconnectDB();
+      expect(mockEnd).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -53,6 +53,9 @@ export const CONFIG = {
     evening: optionalEnv('CRON_EVENING', '0 18 * * *'),
     night: optionalEnv('CRON_NIGHT', '0 23 * * *'),
   },
+  db: {
+    url: requireEnv('DATABASE_URL'),
+  },
   routineCron: {
     morning: optionalEnv('CRON_ROUTINE_MORNING', '0 9 * * *'),
     lunch: optionalEnv('CRON_ROUTINE_LUNCH', '0 13 * * *'),

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -1,0 +1,57 @@
+import pg from 'pg';
+
+const { Pool } = pg;
+
+let pool: pg.Pool | null = null;
+
+/** PostgreSQL 연결 풀 초기화 */
+export const connectDB = async (databaseUrl: string): Promise<void> => {
+  if (pool) {
+    console.warn('[DB] 이미 연결되어 있습니다');
+    return;
+  }
+
+  pool = new Pool({
+    connectionString: databaseUrl,
+    max: 5,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 5_000,
+  });
+
+  const client = await pool.connect();
+  client.release();
+  console.log('[DB] PostgreSQL 연결 완료');
+};
+
+/** 연결 풀 반환 (미연결 시 에러) */
+const getPool = (): pg.Pool => {
+  if (!pool) {
+    throw new Error('[DB] 연결되지 않음. connectDB()를 먼저 호출하세요.');
+  }
+  return pool;
+};
+
+/** SQL 쿼리 실행 */
+export const query = async <T extends pg.QueryResultRow = pg.QueryResultRow>(
+  text: string,
+  params?: unknown[],
+): Promise<pg.QueryResult<T>> => {
+  return getPool().query<T>(text, params);
+};
+
+/** SQL 쿼리 실행 후 첫 번째 행 반환 (없으면 null) */
+export const queryOne = async <T extends pg.QueryResultRow = pg.QueryResultRow>(
+  text: string,
+  params?: unknown[],
+): Promise<T | null> => {
+  const result = await query<T>(text, params);
+  return result.rows[0] ?? null;
+};
+
+/** 연결 풀 종료 */
+export const disconnectDB = async (): Promise<void> => {
+  if (!pool) return;
+  await pool.end();
+  pool = null;
+  console.log('[DB] PostgreSQL 연결 해제');
+};

--- a/src/shared/migrate.ts
+++ b/src/shared/migrate.ts
@@ -1,0 +1,49 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { query } from './db.js';
+
+const MIGRATIONS_DIR = join(import.meta.dirname, '../../db/migrations');
+
+/** 마이그레이션 추적 테이블 생성 */
+const ensureMigrationsTable = async (): Promise<void> => {
+  await query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      filename TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+};
+
+/** 적용 완료된 마이그레이션 목록 조회 */
+const getAppliedMigrations = async (): Promise<Set<string>> => {
+  const result = await query<{ filename: string }>(
+    'SELECT filename FROM schema_migrations ORDER BY filename',
+  );
+  return new Set(result.rows.map((r) => r.filename));
+};
+
+/** 미적용 마이그레이션을 순서대로 실행 */
+export const runMigrations = async (): Promise<void> => {
+  await ensureMigrationsTable();
+  const applied = await getAppliedMigrations();
+
+  const files = await readdir(MIGRATIONS_DIR);
+  const sqlFiles = files.filter((f) => f.endsWith('.sql')).sort();
+
+  let count = 0;
+  for (const file of sqlFiles) {
+    if (applied.has(file)) continue;
+
+    const sql = await readFile(join(MIGRATIONS_DIR, file), 'utf-8');
+    console.log(`[Migrate] 적용 중: ${file}`);
+    await query(sql);
+    await query('INSERT INTO schema_migrations (filename) VALUES ($1)', [file]);
+    count++;
+  }
+
+  if (count > 0) {
+    console.log(`[Migrate] ${count}개 마이그레이션 적용 완료`);
+  } else {
+    console.log('[Migrate] 적용할 마이그레이션 없음');
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,6 +605,15 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/pg@^8.18.0":
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.18.0.tgz#0535e33bda45c34803d809719f7afc62c145ed50"
+  integrity sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/retry@0.12.0":
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
@@ -2098,6 +2107,62 @@ pathe@^2.0.3:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
+pg-cloudflare@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz#386035d4bfcf1a7045b026f8b21acf5353f14d65"
+  integrity sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==
+
+pg-connection-string@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.12.0.tgz#4084f917902bb2daae3dc1376fe24ac7b4eaccf2"
+  integrity sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.13.0.tgz#416482e9700e8f80c685a6ae5681697a413c13a3"
+  integrity sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==
+
+pg-protocol@*, pg-protocol@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.13.0.tgz#fdaf6d020bca590d58bb991b4b16fc448efe0511"
+  integrity sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==
+
+pg-types@2.2.0, pg-types@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.20.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.20.0.tgz#1a274de944cb329fd6dd77a6d371a005ba6b136d"
+  integrity sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==
+  dependencies:
+    pg-connection-string "^2.12.0"
+    pg-pool "^3.13.0"
+    pg-protocol "^1.13.0"
+    pg-types "2.2.0"
+    pgpass "1.0.5"
+  optionalDependencies:
+    pg-cloudflare "^1.3.0"
+
+pgpass@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
+
 picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -2121,6 +2186,28 @@ postcss@^8.5.6:
     nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz#c40b3da0222c500ff1e51c5d7014b60b79697c7a"
+  integrity sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -2366,6 +2453,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+split2@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
 stackback@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
@@ -2382,6 +2474,7 @@ std-env@^3.10.0:
   integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2400,6 +2493,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     strip-ansi "^7.0.1"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2639,6 +2733,11 @@ ws@^8, ws@^8.18.0:
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.19.0.tgz#ddc2bdfa5b9ad860204f5a72a4863a8895fd8c8b"
   integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary
- Notion → PostgreSQL 전환 첫 단계 (v2 인프라)
- `pg` 패키지 기반 싱글톤 connection pool + query/queryOne 헬퍼 (`src/shared/db.ts`)
- Plain SQL 마이그레이션 시스템 (`src/shared/migrate.ts`) — `schema_migrations` 테이블로 추적
- 초기 스키마: `schedules`, `routine_templates`, `routine_records` (`db/migrations/001_initial_schema.sql`)
- Docker Compose에 `postgres:17-alpine` 서비스 + healthcheck + pgdata 볼륨
- `app.ts` startup/shutdown에 DB 라이프사이클 연결
- db.test.ts 유닛 테스트 7개 통과

## 변경 파일
| 구분 | 파일 | 내용 |
|------|------|------|
| NEW | `src/shared/db.ts` | Connection pool + query 헬퍼 |
| NEW | `src/shared/migrate.ts` | SQL 마이그레이션 러너 |
| NEW | `src/shared/__tests__/db.test.ts` | db 모듈 단위 테스트 (7개) |
| NEW | `db/migrations/001_initial_schema.sql` | 초기 스키마 |
| NEW | `db/test-connection.ts` | 수동 접속 테스트 스크립트 |
| MOD | `docker-compose.yml` | postgres 서비스 + pgdata 볼륨 |
| MOD | `Dockerfile` | `COPY db/ ./db/` 추가 |
| MOD | `src/shared/config.ts` | `db.url` (DATABASE_URL) 추가 |
| MOD | `src/app.ts` | connectDB + runMigrations + disconnectDB |
| MOD | `.env.example` | DATABASE_URL 추가 |
| MOD | `.dockerignore` | test-connection.ts 제외 |
| MOD | `package.json` | pg + @types/pg |

## Test plan
- [x] `yarn build` 타입 체크 통과
- [x] `yarn test` 전체 721개 테스트 통과 (db.test.ts 7개 포함)
- [x] `docker compose up` 후 postgres + app 정상 기동 (VM 배포 시 확인)
- [x] `npx tsx db/test-connection.ts` 로컬 접속 테스트

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)