### PR TITLE
feat: 웹 대시보드 Phase 3 — 버그 수정 + UX 개선 + 기능 추가

### DIFF
--- a/web/src/app/api/categories/reorder/route.ts
+++ b/web/src/app/api/categories/reorder/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import { reorderCategories } from '@/lib/queries';
+
+export async function POST(request: Request) {
+  if (!(await requireAuth())) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = (await request.json()) as { orders?: { id: number; sort_order: number }[] };
+
+    if (!Array.isArray(body.orders) || body.orders.length === 0) {
+      return NextResponse.json({ error: '순서 데이터가 필요해' }, { status: 400 });
+    }
+
+    for (const item of body.orders) {
+      if (typeof item.id !== 'number' || typeof item.sort_order !== 'number' || !Number.isFinite(item.id) || !Number.isFinite(item.sort_order)) {
+        return NextResponse.json({ error: '잘못된 순서 데이터' }, { status: 400 });
+      }
+    }
+
+    await reorderCategories(body.orders);
+    return NextResponse.json({ data: { ok: true } });
+  } catch {
+    return NextResponse.json({ error: '순서 변경 실패' }, { status: 500 });
+  }
+}

--- a/web/src/app/backlog/page.tsx
+++ b/web/src/app/backlog/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useCallback } from 'react';
 import { getCategoryStyle } from '@/lib/types';
 import { useBacklog } from '@/hooks/use-backlog';
 import { AppShell } from '@/components/ui/app-shell';
@@ -25,6 +26,12 @@ export default function BacklogPage() {
     handleDelete,
     handleCreate,
   } = useBacklog();
+
+  const [formDirty, setFormDirty] = useState(false);
+  const handleBeforeClose = useCallback(
+    () => !formDirty || confirm('수정 중인 내용이 있어. 닫을까?'),
+    [formDirty],
+  );
 
   if (loading) {
     return (
@@ -52,7 +59,7 @@ export default function BacklogPage() {
         </div>
       </div>
 
-      <div className="mx-auto max-w-3xl p-4">
+      <div className="mx-auto max-w-3xl overflow-hidden p-4">
         {schedules.length === 0 ? (
           <div className="py-16 text-center">
             <p className="text-gray-400">백로그 없음</p>
@@ -85,7 +92,7 @@ export default function BacklogPage() {
                     {items.map((s) => (
                       <div
                         key={s.id}
-                        className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3"
+                        className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3 max-md:flex-wrap"
                       >
                         <div
                           className="min-w-0 flex-1 cursor-pointer"
@@ -103,14 +110,14 @@ export default function BacklogPage() {
 
                         {/* 날짜 지정 */}
                         {assigningDate?.id === s.id ? (
-                          <div className="flex items-center gap-1">
+                          <div className="flex items-center gap-1 max-md:w-full">
                             <input
                               type="date"
                               value={assigningDate.date}
                               onChange={(e) =>
                                 setAssigningDate({ id: s.id, date: e.target.value })
                               }
-                              className="rounded border border-gray-300 px-2 py-1 text-xs"
+                              className="min-w-0 flex-1 rounded border border-gray-300 px-2 py-1 text-xs"
                               autoFocus
                             />
                             <button
@@ -151,12 +158,13 @@ export default function BacklogPage() {
       </div>
 
       {/* 생성 모달 */}
-      <Modal open={showCreateModal} onClose={() => setShowCreateModal(false)} title="백로그 추가">
+      <Modal open={showCreateModal} onClose={() => setShowCreateModal(false)} onBeforeClose={handleBeforeClose} title="백로그 추가">
         <ScheduleForm
           categories={categories}
           defaultDate={null}
           onSubmit={handleCreate}
           onClose={() => setShowCreateModal(false)}
+          onDirtyChange={setFormDirty}
         />
       </Modal>
 
@@ -164,6 +172,7 @@ export default function BacklogPage() {
       <Modal
         open={!!editingSchedule}
         onClose={() => setEditingSchedule(null)}
+        onBeforeClose={handleBeforeClose}
         title="일정 수정"
       >
         {editingSchedule && (
@@ -173,6 +182,7 @@ export default function BacklogPage() {
             onSubmit={handleUpdate}
             onDelete={handleDelete}
             onClose={() => setEditingSchedule(null)}
+            onDirtyChange={setFormDirty}
           />
         )}
       </Modal>

--- a/web/src/app/categories/page.tsx
+++ b/web/src/app/categories/page.tsx
@@ -1,6 +1,23 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  MouseSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragStartEvent,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { CategoryRow } from '@/lib/types';
 import { getCategoryStyle } from '@/lib/types';
 import { AppShell } from '@/components/ui/app-shell';
@@ -14,6 +31,11 @@ export default function CategoriesPage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editName, setEditName] = useState('');
   const [editColor, setEditColor] = useState('');
+  const [activeId, setActiveId] = useState<number | null>(null);
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+  );
 
   const fetchCategories = useCallback(async () => {
     try {
@@ -32,6 +54,66 @@ export default function CategoriesPage() {
   useEffect(() => {
     fetchCategories();
   }, [fetchCategories]);
+
+  const saveOrder = useCallback(async (items: CategoryRow[]) => {
+    const orders = items.map((c, i) => ({ id: c.id, sort_order: i + 1 }));
+    try {
+      await fetch('/api/categories/reorder', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orders }),
+      });
+    } catch {
+      // ignore — 로컬 순서는 이미 반영됨
+    }
+  }, []);
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(Number(event.active.id));
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveId(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      setCategories((prev) => {
+        const oldIndex = prev.findIndex((c) => c.id === Number(active.id));
+        const newIndex = prev.findIndex((c) => c.id === Number(over.id));
+        const updated = arrayMove(prev, oldIndex, newIndex);
+        saveOrder(updated);
+        return updated;
+      });
+    },
+    [saveOrder],
+  );
+
+  const handleMoveUp = useCallback(
+    (id: number) => {
+      setCategories((prev) => {
+        const idx = prev.findIndex((c) => c.id === id);
+        if (idx <= 0) return prev;
+        const updated = arrayMove(prev, idx, idx - 1);
+        saveOrder(updated);
+        return updated;
+      });
+    },
+    [saveOrder],
+  );
+
+  const handleMoveDown = useCallback(
+    (id: number) => {
+      setCategories((prev) => {
+        const idx = prev.findIndex((c) => c.id === id);
+        if (idx < 0 || idx >= prev.length - 1) return prev;
+        const updated = arrayMove(prev, idx, idx + 1);
+        saveOrder(updated);
+        return updated;
+      });
+    },
+    [saveOrder],
+  );
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -96,6 +178,8 @@ export default function CategoriesPage() {
     setEditColor(cat.color);
   };
 
+  const activeCat = activeId ? categories.find((c) => c.id === activeId) : null;
+
   if (loading) {
     return (
       <AppShell>
@@ -111,6 +195,7 @@ export default function CategoriesPage() {
       <div className="border-b border-gray-200 bg-white px-4 py-3">
         <div className="mx-auto max-w-2xl">
           <h1 className="text-lg font-bold text-gray-800">카테고리 관리</h1>
+          <p className="mt-0.5 text-xs text-gray-400">순서를 변경하면 일정에도 반영돼</p>
         </div>
       </div>
 
@@ -139,23 +224,87 @@ export default function CategoriesPage() {
           </div>
         </form>
 
-        {/* 카테고리 목록 */}
-        <div className="space-y-2">
-          {categories.map((cat) => {
+        {/* 카테고리 목록 — 데스크탑 DnD */}
+        <div className="hidden md:block">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={categories.map((c) => c.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="space-y-2">
+                {categories.map((cat) => (
+                  <SortableCategoryItem
+                    key={cat.id}
+                    cat={cat}
+                    isEditing={editingId === cat.id}
+                    editName={editName}
+                    editColor={editColor}
+                    onEditNameChange={setEditName}
+                    onEditColorChange={setEditColor}
+                    onStartEdit={startEdit}
+                    onSaveEdit={handleUpdate}
+                    onCancelEdit={() => setEditingId(null)}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+            <DragOverlay>
+              {activeCat && (
+                <div className="rounded-lg border border-blue-300 bg-blue-50 p-3 shadow-lg">
+                  <CategoryBadge name={activeCat.name} colorKey={activeCat.color} />
+                </div>
+              )}
+            </DragOverlay>
+          </DndContext>
+        </div>
+
+        {/* 카테고리 목록 — 모바일 (화살표 버튼) */}
+        <div className="space-y-2 md:hidden">
+          {categories.map((cat, idx) => {
             const isEditing = editingId === cat.id;
 
             return (
               <div
                 key={cat.id}
-                className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3"
+                className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white p-3"
               >
+                {/* 순서 변경 버튼 */}
+                <div className="flex shrink-0 flex-col gap-0.5">
+                  <button
+                    onClick={() => handleMoveUp(cat.id)}
+                    disabled={idx === 0}
+                    className="rounded p-0.5 text-gray-400 transition hover:bg-gray-100 disabled:opacity-20"
+                    aria-label="위로 이동"
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleMoveDown(cat.id)}
+                    disabled={idx === categories.length - 1}
+                    className="rounded p-0.5 text-gray-400 transition hover:bg-gray-100 disabled:opacity-20"
+                    aria-label="아래로 이동"
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                </div>
+
                 {isEditing ? (
-                  <>
+                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                     <input
                       type="text"
                       value={editName}
                       onChange={(e) => setEditName(e.target.value)}
-                      className="flex-1 rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
+                      className="min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
                       autoFocus
                     />
                     <ColorPicker value={editColor} onChange={setEditColor} previewLabel={editName.trim() || '카테고리'} />
@@ -171,7 +320,7 @@ export default function CategoriesPage() {
                     >
                       취소
                     </button>
-                  </>
+                  </div>
                 ) : (
                   <>
                     <CategoryBadge name={cat.name} colorKey={cat.color} />
@@ -198,6 +347,118 @@ export default function CategoriesPage() {
     </AppShell>
   );
 }
+
+// ─── 데스크탑 정렬 가능 아이템 ─────────────────────────────
+
+interface SortableCategoryItemProps {
+  cat: CategoryRow;
+  isEditing: boolean;
+  editName: string;
+  editColor: string;
+  onEditNameChange: (v: string) => void;
+  onEditColorChange: (v: string) => void;
+  onStartEdit: (cat: CategoryRow) => void;
+  onSaveEdit: (id: number) => void;
+  onCancelEdit: () => void;
+  onDelete: (id: number) => void;
+}
+
+function SortableCategoryItem({
+  cat,
+  isEditing,
+  editName,
+  editColor,
+  onEditNameChange,
+  onEditColorChange,
+  onStartEdit,
+  onSaveEdit,
+  onCancelEdit,
+  onDelete,
+}: SortableCategoryItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: cat.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.3 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3"
+    >
+      {/* 드래그 핸들 */}
+      <button
+        {...attributes}
+        {...listeners}
+        className="cursor-grab rounded p-1 text-gray-400 transition hover:bg-gray-100 active:cursor-grabbing"
+        aria-label="드래그하여 순서 변경"
+      >
+        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+          <circle cx="9" cy="6" r="1.5" />
+          <circle cx="15" cy="6" r="1.5" />
+          <circle cx="9" cy="12" r="1.5" />
+          <circle cx="15" cy="12" r="1.5" />
+          <circle cx="9" cy="18" r="1.5" />
+          <circle cx="15" cy="18" r="1.5" />
+        </svg>
+      </button>
+
+      {isEditing ? (
+        <>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => onEditNameChange(e.target.value)}
+            className="flex-1 rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
+            autoFocus
+          />
+          <ColorPicker value={editColor} onChange={onEditColorChange} previewLabel={editName.trim() || '카테고리'} />
+          <button
+            onClick={() => onSaveEdit(cat.id)}
+            className="rounded-lg bg-blue-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-600"
+          >
+            저장
+          </button>
+          <button
+            onClick={onCancelEdit}
+            className="rounded-lg px-3 py-1.5 text-xs text-gray-400 hover:bg-gray-100"
+          >
+            취소
+          </button>
+        </>
+      ) : (
+        <>
+          <CategoryBadge name={cat.name} colorKey={cat.color} />
+          <div className="flex-1" />
+          <button
+            onClick={() => onStartEdit(cat)}
+            className="rounded-lg px-3 py-1.5 text-xs text-gray-500 hover:bg-gray-100"
+          >
+            수정
+          </button>
+          <button
+            onClick={() => onDelete(cat.id)}
+            className="rounded-lg px-3 py-1.5 text-xs text-red-400 hover:bg-red-50"
+          >
+            삭제
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── 공통 컴포넌트 ─────────────────────────────────────────
 
 function CategoryBadge({ name, colorKey }: { name: string; colorKey: string }) {
   const style = getCategoryStyle(colorKey);

--- a/web/src/app/schedules/page.tsx
+++ b/web/src/app/schedules/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useState, useCallback } from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { startOfWeek, endOfWeek } from 'date-fns';
+import { WEEK_START } from '@/lib/calendar-utils';
 import { useSchedules } from '@/hooks/use-schedules';
 import { AppShell } from '@/components/ui/app-shell';
 import { CalendarHeader } from '@/components/calendar/calendar-header';
@@ -11,6 +13,7 @@ import { WeekView } from '@/components/calendar/week-view';
 import { DayView } from '@/components/calendar/day-view';
 import { FilterBar } from '@/components/ui/filter-bar';
 import { DndCalendar } from '@/components/calendar/dnd-calendar';
+import { BottomSheet } from '@/components/ui/bottom-sheet';
 import { Modal } from '@/components/ui/modal';
 import { ScheduleForm } from '@/components/schedule/schedule-form';
 
@@ -19,8 +22,8 @@ function getTitle(view: string, currentDate: Date): string {
     case 'month':
       return format(currentDate, 'yyyy년 M월', { locale: ko });
     case 'week': {
-      const ws = startOfWeek(currentDate, { weekStartsOn: 0 });
-      const we = endOfWeek(currentDate, { weekStartsOn: 0 });
+      const ws = startOfWeek(currentDate, { weekStartsOn: WEEK_START });
+      const we = endOfWeek(currentDate, { weekStartsOn: WEEK_START });
       return `${format(ws, 'M/d')} - ${format(we, 'M/d')}`;
     }
     case 'day':
@@ -59,6 +62,12 @@ export default function SchedulesPage() {
     toggleStatus,
     clearFilters,
   } = useSchedules();
+
+  const [formDirty, setFormDirty] = useState(false);
+  const handleBeforeClose = useCallback(
+    () => !formDirty || confirm('수정 중인 내용이 있어. 닫을까?'),
+    [formDirty],
+  );
 
   if (loading) {
     return (
@@ -133,8 +142,9 @@ export default function SchedulesPage() {
               )}
             </div>
 
+            {/* 데스크탑: 사이드 패널 */}
             {view === 'month' && selectedDate && (
-              <div className="w-full md:sticky md:top-0 md:w-80 md:self-stretch md:max-h-[calc(100vh-160px)] md:overflow-y-auto">
+              <div className="hidden md:block md:sticky md:top-0 md:w-80 md:self-stretch md:max-h-[calc(100vh-160px)] md:overflow-y-auto">
                 <DayDetailPanel
                   dateStr={selectedDate}
                   schedules={filteredSchedules}
@@ -149,10 +159,28 @@ export default function SchedulesPage() {
         </DndCalendar>
       </div>
 
+      {/* 모바일: 바텀시트 */}
+      <BottomSheet
+        open={view === 'month' && !!selectedDate}
+        onClose={() => selectedDate && handleSelectDate(selectedDate)}
+      >
+        {selectedDate && (
+          <DayDetailPanel
+            dateStr={selectedDate}
+            schedules={filteredSchedules}
+            categories={categories}
+            onScheduleClick={setEditingSchedule}
+            onStatusChange={handleStatusChange}
+            onClose={() => handleSelectDate(selectedDate)}
+          />
+        )}
+      </BottomSheet>
+
       {/* 생성 모달 */}
       <Modal
         open={showCreateModal}
         onClose={() => setShowCreateModal(false)}
+        onBeforeClose={handleBeforeClose}
         title="일정 추가"
       >
         <ScheduleForm
@@ -160,6 +188,7 @@ export default function SchedulesPage() {
           defaultDate={selectedDate ?? format(currentDate, 'yyyy-MM-dd')}
           onSubmit={handleCreate}
           onClose={() => setShowCreateModal(false)}
+          onDirtyChange={setFormDirty}
         />
       </Modal>
 
@@ -167,6 +196,7 @@ export default function SchedulesPage() {
       <Modal
         open={!!editingSchedule}
         onClose={() => setEditingSchedule(null)}
+        onBeforeClose={handleBeforeClose}
         title="일정 수정"
       >
         {editingSchedule && (
@@ -176,6 +206,7 @@ export default function SchedulesPage() {
             onSubmit={handleUpdate}
             onDelete={handleDelete}
             onClose={() => setEditingSchedule(null)}
+            onDirtyChange={setFormDirty}
           />
         )}
       </Modal>

--- a/web/src/components/calendar/day-view.tsx
+++ b/web/src/components/calendar/day-view.tsx
@@ -53,7 +53,7 @@ export function DayView({
   ).length;
 
   return (
-    <div className="mx-auto max-w-3xl p-4 md:flex-1">
+    <div className="mx-auto w-full max-w-3xl p-4 md:flex-1">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-bold text-gray-800">{formatted}</h2>
         {totalTasks > 0 && (

--- a/web/src/components/calendar/dnd-calendar.tsx
+++ b/web/src/components/calendar/dnd-calendar.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import {
   DndContext,
-  DragOverlay,
-  PointerSensor,
+  MouseSensor,
+  pointerWithin,
   useSensor,
   useSensors,
   type DragStartEvent,
   type DragEndEvent,
 } from '@dnd-kit/core';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
-import { ScheduleCard } from '../schedule/schedule-card';
 
 type DragType = 'move' | 'resize-left' | 'resize-right';
 
@@ -52,19 +52,36 @@ export function DndCalendar({
 }: DndCalendarProps) {
   const [activeSchedule, setActiveSchedule] = useState<ScheduleRow | null>(null);
   const [dragType, setDragType] = useState<DragType>('move');
+  const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+  const isDragging = useRef(false);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(MouseSensor, {
       activationConstraint: { distance: 8 },
     }),
   );
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (isDragging.current) {
+        setMousePos({ x: e.clientX, y: e.clientY });
+      }
+    };
+    document.addEventListener('mousemove', handler);
+    return () => document.removeEventListener('mousemove', handler);
+  }, []);
 
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
       const { type, scheduleId } = parseDragId(event.active.id);
       setDragType(type);
       const schedule = schedules.find((s) => s.id === scheduleId);
-      if (schedule) setActiveSchedule(schedule);
+      if (schedule) {
+        isDragging.current = true;
+        const e = event.activatorEvent as MouseEvent;
+        setMousePos({ x: e.clientX, y: e.clientY });
+        setActiveSchedule(schedule);
+      }
     },
     [schedules],
   );
@@ -72,6 +89,7 @@ export function DndCalendar({
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const currentDragType = dragType;
+      isDragging.current = false;
       setActiveSchedule(null);
       const { active, over } = event;
       if (!over) return;
@@ -133,29 +151,36 @@ export function DndCalendar({
   const isResize = dragType === 'resize-left' || dragType === 'resize-right';
 
   return (
-    <DndContext
-      sensors={sensors}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-    >
-      {children}
-      <DragOverlay dropAnimation={null}>
-        {activeSchedule && (
-          <div className={`w-48 opacity-80 ${!isResize ? 'rotate-2' : ''}`}>
-            {isResize ? (
-              <div className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-700">
-                {activeSchedule.title} — 기간 설정 중
-              </div>
-            ) : (
-              <ScheduleCard
-                schedule={activeSchedule}
-                categories={categories}
-                compact
-              />
-            )}
-          </div>
+    <>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={pointerWithin}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        {children}
+      </DndContext>
+      {activeSchedule &&
+        createPortal(
+          <div
+            style={{
+              position: 'fixed',
+              left: mousePos.x + 12,
+              top: mousePos.y - 16,
+              pointerEvents: 'none',
+              zIndex: 9999,
+            }}
+          >
+            <div className="w-48 rounded-lg bg-white/95 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-lg ring-1 ring-gray-200">
+              {isResize ? (
+                <span className="text-blue-600">{activeSchedule.title} — 기간 설정 중</span>
+              ) : (
+                <span className="truncate block">{activeSchedule.title}</span>
+              )}
+            </div>
+          </div>,
+          document.body,
         )}
-      </DragOverlay>
-    </DndContext>
+    </>
   );
 }

--- a/web/src/components/calendar/draggable-card.tsx
+++ b/web/src/components/calendar/draggable-card.tsx
@@ -82,19 +82,41 @@ export function DraggableCard({
     );
   }
 
+  const faded = isDragging || isResizingL || isResizingR;
   return (
-    <div
-      ref={setNodeRef}
-      {...listeners}
-      {...attributes}
-      className={isDragging ? 'opacity-30' : ''}
-    >
-      <ScheduleCard
-        schedule={schedule}
-        categories={categories}
-        onStatusChange={onStatusChange}
-        onClick={onClick}
-      />
+    <div className={`group relative ${faded ? 'opacity-30' : ''}`}>
+      {/* 리사이즈 핸들 (좌측) */}
+      <div
+        ref={resizeLRef}
+        {...resizeLListeners}
+        {...resizeLAttrs}
+        className="absolute top-0 left-0 z-10 h-full w-3 cursor-col-resize opacity-0 group-hover:opacity-100"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mx-auto h-full w-0.5 rounded bg-gray-400" />
+      </div>
+      <div
+        ref={setNodeRef}
+        {...listeners}
+        {...attributes}
+      >
+        <ScheduleCard
+          schedule={schedule}
+          categories={categories}
+          onStatusChange={onStatusChange}
+          onClick={onClick}
+        />
+      </div>
+      {/* 리사이즈 핸들 (우측) */}
+      <div
+        ref={resizeRRef}
+        {...resizeRListeners}
+        {...resizeRAttrs}
+        className="absolute top-0 right-0 z-10 h-full w-3 cursor-col-resize opacity-0 group-hover:opacity-100"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mx-auto h-full w-0.5 rounded bg-gray-400" />
+      </div>
     </div>
   );
 }

--- a/web/src/components/calendar/month-view.tsx
+++ b/web/src/components/calendar/month-view.tsx
@@ -14,7 +14,7 @@ import { ko } from 'date-fns/locale';
 import { useDraggable } from '@dnd-kit/core';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
 import { getCategoryStyle, compareByStatus } from '@/lib/types';
-import { computeWeekLayout, type WeekSpan } from '@/lib/calendar-utils';
+import { computeWeekLayout, WEEK_START, type WeekSpan } from '@/lib/calendar-utils';
 import { ScheduleCard } from '../schedule/schedule-card';
 import { DroppableDay } from './droppable-day';
 import { DraggableCard } from './draggable-card';
@@ -29,7 +29,7 @@ interface MonthViewProps {
   onStatusChange: (id: number, status: string) => void;
 }
 
-const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
+const DAY_NAMES = ['월', '화', '수', '목', '금', '토', '일'];
 const MAX_VISIBLE = 3;
 const LANE_HEIGHT = 22;
 const DATE_ROW_HEIGHT = 34;
@@ -45,8 +45,8 @@ export function MonthView({
 }: MonthViewProps) {
   const monthStart = startOfMonth(currentDate);
   const monthEnd = endOfMonth(currentDate);
-  const calStart = startOfWeek(monthStart, { weekStartsOn: 0 });
-  const calEnd = endOfWeek(monthEnd, { weekStartsOn: 0 });
+  const calStart = startOfWeek(monthStart, { weekStartsOn: WEEK_START });
+  const calEnd = endOfWeek(monthEnd, { weekStartsOn: WEEK_START });
   const days = eachDayOfInterval({ start: calStart, end: calEnd });
 
   // 주 단위로 분할
@@ -63,7 +63,7 @@ export function MonthView({
           <div
             key={name}
             className={`py-2 text-center text-xs font-medium ${
-              i === 0 ? 'text-red-400' : i === 6 ? 'text-blue-400' : 'text-gray-500'
+              i === 6 ? 'text-red-400' : i === 5 ? 'text-blue-400' : 'text-gray-500'
             }`}
           >
             {name}

--- a/web/src/components/calendar/week-view.tsx
+++ b/web/src/components/calendar/week-view.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { useRef, useEffect } from 'react';
 import { startOfWeek, addDays, format, isToday } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { useDraggable } from '@dnd-kit/core';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
 import { getCategoryStyle, compareByStatus } from '@/lib/types';
-import { computeWeekLayout, type WeekSpan } from '@/lib/calendar-utils';
+import { computeWeekLayout, WEEK_START, type WeekSpan } from '@/lib/calendar-utils';
 import { StatusBadge } from '../schedule/status-badge';
 import { DroppableDay } from './droppable-day';
 import { DraggableCard } from './draggable-card';
@@ -45,10 +46,19 @@ export function WeekView({
   onScheduleClick,
   onStatusChange,
 }: WeekViewProps) {
-  const weekStart = startOfWeek(currentDate, { weekStartsOn: 0 });
+  const todayRef = useRef<HTMLDivElement>(null);
+  const weekStart = startOfWeek(currentDate, { weekStartsOn: WEEK_START });
   const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
   const layout = computeWeekLayout(days, schedules);
   const spanAreaHeight = layout.laneCount * LANE_HEIGHT;
+
+  // 모바일: 오늘 날짜로 자동 스크롤 (뷰 진입, 오늘 버튼, 주 이동 시)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      todayRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [currentDate]);
 
   return (
     <div className="flex flex-col md:flex-1">
@@ -131,6 +141,7 @@ export function WeekView({
           return (
             <div
               key={dateStr}
+              ref={today ? todayRef : undefined}
               onClick={() => onSelectDate(dateStr)}
               className={`border-b border-gray-100 px-4 py-3 ${selected ? 'bg-blue-50/30' : ''}`}
             >
@@ -260,7 +271,7 @@ function WeekSpanBar({
           ref={resizeLRef}
           {...resizeLListeners}
           {...resizeLAttrs}
-          className="absolute top-0 left-0 z-20 h-full w-2 cursor-col-resize opacity-0 hover:opacity-100"
+          className="absolute top-0 left-0 z-20 h-full w-3 cursor-col-resize opacity-0 group-hover:opacity-100"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="mx-auto h-full w-0.5 rounded bg-gray-400" />
@@ -311,7 +322,7 @@ function WeekSpanBar({
           ref={resizeRRef}
           {...resizeRListeners}
           {...resizeRAttrs}
-          className="absolute top-0 right-0 z-20 h-full w-2 cursor-col-resize opacity-0 hover:opacity-100"
+          className="absolute top-0 right-0 z-20 h-full w-3 cursor-col-resize opacity-0 group-hover:opacity-100"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="mx-auto h-full w-0.5 rounded bg-gray-400" />

--- a/web/src/components/schedule/schedule-card.tsx
+++ b/web/src/components/schedule/schedule-card.tsx
@@ -45,11 +45,16 @@ export function ScheduleCard({
     }
   };
 
+  const handleCardClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onClick?.(schedule);
+  };
+
   if (compact) {
     if (catStyle.isPreset && catStyle.classes) {
       return (
         <div
-          onClick={() => onClick?.(schedule)}
+          onClick={handleCardClick}
           className={`cursor-pointer truncate rounded px-1.5 py-0.5 text-xs leading-tight ${catStyle.classes.bg} ${catStyle.classes.text} border-l-2 ${catStyle.classes.border} ${isDone ? 'line-through opacity-60' : ''}`}
         >
           {schedule.important && <span className="mr-0.5 text-amber-500">★</span>}
@@ -59,7 +64,7 @@ export function ScheduleCard({
     }
     return (
       <div
-        onClick={() => onClick?.(schedule)}
+        onClick={handleCardClick}
         className={`cursor-pointer truncate rounded border-l-2 px-1.5 py-0.5 text-xs leading-tight ${isDone ? 'line-through opacity-60' : ''}`}
         style={{ backgroundColor: catStyle.styles?.bg, color: catStyle.styles?.text, borderLeftColor: catStyle.styles?.border }}
       >
@@ -71,7 +76,7 @@ export function ScheduleCard({
 
   return (
     <div
-      onClick={() => onClick?.(schedule)}
+      onClick={handleCardClick}
       className={`cursor-pointer rounded-lg border p-3 transition hover:shadow-sm ${STATUS_BG[schedule.status] ?? 'bg-white'} ${
         !isDone && schedule.date && new Date(schedule.date + 'T12:00:00+09:00') < new Date(new Date().toISOString().slice(0, 10) + 'T12:00:00+09:00') && schedule.status === 'todo'
           ? 'border-red-300'
@@ -101,17 +106,30 @@ export function ScheduleCard({
           <div className="mt-1 flex flex-wrap items-center gap-1.5">
             <StatusBadge status={schedule.status} />
             {schedule.category && <CategoryBadge colorKey={colorKey} label={schedule.category} />}
+            {schedule.end_date && schedule.end_date !== schedule.date && (
+              <span className="text-xs text-gray-400">
+                {formatDateRange(schedule.date, schedule.end_date)}
+              </span>
+            )}
           </div>
 
           {schedule.memo && (
-            <p className={`mt-1.5 text-xs leading-relaxed ${isDone ? 'text-gray-300' : 'text-gray-500'}`}>
-              {schedule.memo.length > 80 ? schedule.memo.slice(0, 80) + '...' : schedule.memo}
+            <p className={`mt-1.5 line-clamp-3 whitespace-pre-wrap text-xs leading-relaxed ${isDone ? 'text-gray-300' : 'text-gray-500'}`}>
+              {schedule.memo}
             </p>
           )}
         </div>
       </div>
     </div>
   );
+}
+
+function formatDateRange(date: string | null, endDate: string): string {
+  const fmt = (d: string) => {
+    const [, m, day] = d.split('-');
+    return `${Number(m)}/${Number(day)}`;
+  };
+  return date ? `${fmt(date)} - ${fmt(endDate)}` : fmt(endDate);
 }
 
 function CategoryBadge({ colorKey, label }: { colorKey: string; label: string }) {

--- a/web/src/components/schedule/schedule-form.tsx
+++ b/web/src/components/schedule/schedule-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
 import { SCHEDULE_STATUSES, STATUS_LABELS } from '@/lib/types';
 
@@ -11,6 +11,7 @@ interface ScheduleFormProps {
   onSubmit: (data: Partial<ScheduleRow>) => Promise<void>;
   onDelete?: () => Promise<void>;
   onClose: () => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 export function ScheduleForm({
@@ -20,6 +21,7 @@ export function ScheduleForm({
   onSubmit,
   onDelete,
   onClose,
+  onDirtyChange,
 }: ScheduleFormProps) {
   const [title, setTitle] = useState(schedule?.title ?? '');
   const [date, setDate] = useState(schedule?.date ?? defaultDate ?? '');
@@ -30,6 +32,31 @@ export function ScheduleForm({
   const [memo, setMemo] = useState(schedule?.memo ?? '');
   const [important, setImportant] = useState(schedule?.important ?? false);
   const [saving, setSaving] = useState(false);
+  const [editingMemo, setEditingMemo] = useState(!schedule?.memo);
+
+  const isDirty = useCallback(() => {
+    if (!schedule) {
+      return !!(title || date || endDate || memo || category || important);
+    }
+    return (
+      title !== (schedule.title ?? '') ||
+      date !== (schedule.date ?? '') ||
+      endDate !== (schedule.end_date ?? '') ||
+      status !== schedule.status ||
+      category !== (schedule.category ?? '') ||
+      memo !== (schedule.memo ?? '') ||
+      important !== (schedule.important ?? false)
+    );
+  }, [title, date, endDate, status, category, memo, important, schedule]);
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty());
+  }, [isDirty, onDirtyChange]);
+
+  const handleClose = useCallback(() => {
+    if (isDirty() && !confirm('수정 중인 내용이 있어. 닫을까?')) return;
+    onClose();
+  }, [isDirty, onClose]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -61,7 +88,7 @@ export function ScheduleForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4 overflow-hidden">
       {/* 제목 */}
       <div>
         <input
@@ -82,7 +109,7 @@ export function ScheduleForm({
           type="date"
           value={date}
           onChange={(e) => setDate(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+          className="w-full min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
         />
       </div>
 
@@ -114,7 +141,7 @@ export function ScheduleForm({
             type="date"
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            className="w-full min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
           />
         </div>
       )}
@@ -170,14 +197,33 @@ export function ScheduleForm({
 
       {/* 메모 */}
       <div>
-        <label className="mb-1 block text-xs text-gray-500">메모</label>
-        <textarea
-          value={memo}
-          onChange={(e) => setMemo(e.target.value)}
-          placeholder="메모 (선택)"
-          rows={3}
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-        />
+        <div className="mb-1 flex items-center justify-between">
+          <label className="text-xs text-gray-500">메모</label>
+          {!editingMemo && (
+            <button
+              type="button"
+              onClick={() => setEditingMemo(true)}
+              className="text-xs text-blue-500 hover:text-blue-600"
+            >
+              메모 수정
+            </button>
+          )}
+        </div>
+        {editingMemo ? (
+          <textarea
+            value={memo}
+            onChange={(e) => setMemo(e.target.value)}
+            placeholder="메모 (선택)"
+            rows={3}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none md:min-h-[140px]"
+          />
+        ) : (
+          <div className="max-h-[120px] overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 md:max-h-[200px]">
+            <p className="whitespace-pre-wrap text-sm text-gray-700">
+              {memo || <span className="text-gray-400">메모 없음</span>}
+            </p>
+          </div>
+        )}
       </div>
 
       {/* 버튼 */}
@@ -194,7 +240,7 @@ export function ScheduleForm({
         <div className="flex-1" />
         <button
           type="button"
-          onClick={onClose}
+          onClick={handleClose}
           className="rounded-lg px-4 py-2.5 text-sm font-medium text-gray-500 transition hover:bg-gray-100"
         >
           취소

--- a/web/src/components/ui/app-shell.tsx
+++ b/web/src/components/ui/app-shell.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 
 const NAV_ITEMS = [
-  { href: '/schedules', label: '캘린더', icon: '📅' },
+  { href: '/schedules', label: '일정', icon: '📅' },
   { href: '/backlog', label: '백로그', icon: '📋' },
   { href: '/categories', label: '카테고리', icon: '🏷' },
 ] as const;
@@ -109,7 +109,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             }`}
           >
             <span className="text-lg">📅</span>
-            <span>캘린더</span>
+            <span>일정</span>
           </a>
           <a
             href="/backlog"

--- a/web/src/components/ui/bottom-sheet.tsx
+++ b/web/src/components/ui/bottom-sheet.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export function BottomSheet({ open, onClose, children }: BottomSheetProps) {
+  const [visible, setVisible] = useState(false);
+  const [animating, setAnimating] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setVisible(true);
+      const t = setTimeout(() => setAnimating(true), 50);
+      return () => clearTimeout(t);
+    } else {
+      setAnimating(false);
+      const timer = setTimeout(() => setVisible(false), 500);
+      return () => clearTimeout(timer);
+    }
+  }, [open]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60] md:hidden">
+      {/* 백드롭 */}
+      <div
+        className={`absolute inset-0 bg-black/40 transition-opacity duration-500 ${
+          animating ? 'opacity-100' : 'opacity-0'
+        }`}
+        onClick={onClose}
+      />
+      {/* 시트 */}
+      <div
+        className={`absolute inset-x-0 bottom-0 max-h-[90vh] overflow-y-auto rounded-t-2xl bg-white pb-[calc(1rem+env(safe-area-inset-bottom))] shadow-xl transition-transform duration-500 ease-out ${
+          animating ? 'translate-y-0' : 'translate-y-full'
+        }`}
+      >
+        {/* 핸들 바 */}
+        <div className="sticky top-0 z-10 flex justify-center rounded-t-2xl bg-white pt-3 pb-1">
+          <div className="h-1 w-10 rounded-full bg-gray-300" />
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/modal.tsx
+++ b/web/src/components/ui/modal.tsx
@@ -7,10 +7,17 @@ interface ModalProps {
   onClose: () => void;
   title: string;
   children: React.ReactNode;
+  /** 닫기 전 확인. false 반환 시 닫기 취소 */
+  onBeforeClose?: () => boolean;
 }
 
-export function Modal({ open, onClose, title, children }: ModalProps) {
+export function Modal({ open, onClose, title, children, onBeforeClose }: ModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const guardedClose = useCallback(() => {
+    if (onBeforeClose && !onBeforeClose()) return;
+    onClose();
+  }, [onClose, onBeforeClose]);
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -23,13 +30,27 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
     }
   }, [open]);
 
+  // ESC 키로 닫을 때 가드 적용
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog || !open) return;
+
+    const handleCancel = (e: Event) => {
+      e.preventDefault();
+      guardedClose();
+    };
+
+    dialog.addEventListener('cancel', handleCancel);
+    return () => dialog.removeEventListener('cancel', handleCancel);
+  }, [open, guardedClose]);
+
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent<HTMLDialogElement>) => {
       if (e.target === dialogRef.current) {
-        onClose();
+        guardedClose();
       }
     },
-    [onClose],
+    [guardedClose],
   );
 
   if (!open) return null;
@@ -37,15 +58,14 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
   return (
     <dialog
       ref={dialogRef}
-      onClose={onClose}
       onClick={handleBackdropClick}
-      className="fixed inset-0 m-auto w-full max-w-lg rounded-xl border-0 bg-white p-0 shadow-xl backdrop:bg-black/40"
+      className="fixed inset-0 m-auto w-[calc(100vw-2rem)] max-w-lg rounded-xl border-0 bg-white p-0 shadow-xl backdrop:bg-black/40"
     >
       <div onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
           <h2 className="text-lg font-semibold">{title}</h2>
           <button
-            onClick={onClose}
+            onClick={guardedClose}
             className="rounded-lg p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
           >
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/web/src/hooks/use-backlog.ts
+++ b/web/src/hooks/use-backlog.ts
@@ -39,6 +39,13 @@ export function useBacklog() {
 
   useEffect(() => {
     fetchData();
+
+    const id = setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        fetchData();
+      }
+    }, 15_000);
+    return () => clearInterval(id);
   }, [fetchData]);
 
   // 카테고리별 그룹핑

--- a/web/src/hooks/use-schedules.ts
+++ b/web/src/hooks/use-schedules.ts
@@ -16,9 +16,15 @@ import {
 } from 'date-fns';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
 import type { CalendarView } from '@/components/calendar/calendar-header';
+import { WEEK_START } from '@/lib/calendar-utils';
+
+function getInitialView(): CalendarView {
+  if (typeof window === 'undefined') return 'day';
+  return window.innerWidth >= 768 ? 'month' : 'day';
+}
 
 export function useSchedules() {
-  const [view, setView] = useState<CalendarView>('week');
+  const [view, setView] = useState<CalendarView>(getInitialView);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [schedules, setSchedules] = useState<ScheduleRow[]>([]);
   const [categories, setCategories] = useState<CategoryRow[]>([]);
@@ -35,12 +41,12 @@ export function useSchedules() {
 
     switch (view) {
       case 'month':
-        start = startOfWeek(startOfMonth(currentDate), { weekStartsOn: 0 });
-        end = endOfWeek(endOfMonth(currentDate), { weekStartsOn: 0 });
+        start = startOfWeek(startOfMonth(currentDate), { weekStartsOn: WEEK_START });
+        end = endOfWeek(endOfMonth(currentDate), { weekStartsOn: WEEK_START });
         break;
       case 'week':
-        start = startOfWeek(currentDate, { weekStartsOn: 0 });
-        end = endOfWeek(currentDate, { weekStartsOn: 0 });
+        start = startOfWeek(currentDate, { weekStartsOn: WEEK_START });
+        end = endOfWeek(currentDate, { weekStartsOn: WEEK_START });
         break;
       case 'day':
         start = currentDate;
@@ -83,6 +89,14 @@ export function useSchedules() {
 
   useEffect(() => {
     fetchData();
+
+    // 15초 폴링 (탭이 보이는 동안만)
+    const id = setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        fetchData();
+      }
+    }, 15_000);
+    return () => clearInterval(id);
   }, [fetchData]);
 
   // 필터링

--- a/web/src/lib/calendar-utils.ts
+++ b/web/src/lib/calendar-utils.ts
@@ -2,6 +2,9 @@ import { format } from 'date-fns';
 import type { ScheduleRow } from './types';
 import { compareByStatus } from './types';
 
+/** 주간 시작 요일: 1 = 월요일 */
+export const WEEK_START = 1 as const;
+
 export interface WeekSpan {
   schedule: ScheduleRow;
   startCol: number;

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -177,6 +177,15 @@ export const deleteCategory = async (id: number): Promise<boolean> => {
   return result.rowCount !== null && result.rowCount > 0;
 };
 
+/** 카테고리 순서 일괄 업데이트 */
+export const reorderCategories = async (
+  orders: { id: number; sort_order: number }[],
+): Promise<void> => {
+  for (const { id, sort_order } of orders) {
+    await query('UPDATE categories SET sort_order = $1 WHERE id = $2', [sort_order, id]);
+  }
+};
+
 /** 일정에서 사용 중인 카테고리가 categories 테이블에 없으면 자동 추가 */
 export const ensureCategoryExists = async (name: string): Promise<void> => {
   const existing = await queryOne<CategoryRow>(


### PR DESCRIPTION
## Summary
- 모바일/데스크탑 레이아웃 버그 수정 (모달 너비, 카드 너비, 바텀시트 z-index)
- UX 개선 (주 시작일 월요일, 반응형 기본 뷰, 바텀시트 애니메이션, 메모 읽기/수정 분리, 수정 확인 경고)
- 기능 추가 (카테고리 순서 변경, 주간뷰 리사이즈, 15초 폴링)
- DragOverlay를 커스텀 포탈 오버레이로 교체 (위치/너비 문제 해결)

## Test plan
- [ ] 월간뷰 일정 드래그 이동
- [ ] 주간뷰 일정 드래그 이동 + 리사이즈
- [ ] 모바일 바텀시트 열기/닫기 애니메이션
- [ ] 카테고리 순서 변경 (데스크탑 DnD, 모바일 화살표)
- [ ] 수정 모달 닫기 확인 경고

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)