### PR TITLE
fix: ActionMenu Portal 전환 — z-index 근본 해결

### DIFF
--- a/web/src/features/schedule/components/action-menu.tsx
+++ b/web/src/features/schedule/components/action-menu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 
 interface ActionMenuProps {
   scheduleId: number;
@@ -20,20 +21,44 @@ export function ActionMenu({
   onDelete,
 }: ActionMenuProps) {
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuPos, setMenuPos] = useState({ top: 0, left: 0 });
+
+  const updatePosition = useCallback(() => {
+    if (!buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setMenuPos({
+      top: rect.bottom + 4,
+      left: rect.right - 160, // w-40 = 160px, 오른쪽 정렬
+    });
+  }, []);
 
   useEffect(() => {
     if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    updatePosition();
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        menuRef.current && !menuRef.current.contains(e.target as Node) &&
+        buttonRef.current && !buttonRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
     };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
+
+    document.addEventListener('mousedown', handleClickOutside);
+    window.addEventListener('scroll', () => setOpen(false), true);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('scroll', () => setOpen(false), true);
+    };
+  }, [open, updatePosition]);
 
   return (
-    <div className="relative" ref={ref}>
+    <>
       <button
+        ref={buttonRef}
         onClick={(e) => {
           e.stopPropagation();
           setOpen(!open);
@@ -45,53 +70,59 @@ export function ActionMenu({
         </svg>
       </button>
 
-      {open && (
-        <div className="absolute right-0 z-50 mt-1 w-40 rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
-          {onToggleImportant && (
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="fixed z-[9999] w-40 rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+            style={{ top: menuPos.top, left: menuPos.left }}
+          >
+            {onToggleImportant && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setOpen(false);
+                  onToggleImportant(scheduleId);
+                }}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+              >
+                {important ? '중요 해제' : '중요 설정'}
+              </button>
+            )}
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 setOpen(false);
-                onToggleImportant(scheduleId);
+                onPostpone(scheduleId);
               }}
               className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
             >
-              {important ? '중요 해제' : '중요 설정'}
+              내일로 미루기
             </button>
-          )}
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setOpen(false);
-              onPostpone(scheduleId);
-            }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
-          >
-            내일로 미루기
-          </button>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setOpen(false);
-              onMoveToBacklog(scheduleId);
-            }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
-          >
-            백로그로 이동
-          </button>
-          <div className="my-1 border-t border-gray-100" />
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setOpen(false);
-              onDelete(scheduleId);
-            }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-500 hover:bg-red-50"
-          >
-            삭제
-          </button>
-        </div>
-      )}
-    </div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+                onMoveToBacklog(scheduleId);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+            >
+              백로그로 이동
+            </button>
+            <div className="my-1 border-t border-gray-100" />
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+                onDelete(scheduleId);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-500 hover:bg-red-50"
+            >
+              삭제
+            </button>
+          </div>,
+          document.body,
+        )}
+    </>
   );
 }

--- a/web/src/features/schedule/components/week-view.tsx
+++ b/web/src/features/schedule/components/week-view.tsx
@@ -109,8 +109,8 @@ export function WeekView({
               {/* 스패닝 바 공간 확보 — 해당 요일을 지나는 기간일정 레인 수만큼만 */}
               {daySpanHeight > 0 && <div style={{ height: `${daySpanHeight}px` }} />}
 
-              {/* 단일 일정 — z-[20]로 span bar(z-10) 위에 표시 */}
-              <div className="relative z-[20] space-y-1.5">
+              {/* 단일 일정 */}
+              <div className="space-y-1.5">
                 {daySingles.map((s) => (
                   <DraggableCard
                     key={s.id}


### PR DESCRIPTION
## Summary
- ActionMenu 드롭다운을 `createPortal`로 `document.body`에 렌더링
- CSS stacking context 문제 근본 해결 — span bar/단일 일정 어디서든 메뉴가 항상 최상위 표시
- week-view 단일 일정 컨테이너의 `z-[20]` 제거 (Portal이 해결하므로 불필요)

## 원인
span bar(`z-10`) 안의 ActionMenu(`z-50`)가 단일 일정 컨테이너(`z-[20]`) 아래로 묻히는 문제.
CSS stacking context 특성상 자식의 z-index는 부모의 stacking context 안에 갇힘.
z-index 조절로는 해결 불가 → Portal로 DOM 트리에서 완전히 분리.

## Test plan
- [x] TypeScript 빌드 통과
- [x] 17개 테스트 통과
- [ ] span bar 액션 메뉴가 단일 일정 카드 위에 표시되는지 확인
- [ ] 단일 일정 카드 액션 메뉴가 정상 동작하는지 확인
- [ ] 스크롤 시 메뉴가 자동으로 닫히는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)