### PR TITLE
fix: 주간뷰 스페이서를 열별 실제 레인 수로 계산

### DIFF
--- a/web/src/features/schedule/lib/__tests__/calendar-utils.test.ts
+++ b/web/src/features/schedule/lib/__tests__/calendar-utils.test.ts
@@ -207,8 +207,8 @@ describe('computeWeekLayout', () => {
     expect(result.laneCountPerDay).toEqual([0, 1, 1, 0, 0, 0, 0]);
   });
 
-  it('기간일정이 있는 요일은 전체 laneCount를 사용한다', () => {
-    // 화~수(col 1~2) + 목~토(col 3~5) + 금~토(col 4~5) → laneCount=2
+  it('겹치는 기간일정이 있는 요일만 높은 레인 수를 가진다', () => {
+    // 화~수(col 1~2) lane0 + 목~토(col 3~5) lane0 + 금~토(col 4~5) lane1
     const schedules = [
       makeSchedule({ id: 1, date: '2026-03-10', end_date: '2026-03-11' }),
       makeSchedule({ id: 2, date: '2026-03-12', end_date: '2026-03-14' }),
@@ -216,8 +216,8 @@ describe('computeWeekLayout', () => {
     ];
     const result = computeWeekLayout(weekDays, schedules);
 
-    // 기간일정이 지나는 열은 전부 laneCount(2), 없는 열은 0
-    expect(result.laneCountPerDay).toEqual([0, 2, 2, 2, 2, 2, 0]);
+    // 월(0)=0, 화(1)=1, 수(2)=1, 목(3)=1, 금(4)=2, 토(5)=2, 일(6)=0
+    expect(result.laneCountPerDay).toEqual([0, 1, 1, 1, 2, 2, 0]);
   });
 
   it('겹치지 않는 기간일정이 같은 레인을 공유하면 각 요일 레인 수는 1이다', () => {

--- a/web/src/features/schedule/lib/calendar-utils.ts
+++ b/web/src/features/schedule/lib/calendar-utils.ts
@@ -94,10 +94,13 @@ export function computeWeekLayout(weekDays: Date[], schedules: ScheduleRow[], ca
     items.sort((a, b) => compareSchedulePriority(a, b, categories));
   }
 
-  // 요일별 스페이서: 기간일정이 지나는 열은 전체 laneCount, 없는 열은 0
+  // 요일별 스페이서: 해당 열을 실제로 점유하는 최대 레인 수
   const laneCountPerDay = Array.from({ length: 7 }, (_, col) => {
-    const hasSpan = lanes.some((lane) => lane[col]);
-    return hasSpan ? lanes.length : 0;
+    let maxLane = -1;
+    for (let l = 0; l < lanes.length; l++) {
+      if (lanes[l]![col]) maxLane = l;
+    }
+    return maxLane + 1;
   });
 
   return { spans, singleDay, laneCount: lanes.length, laneCountPerDay };


### PR DESCRIPTION
## Summary
- laneCountPerDay를 전체 laneCount 대신 해당 열의 실제 최대 레인 수로 계산
- 금토에만 겹치는 기간일정이 월화수목에 불필요한 여백을 만들지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)