### PR TITLE
Slack 일정 표시 전면 수정 — 메모 제거 + event 타입 분리

### DIFF
--- a/db/migrations/022_category_event_type.sql
+++ b/db/migrations/022_category_event_type.sql
@@ -1,0 +1,2 @@
+-- 약속 카테고리를 event 타입으로 변경
+UPDATE categories SET type = 'event' WHERE name = '약속';

--- a/src/agents/life/__tests__/blocks.test.ts
+++ b/src/agents/life/__tests__/blocks.test.ts
@@ -35,6 +35,7 @@ const makeSchedule = (overrides: Partial<ScheduleRow> = {}): ScheduleRow => ({
   end_date: null,
   status: 'todo',
   category: '업무',
+  category_type: 'task',
   memo: null,
   important: false,
   ...overrides,
@@ -239,29 +240,53 @@ describe('buildScheduleBlocks', () => {
     expect(textContent).toContain('보고서');
   });
 
-  it('overflow 메뉴 포함 (약속 제외)', () => {
+  it('task 항목에 전체 overflow 메뉴 포함', () => {
     const items = [
       makeSchedule({ id: 1, title: '회의', category: '업무' }),
-      makeSchedule({ id: 2, title: '점심 약속', category: '약속' }),
     ];
 
     const { blocks } = buildScheduleBlocks(items, '2026-03-08');
 
-    // overflow가 있는 블록 (업무 항목)
     const overflowBlocks = blocks.filter((b) => b.type === 'section' && 'accessory' in b);
     expect(overflowBlocks.length).toBe(1);
 
     if (overflowBlocks[0] && 'accessory' in overflowBlocks[0]) {
-      const accessory = overflowBlocks[0].accessory as { action_id: string };
+      const accessory = overflowBlocks[0].accessory as { action_id: string; options: Array<{ text: { text: string } }> };
       expect(accessory.action_id).toBe(SCHEDULE_ACTION_ID);
+      const labels = accessory.options.map((o) => o.text.text);
+      expect(labels).toContain('완료');
+      expect(labels).toContain('내일로 미루기');
     }
   });
 
-  it('완료 통계 (약속 제외)', () => {
+  it('event 타입은 📅 접두어 + 중요/삭제 overflow만', () => {
+    const items = [
+      makeSchedule({ id: 1, title: '팀 회의', category: '약속', category_type: 'event' }),
+    ];
+
+    const { blocks } = buildScheduleBlocks(items, '2026-03-08');
+
+    // 📅 접두어 확인
+    const sectionTexts = blocks
+      .filter((b) => b.type === 'section')
+      .map((b) => ('text' in b ? (b.text as { text: string }).text : ''));
+    expect(sectionTexts.some((t) => t.includes('📅 팀 회의'))).toBe(true);
+
+    // overflow에 중요/삭제만 있어야 함
+    const overflowBlocks = blocks.filter((b) => b.type === 'section' && 'accessory' in b);
+    expect(overflowBlocks.length).toBe(1);
+    if (overflowBlocks[0] && 'accessory' in overflowBlocks[0]) {
+      const accessory = overflowBlocks[0].accessory as { options: Array<{ text: { text: string } }> };
+      const labels = accessory.options.map((o) => o.text.text);
+      expect(labels).toEqual(['중요 표시', '삭제하기']);
+    }
+  });
+
+  it('완료 통계 (event 타입 제외)', () => {
     const items = [
       makeSchedule({ id: 1, status: 'done' }),
       makeSchedule({ id: 2, title: '보고서', status: 'todo' }),
-      makeSchedule({ id: 3, title: '점심', category: '약속' }),
+      makeSchedule({ id: 3, title: '점심', category: '약속', category_type: 'event' }),
     ];
 
     const { blocks } = buildScheduleBlocks(items, '2026-03-08');
@@ -274,22 +299,16 @@ describe('buildScheduleBlocks', () => {
     }
   });
 
-  it('메모가 있으면 context 블록으로 표시', () => {
+  it('메모가 있어도 표시하지 않음', () => {
     const items = [makeSchedule({ id: 1, title: '회의', memo: '자료 준비 필요' })];
 
     const { blocks } = buildScheduleBlocks(items, '2026-03-08');
-
-    const sectionText = blocks
-      .filter((b) => b.type === 'section')
-      .map((b) => ('text' in b ? (b.text as { text: string }).text : ''))
-      .join(' ');
-    expect(sectionText).toContain('회의');
 
     const contextTexts = blocks
       .filter((b) => b.type === 'context')
       .map((b) => ('elements' in b ? (b.elements as Array<{ text: string }>)[0]?.text : ''))
       .join(' ');
-    expect(contextTexts).toContain('자료 준비 필요');
+    expect(contextTexts).not.toContain('자료 준비 필요');
   });
 
   it('compact 모드: overflow 메뉴 없이 렌더링', () => {
@@ -299,30 +318,6 @@ describe('buildScheduleBlocks', () => {
 
     const overflowBlocks = blocks.filter((b) => b.type === 'section' && 'accessory' in b);
     expect(overflowBlocks).toHaveLength(0);
-  });
-
-  it('완료 일정 메모에 취소선 적용', () => {
-    const items = [makeSchedule({ id: 1, title: '발송', status: 'done', memo: '택배 3건' })];
-
-    const { blocks } = buildScheduleBlocks(items, '2026-03-08');
-    const contextTexts = blocks
-      .filter((b) => b.type === 'context')
-      .map((b) => ('elements' in b ? (b.elements as Array<{ text: string }>)[0]?.text : ''));
-
-    expect(contextTexts.some((t) => t.includes('~택배 3건~'))).toBe(true);
-  });
-
-  it('메모가 없으면 └ 미표시', () => {
-    const items = [makeSchedule({ id: 1, title: '회의', memo: null })];
-
-    const { blocks } = buildScheduleBlocks(items, '2026-03-08');
-    const textContent = blocks
-      .filter((b) => b.type === 'section')
-      .map((b) => ('text' in b ? (b.text as { text: string }).text : ''))
-      .join(' ');
-
-    expect(textContent).toContain('회의');
-    expect(textContent).not.toContain('└');
   });
 
   it('미분류 카테고리 맨 끝', () => {

--- a/src/agents/life/__tests__/home.test.ts
+++ b/src/agents/life/__tests__/home.test.ts
@@ -98,6 +98,7 @@ describe('publishHomeView', () => {
         end_date: null,
         status: 'todo',
         category: '업무',
+        category_type: 'task',
         memo: null,
         important: false,
       },

--- a/src/agents/life/blocks.ts
+++ b/src/agents/life/blocks.ts
@@ -254,10 +254,17 @@ const groupByCategory = (items: ScheduleRow[]): CategoryGroup[] => {
   }
 
   const result: CategoryGroup[] = [];
-  // 알파벳순, 미분류 맨 끝
+  // event 카테고리 상단 → 알파벳순 → 미분류 맨 끝
+  const isEventCategory = (cat: string): boolean => {
+    const first = categoryMap.get(cat)?.[0];
+    return first?.category_type === 'event';
+  };
   const categories = [...categoryMap.keys()].sort((a, b) => {
     if (a === '미분류') return 1;
     if (b === '미분류') return -1;
+    const aEvent = isEventCategory(a) ? 0 : 1;
+    const bEvent = isEventCategory(b) ? 0 : 1;
+    if (aEvent !== bEvent) return aEvent - bEvent;
     return a.localeCompare(b, 'ko');
   });
 
@@ -274,10 +281,12 @@ const groupByCategory = (items: ScheduleRow[]): CategoryGroup[] => {
   return result;
 };
 
+/** event 타입 판별 (categories.type = 'event') */
+const isEventType = (item: ScheduleRow): boolean =>
+  item.category_type === 'event';
+
 /** 일정 항목 제목 포맷 (메모 제외) */
 const formatScheduleTitle = (item: ScheduleRow): string => {
-  const isAppointment = item.category === '약속';
-
   // 기간 일정 표시
   let rangePart = '';
   if (item.date && item.end_date) {
@@ -287,7 +296,7 @@ const formatScheduleTitle = (item: ScheduleRow): string => {
   // 중요 표시 (제목 뒤)
   const star = item.important ? ' ★' : '';
 
-  if (isAppointment) return `${item.title}${rangePart}${star}`;
+  if (isEventType(item)) return `📅 ${item.title}${rangePart}${star}`;
   if (item.status === 'done') return `~${item.title}~${rangePart}${star}`;
   if (item.status === 'in-progress') return `► ${item.title}${rangePart}${star}`;
   return `${item.title}${rangePart}${star}`;
@@ -347,14 +356,20 @@ const buildOverflowOptions = (
   return options;
 };
 
-/** 메모 텍스트에 취소선 적용 (완료 일정용) */
-const formatMemoWithStrike = (memo: string, isDone: boolean): string =>
-  isDone
-    ? memo
-        .split('\n')
-        .map((l) => `~${l}~`)
-        .join('\n')
-    : memo;
+/** event 전용 overflow: 중요 표시 + 삭제만 */
+const buildEventOverflowOptions = (
+  item: ScheduleRow,
+  targetDate: string,
+): Array<{ text: { type: 'plain_text'; text: string }; value: string }> => [
+  {
+    text: { type: 'plain_text' as const, text: item.important ? '중요 해제' : '중요 표시' },
+    value: encodeOverflowValue(item.id, TOGGLE_IMPORTANT_ACTION, targetDate),
+  },
+  {
+    text: { type: 'plain_text' as const, text: '삭제하기' },
+    value: encodeOverflowValue(item.id, DELETE_ACTION, targetDate),
+  },
+];
 
 /** backlog 전용 overflow: "오늘로 이동" + "삭제" */
 const buildBacklogOverflowOptions = (
@@ -375,11 +390,10 @@ export const buildScheduleBlocks = (
   items: ScheduleRow[],
   targetDate: string,
   headerText?: string,
-  options?: { compact?: boolean; backlog?: boolean; hideCompletedMemo?: boolean },
+  options?: { compact?: boolean; backlog?: boolean },
 ): { text: string; blocks: KnownBlock[] } => {
   const blocks: KnownBlock[] = [];
   const backlog = options?.backlog ?? false;
-  const hideCompletedMemo = options?.hideCompletedMemo ?? false;
   const formatted = backlog ? '' : formatDateShort(targetDate);
   const compact = options?.compact ?? false;
   const headerLabel = backlog
@@ -399,17 +413,8 @@ export const buildScheduleBlocks = (
       text: { type: 'mrkdwn', text: `*[${group.category}]*` },
     });
 
-    const addMemoContext = (memo: string | null, isDone: boolean): void => {
-      if (!memo) return;
-      if (hideCompletedMemo && isDone) return;
-      blocks.push({
-        type: 'context',
-        elements: [{ type: 'mrkdwn', text: formatMemoWithStrike(memo, isDone) }],
-      });
-    };
-
     if (compact) {
-      // compact: overflow 없이, 메모 있는 항목은 개별 섹션+context
+      // compact: overflow 없이
       const batch: string[] = [];
       const flushBatch = (): void => {
         if (batch.length === 0) return;
@@ -421,35 +426,23 @@ export const buildScheduleBlocks = (
       };
 
       for (const item of group.items) {
-        const titleText = formatScheduleTitle(item);
-        if (item.memo) {
-          flushBatch();
-          blocks.push({
-            type: 'section',
-            text: { type: 'mrkdwn', text: titleText },
-          });
-          addMemoContext(item.memo, item.status === 'done');
-        } else {
-          batch.push(titleText);
-        }
+        batch.push(formatScheduleTitle(item));
       }
       flushBatch();
     } else {
       // full: overflow 메뉴 포함
-      const noOverflowLines: { title: string; memo: string | null; isDone: boolean }[] = [];
+      const noOverflowLines: string[] = [];
 
       const flushNoOverflow = (): void => {
         if (noOverflowLines.length === 0) return;
         blocks.push({
           type: 'section',
-          text: { type: 'mrkdwn', text: noOverflowLines.map((l) => l.title).join('\n') },
+          text: { type: 'mrkdwn', text: noOverflowLines.join('\n') },
         });
-        for (const l of noOverflowLines) addMemoContext(l.memo, l.isDone);
         noOverflowLines.length = 0;
       };
 
       for (const item of group.items) {
-        const isAppointment = item.category === '약속';
         const titleText = formatScheduleTitle(item);
 
         if (backlog) {
@@ -464,14 +457,22 @@ export const buildScheduleBlocks = (
               options: buildBacklogOverflowOptions(item),
             },
           });
-          addMemoContext(item.memo, item.status === 'done');
-        } else if (isAppointment || !item.status) {
-          noOverflowLines.push({
-            title: titleText,
-            memo: item.memo,
-            isDone: item.status === 'done',
+        } else if (isEventType(item)) {
+          // event: 중요/삭제만
+          flushNoOverflow();
+          blocks.push({
+            type: 'section',
+            text: { type: 'mrkdwn', text: titleText },
+            accessory: {
+              type: 'overflow',
+              action_id: SCHEDULE_ACTION_ID,
+              options: buildEventOverflowOptions(item, targetDate),
+            },
           });
+        } else if (!item.status) {
+          noOverflowLines.push(titleText);
         } else {
+          // task: 전체 상태변경
           flushNoOverflow();
           blocks.push({
             type: 'section',
@@ -482,7 +483,6 @@ export const buildScheduleBlocks = (
               options: buildOverflowOptions(item, targetDate),
             },
           });
-          addMemoContext(item.memo, item.status === 'done');
         }
       }
 
@@ -490,8 +490,8 @@ export const buildScheduleBlocks = (
     }
   }
 
-  // 하단 통계 — 약속 제외
-  const tasks = items.filter((i) => i.category !== '약속');
+  // 하단 통계 — event 타입 제외
+  const tasks = items.filter((i) => !isEventType(i));
   const done = tasks.filter((i) => i.status === 'done').length;
 
   blocks.push({
@@ -522,17 +522,6 @@ export const buildScheduleText = (
     lines.push(`[${group.category}]`);
     for (const item of group.items) {
       lines.push(formatScheduleTitle(item));
-      if (item.memo) {
-        const isDone = item.status === 'done';
-        const memoLines = item.memo.split('\n');
-        if (isDone) {
-          lines.push(`~└ ${memoLines[0]}~`);
-          for (let i = 1; i < memoLines.length; i++) lines.push(`~  ${memoLines[i]}~`);
-        } else {
-          lines.push(`└ ${memoLines[0]}`);
-          for (let i = 1; i < memoLines.length; i++) lines.push(`  ${memoLines[i]}`);
-        }
-      }
     }
     lines.push('');
   }
@@ -540,10 +529,10 @@ export const buildScheduleText = (
   return lines.join('\n').trimEnd();
 };
 
-/** 밤 미완료 일정 텍스트 (없으면 null) */
+/** 밤 미완료 일정 텍스트 (없으면 null) — event 타입 제외 */
 export const buildNightScheduleText = (items: ScheduleRow[], targetDate: string): string | null => {
   const incomplete = items.filter(
-    (s) => s.category !== '약속' && s.status !== 'done' && s.status !== 'cancelled',
+    (s) => !isEventType(s) && s.status !== 'done' && s.status !== 'cancelled',
   );
   if (incomplete.length === 0) return null;
   return buildScheduleText(

--- a/src/agents/life/home.ts
+++ b/src/agents/life/home.ts
@@ -71,7 +71,7 @@ export const publishHomeView = async (
   // 일정 섹션
   blocks.push({ type: 'divider' });
   if (schedules.length > 0) {
-    const { blocks: scheduleBlocks } = buildScheduleBlocks(schedules, today, undefined, { hideCompletedMemo: true });
+    const { blocks: scheduleBlocks } = buildScheduleBlocks(schedules, today);
     blocks.push(...scheduleBlocks);
   } else {
     blocks.push({

--- a/src/agents/life/prompt.ts
+++ b/src/agents/life/prompt.ts
@@ -86,6 +86,7 @@ ${lifeContext}
 
 ## DB 스키마 (모든 테이블에 id SERIAL PK, created_at TIMESTAMPTZ, user_id INTEGER 있음)
 - schedules: user_id, title, date(DATE), end_date, status(todo/in-progress/done/cancelled), category, memo, important(bool)
+- categories: name(UNIQUE), type('task'/'event'), color, sort_order
 - routine_templates: user_id, name, time_slot(아침/점심/저녁/밤), frequency(매일/격일/3일마다/주1회), active
 - routine_records: user_id, template_id(FK), date, completed, completed_at(완료 시점), memo
 - sleep_records: user_id, date, bedtime, wake_time, duration_minutes, sleep_type(night/nap), memo
@@ -100,9 +101,6 @@ ${lifeContext}
 - INSERT: user_id 컬럼에 1 포함
 - UPDATE/DELETE: WHERE user_id = 1 AND ...
 이 규칙은 sleep_events, notification_settings, reminders를 제외한 모든 테이블에 적용.
-
-## ⚠️ 절대 규칙: 완료 일정 메모 숨김
-status='done'인 일정의 memo는 어떤 상황에서든 표시하지 마. 사용자가 명시적으로 "완료된 일정 메모 보여줘"라고 요청할 때만 예외. 이 규칙은 매 응답마다 적용해.
 
 ## 일정 조회 SQL — 3대 필수 규칙
 
@@ -119,8 +117,8 @@ SELECT *, EXTRACT(DOW FROM date) as dow FROM schedules WHERE ...
 위의 날짜 참조표에 있는 날짜는 참조해도 돼. 그 외 날짜는 반드시 SQL.
 
 ### 3. 정렬 순서
-카테고리 내에서 완료 → 진행중 → 할일 순서. 반드시 이 ORDER BY 사용:
-ORDER BY category NULLS LAST, CASE status WHEN 'done' THEN 1 WHEN 'in-progress' THEN 2 WHEN 'todo' THEN 3 END, title
+event 타입 상단 + 카테고리 내에서 완료 → 진행중 → 할일 순서. 반드시 이 ORDER BY 사용:
+ORDER BY CASE WHEN c.type = 'event' THEN 0 ELSE 1 END, s.category NULLS LAST, CASE s.status WHEN 'done' THEN 1 WHEN 'in-progress' THEN 2 WHEN 'todo' THEN 3 END, s.title
 
 ### 일정 등록 시 날짜 계산
 - "다음 월요일", "이번 주 금요일" 등 요일 기반 날짜는 절대 직접 계산하지 마.
@@ -132,23 +130,24 @@ ORDER BY category NULLS LAST, CASE status WHEN 'done' THEN 1 WHEN 'in-progress' 
 일정 목록을 보여줄 때 아래 포맷을 따라 (Slack mrkdwn):
 - 카테고리별로 그룹화. 카테고리 헤더: *[카테고리명]*
 - SQL 결과 순서 그대로 표시해 (위 ORDER BY가 정렬을 보장).
-- 상태 표시: ► 진행중(in-progress), ~취소선~ 완료(done).
+- 할일(task) 타입: ► 진행중(in-progress), ~취소선~ 완료(done).
+- 일정(event) 타입: 📅 접두어. 상태 표시 안 함. 달성률/완료 통계에서 제외.
+- categories.type = 'event'인 카테고리가 일정 타입이야. 조회할 때 LEFT JOIN categories c ON c.name = s.category 해서 c.type으로 확인해.
 - 중요 표시: 제목 뒤에 ★ (important=true일 때만).
 - 기간 일정(end_date 있음): 제목 옆에 M/D(요일)~M/D(요일).
-- 메모: 제목 아래 └ 접두어. **완료(done) 일정의 메모는 절대 표시하지 마. status='done'이면 memo 무조건 생략.**
+- 메모 표시 안 함 (웹 대시보드에서 확인).
 - 카테고리 사이는 빈 줄.
 예시:
-*[개인]*
-분리수거
-└ 오전에 하기
+*[약속]*
+📅 팀 회의
+📅 치과 예약 ★
 *[사업]*
 ~발송 완료~
-► 제품 포장 3/7(토)~3/8(일)
+► 제품 포장
 포장카드 주문하기 ★
-└ 디자인 시안 3개 중 선택
 
 ## 일정/백로그 규칙
-- 메모: schedules.memo. "메모 추가" → UPDATE, "메모 삭제" → NULL. 원문 그대로 저장.
+- 메모: schedules.memo. "메모 추가" → UPDATE, "메모 삭제" → NULL. 원문 그대로 저장. 단, 응답에 메모 내용은 표시하지 마.
 - 변경 후: 해당 날짜 전체 일정을 3대 필수 규칙으로 조회해서 보여줘. 잔소리 한 문장.
 - 백로그: date IS NULL인 일정. 표시 포맷 동일, 날짜 범위 없음.
 

--- a/src/shared/life-context.ts
+++ b/src/shared/life-context.ts
@@ -210,13 +210,17 @@ const queryRoutineContext = async (dates: DateParams, timing: ContextTiming): Pr
 const queryScheduleContext = async ({ today }: DateParams): Promise<string> => {
   const parts: string[] = [];
 
-  // 오늘 일정 (전체 + 미완료)
+  // 오늘 일정 (전체 + 미완료 — event 타입은 미완료에서 제외)
   const todayResult = await query<{ total: string; incomplete: string }>(
     `SELECT COUNT(*)::text as total,
-            COUNT(*) FILTER (WHERE status = 'todo' OR status = 'in-progress')::text as incomplete
-     FROM schedules
-     WHERE status != 'cancelled' AND user_id = 1
-       AND (date = $1 OR (date <= $1 AND end_date >= $1))`,
+            COUNT(*) FILTER (
+              WHERE (s.status = 'todo' OR s.status = 'in-progress')
+                AND COALESCE(c.type, 'task') = 'task'
+            )::text as incomplete
+     FROM schedules s
+     LEFT JOIN categories c ON c.name = s.category
+     WHERE s.status != 'cancelled' AND s.user_id = 1
+       AND (s.date = $1 OR (s.date <= $1 AND s.end_date >= $1))`,
     [today],
   );
 

--- a/src/shared/life-queries.ts
+++ b/src/shared/life-queries.ts
@@ -34,6 +34,7 @@ export interface ScheduleRow {
   end_date: string | null;
   status: string;
   category: string | null;
+  category_type: string | null;
   memo: string | null;
   important: boolean;
 }
@@ -163,27 +164,33 @@ export const completeRecord = async (id: number): Promise<void> => {
 
 // ─── 일정 쿼리 ──────────────────────────────────────────
 
-/** 특정 날짜의 일정 조회 (당일 + 기간 일정 포함) */
+/** 특정 날짜의 일정 조회 (당일 + 기간 일정 포함, categories JOIN) */
 export const queryTodaySchedules = async (today: string): Promise<ScheduleRow[]> =>
   (
     await query<ScheduleRow>(
-      `SELECT id, title, date::text, end_date::text, status, category, memo, important
-     FROM schedules
-     WHERE status != 'cancelled' AND user_id = 1
-       AND (date = $1 OR (date <= $1 AND end_date >= $1))
-     ORDER BY category NULLS LAST, status, title`,
+      `SELECT s.id, s.title, s.date::text, s.end_date::text, s.status,
+              s.category, c.type AS category_type, s.memo, s.important
+     FROM schedules s
+     LEFT JOIN categories c ON c.name = s.category
+     WHERE s.status != 'cancelled' AND s.user_id = 1
+       AND (s.date = $1 OR (s.date <= $1 AND s.end_date >= $1))
+     ORDER BY
+       CASE WHEN c.type = 'event' THEN 0 ELSE 1 END,
+       s.category NULLS LAST, s.status, s.title`,
       [today],
     )
   ).rows;
 
-/** 백로그 일정 조회 (날짜 미지정 항목) */
+/** 백로그 일정 조회 (날짜 미지정 항목, categories JOIN) */
 export const queryBacklogSchedules = async (): Promise<ScheduleRow[]> =>
   (
     await query<ScheduleRow>(
-      `SELECT id, title, date::text, end_date::text, status, category, memo, important
-     FROM schedules
-     WHERE date IS NULL AND status != 'cancelled' AND user_id = 1
-     ORDER BY category NULLS LAST, important DESC, title`,
+      `SELECT s.id, s.title, s.date::text, s.end_date::text, s.status,
+              s.category, c.type AS category_type, s.memo, s.important
+     FROM schedules s
+     LEFT JOIN categories c ON c.name = s.category
+     WHERE s.date IS NULL AND s.status != 'cancelled' AND s.user_id = 1
+     ORDER BY s.category NULLS LAST, s.important DESC, s.title`,
     )
   ).rows;
 


### PR DESCRIPTION
## Summary
- 일정 메모 Slack 표시 전면 제거 (앱홈, fast path, LLM 응답, 크론)
- event 타입(categories.type='event') 도입: 📅 접두어, 상단 배치, 중요/삭제 overflow만
- `약속` 하드코딩 → `category_type` 기반 일반화 (LEFT JOIN categories)
- LLM 달성률/완료 통계에서 event 타입 제외
- 루틴 메모는 변경 없이 유지

## 변경 파일
| 파일 | 변경 |
|------|------|
| `src/shared/life-queries.ts` | ScheduleRow에 category_type 추가, 쿼리 LEFT JOIN |
| `src/agents/life/blocks.ts` | 메모 제거, isEventType(), event overflow, 📅 접두어, groupByCategory event-first |
| `src/agents/life/prompt.ts` | LLM 지시: 메모 표시 안 함, event 타입 규칙, categories 스키마 |
| `src/shared/life-context.ts` | 미완료 카운트에서 event 제외 |
| `src/agents/life/home.ts` | hideCompletedMemo 옵션 제거 |
| `db/migrations/022_category_event_type.sql` | 약속 카테고리 type → event |

## Test plan
- [x] `yarn test` — 245 테스트 전부 통과
- [x] `yarn lint` — 에러 0
- [ ] 배포 후 마이그레이션 실행 (022_category_event_type.sql)
- [ ] 앱홈에서 일정 메모 미표시 + event 📅 확인
- [ ] 채널 fast path 일정 조회 확인
- [ ] 크론 알림 일정 형태 확인

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)