### PR TITLE
fix: 크론 알림 중복 발송 수정 — reload() debounce + mutex

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -40,10 +40,10 @@ const startApp = async (): Promise<void> => {
   });
   await cronScheduler.init();
 
-  // SQL modify_db 후 알림 설정 변경 감지 → 크론 리스케줄
-  setPostModifyHook(async (sql: string) => {
+  // SQL modify_db 후 알림 설정 변경 감지 → 크론 리스케줄 (debounce 내장)
+  setPostModifyHook((sql: string) => {
     if (/\bnotification_settings\b/i.test(sql)) {
-      await cronScheduler.reload();
+      cronScheduler.reload();
     }
   });
 

--- a/src/cron/__tests__/life-cron.test.ts
+++ b/src/cron/__tests__/life-cron.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── 순수 유틸 테스트 ──
+
+import { timeToCron, calcRoutineStats, RELOAD_DEBOUNCE_MS } from '../life-cron.js';
+
+describe('timeToCron', () => {
+  it('HH:MM → 크론 표현식', () => {
+    expect(timeToCron('09:00')).toBe('0 9 * * *');
+    expect(timeToCron('13:30')).toBe('30 13 * * *');
+    expect(timeToCron('22:05')).toBe('5 22 * * *');
+  });
+});
+
+describe('calcRoutineStats', () => {
+  it('빈 배열', () => {
+    const stats = calcRoutineStats([]);
+    expect(stats.total).toBe(0);
+    expect(stats.rate).toBe(0);
+    expect(stats.weakestSlot).toBeNull();
+  });
+});
+
+// ── CronScheduler reload debounce/mutex 테스트 ──
+
+// vi.hoisted로 mock 함수 선언 (vi.mock 호이스팅 대응)
+const { mockStop, mockSchedule, mockQuery, mockConnect } = vi.hoisted(() => ({
+  mockStop: vi.fn(),
+  mockSchedule: vi.fn(() => ({ stop: vi.fn() })),
+  mockQuery: vi.fn(),
+  mockConnect: vi.fn(),
+}));
+
+// node-cron mock
+vi.mock('node-cron', () => ({
+  default: { schedule: mockSchedule },
+}));
+
+// DB mock
+vi.mock('pg', () => {
+  const MockPool = vi.fn(function (this: Record<string, unknown>) {
+    this.query = mockQuery;
+    this.connect = mockConnect;
+    this.end = vi.fn();
+  });
+  return { default: { Pool: MockPool, types: { setTypeParser: vi.fn() } } };
+});
+
+vi.mock('../../shared/kst.js', () => ({
+  getTodayISO: () => '2026-03-12',
+  getYesterdayISO: () => '2026-03-11',
+  getKSTTimeString: () => '09:00',
+  getKSTDayOfWeek: () => 4,
+  formatDateShort: (d: string) => d,
+  addDays: (d: string, n: number) => {
+    const date = new Date(`${d}T12:00:00+09:00`);
+    date.setUTCDate(date.getUTCDate() + n);
+    return date.toISOString().slice(0, 10);
+  },
+}));
+
+import { connectDB } from '../../shared/db.js';
+import { CronScheduler, type LifeCronConfig } from '../life-cron.js';
+
+/** notification_settings 쿼리 mock 설정 */
+const setupSettingsMock = (settings: Array<{ slot_name: string; label: string; time_value: string; active: boolean }> = []): void => {
+  mockQuery.mockImplementation((sql: string) => {
+    if (/notification_settings/.test(sql)) {
+      return Promise.resolve({ rows: settings });
+    }
+    if (/reminders/.test(sql)) {
+      return Promise.resolve({ rows: [] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+};
+
+const createMockApp = (): unknown => ({
+  client: {
+    chat: { postMessage: vi.fn().mockResolvedValue({}) },
+  },
+});
+
+describe('CronScheduler reload debounce', () => {
+  let scheduler: CronScheduler;
+  let stopFns: Array<ReturnType<typeof vi.fn>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockConnect.mockResolvedValue({ release: vi.fn() });
+
+    // 각 schedule() 호출마다 고유한 stop 함수를 반환
+    stopFns = [];
+    mockSchedule.mockImplementation(() => {
+      const stop = vi.fn();
+      stopFns.push(stop);
+      return { stop };
+    });
+
+    await connectDB('postgresql://test@localhost/test');
+
+    setupSettingsMock([
+      { slot_name: 'morning', label: '아침', time_value: '09:00', active: true },
+    ]);
+
+    const app = createMockApp();
+    const config: LifeCronConfig = {
+      channelId: 'C123',
+      llmClient: {} as LifeCronConfig['llmClient'],
+    };
+
+    scheduler = new CronScheduler(app as never, config);
+    await scheduler.init();
+
+    // init 후 상태 초기화 (쿼리 카운트 리셋)
+    mockQuery.mock.calls.length = 0;
+
+    // 리로드용 settings mock 재설정
+    setupSettingsMock([
+      { slot_name: 'morning', label: '아침', time_value: '09:30', active: true },
+    ]);
+  });
+
+  afterEach(() => {
+    scheduler.destroy();
+    vi.useRealTimers();
+  });
+
+  it('연속 reload() 호출 → debounce로 1회만 실행', async () => {
+    // 5회 연속 호출 (agent loop에서 modify_db 5번)
+    scheduler.reload();
+    scheduler.reload();
+    scheduler.reload();
+    scheduler.reload();
+    scheduler.reload();
+
+    // debounce 전에는 실행 안 됨
+    expect(mockQuery).not.toHaveBeenCalled();
+
+    // debounce 시간 경과
+    await vi.advanceTimersByTimeAsync(RELOAD_DEBOUNCE_MS);
+
+    // loadAndSchedule 1회만 실행됨 (notification_settings 쿼리 1회)
+    const settingsQueries = mockQuery.mock.calls.filter(
+      (call) => /notification_settings/.test(call[0] as string),
+    );
+    expect(settingsQueries).toHaveLength(1);
+  });
+
+  it('destroy() 시 pending debounce 타이머 정리', () => {
+    scheduler.reload();
+    scheduler.destroy();
+
+    // destroy 후 타이머 경과해도 실행 안 됨
+    vi.advanceTimersByTime(RELOAD_DEBOUNCE_MS * 2);
+
+    // destroy 시점 이후 notification_settings 쿼리 없음
+    const settingsQueries = mockQuery.mock.calls.filter(
+      (call) => /notification_settings/.test(call[0] as string),
+    );
+    expect(settingsQueries).toHaveLength(0);
+  });
+
+  it('reload 시 기존 task의 stop()이 호출됨', async () => {
+    // init에서 생성된 stop 함수들 기억
+    const initStopFns = [...stopFns];
+    expect(initStopFns.length).toBeGreaterThan(0);
+
+    scheduler.reload();
+    await vi.advanceTimersByTimeAsync(RELOAD_DEBOUNCE_MS);
+
+    // destroyAll에서 init 시 생성된 task들의 stop()이 호출됨
+    for (const stop of initStopFns) {
+      expect(stop).toHaveBeenCalled();
+    }
+  });
+});

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -367,12 +367,18 @@ const SLOT_TASKS: Record<string, CronTaskFn> = {
 
 // ─── CronScheduler 클래스 ───────────────────────────────
 
+/** reload() debounce 대기 시간 (ms) */
+export const RELOAD_DEBOUNCE_MS = 500;
+
 interface CronTask {
   stop: () => void;
 }
 
 export class CronScheduler {
   private tasks = new Map<string, CronTask>();
+  private reloadTimer: ReturnType<typeof setTimeout> | null = null;
+  private reloading = false;
+  private reloadQueued = false;
 
   constructor(
     private readonly app: App,
@@ -385,20 +391,55 @@ export class CronScheduler {
     this.startReminderChecker();
   }
 
-  /** 기존 태스크 전체 파기 → DB 재로드 → 새 스케줄로 등록 */
-  async reload(): Promise<void> {
-    this.destroyAll();
-    await this.loadAndSchedule();
-    this.startReminderChecker();
-    console.warn('[Life Cron] 스케줄 리로드 완료');
+  /**
+   * 기존 태스크 전체 파기 → DB 재로드 → 새 스케줄로 등록.
+   * debounce 적용: 연속 호출 시 마지막 호출만 실행.
+   * mutex 적용: 실행 중 재호출 시 큐잉 후 완료 후 1회 재실행.
+   */
+  reload(): void {
+    if (this.reloadTimer) {
+      clearTimeout(this.reloadTimer);
+    }
+    this.reloadTimer = setTimeout(() => {
+      this.reloadTimer = null;
+      void this.executeReload();
+    }, RELOAD_DEBOUNCE_MS);
   }
 
-  /** 모든 태스크 정지 + 제거 */
+  /** 모든 태스크 정지 + 제거 (pending debounce 포함) */
   destroy(): void {
+    if (this.reloadTimer) {
+      clearTimeout(this.reloadTimer);
+      this.reloadTimer = null;
+    }
     this.destroyAll();
   }
 
   // ── 내부 메서드 ──
+
+  private async executeReload(): Promise<void> {
+    if (this.reloading) {
+      this.reloadQueued = true;
+      return;
+    }
+
+    this.reloading = true;
+    try {
+      this.destroyAll();
+      await this.loadAndSchedule();
+      this.startReminderChecker();
+      console.warn('[Life Cron] 스케줄 리로드 완료');
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error('[Life Cron] 리로드 실패:', msg);
+    } finally {
+      this.reloading = false;
+      if (this.reloadQueued) {
+        this.reloadQueued = false;
+        await this.executeReload();
+      }
+    }
+  }
 
   private async loadAndSchedule(): Promise<void> {
     const settings = await queryNotificationSettings();
@@ -415,6 +456,11 @@ export class CronScheduler {
       const task = cron.schedule(cronExpr, wrapTask(taskFn, this.app, this.config, setting.label), {
         timezone,
       });
+
+      // 안전장치: 기존 task가 있으면 먼저 정지 (좀비 방지)
+      const existing = this.tasks.get(setting.slot_name);
+      if (existing) existing.stop();
+
       this.tasks.set(setting.slot_name, task);
       registered.push(`${setting.label}(${setting.time_value})`);
     }
@@ -435,6 +481,10 @@ export class CronScheduler {
       },
       { timezone: 'Asia/Seoul' },
     );
+
+    // 안전장치: 기존 리마인더 체커가 있으면 먼저 정지
+    const existing = this.tasks.get('_reminderChecker');
+    if (existing) existing.stop();
 
     this.tasks.set('_reminderChecker', task);
   }


### PR DESCRIPTION
## Summary
- `CronScheduler.reload()` 레이스 컨디션으로 알림이 3중 발송되던 버그 수정
- `postModifyHook`이 fire-and-forget으로 동시에 여러 `reload()` 호출 → 좀비 cron task 생성
- debounce(500ms) + mutex + 기존 task `stop()` 안전장치로 해결

## 변경 사항
- **`src/cron/life-cron.ts`**: `reload()`에 trailing debounce, `executeReload()`에 mutex + 큐잉, `loadAndSchedule()`/`startReminderChecker()`에서 기존 task stop() 후 교체
- **`src/app.ts`**: `postModifyHook`을 동기 호출로 변경 (debounce가 CronScheduler 내장)
- **`src/cron/__tests__/life-cron.test.ts`**: CronScheduler debounce/mutex 테스트 추가

## Test plan
- [x] 연속 reload() 5회 호출 시 debounce로 1회만 실행되는지 확인
- [x] destroy() 시 pending debounce 타이머 정리 확인
- [x] reload 시 기존 task stop() 호출 확인
- [x] 전체 테스트 211개 통과
- [x] TypeScript 빌드 통과
- [ ] 배포 후 알림 중복 발송 해소 확인

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)