### PR TITLE
feat: 대시보드 UX 개선 — 카테고리 태그, 주간뷰 여백, 메모 확대, 액션 메뉴 수정

### DIFF
--- a/web/src/components/ui/modal.tsx
+++ b/web/src/components/ui/modal.tsx
@@ -59,7 +59,7 @@ export function Modal({ open, onClose, title, children, onBeforeClose }: ModalPr
     <dialog
       ref={dialogRef}
       onClick={handleBackdropClick}
-      className="fixed inset-0 m-auto w-[calc(100vw-2rem)] max-w-lg overflow-hidden rounded-xl border-0 bg-white p-0 shadow-xl backdrop:bg-black/40"
+      className="fixed inset-0 m-auto max-h-[90vh] w-[calc(100vw-2rem)] max-w-lg overflow-hidden rounded-xl border-0 bg-white p-0 shadow-xl backdrop:bg-black/40"
     >
       <div onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
@@ -73,7 +73,9 @@ export function Modal({ open, onClose, title, children, onBeforeClose }: ModalPr
             </svg>
           </button>
         </div>
-        <div className="p-5">{children}</div>
+        <div className="overflow-y-auto p-5" style={{ maxHeight: 'calc(90vh - 57px)' }}>
+          {children}
+        </div>
       </div>
     </dialog>
   );

--- a/web/src/features/schedule/components/schedule-form.tsx
+++ b/web/src/features/schedule/components/schedule-form.tsx
@@ -2,7 +2,9 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import type { ScheduleRow, CategoryRow } from '@/lib/types';
-import { SCHEDULE_STATUSES, STATUS_LABELS } from '@/lib/types';
+import { SCHEDULE_STATUSES, STATUS_LABELS, getCategoryStyle } from '@/lib/types';
+
+const TAG_LIMIT = 8;
 
 interface ScheduleFormProps {
   schedule?: ScheduleRow | null;
@@ -170,18 +172,61 @@ export function ScheduleForm({
       {/* 카테고리 */}
       <div>
         <label className="mb-1 block text-xs text-gray-500">카테고리</label>
-        <select
-          value={category}
-          onChange={(e) => setCategory(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-        >
-          <option value="">없음</option>
-          {categories.map((c) => (
-            <option key={c.id} value={c.name}>
-              {c.name}
-            </option>
-          ))}
-        </select>
+        <div className="flex flex-wrap gap-1.5">
+          {/* 없음 버튼 */}
+          <button
+            type="button"
+            onClick={() => setCategory('')}
+            className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+              category === ''
+                ? 'bg-gray-200 ring-2 ring-gray-400 ring-offset-1'
+                : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+            }`}
+          >
+            없음
+          </button>
+          {/* 태그 버튼 (최대 TAG_LIMIT개) */}
+          {categories.slice(0, TAG_LIMIT).map((c) => {
+            const style = getCategoryStyle(c.color);
+            const selected = category === c.name;
+            return (
+              <button
+                key={c.id}
+                type="button"
+                onClick={() => setCategory(c.name)}
+                className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                  selected ? '' : 'opacity-60 hover:opacity-100'
+                }`}
+                style={{
+                  backgroundColor: style.bg,
+                  color: style.text,
+                  ...(selected
+                    ? { outline: `2px solid ${style.border}`, outlineOffset: '2px' }
+                    : {}),
+                }}
+              >
+                {c.name}
+              </button>
+            );
+          })}
+        </div>
+        {/* 초과분은 셀렉트 */}
+        {categories.length > TAG_LIMIT && (
+          <select
+            value={categories.slice(TAG_LIMIT).some((c) => c.name === category) ? category : ''}
+            onChange={(e) => {
+              if (e.target.value) setCategory(e.target.value);
+            }}
+            className="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+          >
+            <option value="">더보기...</option>
+            {categories.slice(TAG_LIMIT).map((c) => (
+              <option key={c.id} value={c.name}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
 
       {/* 중요 */}
@@ -214,8 +259,8 @@ export function ScheduleForm({
             value={memo}
             onChange={(e) => setMemo(e.target.value)}
             placeholder="메모 (선택)"
-            rows={3}
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none md:min-h-[140px]"
+            rows={6}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none md:min-h-[200px]"
           />
         ) : (
           <div className="max-h-[120px] overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 md:max-h-[200px]">

--- a/web/src/features/schedule/components/week-view.tsx
+++ b/web/src/features/schedule/components/week-view.tsx
@@ -59,7 +59,6 @@ export function WeekView({
   const weekStart = startOfWeek(currentDate, { weekStartsOn: WEEK_START });
   const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
   const layout = computeWeekLayout(days, schedules, categories);
-  const spanAreaHeight = layout.laneCount * LANE_HEIGHT;
 
   // 모바일: 오늘 날짜로 자동 스크롤 (뷰 진입, 오늘 버튼, 주 이동 시)
   useEffect(() => {
@@ -73,12 +72,13 @@ export function WeekView({
     <div className="flex flex-col md:flex-1">
       {/* 데스크탑: 가로 7열 + 스패닝 바 */}
       <div className="relative hidden bg-white md:grid md:flex-1 md:grid-cols-7">
-        {days.map((day) => {
+        {days.map((day, colIndex) => {
           const dateStr = format(day, 'yyyy-MM-dd');
           const daySingles = layout.singleDay.get(dateStr) ?? [];
           const today = isToday(day);
           const selected = selectedDate === dateStr;
           const dayOfWeek = day.getDay();
+          const daySpanHeight = layout.laneCountPerDay[colIndex]! * LANE_HEIGHT;
 
           return (
             <DroppableDay
@@ -106,8 +106,8 @@ export function WeekView({
                 </div>
               </div>
 
-              {/* 스패닝 바 공간 확보 */}
-              {spanAreaHeight > 0 && <div style={{ height: `${spanAreaHeight}px` }} />}
+              {/* 스패닝 바 공간 확보 — 해당 요일을 지나는 기간일정 레인 수만큼만 */}
+              {daySpanHeight > 0 && <div style={{ height: `${daySpanHeight}px` }} />}
 
               {/* 단일 일정 */}
               <div className="space-y-1.5">
@@ -325,7 +325,7 @@ function WeekSpanBar({
         ref={moveRef}
         {...moveListeners}
         {...moveAttrs}
-        className={`h-full overflow-hidden rounded-lg border p-3 transition hover:shadow-sm ${
+        className={`h-full overflow-visible rounded-lg border p-3 transition hover:shadow-sm ${
           STATUS_BG[span.schedule.status] ?? 'bg-white'
         } ${isOverdue ? 'border-red-300' : 'border-gray-200'}`}
       >

--- a/web/src/features/schedule/lib/__tests__/calendar-utils.test.ts
+++ b/web/src/features/schedule/lib/__tests__/calendar-utils.test.ts
@@ -43,6 +43,7 @@ describe('computeWeekLayout', () => {
     expect(result.spans).toHaveLength(0);
     expect(result.singleDay.size).toBe(0);
     expect(result.laneCount).toBe(0);
+    expect(result.laneCountPerDay).toEqual([0, 0, 0, 0, 0, 0, 0]);
   });
 
   // ─── 단일 일정 ─────────────────────────────────────
@@ -191,5 +192,42 @@ describe('computeWeekLayout', () => {
 
     expect(result.spans).toHaveLength(0);
     expect(result.singleDay.has('2026-03-10')).toBe(true);
+  });
+
+  // ─── laneCountPerDay ────────────────────────────────
+
+  it('기간일정이 지나는 요일만 레인 수를 가진다', () => {
+    // 화~수(col 1~2) 기간일정
+    const schedules = [
+      makeSchedule({ id: 1, date: '2026-03-10', end_date: '2026-03-11' }),
+    ];
+    const result = computeWeekLayout(weekDays, schedules);
+
+    // 월(0)=0, 화(1)=1, 수(2)=1, 목~일(3~6)=0
+    expect(result.laneCountPerDay).toEqual([0, 1, 1, 0, 0, 0, 0]);
+  });
+
+  it('겹치는 기간일정이 있는 요일은 더 높은 레인 수를 가진다', () => {
+    // 화~수(col 1~2) + 목~토(col 3~5) + 금~토(col 4~5)
+    const schedules = [
+      makeSchedule({ id: 1, date: '2026-03-10', end_date: '2026-03-11' }),
+      makeSchedule({ id: 2, date: '2026-03-12', end_date: '2026-03-14' }),
+      makeSchedule({ id: 3, date: '2026-03-13', end_date: '2026-03-14' }),
+    ];
+    const result = computeWeekLayout(weekDays, schedules);
+
+    // 월(0)=0, 화(1)=1, 수(2)=1, 목(3)=1, 금(4)=2, 토(5)=2, 일(6)=0
+    expect(result.laneCountPerDay).toEqual([0, 1, 1, 1, 2, 2, 0]);
+  });
+
+  it('겹치지 않는 기간일정이 같은 레인을 공유하면 각 요일 레인 수는 1이다', () => {
+    // 월~화(col 0~1) + 목~금(col 3~4) — 같은 레인 0
+    const schedules = [
+      makeSchedule({ id: 1, date: '2026-03-09', end_date: '2026-03-10' }),
+      makeSchedule({ id: 2, date: '2026-03-12', end_date: '2026-03-13' }),
+    ];
+    const result = computeWeekLayout(weekDays, schedules);
+
+    expect(result.laneCountPerDay).toEqual([1, 1, 0, 1, 1, 0, 0]);
   });
 });

--- a/web/src/features/schedule/lib/calendar-utils.ts
+++ b/web/src/features/schedule/lib/calendar-utils.ts
@@ -18,6 +18,8 @@ export interface WeekLayout {
   spans: WeekSpan[];
   singleDay: Map<string, ScheduleRow[]>;
   laneCount: number;
+  /** 요일별(0~6) 해당 열을 지나는 기간일정의 최대 레인 수 */
+  laneCountPerDay: number[];
 }
 
 /**
@@ -92,5 +94,14 @@ export function computeWeekLayout(weekDays: Date[], schedules: ScheduleRow[], ca
     items.sort((a, b) => compareSchedulePriority(a, b, categories));
   }
 
-  return { spans, singleDay, laneCount: lanes.length };
+  // 요일별 실제 사용된 레인 수 계산
+  const laneCountPerDay = Array.from({ length: 7 }, (_, col) => {
+    let maxLane = -1;
+    for (let l = 0; l < lanes.length; l++) {
+      if (lanes[l]![col]) maxLane = l;
+    }
+    return maxLane + 1;
+  });
+
+  return { spans, singleDay, laneCount: lanes.length, laneCountPerDay };
 }


### PR DESCRIPTION
## Summary
- 일정 수정 모달의 카테고리 `<select>` → 색상 배경 태그 버튼으로 교체 (8개 초과 시 셀렉트 유지)
- 주간뷰 기간일정 스페이서를 요일별 개별 높이로 계산하여 불필요 여백 제거
- 메모 textarea 높이 확대 (rows 3→6, min-height 140→200px) + 모달 max-height 90vh 스크롤
- WeekSpanBar overflow-hidden → overflow-visible로 액션 메뉴 잘림 수정

## 변경 파일
| 파일 | 변경 |
|------|------|
| `calendar-utils.ts` | `WeekLayout`에 `laneCountPerDay: number[]` 추가 |
| `week-view.tsx` | 요일별 개별 스페이서 + span bar overflow visible |
| `schedule-form.tsx` | 카테고리 태그 버튼 + 메모 높이 확대 |
| `modal.tsx` | max-height 90vh + overflow-y-auto |
| `calendar-utils.test.ts` | `laneCountPerDay` 테스트 3개 추가 (17개 통과) |

## Test plan
- [ ] 주간뷰에서 기간일정이 없는 요일의 여백이 줄어들었는지 확인
- [ ] 일정 수정 모달에서 카테고리가 색상 태그 버튼으로 표시되는지 확인
- [ ] 메모 textarea가 더 넓어졌는지 확인
- [ ] 기간일정 카드의 액션 메뉴가 잘리지 않는지 확인
- [ ] 모바일에서 모달 스크롤이 정상 동작하는지 확인

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)