### PR TITLE
feat: CI/CD 강화 + Slack 배포 알림 (#97)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   ci:
     name: Lint / Test / Build
@@ -32,8 +36,31 @@ jobs:
     name: Deploy to Oracle VM
     needs: ci
     runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Notify deploy start
+        if: env.SLACK_WEBHOOK_URL != ''
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=format:'%s' | jq -Rs '.[:-1]')
+          COMMIT_AUTHOR=$(git log -1 --pretty=format:'%an' | jq -Rs '.[:-1]')
+          COMMIT_SHA=$(git log -1 --pretty=format:'%h')
+          ACTIONS_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          jq -n \
+            --arg sha "$COMMIT_SHA" \
+            --argjson msg "$COMMIT_MSG" \
+            --argjson author "$COMMIT_AUTHOR" \
+            --arg url "$ACTIONS_URL" \
+            '{blocks: [
+              {type: "section", text: {type: "mrkdwn", text: (":rocket: *배포 시작*\n`" + $sha + "` " + $msg + "\n_by " + $author + "_")}},
+              {type: "context", elements: [{type: "mrkdwn", text: ("<" + $url + "|Actions 로그>")}]}
+            ]}' | curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' -d @-
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
         with:
@@ -41,3 +68,46 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: bash ~/deploy.sh
+
+      - name: Notify deploy success
+        if: success() && env.SLACK_WEBHOOK_URL != ''
+        run: |
+          COMMIT_SHA=$(git log -1 --pretty=format:'%h')
+          jq -n --arg sha "$COMMIT_SHA" \
+            '{blocks: [{type: "section", text: {type: "mrkdwn", text: (":white_check_mark: *배포 완료* `" + $sha + "`")}}]}' \
+            | curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' -d @-
+
+      - name: Notify deploy failure
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
+        run: |
+          COMMIT_SHA=$(git log -1 --pretty=format:'%h')
+          ACTIONS_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          jq -n --arg sha "$COMMIT_SHA" --arg url "$ACTIONS_URL" \
+            '{blocks: [{type: "section", text: {type: "mrkdwn", text: (":x: *배포 실패* `" + $sha + "`\n<" + $url + "|에러 로그 확인>")}}]}' \
+            | curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' -d @-
+
+  notify-ci-failure:
+    name: Notify CI Failure
+    needs: ci
+    if: failure()
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Notify CI failure
+        if: env.SLACK_WEBHOOK_URL != ''
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=format:'%s' | jq -Rs '.[:-1]')
+          COMMIT_SHA=$(git log -1 --pretty=format:'%h')
+          ACTIONS_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          jq -n \
+            --arg sha "$COMMIT_SHA" \
+            --argjson msg "$COMMIT_MSG" \
+            --arg url "$ACTIONS_URL" \
+            '{blocks: [{type: "section", text: {type: "mrkdwn", text: (":warning: *CI 실패* (배포 중단)\n`" + $sha + "` " + $msg + "\n<" + $url + "|에러 로그 확인>")}}]}' \
+            | curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' -d @-


### PR DESCRIPTION
## Summary

- deploy.yml에 Slack Incoming Webhook 기반 배포 알림 추가
  - :rocket: 배포 시작 (커밋 정보 + Actions 로그 링크)
  - :white_check_mark: 배포 완료
  - :x: 배포 실패 (에러 로그 링크)
  - :warning: CI 실패 시 배포 중단 알림
- concurrency 제어로 동시 배포 방지
- `jq`로 커밋 메시지 JSON 이스케이프 처리 (특수문자 안전)
- `SLACK_WEBHOOK_URL` 미설정 시 알림 자동 스킵

## 셋업 가이드

1. Slack 워크스페이스에서 Incoming Webhook 앱 추가
2. 알림 받을 채널 선택 → Webhook URL 복사
3. GitHub repo → Settings → Secrets → `SLACK_WEBHOOK_URL` 추가

## 보안

- Webhook URL은 GitHub Secrets로 관리
- 알림 메시지에 민감정보(IP, 토큰 등) 미포함

## Test plan

- [ ] SLACK_WEBHOOK_URL 설정 후 main push → 배포 시작/완료 알림 수신 확인
- [ ] SLACK_WEBHOOK_URL 미설정 → 기존 배포 동작 정상 확인
- [ ] 의도적 빌드 실패 → CI 실패 알림 수신 확인

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)