### PR TITLE
feat: 앱 홈에 웹 대시보드 바로가기 버튼 추가

### DIFF
--- a/src/agents/life/home.ts
+++ b/src/agents/life/home.ts
@@ -54,6 +54,20 @@ export const publishHomeView = async (
     text: { type: 'plain_text', text: `${formatDateShort(today)} 대시보드`, emoji: true },
   });
 
+  // 웹 대시보드 바로가기
+  const domain = process.env.DOMAIN;
+  if (domain) {
+    blocks.push({
+      type: 'actions',
+      elements: [{
+        type: 'button',
+        text: { type: 'plain_text', text: '웹 대시보드 열기', emoji: true },
+        url: `https://${domain}`,
+        style: 'primary',
+      }],
+    });
+  }
+
   // 일정 섹션
   blocks.push({ type: 'divider' });
   if (schedules.length > 0) {


### PR DESCRIPTION
## Summary
- Slack 앱 홈 탭 헤더 바로 아래에 "웹 대시보드 열기" primary 버튼 추가
- `DOMAIN` 환경변수가 설정된 경우에만 표시 (조건부 렌더링)
- 모바일/데스크탑 어디서든 한 탭으로 웹 대시보드 진입 가능

Closes #83

## Test plan
- [ ] `DOMAIN` 환경변수 설정 후 앱 홈 탭 열기 → 버튼 표시 확인
- [ ] 버튼 클릭 → 웹 대시보드 HTTPS URL로 이동 확인
- [ ] `DOMAIN` 미설정 시 버튼 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)