### PR TITLE
feat: Next.js 캐싱 — Neon cold start 대응 (#99)

### DIFF
--- a/web/src/app/api/categories/[id]/route.ts
+++ b/web/src/app/api/categories/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
 import { updateCategory, deleteCategory } from '@/features/schedule/lib/queries';
 
@@ -22,6 +23,7 @@ export async function PATCH(
     if (!data) {
       return NextResponse.json({ error: '카테고리를 찾을 수 없어' }, { status: 404 });
     }
+    revalidateTag('categories', 'seconds');
     return NextResponse.json({ data });
   } catch (err) {
     const message = err instanceof Error ? err.message : '카테고리 수정 실패';
@@ -47,6 +49,7 @@ export async function DELETE(
     if (!deleted) {
       return NextResponse.json({ error: '카테고리를 찾을 수 없어' }, { status: 404 });
     }
+    revalidateTag('categories', 'seconds');
     return NextResponse.json({ data: { id: Number(id) } });
   } catch {
     return NextResponse.json({ error: '카테고리 삭제 실패' }, { status: 500 });

--- a/web/src/app/api/categories/reorder/route.ts
+++ b/web/src/app/api/categories/reorder/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
 import { reorderCategories } from '@/features/schedule/lib/queries';
 
@@ -21,6 +22,7 @@ export async function POST(request: Request) {
     }
 
     await reorderCategories(body.orders);
+    revalidateTag('categories', 'seconds');
     return NextResponse.json({ data: { ok: true } });
   } catch {
     return NextResponse.json({ error: '순서 변경 실패' }, { status: 500 });

--- a/web/src/app/api/categories/route.ts
+++ b/web/src/app/api/categories/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
-import { queryCategories, createCategory } from '@/features/schedule/lib/queries';
+import { createCategory } from '@/features/schedule/lib/queries';
+import { getCachedCategories } from '@/lib/cache';
 
 export async function GET() {
   if (!(await requireAuth())) {
@@ -8,7 +10,7 @@ export async function GET() {
   }
 
   try {
-    const data = await queryCategories();
+    const data = await getCachedCategories();
     return NextResponse.json({ data });
   } catch {
     return NextResponse.json({ error: '카테고리 조회 실패' }, { status: 500 });
@@ -31,6 +33,7 @@ export async function POST(request: Request) {
       name: body.name.trim(),
       color: body.color,
     });
+    revalidateTag('categories', 'seconds');
     return NextResponse.json({ data }, { status: 201 });
   } catch (err) {
     const message = err instanceof Error ? err.message : '카테고리 생성 실패';

--- a/web/src/app/api/schedules/[id]/route.ts
+++ b/web/src/app/api/schedules/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
 import {
   queryScheduleById,
@@ -60,6 +61,8 @@ export async function PATCH(
     if (!data) {
       return NextResponse.json({ error: '일정을 찾을 수 없어' }, { status: 404 });
     }
+    revalidateTag('schedules', 'seconds');
+    if (body.category) revalidateTag('categories', 'seconds');
     return NextResponse.json({ data });
   } catch {
     return NextResponse.json({ error: '일정 수정 실패' }, { status: 500 });
@@ -80,6 +83,7 @@ export async function DELETE(
     if (!deleted) {
       return NextResponse.json({ error: '일정을 찾을 수 없어' }, { status: 404 });
     }
+    revalidateTag('schedules', 'seconds');
     return NextResponse.json({ data: { id: Number(id) } });
   } catch {
     return NextResponse.json({ error: '일정 삭제 실패' }, { status: 500 });

--- a/web/src/app/api/schedules/route.ts
+++ b/web/src/app/api/schedules/route.ts
@@ -1,11 +1,8 @@
 import { NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
-import {
-  querySchedulesByRange,
-  queryBacklogSchedules,
-  createSchedule,
-  ensureCategoryExists,
-} from '@/features/schedule/lib/queries';
+import { createSchedule, ensureCategoryExists } from '@/features/schedule/lib/queries';
+import { getCachedSchedulesByRange, getCachedBacklogSchedules } from '@/lib/cache';
 import { isValidStatus } from '@/lib/types';
 
 export async function GET(request: Request) {
@@ -20,12 +17,12 @@ export async function GET(request: Request) {
     const to = searchParams.get('to');
 
     if (backlog === 'true') {
-      const data = await queryBacklogSchedules();
+      const data = await getCachedBacklogSchedules();
       return NextResponse.json({ data });
     }
 
     if (from && to) {
-      const data = await querySchedulesByRange(from, to);
+      const data = await getCachedSchedulesByRange(from, to);
       return NextResponse.json({ data });
     }
 
@@ -73,6 +70,8 @@ export async function POST(request: Request) {
       important: body.important,
     });
 
+    revalidateTag('schedules', 'seconds');
+    if (body.category) revalidateTag('categories', 'seconds');
     return NextResponse.json({ data }, { status: 201 });
   } catch {
     return NextResponse.json({ error: '일정 생성 실패' }, { status: 500 });

--- a/web/src/lib/cache.ts
+++ b/web/src/lib/cache.ts
@@ -1,0 +1,26 @@
+import { unstable_cache } from 'next/cache';
+import {
+  querySchedulesByRange,
+  queryBacklogSchedules,
+  queryCategories,
+} from '@/features/schedule/lib/queries';
+
+const REVALIDATE_SECONDS = 30;
+
+export const getCachedSchedulesByRange = unstable_cache(
+  async (from: string, to: string) => querySchedulesByRange(from, to),
+  ['schedules-by-range'],
+  { revalidate: REVALIDATE_SECONDS, tags: ['schedules'] },
+);
+
+export const getCachedBacklogSchedules = unstable_cache(
+  async () => queryBacklogSchedules(),
+  ['backlog-schedules'],
+  { revalidate: REVALIDATE_SECONDS, tags: ['schedules'] },
+);
+
+export const getCachedCategories = unstable_cache(
+  async () => queryCategories(),
+  ['categories'],
+  { revalidate: REVALIDATE_SECONDS, tags: ['categories'] },
+);


### PR DESCRIPTION
## Summary

- Next.js `unstable_cache`로 DB 읽기 쿼리 캐싱 (30초 TTL)
  - `schedules` 태그: 일정 범위 조회, 백로그 조회
  - `categories` 태그: 카테고리 목록 조회
- 뮤테이션(POST/PATCH/DELETE) 시 `revalidateTag()` 즉시 캐시 무효화
- `ensureCategoryExists` 호출 시 categories 태그도 함께 무효화

## 효과

- **Neon cold start 완화**: 캐시 히트 시 DB 쿼리 스킵 → 즉시 응답
- **반복 조회 최적화**: 15초 폴링 중 동일 쿼리 캐시 재사용
- **웹 UI 뮤테이션**: revalidateTag로 즉시 캐시 갱신 → 사용자 체감 지연 없음
- **Slack 봇 변경**: 30초 TTL 내 자동 갱신 (폴링으로 보완)

## 보안

- `requireAuth()` 체크가 캐시 이전에 실행 (인증 우회 불가)
- 캐시된 데이터는 서버 내부 → 외부 노출 없음

## Test plan

- [ ] 캘린더 페이지 로드 → 정상 데이터 표시 확인
- [ ] 일정 생성/수정/삭제 → 즉시 반영 확인 (캐시 무효화)
- [ ] 카테고리 생성/수정/삭제/정렬 → 즉시 반영 확인
- [ ] Slack 봇으로 일정 추가 → 30초 내 웹 대시보드 반영 확인

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)