### PR TITLE
feat: Slack App Home 탭 대시보드 구현

### DIFF
--- a/src/agents/life/__tests__/home.test.ts
+++ b/src/agents/life/__tests__/home.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RoutineRecordRow, ScheduleRow, SleepRecordRow } from '../../../shared/life-queries.js';
+
+// ── DB mock ──
+vi.mock('../../../shared/db.js', () => ({
+  query: vi.fn(async () => ({ rows: [] })),
+  connectDB: vi.fn(),
+}));
+
+// ── life-queries mock ──
+const mockQueryTodayRecords = vi.fn<() => Promise<RoutineRecordRow[]>>(async () => []);
+const mockQueryTodaySchedules = vi.fn<() => Promise<ScheduleRow[]>>(async () => []);
+const mockQueryLatestSleep = vi.fn<() => Promise<SleepRecordRow | null>>(async () => null);
+
+vi.mock('../../../shared/life-queries.js', () => ({
+  queryTodayRecords: (...args: unknown[]) => mockQueryTodayRecords(),
+  queryTodaySchedules: (...args: unknown[]) => mockQueryTodaySchedules(),
+  queryLatestSleep: () => mockQueryLatestSleep(),
+  frequencyBadge: vi.fn(() => ''),
+}));
+
+// ── life-cron mock ──
+const mockCreateTodayRecords = vi.fn(async () => 0);
+vi.mock('../../../cron/life-cron.js', () => ({
+  createTodayRecords: () => mockCreateTodayRecords(),
+}));
+
+import { publishHomeView } from '../home.js';
+
+// ── 블록에서 텍스트 추출 헬퍼 ──
+interface BlockWithText {
+  type: string;
+  text?: { text: string };
+  elements?: Array<{ text: string }>;
+}
+
+const extractSectionTexts = (blocks: BlockWithText[]): string[] =>
+  blocks
+    .filter((b) => b.type === 'section' && b.text?.text)
+    .map((b) => b.text!.text);
+
+describe('publishHomeView', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockPublish = vi.fn(async () => ({}) as any);
+  const mockClient = {
+    views: { publish: mockPublish },
+  } as unknown as Parameters<typeof publishHomeView>[0];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const getBlocks = (): BlockWithText[] => {
+    const call = mockPublish.mock.calls[0] as unknown[];
+    const arg = call[0] as { view: { blocks: BlockWithText[] } };
+    return arg.view.blocks;
+  };
+
+  it('views.publish를 호출한다', async () => {
+    await publishHomeView(mockClient, 'U123');
+
+    expect(mockPublish).toHaveBeenCalledOnce();
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'U123',
+        view: expect.objectContaining({ type: 'home' }),
+      }),
+    );
+  });
+
+  it('오늘 루틴 레코드를 생성한다', async () => {
+    await publishHomeView(mockClient, 'U123');
+
+    expect(mockCreateTodayRecords).toHaveBeenCalledOnce();
+  });
+
+  it('데이터가 없으면 빈 상태 메시지를 표시한다', async () => {
+    await publishHomeView(mockClient, 'U123');
+
+    const texts = extractSectionTexts(getBlocks());
+
+    expect(texts.some((t) => t.includes('일정 없음'))).toBe(true);
+    expect(texts.some((t) => t.includes('루틴 없음'))).toBe(true);
+    expect(texts.some((t) => t.includes('기록 없음'))).toBe(true);
+  });
+
+  it('일정이 있으면 일정 블록을 포함한다', async () => {
+    mockQueryTodaySchedules.mockResolvedValueOnce([
+      {
+        id: 1, title: '미팅', date: '2025-03-08', end_date: null,
+        status: 'todo', category: '업무', memo: null, important: false,
+      },
+    ]);
+
+    await publishHomeView(mockClient, 'U123');
+
+    const texts = extractSectionTexts(getBlocks());
+    expect(texts.some((t) => t.includes('미팅'))).toBe(true);
+    expect(texts.some((t) => t.includes('일정 없음'))).toBe(false);
+  });
+
+  it('루틴이 있으면 루틴 블록을 포함한다', async () => {
+    mockQueryTodayRecords.mockResolvedValueOnce([
+      {
+        id: 1, template_id: 1, date: '2025-03-08', completed: false,
+        name: '스트레칭', time_slot: '아침', frequency: '매일',
+      },
+    ]);
+
+    await publishHomeView(mockClient, 'U123');
+
+    const texts = extractSectionTexts(getBlocks());
+    expect(texts.some((t) => t.includes('스트레칭'))).toBe(true);
+    expect(texts.some((t) => t.includes('루틴 없음'))).toBe(false);
+  });
+
+  it('수면 기록이 있으면 수면 블록을 포함한다', async () => {
+    mockQueryLatestSleep.mockResolvedValueOnce({
+      id: 1, date: '2025-03-07', bedtime: '23:30', wake_time: '07:00',
+      duration_minutes: 450, sleep_type: 'night', memo: null,
+    });
+
+    await publishHomeView(mockClient, 'U123');
+
+    const texts = extractSectionTexts(getBlocks());
+    expect(texts.some((t) => t.includes('23:30'))).toBe(true);
+    expect(texts.some((t) => t.includes('07:00'))).toBe(true);
+    expect(texts.some((t) => t.includes('기록 없음'))).toBe(false);
+  });
+
+  it('헤더에 대시보드를 포함한다', async () => {
+    await publishHomeView(mockClient, 'U123');
+
+    const blocks = getBlocks();
+    const headers = blocks.filter((b) => b.type === 'header');
+
+    expect(headers).toHaveLength(1);
+    expect(headers[0]!.text!.text).toContain('대시보드');
+  });
+
+  it('마지막 업데이트 시각을 포함한다', async () => {
+    await publishHomeView(mockClient, 'U123');
+
+    const blocks = getBlocks();
+    const contexts = blocks.filter((b) => b.type === 'context');
+    const lastContext = contexts[contexts.length - 1]!;
+
+    expect(lastContext.elements![0]!.text).toMatch(/마지막 업데이트: \d{2}:\d{2}/);
+  });
+});

--- a/src/agents/life/actions.ts
+++ b/src/agents/life/actions.ts
@@ -23,6 +23,7 @@ import {
   buildScheduleBlocks,
 } from './blocks.js';
 import { getTodayISO } from './prompt.js';
+import { publishHomeView } from './home.js';
 
 /** 날짜를 N일 이동 (YYYY-MM-DD) */
 const addDays = (dateStr: string, days: number): string => {
@@ -66,6 +67,14 @@ export const registerLifeActions = (app: App): void => {
       if (channelId && messageTs) {
         await updateMessage(client, channelId, messageTs, text, blocks);
       }
+
+      // Home 탭 갱신
+      const userId = 'user' in body && body.user
+        ? (typeof body.user === 'string' ? body.user : body.user.id)
+        : undefined;
+      if (userId) {
+        await publishHomeView(client, userId).catch(() => {});
+      }
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       console.error(`[Life Action] 루틴 완료 처리 오류: ${msg}`);
@@ -103,6 +112,14 @@ export const registerLifeActions = (app: App): void => {
 
       if (channelId && messageTs) {
         await updateMessage(client, channelId, messageTs, text, blocks);
+      }
+
+      // Home 탭 갱신
+      const userId = 'user' in body && body.user
+        ? (typeof body.user === 'string' ? body.user : body.user.id)
+        : undefined;
+      if (userId) {
+        await publishHomeView(client, userId).catch(() => {});
       }
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/src/agents/life/blocks.ts
+++ b/src/agents/life/blocks.ts
@@ -4,7 +4,7 @@
  */
 
 import type { KnownBlock } from '@slack/types';
-import type { RoutineRecordRow, ScheduleRow } from '../../shared/life-queries.js';
+import type { RoutineRecordRow, ScheduleRow, SleepRecordRow } from '../../shared/life-queries.js';
 import { frequencyBadge } from '../../shared/life-queries.js';
 
 // ─── 상수 ───────────────────────────────────────────────
@@ -445,4 +445,28 @@ export const buildScheduleBlocks = (
 
   const fallbackText = `${formatted} 일정 (${items.length}개)`;
   return { text: fallbackText, blocks };
+};
+
+// ─── 수면 블록 ──────────────────────────────────────────
+
+/** 수면 요약 Block Kit */
+export const buildSleepBlocks = (sleep: SleepRecordRow | null): KnownBlock[] => {
+  if (!sleep) {
+    return [
+      { type: 'section', text: { type: 'mrkdwn', text: '*수면*\n기록 없음' } },
+    ];
+  }
+  const hours = Math.floor(sleep.duration_minutes / 60);
+  const mins = sleep.duration_minutes % 60;
+  const duration = mins > 0 ? `${hours}시간 ${mins}분` : `${hours}시간`;
+  const dateStr = formatDateShort(sleep.date);
+  return [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*수면* (${dateStr})\n취침 ${sleep.bedtime} → 기상 ${sleep.wake_time} (${duration})`,
+      },
+    },
+  ];
 };

--- a/src/agents/life/home.ts
+++ b/src/agents/life/home.ts
@@ -1,0 +1,117 @@
+/**
+ * Slack App Home 탭 — 오늘의 일정, 루틴, 수면 대시보드.
+ * app_home_opened 이벤트 시 views.publish로 갱신.
+ */
+
+import type { App } from '@slack/bolt';
+import type { WebClient } from '@slack/web-api';
+import type { KnownBlock } from '@slack/types';
+import { getTodayISO } from './prompt.js';
+import {
+  formatDateShort,
+  buildRoutineBlocks,
+  buildScheduleBlocks,
+  buildSleepBlocks,
+} from './blocks.js';
+import {
+  queryTodayRecords,
+  queryTodaySchedules,
+  queryLatestSleep,
+} from '../../shared/life-queries.js';
+import { createTodayRecords } from '../../cron/life-cron.js';
+
+// ─── KST 시각 헬퍼 ──────────────────────────────────
+
+/** KST(UTC+9) 기준 현재 시각의 HH:MM 문자열 */
+const getKSTTimeString = (): string => {
+  const now = new Date();
+  const kst = new Date(now.getTime() + (now.getTimezoneOffset() + 540) * 60_000);
+  const hh = String(kst.getHours()).padStart(2, '0');
+  const mm = String(kst.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+};
+
+// ─── Home 탭 빌드 ───────────────────────────────────
+
+/** Home 탭 뷰 발행 */
+export const publishHomeView = async (
+  client: WebClient,
+  userId: string,
+): Promise<void> => {
+  const today = getTodayISO();
+
+  // 오늘 루틴 레코드 보장 (없으면 생성)
+  await createTodayRecords(today);
+
+  const [records, schedules, sleep] = await Promise.all([
+    queryTodayRecords(today),
+    queryTodaySchedules(today),
+    queryLatestSleep(),
+  ]);
+
+  const blocks: KnownBlock[] = [];
+
+  // 헤더
+  blocks.push({
+    type: 'header',
+    text: { type: 'plain_text', text: `${formatDateShort(today)} 대시보드`, emoji: true },
+  });
+
+  // 일정 섹션
+  blocks.push({ type: 'divider' });
+  if (schedules.length > 0) {
+    const { blocks: scheduleBlocks } = buildScheduleBlocks(schedules, today);
+    blocks.push(...scheduleBlocks);
+  } else {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: '*일정*\n오늘 일정 없음' },
+    });
+  }
+
+  // 루틴 섹션
+  blocks.push({ type: 'divider' });
+  if (records.length > 0) {
+    const { blocks: routineBlocks } = buildRoutineBlocks(records, today);
+    blocks.push(...routineBlocks);
+  } else {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: '*루틴*\n오늘 루틴 없음' },
+    });
+  }
+
+  // 수면 섹션
+  blocks.push({ type: 'divider' });
+  blocks.push(...buildSleepBlocks(sleep));
+
+  // 업데이트 시각
+  blocks.push({ type: 'divider' });
+  blocks.push({
+    type: 'context',
+    elements: [{ type: 'mrkdwn', text: `마지막 업데이트: ${getKSTTimeString()}` }],
+  });
+
+  await client.views.publish({
+    user_id: userId,
+    view: {
+      type: 'home',
+      blocks,
+    },
+  });
+};
+
+// ─── 이벤트 등록 ────────────────────────────────────
+
+/** app_home_opened 이벤트 핸들러 등록 */
+export const registerHomeTab = (app: App): void => {
+  app.event('app_home_opened', async ({ event, client }) => {
+    if (event.tab !== 'home') return;
+    try {
+      await publishHomeView(client, event.user);
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`[Home] 탭 갱신 오류: ${msg}`);
+    }
+  });
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { runMigrations } from './shared/migrate.js';
 import { createLLMClient } from './shared/llm.js';
 import { createLifeAgent } from './agents/life/index.js';
 import { registerLifeActions } from './agents/life/actions.js';
+import { registerHomeTab } from './agents/life/home.js';
 import { initLifeCron } from './cron/life-cron.js';
 
 const app = new App({
@@ -28,6 +29,7 @@ const startApp = async (): Promise<void> => {
   const lifeAgent = createLifeAgent(llmClient);
   registerAgent(CONFIG.channels.life, lifeAgent);
   registerLifeActions(app);
+  registerHomeTab(app);
   initLifeCron(app, {
     channelId: CONFIG.channels.life,
     schedules: CONFIG.lifeCron,

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -59,7 +59,7 @@ const getYesterdayISO = (): string => {
 // ─── 루틴 기록 생성 ─────────────────────────────────────
 
 /** 활성 템플릿 → 빈도 체크 → 오늘 기록 생성 */
-const createTodayRecords = async (today: string): Promise<number> => {
+export const createTodayRecords = async (today: string): Promise<number> => {
   const templates = await queryActiveTemplates();
   const existingIds = await queryExistingTemplateIds(today);
 

--- a/src/shared/life-queries.ts
+++ b/src/shared/life-queries.ts
@@ -36,6 +36,16 @@ export interface ScheduleRow {
   important: boolean;
 }
 
+export interface SleepRecordRow {
+  id: number;
+  date: string;
+  bedtime: string;
+  wake_time: string;
+  duration_minutes: number;
+  sleep_type: string;
+  memo: string | null;
+}
+
 // ─── 빈도 헬퍼 ─────────────────────────────────────────
 
 /** 두 날짜 사이의 일수 (YYYY-MM-DD) */
@@ -163,4 +173,17 @@ export const postponeSchedule = async (id: number, newDate: string): Promise<voi
     "UPDATE schedules SET date = $1, status = 'todo' WHERE id = $2",
     [newDate, id],
   );
+};
+
+// ─── 수면 쿼리 ──────────────────────────────────────
+
+/** 최근 수면 기록 조회 (밤잠 최신 1건) */
+export const queryLatestSleep = async (): Promise<SleepRecordRow | null> => {
+  const result = await query<SleepRecordRow>(
+    `SELECT id, date::text, bedtime, wake_time, duration_minutes, sleep_type, memo
+     FROM sleep_records
+     WHERE sleep_type = 'night'
+     ORDER BY date DESC LIMIT 1`,
+  );
+  return result.rows[0] ?? null;
 };


### PR DESCRIPTION
## Summary
- 루틴 체크리스트가 #life 채널 대화에 밀리는 UX 문제 해결
- Slack App Home 탭에 오늘의 일정, 루틴, 수면 요약 대시보드 구현
- 버튼 클릭(루틴 완료, 일정 상태 변경) 시 Home 탭 실시간 갱신

## 변경 내용
- **`src/agents/life/home.ts`** (NEW) — `publishHomeView` + `registerHomeTab`
- **`src/shared/life-queries.ts`** — `SleepRecordRow` 타입 + `queryLatestSleep()` 추가
- **`src/agents/life/blocks.ts`** — `buildSleepBlocks()` 추가
- **`src/agents/life/actions.ts`** — 버튼 클릭 시 Home 탭 갱신 로직 추가
- **`src/cron/life-cron.ts`** — `createTodayRecords` export 변경
- **`src/app.ts`** — `registerHomeTab(app)` 등록

## Test plan
- [x] `yarn build` 통과
- [x] `yarn test` 137개 테스트 통과
- [x] Slack API 대시보드에서 `app_home_opened` 이벤트 구독 추가
- [x] App Home → Show Tabs → "Home Tab" 활성화
- [ ] `yarn dev` → Slack에서 잔소리꾼 앱 클릭 → Home 탭 표시 확인
- [ ] 루틴 완료 버튼 클릭 → Home 탭 실시간 갱신 확인
- [ ] 일정 상태 변경 → Home 탭 갱신 확인

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)