### PR TITLE
웹 대시보드 UX 개선 — 기본뷰, 일간뷰 액션, 백로그 간소화

### DIFF
--- a/web/src/app/backlog/page.tsx
+++ b/web/src/app/backlog/page.tsx
@@ -16,8 +16,6 @@ export default function BacklogPage() {
     setEditingSchedule,
     showCreateModal,
     setShowCreateModal,
-    assigningDate,
-    setAssigningDate,
     loading,
     grouped,
     sortedCategories,
@@ -32,6 +30,11 @@ export default function BacklogPage() {
     () => !formDirty || confirm('수정 중인 내용이 있어. 닫을까?'),
     [formDirty],
   );
+
+  const handleAddToToday = (id: number) => {
+    const today = new Date().toISOString().slice(0, 10);
+    handleAssignDate(id, today);
+  };
 
   if (loading) {
     return (
@@ -108,45 +111,12 @@ export default function BacklogPage() {
                           )}
                         </div>
 
-                        {/* 날짜 지정 */}
-                        {assigningDate?.id === s.id ? (
-                          <div className="flex items-center gap-1 max-md:w-full">
-                            <input
-                              type="date"
-                              value={assigningDate.date}
-                              onChange={(e) =>
-                                setAssigningDate({ id: s.id, date: e.target.value })
-                              }
-                              className="min-w-0 flex-1 rounded border border-gray-300 px-2 py-1 text-xs"
-                              autoFocus
-                            />
-                            <button
-                              onClick={() => handleAssignDate(s.id, assigningDate.date)}
-                              disabled={!assigningDate.date}
-                              className="rounded bg-blue-500 px-2 py-1 text-xs text-white disabled:opacity-50"
-                            >
-                              확인
-                            </button>
-                            <button
-                              onClick={() => setAssigningDate(null)}
-                              className="rounded px-2 py-1 text-xs text-gray-400"
-                            >
-                              취소
-                            </button>
-                          </div>
-                        ) : (
-                          <button
-                            onClick={() =>
-                              setAssigningDate({
-                                id: s.id,
-                                date: new Date().toISOString().slice(0, 10),
-                              })
-                            }
-                            className="shrink-0 rounded-lg border border-gray-200 px-3 py-1.5 text-xs text-gray-500 transition hover:bg-gray-100"
-                          >
-                            날짜 지정
-                          </button>
-                        )}
+                        <button
+                          onClick={() => handleAddToToday(s.id)}
+                          className="shrink-0 rounded-lg border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-600 transition hover:bg-blue-100"
+                        >
+                          오늘 추가
+                        </button>
                       </div>
                     ))}
                   </div>

--- a/web/src/app/schedules/page.tsx
+++ b/web/src/app/schedules/page.tsx
@@ -58,6 +58,9 @@ export default function SchedulesPage() {
     handleCreate,
     handleUpdate,
     handleDelete,
+    handlePostpone,
+    handleMoveToBacklog,
+    handleDeleteById,
     handleSelectDate,
     toggleCategory,
     toggleStatus,
@@ -139,6 +142,9 @@ export default function SchedulesPage() {
                   categories={categories}
                   onScheduleClick={setEditingSchedule}
                   onStatusChange={handleStatusChange}
+                  onPostpone={handlePostpone}
+                  onMoveToBacklog={handleMoveToBacklog}
+                  onDelete={handleDeleteById}
                 />
               )}
             </div>

--- a/web/src/components/ui/modal.tsx
+++ b/web/src/components/ui/modal.tsx
@@ -73,7 +73,7 @@ export function Modal({ open, onClose, title, children, onBeforeClose }: ModalPr
             </svg>
           </button>
         </div>
-        <div className="p-5">{children}</div>
+        <div className="overflow-hidden p-5">{children}</div>
       </div>
     </dialog>
   );

--- a/web/src/features/schedule/components/day-view.tsx
+++ b/web/src/features/schedule/components/day-view.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useRef, useEffect } from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
@@ -12,6 +13,85 @@ interface DayViewProps {
   categories: CategoryRow[];
   onScheduleClick: (schedule: ScheduleRow) => void;
   onStatusChange: (id: number, status: string) => void;
+  onPostpone: (id: number) => void;
+  onMoveToBacklog: (id: number) => void;
+  onDelete: (id: number) => void;
+}
+
+function ActionMenu({
+  scheduleId,
+  onPostpone,
+  onMoveToBacklog,
+  onDelete,
+}: {
+  scheduleId: number;
+  onPostpone: (id: number) => void;
+  onMoveToBacklog: (id: number) => void;
+  onDelete: (id: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(!open);
+        }}
+        className="rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
+      >
+        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M10 6a2 2 0 110-4 2 2 0 010 4zm0 6a2 2 0 110-4 2 2 0 010 4zm0 6a2 2 0 110-4 2 2 0 010 4z" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 z-50 mt-1 w-40 rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onPostpone(scheduleId);
+            }}
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+          >
+            내일로 미루기
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onMoveToBacklog(scheduleId);
+            }}
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+          >
+            백로그로 이동
+          </button>
+          <div className="my-1 border-t border-gray-100" />
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onDelete(scheduleId);
+            }}
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-500 hover:bg-red-50"
+          >
+            삭제
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function DayView({
@@ -20,6 +100,9 @@ export function DayView({
   categories,
   onScheduleClick,
   onStatusChange,
+  onPostpone,
+  onMoveToBacklog,
+  onDelete,
 }: DayViewProps) {
   const dateStr = format(currentDate, 'yyyy-MM-dd');
   const daySchedules = schedules.filter((s) => {
@@ -78,13 +161,22 @@ export function DayView({
                 </h3>
                 <div className="space-y-2">
                   {items.map((s) => (
-                    <ScheduleCard
-                      key={s.id}
-                      schedule={s}
-                      categories={categories}
-                      onStatusChange={onStatusChange}
-                      onClick={onScheduleClick}
-                    />
+                    <div key={s.id} className="flex items-start gap-1">
+                      <div className="min-w-0 flex-1">
+                        <ScheduleCard
+                          schedule={s}
+                          categories={categories}
+                          onStatusChange={onStatusChange}
+                          onClick={onScheduleClick}
+                        />
+                      </div>
+                      <ActionMenu
+                        scheduleId={s.id}
+                        onPostpone={onPostpone}
+                        onMoveToBacklog={onMoveToBacklog}
+                        onDelete={onDelete}
+                      />
+                    </div>
                   ))}
                 </div>
               </div>

--- a/web/src/features/schedule/components/schedule-form.tsx
+++ b/web/src/features/schedule/components/schedule-form.tsx
@@ -109,7 +109,7 @@ export function ScheduleForm({
           type="date"
           value={date}
           onChange={(e) => setDate(e.target.value)}
-          className="w-full min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+          className="w-full min-w-0 max-w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
         />
       </div>
 
@@ -141,7 +141,7 @@ export function ScheduleForm({
             type="date"
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
-            className="w-full min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            className="w-full min-w-0 max-w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
           />
         </div>
       )}

--- a/web/src/features/schedule/hooks/use-backlog.ts
+++ b/web/src/features/schedule/hooks/use-backlog.ts
@@ -8,7 +8,6 @@ export function useBacklog() {
   const [categories, setCategories] = useState<CategoryRow[]>([]);
   const [editingSchedule, setEditingSchedule] = useState<ScheduleRow | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
-  const [assigningDate, setAssigningDate] = useState<{ id: number; date: string } | null>(null);
   const [loading, setLoading] = useState(true);
 
   const fetchData = useCallback(async () => {
@@ -71,7 +70,6 @@ export function useBacklog() {
         body: JSON.stringify({ date, status: 'todo' }),
       });
       if (res.ok) {
-        setAssigningDate(null);
         await fetchData();
       }
     } catch {
@@ -131,8 +129,6 @@ export function useBacklog() {
     setEditingSchedule,
     showCreateModal,
     setShowCreateModal,
-    assigningDate,
-    setAssigningDate,
     loading,
     grouped,
     sortedCategories,

--- a/web/src/features/schedule/hooks/use-schedules.ts
+++ b/web/src/features/schedule/hooks/use-schedules.ts
@@ -20,7 +20,7 @@ import { WEEK_START } from '@/features/schedule/lib/calendar-utils';
 
 function getInitialView(): CalendarView {
   if (typeof window === 'undefined') return 'day';
-  return window.innerWidth >= 768 ? 'month' : 'day';
+  return window.innerWidth >= 768 ? 'week' : 'day';
 }
 
 export function useSchedules() {
@@ -246,6 +246,45 @@ export function useSchedules() {
     }
   };
 
+  const handlePostpone = async (id: number) => {
+    const schedule = schedules.find((s) => s.id === id);
+    if (!schedule?.date) return;
+    const next = format(addDays(new Date(schedule.date + 'T12:00:00'), 1), 'yyyy-MM-dd');
+    try {
+      const res = await fetch(`/api/schedules/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ date: next, end_date: null }),
+      });
+      if (res.ok) await fetchData();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleMoveToBacklog = async (id: number) => {
+    try {
+      const res = await fetch(`/api/schedules/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ date: null, end_date: null }),
+      });
+      if (res.ok) await fetchData();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleDeleteById = async (id: number) => {
+    if (!confirm('이 일정을 삭제할까?')) return;
+    try {
+      const res = await fetch(`/api/schedules/${id}`, { method: 'DELETE' });
+      if (res.ok) await fetchData();
+    } catch {
+      alert('삭제에 실패했어');
+    }
+  };
+
   const handleSelectDate = (dateStr: string) => {
     setSelectedDate(dateStr === selectedDate ? null : dateStr);
   };
@@ -296,6 +335,9 @@ export function useSchedules() {
     handleCreate,
     handleUpdate,
     handleDelete,
+    handlePostpone,
+    handleMoveToBacklog,
+    handleDeleteById,
     handleSelectDate,
     toggleCategory,
     toggleStatus,


### PR DESCRIPTION
## Summary
Closes #93

- 모바일 날짜 필드 오버플로우 수정 (모달 `overflow-hidden` + date input `max-w-full`)
- 데스크탑 기본뷰를 월간 → 주간뷰로 변경
- 일간뷰에 액션 드롭다운 추가 (내일로 미루기 / 백로그 이동 / 삭제)
- 백로그 날짜 지정 UI 제거 → "오늘 추가" 원클릭 버튼으로 교체
- Vercel 배포 전환은 별도 이슈(#94)로 분리

## 변경 파일 (7개)
- `modal.tsx` — 콘텐츠 영역 overflow-hidden
- `schedule-form.tsx` — date input max-w-full 추가
- `use-schedules.ts` — handlePostpone, handleMoveToBacklog, handleDeleteById 추가
- `day-view.tsx` — ActionMenu 드롭다운 컴포넌트 추가
- `schedules/page.tsx` — 새 핸들러 연결
- `backlog/page.tsx` — 날짜 지정 UI → "오늘 추가" 버튼
- `use-backlog.ts` — assigningDate 상태 제거

## Test plan
- [ ] 모바일에서 일정 추가/수정 모달의 날짜 필드가 잘리지 않는지 확인
- [ ] 데스크탑에서 일정 페이지 진입 시 주간뷰가 기본인지 확인
- [ ] 일간뷰에서 ⋯ 버튼 → 내일로 미루기/백로그 이동/삭제 동작 확인
- [ ] 백로그에서 "오늘 추가" 클릭 시 오늘 날짜로 배정되는지 확인
- [ ] 백로그에서 일정 클릭 → 수정 모달에서 날짜 직접 지정 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)