### PR TITLE
feat: API 크레딧 부족 시 충전 안내 메시지

### DIFF
--- a/src/shared/agent-loop.ts
+++ b/src/shared/agent-loop.ts
@@ -184,6 +184,16 @@ export const runAgentLoop = async (
         // 직렬화 불가 시 무시
       }
 
+      // 크레딧 부족 (402 / billing / credit) — 재시도 불필요, 즉시 안내
+      const isCreditError = /\b(402|credit_balance|insufficient.credit|billing|prepaid)\b/i.test(errorMsg);
+      if (isCreditError) {
+        return {
+          text: 'API 크레딧이 부족해서 응답할 수 없어. 여기서 충전해줘: https://platform.claude.com/settings/billing',
+          toolNames: calledToolNames,
+          toolArgs: calledToolArgs,
+        };
+      }
+
       const isRateLimit = /\b(429|RESOURCE_EXHAUSTED|quota)\b/i.test(errorMsg);
       const isTransient = /\b(500|503|429|INTERNAL|UNAVAILABLE|DEADLINE_EXCEEDED|overloaded|high demand|fetch failed|timeout)\b/i.test(errorMsg);
       const maxRetries = isRateLimit ? MAX_RATE_LIMIT_RETRIES : MAX_RETRIES;


### PR DESCRIPTION
## Summary
- Anthropic API 크레딧 소진 오류(402, credit_balance 등) 감지 로직 추가
- 감지 시 재시도 없이 빌링 페이지 링크 포함 안내 메시지 즉시 반환
- 기존 rate limit / transient 에러 처리에 영향 없음

Closes #85

## Test plan
- [ ] 크레딧 소진 상태에서 메시지 전송 → 충전 안내 메시지 + 링크 표시 확인
- [ ] 정상 상태에서 기존 동작 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)