### PR TITLE
feat: 대시보드 UX 개선 — 중요 토글 + 정렬 + Safari 수정

### DIFF
--- a/web/src/app/schedules/page.tsx
+++ b/web/src/app/schedules/page.tsx
@@ -53,6 +53,7 @@ export default function SchedulesPage() {
     handleNext,
     handleToday,
     handleStatusChange,
+    handleToggleImportant,
     handleDateChange,
     handleEndDateChange,
     handleCreate,
@@ -145,6 +146,7 @@ export default function SchedulesPage() {
                   onSelectDate={handleSelectDate}
                   onScheduleClick={setEditingSchedule}
                   onStatusChange={handleStatusChange}
+                  onToggleImportant={handleToggleImportant}
                   onPostpone={handlePostpone}
                   onMoveToBacklog={handleMoveToBacklog}
                   onDelete={handleDeleteById}
@@ -157,6 +159,7 @@ export default function SchedulesPage() {
                   categories={categories}
                   onScheduleClick={setEditingSchedule}
                   onStatusChange={handleStatusChange}
+                  onToggleImportant={handleToggleImportant}
                   onPostpone={handlePostpone}
                   onMoveToBacklog={handleMoveToBacklog}
                   onDelete={handleDeleteById}

--- a/web/src/features/schedule/components/action-menu.tsx
+++ b/web/src/features/schedule/components/action-menu.tsx
@@ -4,6 +4,8 @@ import { useState, useRef, useEffect } from 'react';
 
 interface ActionMenuProps {
   scheduleId: number;
+  important?: boolean;
+  onToggleImportant?: (id: number) => void;
   onPostpone: (id: number) => void;
   onMoveToBacklog: (id: number) => void;
   onDelete: (id: number) => void;
@@ -11,6 +13,8 @@ interface ActionMenuProps {
 
 export function ActionMenu({
   scheduleId,
+  important,
+  onToggleImportant,
   onPostpone,
   onMoveToBacklog,
   onDelete,
@@ -43,6 +47,18 @@ export function ActionMenu({
 
       {open && (
         <div className="absolute right-0 z-50 mt-1 w-40 rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+          {onToggleImportant && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+                onToggleImportant(scheduleId);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+            >
+              {important ? '★ 중요 해제' : '☆ 중요 설정'}
+            </button>
+          )}
           <button
             onClick={(e) => {
               e.stopPropagation();

--- a/web/src/features/schedule/components/day-detail-panel.tsx
+++ b/web/src/features/schedule/components/day-detail-panel.tsx
@@ -3,7 +3,7 @@
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
-import { compareByStatus } from '@/lib/types';
+import { compareSchedulePriority } from '@/lib/types';
 import { ScheduleCard } from './schedule-card';
 
 interface DayDetailPanelProps {
@@ -32,7 +32,7 @@ export function DayDetailPanel({
       if (s.date && s.end_date && s.date <= dateStr && s.end_date >= dateStr) return true;
       return false;
     })
-    .sort(compareByStatus);
+    .sort((a, b) => compareSchedulePriority(a, b, categories));
 
   return (
     <div className="min-h-full border-t border-b border-gray-200 bg-white p-4 md:border-l">

--- a/web/src/features/schedule/components/day-view.tsx
+++ b/web/src/features/schedule/components/day-view.tsx
@@ -3,7 +3,7 @@
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
-import { compareByStatus } from '@/lib/types';
+import { compareByStatus, isMultiDaySchedule } from '@/lib/types';
 import { ScheduleCard } from './schedule-card';
 import { ActionMenu } from './action-menu';
 
@@ -13,9 +13,15 @@ interface DayViewProps {
   categories: CategoryRow[];
   onScheduleClick: (schedule: ScheduleRow) => void;
   onStatusChange: (id: number, status: string) => void;
+  onToggleImportant: (id: number) => void;
   onPostpone: (id: number) => void;
   onMoveToBacklog: (id: number) => void;
   onDelete: (id: number) => void;
+}
+
+interface Section {
+  title: string;
+  items: ScheduleRow[];
 }
 
 export function DayView({
@@ -24,6 +30,7 @@ export function DayView({
   categories,
   onScheduleClick,
   onStatusChange,
+  onToggleImportant,
   onPostpone,
   onMoveToBacklog,
   onDelete,
@@ -37,24 +44,8 @@ export function DayView({
 
   const formatted = format(currentDate, 'yyyy년 M월 d일 (EEE)', { locale: ko });
 
-  // 카테고리별 그룹핑 (그룹 내 상태순 정렬)
-  const sorted = [...daySchedules].sort(compareByStatus);
-  const grouped = new Map<string, ScheduleRow[]>();
-  for (const s of sorted) {
-    const cat = s.category ?? '미분류';
-    const list = grouped.get(cat) ?? [];
-    list.push(s);
-    grouped.set(cat, list);
-  }
-
-  // 카테고리 정렬 (sort_order 기준, 미분류 맨 끝)
-  const sortedCategories = [...grouped.keys()].sort((a, b) => {
-    if (a === '미분류') return 1;
-    if (b === '미분류') return -1;
-    const catA = categories.find((c) => c.name === a);
-    const catB = categories.find((c) => c.name === b);
-    return (catA?.sort_order ?? 999) - (catB?.sort_order ?? 999);
-  });
+  // 3단 섹션 분리: 기간 일정 → 중요 → 카테고리별
+  const sections = buildDaySections(daySchedules, categories);
 
   const totalTasks = daySchedules.filter((s) => s.category !== '약속').length;
   const doneTasks = daySchedules.filter(
@@ -78,37 +69,86 @@ export function DayView({
         </div>
       ) : (
         <div className="space-y-4">
-          {sortedCategories.map((cat) => {
-            const items = grouped.get(cat) ?? [];
-            return (
-              <div key={cat}>
-                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                  {cat}
-                </h3>
-                <div className="space-y-2">
-                  {items.map((s) => (
-                    <ScheduleCard
-                      key={s.id}
-                      schedule={s}
-                      categories={categories}
-                      onStatusChange={onStatusChange}
-                      onClick={onScheduleClick}
-                      action={
-                        <ActionMenu
-                          scheduleId={s.id}
-                          onPostpone={onPostpone}
-                          onMoveToBacklog={onMoveToBacklog}
-                          onDelete={onDelete}
-                        />
-                      }
-                    />
-                  ))}
-                </div>
+          {sections.map((section) => (
+            <div key={section.title}>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                {section.title}
+              </h3>
+              <div className="space-y-2">
+                {section.items.map((s) => (
+                  <ScheduleCard
+                    key={s.id}
+                    schedule={s}
+                    categories={categories}
+                    onStatusChange={onStatusChange}
+                    onClick={onScheduleClick}
+                    action={
+                      <ActionMenu
+                        scheduleId={s.id}
+                        important={s.important}
+                        onToggleImportant={onToggleImportant}
+                        onPostpone={onPostpone}
+                        onMoveToBacklog={onMoveToBacklog}
+                        onDelete={onDelete}
+                      />
+                    }
+                  />
+                ))}
               </div>
-            );
-          })}
+            </div>
+          ))}
         </div>
       )}
     </div>
   );
+}
+
+/** 일정을 기간 → 중요 → 카테고리별 섹션으로 분리 */
+function buildDaySections(schedules: ScheduleRow[], categories: CategoryRow[]): Section[] {
+  const byCatThenStatus = (a: ScheduleRow, b: ScheduleRow) => {
+    const catA = categories.find((c) => c.name === a.category);
+    const catB = categories.find((c) => c.name === b.category);
+    const orderA = a.category ? (catA?.sort_order ?? 999) : 9999;
+    const orderB = b.category ? (catB?.sort_order ?? 999) : 9999;
+    if (orderA !== orderB) return orderA - orderB;
+    return compareByStatus(a, b);
+  };
+
+  // 1. 기간 일정
+  const multiDay = schedules.filter(isMultiDaySchedule).sort(byCatThenStatus);
+
+  // 2. 중요 단일 일정 (기간 제외)
+  const importantSingle = schedules
+    .filter((s) => !isMultiDaySchedule(s) && s.important)
+    .sort(byCatThenStatus);
+
+  // 3. 나머지 → 카테고리별 그룹
+  const regular = schedules
+    .filter((s) => !isMultiDaySchedule(s) && !s.important)
+    .sort(compareByStatus);
+
+  const grouped = new Map<string, ScheduleRow[]>();
+  for (const s of regular) {
+    const cat = s.category ?? '미분류';
+    const list = grouped.get(cat) ?? [];
+    list.push(s);
+    grouped.set(cat, list);
+  }
+
+  const sortedCats = [...grouped.keys()].sort((a, b) => {
+    if (a === '미분류') return 1;
+    if (b === '미분류') return -1;
+    const catA = categories.find((c) => c.name === a);
+    const catB = categories.find((c) => c.name === b);
+    return (catA?.sort_order ?? 999) - (catB?.sort_order ?? 999);
+  });
+
+  const sections: Section[] = [];
+  if (multiDay.length > 0) sections.push({ title: '기간 일정', items: multiDay });
+  if (importantSingle.length > 0) sections.push({ title: '중요', items: importantSingle });
+  for (const cat of sortedCats) {
+    sections.push({ title: cat, items: grouped.get(cat) ?? [] });
+  }
+
+  return sections;
 }

--- a/web/src/features/schedule/components/schedule-form.tsx
+++ b/web/src/features/schedule/components/schedule-form.tsx
@@ -88,7 +88,7 @@ export function ScheduleForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4 overflow-hidden">
       {/* 제목 */}
       <div>
         <input
@@ -109,7 +109,7 @@ export function ScheduleForm({
           type="date"
           value={date}
           onChange={(e) => setDate(e.target.value)}
-          className="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+          className="block w-full min-w-0 max-w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
         />
       </div>
 
@@ -141,7 +141,7 @@ export function ScheduleForm({
             type="date"
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
-            className="block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            className="block w-full min-w-0 max-w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
           />
         </div>
       )}

--- a/web/src/features/schedule/components/week-view.tsx
+++ b/web/src/features/schedule/components/week-view.tsx
@@ -5,7 +5,7 @@ import { startOfWeek, addDays, format, isToday } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { useDraggable } from '@dnd-kit/core';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
-import { getCategoryStyle, compareByStatus } from '@/lib/types';
+import { getCategoryStyle, compareSchedulePriority } from '@/lib/types';
 import { computeWeekLayout, WEEK_START, type WeekSpan } from '@/features/schedule/lib/calendar-utils';
 import { StatusBadge } from './status-badge';
 import { DroppableDay } from './droppable-day';
@@ -20,6 +20,7 @@ interface WeekViewProps {
   onSelectDate: (date: string) => void;
   onScheduleClick: (schedule: ScheduleRow) => void;
   onStatusChange: (id: number, status: string) => void;
+  onToggleImportant: (id: number) => void;
   onPostpone: (id: number) => void;
   onMoveToBacklog: (id: number) => void;
   onDelete: (id: number) => void;
@@ -49,6 +50,7 @@ export function WeekView({
   onSelectDate,
   onScheduleClick,
   onStatusChange,
+  onToggleImportant,
   onPostpone,
   onMoveToBacklog,
   onDelete,
@@ -119,6 +121,8 @@ export function WeekView({
                     action={
                       <ActionMenu
                         scheduleId={s.id}
+                        important={s.important}
+                        onToggleImportant={onToggleImportant}
                         onPostpone={onPostpone}
                         onMoveToBacklog={onMoveToBacklog}
                         onDelete={onDelete}
@@ -141,6 +145,7 @@ export function WeekView({
             laneHeight={LANE_HEIGHT}
             onStatusChange={onStatusChange}
             onClick={() => onScheduleClick(span.schedule)}
+            onToggleImportant={onToggleImportant}
             onPostpone={onPostpone}
             onMoveToBacklog={onMoveToBacklog}
             onDelete={onDelete}
@@ -152,7 +157,7 @@ export function WeekView({
       <div className="md:hidden">
         {days.map((day) => {
           const dateStr = format(day, 'yyyy-MM-dd');
-          const daySchedules = getMobileSchedules(day, schedules);
+          const daySchedules = getMobileSchedules(day, schedules, categories);
           const today = isToday(day);
           const selected = selectedDate === dateStr;
 
@@ -194,6 +199,8 @@ export function WeekView({
                         action={
                           <ActionMenu
                             scheduleId={s.id}
+                            important={s.important}
+                            onToggleImportant={onToggleImportant}
                             onPostpone={onPostpone}
                             onMoveToBacklog={onMoveToBacklog}
                             onDelete={onDelete}
@@ -212,8 +219,8 @@ export function WeekView({
   );
 }
 
-/** 모바일용: 해당 날짜의 모든 일정 (다일 포함) */
-function getMobileSchedules(date: Date, schedules: ScheduleRow[]): ScheduleRow[] {
+/** 모바일용: 해당 날짜의 모든 일정 (다일 포함, 우선순위 정렬) */
+function getMobileSchedules(date: Date, schedules: ScheduleRow[], categories: CategoryRow[]): ScheduleRow[] {
   const dateStr = format(date, 'yyyy-MM-dd');
   return schedules
     .filter((s) => {
@@ -221,7 +228,7 @@ function getMobileSchedules(date: Date, schedules: ScheduleRow[]): ScheduleRow[]
       if (s.date && s.end_date && s.date <= dateStr && s.end_date >= dateStr) return true;
       return false;
     })
-    .sort(compareByStatus);
+    .sort((a, b) => compareSchedulePriority(a, b, categories));
 }
 
 function WeekSpanBar({
@@ -231,6 +238,7 @@ function WeekSpanBar({
   laneHeight,
   onStatusChange,
   onClick,
+  onToggleImportant,
   onPostpone,
   onMoveToBacklog,
   onDelete,
@@ -241,6 +249,7 @@ function WeekSpanBar({
   laneHeight: number;
   onStatusChange: (id: number, status: string) => void;
   onClick: () => void;
+  onToggleImportant: (id: number) => void;
   onPostpone: (id: number) => void;
   onMoveToBacklog: (id: number) => void;
   onDelete: (id: number) => void;
@@ -349,6 +358,8 @@ function WeekSpanBar({
           <div className="shrink-0">
             <ActionMenu
               scheduleId={span.schedule.id}
+              important={span.schedule.important}
+              onToggleImportant={onToggleImportant}
               onPostpone={onPostpone}
               onMoveToBacklog={onMoveToBacklog}
               onDelete={onDelete}

--- a/web/src/features/schedule/hooks/use-schedules.ts
+++ b/web/src/features/schedule/hooks/use-schedules.ts
@@ -250,6 +250,28 @@ export function useSchedules() {
     }
   };
 
+  const handleToggleImportant = async (id: number) => {
+    const schedule = schedules.find((s) => s.id === id);
+    if (!schedule) return;
+    const newImportant = !schedule.important;
+    const prev = schedules;
+    setSchedules((s) => s.map((item) => (item.id === id ? { ...item, important: newImportant } : item)));
+    try {
+      const res = await fetch(`/api/schedules/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ important: newImportant }),
+      });
+      if (!res.ok) {
+        setSchedules(prev);
+        alert('중요 설정 변경에 실패했어');
+      }
+    } catch {
+      setSchedules(prev);
+      alert('중요 설정 변경에 실패했어');
+    }
+  };
+
   const handlePostpone = async (id: number) => {
     const schedule = schedules.find((s) => s.id === id);
     if (!schedule?.date) return;
@@ -334,6 +356,7 @@ export function useSchedules() {
     handleNext,
     handleToday,
     handleStatusChange,
+    handleToggleImportant,
     handleDateChange,
     handleEndDateChange,
     handleCreate,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -96,3 +96,33 @@ export function colorToHex(colorKey: string): string {
 }
 
 export const COLOR_OPTIONS = Object.keys(PRESET_COLORS);
+
+/** 기간 일정 여부 */
+export function isMultiDaySchedule(s: ScheduleRow): boolean {
+  return !!s.end_date && s.end_date !== s.date;
+}
+
+/** 일정 우선순위 정렬: 기간 일정 → 중요 → 카테고리순 → 상태순 */
+export function compareSchedulePriority(
+  a: ScheduleRow,
+  b: ScheduleRow,
+  categories: CategoryRow[],
+): number {
+  // 1. 기간 일정 최상위
+  const aMulti = isMultiDaySchedule(a);
+  const bMulti = isMultiDaySchedule(b);
+  if (aMulti !== bMulti) return aMulti ? -1 : 1;
+
+  // 2. 중요 일정 우선
+  if (a.important !== b.important) return a.important ? -1 : 1;
+
+  // 3. 카테고리 sort_order
+  const catA = categories.find((c) => c.name === a.category);
+  const catB = categories.find((c) => c.name === b.category);
+  const orderA = a.category ? (catA?.sort_order ?? 999) : 9999;
+  const orderB = b.category ? (catB?.sort_order ?? 999) : 9999;
+  if (orderA !== orderB) return orderA - orderB;
+
+  // 4. 상태순
+  return compareByStatus(a, b);
+}


### PR DESCRIPTION
## Summary
- ActionMenu에 ★ 중요 일정 설정/해제 토글 버튼 추가
- 일정 정렬 우선순위 개선: 기간 일정 → 중요 → 카테고리 그룹 (DayView, DayDetailPanel, WeekView 전체 적용)
- iOS Safari 날짜 input 오버플로우 수정 (`min-w-0` + `overflow-hidden`)

Closes #110

## Test plan
- [ ] DayView에서 중요 토글 버튼 동작 확인
- [ ] WeekView 데스크탑/모바일 모두 중요 토글 버튼 표시 확인
- [ ] 기간 일정이 항상 최상위에 정렬되는지 확인
- [ ] 중요 일정이 카테고리 무시하고 기간 일정 다음에 정렬되는지 확인
- [ ] iPhone Safari에서 날짜 필드 오버플로우 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)