### PR TITLE
feat: 백로그/내일일정 fast path 추가

### DIFF
--- a/src/agents/life/actions.ts
+++ b/src/agents/life/actions.ts
@@ -8,10 +8,12 @@ import {
   completeRecord,
   queryTodayRecords,
   queryTodaySchedules,
+  queryBacklogSchedules,
   updateScheduleStatus,
   postponeSchedule,
   deleteSchedule,
   toggleScheduleImportant,
+  moveScheduleToDate,
 } from '../../shared/life-queries.js';
 import { updateMessage } from '../../shared/slack.js';
 import { getTodayISO, addDays } from '../../shared/kst.js';
@@ -21,6 +23,7 @@ import {
   POSTPONE_ACTION,
   DELETE_ACTION,
   TOGGLE_IMPORTANT_ACTION,
+  MOVE_TO_TODAY_ACTION,
   parseButtonValue,
   parseOverflowValue,
   buildRoutineBlocks,
@@ -96,12 +99,19 @@ export const registerLifeActions = (app: App): void => {
       } else if (newStatus === POSTPONE_ACTION) {
         const tomorrow = addDays(targetDate, 1);
         await postponeSchedule(scheduleId, tomorrow);
+      } else if (newStatus === MOVE_TO_TODAY_ACTION) {
+        await moveScheduleToDate(scheduleId, getTodayISO());
       } else {
         await updateScheduleStatus(scheduleId, newStatus);
       }
 
-      const items = await queryTodaySchedules(targetDate);
-      const { text, blocks } = buildScheduleBlocks(items, targetDate);
+      const isBacklog = targetDate === 'backlog';
+      const items = isBacklog
+        ? await queryBacklogSchedules()
+        : await queryTodaySchedules(targetDate);
+      const { text, blocks } = isBacklog
+        ? buildScheduleBlocks(items, 'backlog', undefined, { backlog: true })
+        : buildScheduleBlocks(items, targetDate);
 
       const channelId =
         'channel' in body && body.channel ? body.channel.id : undefined;

--- a/src/agents/life/blocks.ts
+++ b/src/agents/life/blocks.ts
@@ -20,6 +20,7 @@ export const SCHEDULE_ACTION_ID = 'life_schedule_status';
 export const POSTPONE_ACTION = 'postpone';
 export const DELETE_ACTION = 'delete';
 export const TOGGLE_IMPORTANT_ACTION = 'toggle_important';
+export const MOVE_TO_TODAY_ACTION = 'move_today';
 
 const TIME_SLOT_ORDER = ['아침', '점심', '저녁', '밤'] as const;
 
@@ -344,20 +345,38 @@ const formatMemoWithStrike = (memo: string, isDone: boolean): string =>
         .join('\n')
     : memo;
 
+/** backlog 전용 overflow: "오늘로 이동" + "삭제" */
+const buildBacklogOverflowOptions = (
+  item: ScheduleRow,
+): Array<{ text: { type: 'plain_text'; text: string }; value: string }> => [
+  {
+    text: { type: 'plain_text' as const, text: '오늘로 이동' },
+    value: encodeOverflowValue(item.id, MOVE_TO_TODAY_ACTION, 'backlog'),
+  },
+  {
+    text: { type: 'plain_text' as const, text: '삭제하기' },
+    value: encodeOverflowValue(item.id, DELETE_ACTION, 'backlog'),
+  },
+];
+
 /** 일정 목록 Block Kit 빌드 (카테고리별 그룹핑 + overflow 메뉴) */
 export const buildScheduleBlocks = (
   items: ScheduleRow[],
   targetDate: string,
   headerText?: string,
-  options?: { compact?: boolean },
+  options?: { compact?: boolean; backlog?: boolean },
 ): { text: string; blocks: KnownBlock[] } => {
   const blocks: KnownBlock[] = [];
-  const formatted = formatDateShort(targetDate);
+  const backlog = options?.backlog ?? false;
+  const formatted = backlog ? '' : formatDateShort(targetDate);
   const compact = options?.compact ?? false;
+  const headerLabel = backlog
+    ? `백로그 (${items.length}건)`
+    : `${formatted} 일정`;
 
   blocks.push({
     type: 'section',
-    text: { type: 'mrkdwn', text: `*${headerText ?? `${formatted} 일정`}*` },
+    text: { type: 'mrkdwn', text: `*${headerText ?? headerLabel}*` },
   });
 
   const groups = groupByCategory(items);
@@ -420,7 +439,20 @@ export const buildScheduleBlocks = (
         const isAppointment = item.category === '약속';
         const titleText = formatScheduleTitle(item);
 
-        if (isAppointment || !item.status) {
+        if (backlog) {
+          // backlog: 모든 항목에 overflow (오늘로 이동 + 삭제)
+          flushNoOverflow();
+          blocks.push({
+            type: 'section',
+            text: { type: 'mrkdwn', text: titleText },
+            accessory: {
+              type: 'overflow',
+              action_id: SCHEDULE_ACTION_ID,
+              options: buildBacklogOverflowOptions(item),
+            },
+          });
+          addMemoContext(item.memo, item.status === 'done');
+        } else if (isAppointment || !item.status) {
           noOverflowLines.push({
             title: titleText,
             memo: item.memo,
@@ -454,7 +486,9 @@ export const buildScheduleBlocks = (
     elements: [{ type: 'mrkdwn', text: `${done}/${tasks.length} 완료` }],
   });
 
-  const fallbackText = `${formatted} 일정 (${items.length}개)`;
+  const fallbackText = backlog
+    ? `백로그 (${items.length}건)`
+    : `${formatted} 일정 (${items.length}개)`;
   return { text: fallbackText, blocks };
 };
 

--- a/src/agents/life/index.ts
+++ b/src/agents/life/index.ts
@@ -4,13 +4,17 @@ import { runAgentLoop } from '../../shared/agent-loop.js';
 import { sendBlockMessage, sendMessage } from '../../shared/slack.js';
 import { SQL_TOOLS, executeSQLTool } from '../../shared/sql-tools.js';
 import { ChatHistory } from '../../shared/chat-history.js';
-import { queryTodaySchedules } from '../../shared/life-queries.js';
+import { queryTodaySchedules, queryBacklogSchedules } from '../../shared/life-queries.js';
 import { buildLifeSystemPrompt } from './prompt.js';
-import { getTodayISO } from '../../shared/kst.js';
+import { getTodayISO, addDays } from '../../shared/kst.js';
 import { buildScheduleBlocks } from './blocks.js';
 
 /** 일정 조회 패턴 (오늘 일정 fast path) */
 const SCHEDULE_QUERY_RE = /^(오늘\s*)?일정(\s*(보여줘|보여|알려줘|뭐야|확인|뭐\s*있어))?[.?!]?$/;
+/** 내일 일정 조회 패턴 */
+const TOMORROW_SCHEDULE_RE = /^내일\s*일정(\s*(보여줘|보여|알려줘|뭐야|확인|뭐\s*있어))?[.?!]?$/;
+/** 백로그 조회 패턴 */
+const BACKLOG_QUERY_RE = /^백로그(\s*(보여줘|보여|알려줘|확인|뭐야|뭐\s*있어))?[.?!]?$/;
 
 /**
  * v2 통합 에이전트 생성.
@@ -26,6 +30,43 @@ export const createLifeAgent = (llmClient: LLMClient): AgentHandler => {
 
     const channelId = message.channel;
     const trimmed = text.trim();
+
+    // ── fast path: 백로그 조회 ──
+    if (BACKLOG_QUERY_RE.test(trimmed)) {
+      try {
+        const items = await queryBacklogSchedules();
+        if (items.length === 0) {
+          await sendMessage(say, '백로그에 쌓인 거 없어.');
+          return;
+        }
+        const { text: fallback, blocks } = buildScheduleBlocks(
+          items, 'backlog', undefined, { backlog: true },
+        );
+        await sendBlockMessage(say, fallback, blocks);
+      } catch (error: unknown) {
+        console.error('[Life Agent] 백로그 fast path 오류:', error);
+        await sendMessage(say, '백로그 조회 중 오류가 발생했어.');
+      }
+      return;
+    }
+
+    // ── fast path: 내일 일정 조회 ──
+    if (TOMORROW_SCHEDULE_RE.test(trimmed)) {
+      try {
+        const tomorrow = addDays(getTodayISO(), 1);
+        const items = await queryTodaySchedules(tomorrow);
+        if (items.length === 0) {
+          await sendMessage(say, '내일은 일정이 없어.');
+          return;
+        }
+        const { text: fallback, blocks } = buildScheduleBlocks(items, tomorrow);
+        await sendBlockMessage(say, fallback, blocks);
+      } catch (error: unknown) {
+        console.error('[Life Agent] 내일 일정 fast path 오류:', error);
+        await sendMessage(say, '내일 일정 조회 중 오류가 발생했어.');
+      }
+      return;
+    }
 
     // ── fast path: 일정 조회 ──
     if (SCHEDULE_QUERY_RE.test(trimmed)) {

--- a/src/shared/life-queries.ts
+++ b/src/shared/life-queries.ts
@@ -176,6 +176,22 @@ export const queryTodaySchedules = async (today: string): Promise<ScheduleRow[]>
     )
   ).rows;
 
+/** 백로그 일정 조회 (날짜 미지정 항목) */
+export const queryBacklogSchedules = async (): Promise<ScheduleRow[]> =>
+  (
+    await query<ScheduleRow>(
+      `SELECT id, title, date::text, end_date::text, status, category, memo, important
+     FROM schedules
+     WHERE date IS NULL AND status != 'cancelled'
+     ORDER BY category NULLS LAST, important DESC, title`,
+    )
+  ).rows;
+
+/** 일정을 특정 날짜로 이동 */
+export const moveScheduleToDate = async (id: number, date: string): Promise<void> => {
+  await query("UPDATE schedules SET date = $1, status = 'todo' WHERE id = $2", [date, id]);
+};
+
 /** 일정 상태 변경 */
 export const updateScheduleStatus = async (id: number, status: string): Promise<void> => {
   await query('UPDATE schedules SET status = $1 WHERE id = $2', [status, id]);


### PR DESCRIPTION
## Summary
- "백로그" 입력 시 LLM 없이 Block Kit 즉시 응답 (overflow: 오늘로 이동 + 삭제)
- "내일 일정" 입력 시 내일 일정 Block Kit 즉시 응답
- `queryBacklogSchedules`, `moveScheduleToDate` 쿼리 추가
- `buildScheduleBlocks`에 backlog 모드 옵션 추가
- `actions.ts`에 `move_today` 핸들러 + backlog 재조회 분기

Closes #68

## Test plan
- [x] `yarn test` 통과 (161 tests)
- [ ] Slack에서 "백로그" 입력 → Block Kit 응답 확인
- [ ] "오늘로 이동" 클릭 → 오늘 일정에 추가
- [ ] "삭제" 클릭 → 백로그에서 제거
- [ ] "내일 일정" 입력 → 내일 일정 Block Kit 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)