### PR TITLE
fix: 앱홈 날짜 갱신 + 크론 수면 데이터 오판 수정

### DIFF
--- a/src/agents/life/home.ts
+++ b/src/agents/life/home.ts
@@ -20,6 +20,13 @@ import {
 } from '../../shared/life-queries.js';
 import { createTodayRecords } from '../../cron/life-cron.js';
 
+// ─── userId 캐시 (크론 능동 갱신용) ─────────────────
+
+let cachedUserId: string | null = null;
+
+/** 캐시된 userId 반환 (app_home_opened에서 저장) */
+export const getCachedHomeUserId = (): string | null => cachedUserId;
+
 // ─── Home 탭 빌드 ───────────────────────────────────
 
 /** Home 탭 뷰 발행 */
@@ -97,6 +104,7 @@ export const publishHomeView = async (
 export const registerHomeTab = (app: App): void => {
   app.event('app_home_opened', async ({ event, client }) => {
     if (event.tab !== 'home') return;
+    cachedUserId = event.user;
     try {
       await publishHomeView(client, event.user);
     } catch (error: unknown) {

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -34,6 +34,7 @@ import {
   buildSleepRecordedText,
 } from '../agents/life/blocks.js';
 import { buildLifeContext } from '../shared/life-context.js';
+import { publishHomeView, getCachedHomeUserId } from '../agents/life/home.js';
 
 export interface LifeCronConfig {
   channelId: string;
@@ -142,8 +143,7 @@ export const createTodayRecords = async (today: string): Promise<number> => {
 /** 수면 기록 체크 — 기록 유무와 관계없이 항상 알림 전송 */
 const sleepCheckTask = async (app: App, config: LifeCronConfig): Promise<void> => {
   const today = getTodayISO();
-  const yesterday = getYesterdayISO();
-  const hasRecord = await queryNightSleepExists(yesterday, today);
+  const hasRecord = await queryNightSleepExists(today);
 
   const text = hasRecord ? buildSleepRecordedText('morning') : buildSleepReminderText('morning');
   await postToChannel(app.client, config.channelId, text);
@@ -205,6 +205,18 @@ const morningTask = async (app: App, config: LifeCronConfig): Promise<void> => {
     await postBlockMessage(app.client, config.channelId, text, fullBlocks);
   } else if (greetingBlocks.length > 0) {
     await postBlockMessage(app.client, config.channelId, '아침 인사', greetingBlocks);
+  }
+
+  // 4. 앱홈 능동 갱신 (날짜 전환 반영)
+  const userId = getCachedHomeUserId();
+  if (userId) {
+    try {
+      await publishHomeView(app.client, userId);
+      console.warn('[Life Cron] 앱홈 갱신 완료');
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`[Life Cron] 앱홈 갱신 실패: ${msg}`);
+    }
   }
 
   console.warn(`[Life Cron] 아침 알림 완료 (기록 ${created}개 생성)`);
@@ -275,7 +287,6 @@ const nightTask = async (app: App, config: LifeCronConfig): Promise<void> => {
 /** 밤 리뷰: 미완료 일정 + 수면 기록 확인 */
 const nightReviewTask = async (app: App, config: LifeCronConfig): Promise<void> => {
   const today = getTodayISO();
-  const yesterday = getYesterdayISO();
 
   // 1. 미완료 일정 텍스트
   const schedules = await queryTodaySchedules(today);
@@ -285,7 +296,7 @@ const nightReviewTask = async (app: App, config: LifeCronConfig): Promise<void> 
   }
 
   // 2. 수면 기록 확인 (마지막에 — 묻히지 않게)
-  const hasRecord = await queryNightSleepExists(yesterday, today);
+  const hasRecord = await queryNightSleepExists(today);
   const sleepText = hasRecord ? buildSleepRecordedText('night') : buildSleepReminderText('night');
   await postToChannel(app.client, config.channelId, sleepText);
 

--- a/src/shared/life-queries.ts
+++ b/src/shared/life-queries.ts
@@ -214,12 +214,12 @@ export const postponeSchedule = async (id: number, newDate: string): Promise<voi
 
 // ─── 수면 쿼리 ──────────────────────────────────────
 
-/** 어젯밤 수면 기록 존재 확인 (date가 어제 또는 오늘인 밤잠) */
-export const queryNightSleepExists = async (yesterday: string, today: string): Promise<boolean> => {
+/** 어젯밤 수면 기록 존재 확인 (date = 기상일 기준 단일 날짜) */
+export const queryNightSleepExists = async (wakeDate: string): Promise<boolean> => {
   const result = await query<{ count: string }>(
     `SELECT COUNT(*)::text as count FROM sleep_records
-     WHERE sleep_type = 'night' AND date IN ($1, $2)`,
-    [yesterday, today],
+     WHERE sleep_type = 'night' AND date = $1`,
+    [wakeDate],
   );
   return Number(result.rows[0]?.count ?? 0) > 0;
 };


### PR DESCRIPTION
## Summary
- 앱홈이 오전 5시 날짜 전환 후에도 전날 데이터를 보여주던 버그 수정
- 크론 알림이 수면 미기록인데 "이미 기록했다"고 오판하던 버그 수정

## 변경 내용

### 버그 1: 앱홈 날짜 갱신 지연
- **원인**: `app_home_opened` 이벤트 기반이라 사용자가 탭을 다시 열지 않으면 갱신 안 됨
- **수정**: 아침 크론(`morningTask`)에서 `publishHomeView` 능동 호출. userId를 `app_home_opened`에서 캐시

### 버그 2: 크론 수면 데이터 오판
- **원인**: `queryNightSleepExists(yesterday, today)` → `date IN (어제, 오늘)`로 조회해서 그저께 밤 기록(date=어제)까지 잡아냄
- **수정**: `queryNightSleepExists(wakeDate)` → `date = $1` 단일 날짜(기상일)만 조회

## Test plan
- [ ] 아침 크론 실행 후 앱홈이 오늘 날짜로 갱신되는지 확인
- [ ] 수면 미기록 상태에서 아침 알림이 "미기록"으로 표시되는지 확인
- [ ] 수면 기록 후 알림이 "기록됨"으로 표시되는지 확인

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)