### PR TITLE
feat: 크론 메시지 전면 개선 — Sonnet + 데이터 통합 + 프롬프트 분리

### DIFF
--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -34,7 +34,8 @@ import {
   buildSleepReminderText,
   buildSleepRecordedText,
 } from '../agents/life/blocks.js';
-import { pickMorningNudge, pickNightNudge } from '../shared/insights.js';
+// insights.ts 넛지는 제거 — Sonnet이 생활 맥락에서 직접 인사이트 도출
+// 복원 시: import { pickMorningNudge, pickNightNudge } from '../shared/insights.js';
 import { weeklyReportTask } from './weekly-report.js';
 import { buildLifeContext } from '../shared/life-context.js';
 import { publishHomeView, getCachedHomeUserId } from '../agents/life/home.js';
@@ -46,24 +47,58 @@ export interface LifeCronConfig {
 
 // ─── LLM 메시지 생성 ────────────────────────────────────
 
-const CRON_SYSTEM_PROMPT = `너는 '잔소리꾼'. 사용자의 루틴과 일정을 관리하는 친구.
+const CRON_BASE_PROMPT = `너는 '잔소리꾼'. 사용자의 루틴과 일정, 수면, 일기, 삶의 고민까지 종합적으로 파악하는 친구.
 ${CHARACTER_PROMPT}
 
-지금 크론 알림 메시지를 생성해. 한두 문장으로 짧게.
-- 데이터 기반으로 구체적이고 따뜻하게
-- 시스템 설명 없이 친구처럼 자연스럽게
-- "핵심 포인트"가 있으면 그걸 중심으로 자연스럽게 녹여서 말해
-- 시간 관계 주의: "어젯밤 수면 N시간"은 어제 밤의 수면량이야. 오늘 취침 시간과 혼동하지 마`;
+응답 포맷: Slack mrkdwn 문법.
+- 굵게: *텍스트* (별표 1개). **텍스트** 절대 금지.
+- 기울임: _텍스트_
+- 제목/헤더(# ## ###) 사용 금지.
+- 내용에 맞게 자연스러운 길이로 써. 억지로 짧게 줄이거나 늘리지 마.`;
+
+const MORNING_SYSTEM_PROMPT = `${CRON_BASE_PROMPT}
+
+지금은 아침이야. 오늘 하루를 시작하는 인사를 해줘.
+
+## 시제 가이드
+- "어젯밤 수면 N시간" → 어제 밤 수면량. 이미 지난 사실.
+- "어제 루틴 달성률" → 어제 결과. 이미 지난 사실.
+- "오늘 일정 N건" → 오늘 할 일. 아직 시작 전.
+- 밀린 일정/백로그 → 오늘 처리하자고 제안.
+
+## 데이터 해석 규칙
+- 제공된 데이터에 없는 내용은 추측하지 마. 데이터에 있는 것만 언급해.
+- 삶의 테마나 고민이 있으면 맥락에 맞게 한마디.
+- 운세 정보가 있으면 자연스럽게 하루 조언에 녹여.
+- 일기 내용이 있으면 어제 하루를 돌아보며 연결.`;
+
+const NIGHT_SYSTEM_PROMPT = `${CRON_BASE_PROMPT}
+
+지금은 밤 22시야. 하루를 마무리하는 메시지를 만들어줘.
+
+## 시제 가이드
+- "오늘 루틴 달성률" → 오늘 하루 결과.
+- "어젯밤 수면 N시간" → 어제 밤 수면. 오늘 취침과 혼동 금지.
+- 지금은 밤 10시. "일찍 자라"는 지금 바로 해당되는 조언이야.
+- "내일 일찍 자봐" 금지 → "오늘은 일찍 자봐"가 맞아.
+
+## 데이터 해석 규칙
+- 제공된 데이터에 없는 내용은 추측하지 마. 데이터에 있는 것만 언급해.
+- 수고했다는 느낌. 못 끝낸 건 내일 하자고 가볍게.
+- 일기 내용이 있으면 하루를 돌아보며 한마디.
+- 삶의 테마나 고민이 있으면 맥락에 맞게 따뜻하게.
+- 운세 정보가 있으면 하루를 되돌아보는 맥락에서 연결.`;
 
 /** LLM으로 크론 메시지 생성 (실패 시 fallback) */
 const generateCronMessage = async (
   llmClient: LLMClient,
+  systemPrompt: string,
   context: string,
   fallback: string,
 ): Promise<string> => {
   try {
     const messages: LLMMessage[] = [
-      { role: 'system', content: CRON_SYSTEM_PROMPT },
+      { role: 'system', content: systemPrompt },
       { role: 'user', content: context },
     ];
     const response = await llmClient.chat(messages);
@@ -175,10 +210,7 @@ const morningTask = async (app: App, config: LifeCronConfig): Promise<void> => {
   // 1. 오늘 기록 생성
   const created = await createTodayRecords(today);
 
-  // 2. 인사이트 넛지 감지 (LLM 컨텍스트에 통합하기 위해 먼저 실행)
-  const morningNudge = await pickMorningNudge(today);
-
-  // 3. 생활 맥락 + 어제 통계 + 넛지 → LLM 통합 인사
+  // 2. 생활 맥락 + 어제 통계 → Sonnet 통합 인사
   const yesterdayRecords = await queryTodayRecords(yesterday);
   const stats = calcRoutineStats(yesterdayRecords);
   const lifeContext = await buildLifeContext('morning');
@@ -192,11 +224,11 @@ const morningTask = async (app: App, config: LifeCronConfig): Promise<void> => {
       ? `어제 루틴 달성률: ${stats.rate}% (${stats.completed}/${stats.total})\n시간대별: ${slotText}${stats.weakestSlot ? `\n가장 약한 시간대: ${stats.weakestSlot}` : ''}`
       : '어제 루틴 기록이 없어.';
 
-  const nudgeContext = morningNudge ? `\n핵심 포인트: ${morningNudge}` : '';
-  const context = `아침 인사 생성해줘. 생활 맥락 기반으로 잔소리 포함해서.\n${baseContext}${lifeContext}${nudgeContext}`;
+  const context = `아침 인사 생성해줘.\n${baseContext}${lifeContext}`;
 
   const greeting = await generateCronMessage(
     config.llmClient,
+    MORNING_SYSTEM_PROMPT,
     context,
     stats.rate > 0
       ? `어제 루틴 ${stats.rate}%. 오늘도 힘내자!`
@@ -204,7 +236,7 @@ const morningTask = async (app: App, config: LifeCronConfig): Promise<void> => {
   );
   const greetingBlocks = buildMorningGreetingBlocks(greeting);
 
-  // 4. 아침 루틴 체크리스트
+  // 3. 아침 루틴 체크리스트
   const todayRecords = await queryTodayRecords(today);
   const hasMorning = todayRecords.some((r) => r.time_slot === '아침');
 
@@ -216,7 +248,7 @@ const morningTask = async (app: App, config: LifeCronConfig): Promise<void> => {
     await postBlockMessage(app.client, config.channelId, '아침 인사', greetingBlocks);
   }
 
-  // 4. 앱홈 능동 갱신 (날짜 전환 반영)
+  // 4. 앱홈 갱신 (날짜 전환 반영)
   const userId = getCachedHomeUserId();
   if (userId) {
     try {
@@ -272,21 +304,18 @@ const nightTask = async (app: App, config: LifeCronConfig): Promise<void> => {
 
   if (records.length === 0) return;
 
-  // 1. 인사이트 넛지 감지 (LLM 컨텍스트에 통합하기 위해 먼저 실행)
-  const nightNudge = await pickNightNudge(today);
-
-  // 2. 루틴 통계 + 생활 맥락 + 넛지 → LLM 통합 마무리 메시지
+  // 루틴 통계 + 생활 맥락 → Sonnet 통합 마무리 메시지
   const stats = calcRoutineStats(records);
   const lifeContext = await buildLifeContext('night');
   const slotText = Object.entries(stats.slotBreakdown)
     .map(([s, d]) => `${s} ${d.rate}%`)
     .join(', ');
 
-  const nudgeContext = nightNudge ? `\n핵심 포인트: ${nightNudge}` : '';
-  const context = `밤 마무리 메시지 생성해줘. 생활 맥락 기반으로 하루를 종합해서 잔소리 포함.\n오늘 루틴 달성률: ${stats.rate}% (${stats.completed}/${stats.total})\n시간대별: ${slotText}${lifeContext}${nudgeContext}`;
+  const context = `밤 마무리 메시지 생성해줘.\n오늘 루틴 달성률: ${stats.rate}% (${stats.completed}/${stats.total})\n시간대별: ${slotText}${lifeContext}`;
 
   const summary = await generateCronMessage(
     config.llmClient,
+    NIGHT_SYSTEM_PROMPT,
     context,
     stats.completed === stats.total
       ? '오늘 루틴 다 했어! 수고했어, 푹 쉬어.'

--- a/src/cron/weekly-report.ts
+++ b/src/cron/weekly-report.ts
@@ -438,7 +438,7 @@ const generateWeeklySummary = async (
   const { sleep, routine, schedule, correlation } = data;
 
   const context = [
-    `주간 리포트 데이터를 보고 한줄 총평을 생성해줘. 반말로, 따뜻하게.`,
+    `주간 리포트 데이터를 보고 총평을 써줘. 잘한 점은 칭찬하고, 개선할 점은 잔소리해. 반말로, 따뜻하게.`,
     `수면: 평균 ${Math.floor(sleep.avgDuration / 60)}시간 ${sleep.avgDuration % 60}분 (${sleep.recordCount}일)`,
     `루틴: ${routine.thisWeekRate}% (${routine.thisWeekCompleted}/${routine.thisWeekTotal})${routine.lastWeekRate != null ? `, 지난주 ${routine.lastWeekRate}%` : ''}`,
     `일정: 완료 ${schedule.completedCount}, 미완료 ${schedule.incompleteCount}`,
@@ -449,7 +449,7 @@ const generateWeeklySummary = async (
 
   try {
     const messages: LLMMessage[] = [
-      { role: 'system', content: `${CHARACTER_PROMPT}\n주간 리포트 데이터를 보고 한줄 총평만 써줘.` },
+      { role: 'system', content: `${CHARACTER_PROMPT}\n주간 리포트 데이터를 보고 총평 써줘. 잘한 점 칭찬, 개선점 잔소리. 자연스러운 길이로.` },
       { role: 'user', content: context },
     ];
     const response = await llmClient.chat(messages);

--- a/src/shared/__tests__/life-context.test.ts
+++ b/src/shared/__tests__/life-context.test.ts
@@ -42,7 +42,7 @@ const setupQueryMock = (overrides: Record<string, MockRow[]> = {}): void => {
     // sleep
     'sleep_type.*night.*date IN': [],
     'AVG.*duration_minutes': [],
-    'rn <= 3.*bedtime': [{ cnt: '0' }],
+    'AS is_late': [],
     'sleep_type.*nap.*date =': [{ nap_count: '0' }],
     // routine
     'routine_records.*routine_templates.*date =': [],
@@ -52,6 +52,12 @@ const setupQueryMock = (overrides: Record<string, MockRow[]> = {}): void => {
     'date.*\\+ 1.*end_date': [{ count: '0' }],
     "status = 'todo'.*date < ": [{ count: '0' }],
     "date IS NULL.*status = 'todo'": [{ count: '0' }],
+    // diary
+    'diary_entries.*date IN': [],
+    // life_themes
+    'life_themes.*active': [],
+    // fortune
+    'fortune_analyses.*daily': [],
   };
 
   const responses = { ...defaultResponses, ...overrides };
@@ -83,7 +89,11 @@ describe('buildLifeContext', () => {
         { date: '2026-03-09', bedtime: '01:30', wake_time: '07:00', duration_minutes: 330, sleep_type: 'night' },
       ],
       'AVG.*duration_minutes': [{ avg_duration: '360', avg_bedtime_hour: '25.5', count: '5' }],
-      'rn <= 3.*bedtime': [{ cnt: '3' }],
+      'AS is_late': [
+        { date: '2026-03-09', is_late: true },
+        { date: '2026-03-08', is_late: true },
+        { date: '2026-03-07', is_late: true },
+      ],
       'sleep_type.*nap.*date =': [{ nap_count: '1' }],
       'routine_records.*routine_templates.*date =': [{ total: '8', completed: '3' }],
       'AVG.*daily_rate': [{ avg_rate: '72' }],
@@ -120,7 +130,7 @@ describe('buildLifeContext', () => {
         { date: '2026-03-08', bedtime: '23:30', wake_time: '07:00', duration_minutes: 450, sleep_type: 'night' },
       ],
       'AVG.*duration_minutes': [{ avg_duration: '420', avg_bedtime_hour: '23.5', count: '3' }],
-      'rn <= 3.*bedtime': [{ cnt: '0' }],
+      'AS is_late': [{ date: '2026-03-08', is_late: false }],
       'routine_records.*routine_templates.*date =': [{ total: '10', completed: '8' }],
       'AVG.*daily_rate': [{ avg_rate: '75' }],
       "status != 'cancelled'.*end_date.*\\$1\\)": [{ total: '3', incomplete: '3' }],
@@ -163,6 +173,96 @@ describe('buildLifeContext', () => {
 
     const result = await buildLifeContext('conversation');
     expect(result).toContain('백로그 7건');
+  });
+
+  // ─── 연속 자정 이후 취침 패턴 ─────────────────────────
+
+  it('연속 자정 이후 취침: 실제 연속일 때만 표시', async () => {
+    setupQueryMock({
+      'AS is_late': [
+        { date: '2026-03-09', is_late: true },
+        { date: '2026-03-08', is_late: true },
+        { date: '2026-03-07', is_late: false },
+      ],
+    });
+
+    const result = await buildLifeContext('conversation');
+    expect(result).toContain('2일 연속 자정 이후 취침');
+  });
+
+  it('연속 자정 이후 취침: 첫 기록이 늦지 않으면 미표시', async () => {
+    setupQueryMock({
+      'AS is_late': [
+        { date: '2026-03-09', is_late: false },
+        { date: '2026-03-08', is_late: true },
+        { date: '2026-03-07', is_late: true },
+      ],
+    });
+
+    const result = await buildLifeContext('conversation');
+    expect(result).not.toContain('자정 이후');
+  });
+
+  it('연속 자정 이후 취침: 1일만이면 미표시', async () => {
+    setupQueryMock({
+      'AS is_late': [
+        { date: '2026-03-09', is_late: true },
+        { date: '2026-03-08', is_late: false },
+      ],
+    });
+
+    const result = await buildLifeContext('conversation');
+    expect(result).not.toContain('자정 이후');
+  });
+
+  // ─── 일기/테마/운세 맥락 ──────────────────────────────
+
+  it('일기 데이터가 있으면 일기 맥락 포함', async () => {
+    setupQueryMock({
+      'diary_entries.*date IN': [
+        { date: '2026-03-09', content: '오늘 면접 봤는데 긴장했다.' },
+      ],
+    });
+
+    const result = await buildLifeContext('conversation');
+    expect(result).toContain('일기:');
+    expect(result).toContain('오늘: 오늘 면접 봤는데 긴장했다.');
+  });
+
+  it('일기 200자 초과 시 잘림', async () => {
+    setupQueryMock({
+      'diary_entries.*date IN': [
+        { date: '2026-03-09', content: 'A'.repeat(250) },
+      ],
+    });
+
+    const result = await buildLifeContext('conversation');
+    expect(result).toContain('...');
+  });
+
+  it('테마 데이터가 있으면 삶의 테마 맥락 포함', async () => {
+    setupQueryMock({
+      'life_themes.*active': [
+        { theme: '이직 준비', category: 'career', detail: '기술 면접 준비 중' },
+      ],
+    });
+
+    const result = await buildLifeContext('conversation');
+    expect(result).toContain('삶의 테마:');
+    expect(result).toContain('[career] 이직 준비: 기술 면접 준비 중');
+  });
+
+  it('운세 데이터가 있으면 운세 맥락 포함', async () => {
+    setupQueryMock({
+      'fortune_analyses.*daily': [
+        { summary: '편관 운이 들어오는 날', advice: '무리하지 마' },
+      ],
+    });
+
+    const result = await buildLifeContext('conversation');
+    expect(result).toContain('오늘 운세:');
+    expect(result).toContain('편관 운이 들어오는 날');
+    expect(result).toContain('조언: 무리하지 마');
   });
 
   it('DB 오류 시 빈 문자열 반환', async () => {

--- a/src/shared/life-context.ts
+++ b/src/shared/life-context.ts
@@ -100,23 +100,24 @@ const queryWeekAvg = async ({ today }: DateParams): Promise<string | null> => {
   return `7일 평균 ${avgM > 0 ? `${avgH}시간 ${avgM}분` : `${avgH}시간`}`;
 };
 
-/** 최근 연속 자정 이후 취침 패턴 */
+/** 최근 연속 자정 이후 취침 패턴 (실제 연속 일수만 카운트) */
 const queryLateNightPattern = async ({ today }: DateParams): Promise<string | null> => {
-  const recentLate = await query<{ cnt: string }>(
-    `WITH ranked AS (
-       SELECT date, bedtime,
-              ROW_NUMBER() OVER (ORDER BY date DESC) as rn
-       FROM sleep_records
-       WHERE sleep_type = 'night' AND date >= ($1::date - 7) AND bedtime IS NOT NULL AND user_id = 1
-     )
-     SELECT COUNT(*)::text as cnt FROM ranked
-     WHERE rn <= 3
-       AND bedtime::time >= '00:00' AND bedtime::time < '06:00'`,
+  const result = await query<{ date: string; is_late: boolean }>(
+    `SELECT date::text,
+            (bedtime::time >= '00:00' AND bedtime::time < '06:00') AS is_late
+     FROM sleep_records
+     WHERE sleep_type = 'night' AND date >= ($1::date - 14) AND bedtime IS NOT NULL AND user_id = 1
+     ORDER BY date DESC
+     LIMIT 10`,
     [today],
   );
 
-  const lateDays = Number(recentLate.rows[0]?.cnt ?? 0);
-  return lateDays >= 2 ? `최근 ${lateDays}일 연속 자정 이후 취침` : null;
+  let consecutive = 0;
+  for (const row of result.rows) {
+    if (row.is_late) consecutive++;
+    else break;
+  }
+  return consecutive >= 2 ? `최근 ${consecutive}일 연속 자정 이후 취침` : null;
 };
 
 /** 오늘 낮잠 횟수 (morning 제외) */
@@ -271,6 +272,63 @@ const queryScheduleContext = async ({ today }: DateParams): Promise<string> => {
   return parts.length > 0 ? `일정: ${parts.join(', ')}.` : '';
 };
 
+// ─── 일기 맥락 ──────────────────────────────────────────
+
+/** 최근 일기 (오늘 + 어제, 각 200자 제한) */
+const queryDiaryContext = async ({ today, yesterday }: DateParams): Promise<string> => {
+  const result = await query<{ date: string; content: string }>(
+    `SELECT date::text, content FROM diary_entries
+     WHERE user_id = 1 AND date IN ($1, $2) ORDER BY date DESC`,
+    [today, yesterday],
+  );
+
+  if (result.rows.length === 0) return '';
+
+  const lines = result.rows.map((r) => {
+    const label = r.date === today ? '오늘' : '어제';
+    const content = r.content.length > 200 ? r.content.slice(0, 200) + '...' : r.content;
+    return `${label}: ${content}`;
+  });
+  return `일기: ${lines.join(' | ')}`;
+};
+
+// ─── 삶의 테마 맥락 ─────────────────────────────────────
+
+/** 활성 삶의 테마 (상위 5개, detail 80자 제한) */
+const queryLifeThemesContext = async (): Promise<string> => {
+  const result = await query<{ theme: string; category: string; detail: string | null }>(
+    `SELECT theme, category, detail FROM life_themes
+     WHERE active = true AND user_id = 1 ORDER BY mention_count DESC LIMIT 5`,
+  );
+
+  if (result.rows.length === 0) return '';
+
+  const lines = result.rows.map(
+    (r) => `[${r.category}] ${r.theme}${r.detail ? `: ${r.detail.slice(0, 80)}` : ''}`,
+  );
+  return `삶의 테마: ${lines.join('. ')}`;
+};
+
+// ─── 운세 맥락 ──────────────────────────────────────────
+
+/** 오늘 일운 요약 (summary + advice만) */
+const queryFortuneContext = async ({ today }: DateParams): Promise<string> => {
+  const result = await query<{ summary: string | null; advice: string | null }>(
+    `SELECT summary, advice FROM fortune_analyses
+     WHERE user_id = 1 AND date = $1 AND period = 'daily'
+     ORDER BY created_at DESC LIMIT 1`,
+    [today],
+  );
+
+  const row = result.rows[0];
+  if (!row) return '';
+
+  const parts: string[] = [];
+  if (row.summary) parts.push(row.summary);
+  if (row.advice) parts.push(`조언: ${row.advice}`);
+  return parts.length > 0 ? `오늘 운세: ${parts.join('. ')}` : '';
+};
+
 // ─── 통합 빌더 ──────────────────────────────────────────
 
 /**
@@ -285,13 +343,16 @@ export const buildLifeContext = async (timing: ContextTiming = 'conversation'): 
       yesterday: getYesterdayISO(),
     };
 
-    const [sleep, routine, schedule] = await Promise.all([
+    const [sleep, routine, schedule, diary, themes, fortune] = await Promise.all([
       querySleepContext(dates, timing),
       queryRoutineContext(dates, timing),
       queryScheduleContext(dates),
+      queryDiaryContext(dates),
+      queryLifeThemesContext(),
+      queryFortuneContext(dates),
     ]);
 
-    const lines = [sleep, routine, schedule].filter(Boolean);
+    const lines = [sleep, routine, schedule, diary, themes, fortune].filter(Boolean);
     if (lines.length === 0) return '';
 
     return `\n\n## 현재 생활 맥락\n${lines.join('\n')}`;

--- a/src/shared/llm.ts
+++ b/src/shared/llm.ts
@@ -166,21 +166,21 @@ export const createLLMClient = async (): Promise<LLMClient> => {
 
 /**
  * 크론 전용 LLM 클라이언트 생성.
- * Gemini Flash로 비용 절감 (단순 인사/요약 메시지 생성용).
- * GEMINI_API_KEY 미설정 시 메인 클라이언트로 폴백.
+ * Sonnet 사용 — 맥락 이해 + 시제 정확도가 크론 메시지 품질에 중요.
+ * Gemini Flash 복원 시: new GeminiLLMClient(CONFIG.llm.geminiApiKey, 'gemini-2.5-flash')
  */
 export const createCronLLMClient = async (): Promise<LLMClient> => {
   const { CONFIG } = await import('./config.js');
 
-  if (CONFIG.llm.geminiApiKey) {
+  if (CONFIG.llm.anthropicApiKey) {
     // eslint-disable-next-line no-console
-    console.log('[LLM] 크론용 Gemini Flash 클라이언트 생성');
-    return new GeminiLLMClient(CONFIG.llm.geminiApiKey, 'gemini-2.5-flash');
+    console.log('[LLM] 크론용 Sonnet 클라이언트 생성');
+    return new ClaudeLLMClient(CONFIG.llm.anthropicApiKey);
   }
 
-  // Gemini API 키 없으면 메인 클라이언트로 폴백
+  // Anthropic 키 없으면 메인 클라이언트로 폴백
   // eslint-disable-next-line no-console
-  console.log('[LLM] GEMINI_API_KEY 미설정 — 크론도 메인 LLM 사용');
+  console.log('[LLM] ANTHROPIC_API_KEY 미설정 — 크론도 메인 LLM 사용');
   return createLLMClient();
 };
 


### PR DESCRIPTION
## Summary
Closes #124

- **LLM 전환**: 크론 메시지 생성을 Gemini Flash → Claude Sonnet으로 변경 (맥락 이해 + 시제 정확도)
- **버그 수정**: `queryLateNightPattern` — 실제 연속 자정 이후 취침만 감지하도록 수정 (false positive 제거)
- **데이터 통합**: 일기(`diary_entries`), 삶의 테마(`life_themes`), 운세(`fortune_analyses`) 맥락을 크론 메시지에 통합
- **프롬프트 분리**: 아침/밤 전용 시스템 프롬프트 (시제 가이드 + 데이터 해석 규칙 포함)
- **인사이트 분리**: 크론에서 `insights.ts` 넛지 호출 제거 — Sonnet이 생활 맥락에서 직접 인사이트 도출
- **주간 총평**: 한줄 제한 해제, 자연스러운 길이로 칭찬/잔소리

## 변경 파일
| 파일 | 변경 |
|------|------|
| `src/shared/llm.ts` | `createCronLLMClient` → Sonnet 우선 |
| `src/shared/life-context.ts` | 연속 패턴 버그 수정 + 일기/테마/운세 쿼리 추가 |
| `src/cron/life-cron.ts` | 아침/밤 프롬프트 분리, insights 호출 제거 |
| `src/cron/weekly-report.ts` | 총평 프롬프트 개선 |
| `src/shared/__tests__/life-context.test.ts` | 연속 패턴 + 새 맥락 테스트 7건 추가 |

## Test plan
- [x] `yarn test` — 246개 전체 통과
- [x] `yarn lint` — 에러 0개
- [ ] 배포 후 아침/밤 크론 메시지 확인 (시제 정확도, 데이터 통합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)