### PR TITLE
feat: event 타입 카테고리 UX 개선 — 상태 버튼 숨김 + overdue 제외

### DIFF
--- a/web/src/features/schedule/components/schedule-card.tsx
+++ b/web/src/features/schedule/components/schedule-card.tsx
@@ -72,7 +72,7 @@ export function ScheduleCard({
     <div
       onClick={handleCardClick}
       className={`cursor-pointer rounded-lg border p-3 transition hover:shadow-sm ${STATUS_BG[schedule.status] ?? 'bg-white'} ${
-        !isDone && schedule.date && new Date(schedule.date + 'T12:00:00+09:00') < new Date(new Date().toISOString().slice(0, 10) + 'T12:00:00+09:00') && schedule.status === 'todo'
+        !isEvent && !isDone && schedule.date && new Date(schedule.date + 'T12:00:00+09:00') < new Date(new Date().toISOString().slice(0, 10) + 'T12:00:00+09:00') && schedule.status === 'todo'
           ? 'border-red-300'
           : 'border-gray-200'
       }`}

--- a/web/src/features/schedule/components/schedule-form.tsx
+++ b/web/src/features/schedule/components/schedule-form.tsx
@@ -147,26 +147,28 @@ export function ScheduleForm({
         </div>
       )}
 
-      {/* 상태 */}
-      <div>
-        <label className="mb-1 block text-xs text-gray-500">상태</label>
-        <div className="flex gap-1">
-          {SCHEDULE_STATUSES.map((s) => (
-            <button
-              key={s}
-              type="button"
-              onClick={() => setStatus(s)}
-              className={`flex-1 rounded-lg px-2 py-1.5 text-xs font-medium transition ${
-                status === s
-                  ? 'bg-blue-500 text-white'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-              }`}
-            >
-              {STATUS_LABELS[s]}
-            </button>
-          ))}
+      {/* 상태 — event 타입 카테고리는 상태 변경 불필요 */}
+      {categories.find((c) => c.name === category)?.type !== 'event' && (
+        <div>
+          <label className="mb-1 block text-xs text-gray-500">상태</label>
+          <div className="flex gap-1">
+            {SCHEDULE_STATUSES.map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => setStatus(s)}
+                className={`flex-1 rounded-lg px-2 py-1.5 text-xs font-medium transition ${
+                  status === s
+                    ? 'bg-blue-500 text-white'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                {STATUS_LABELS[s]}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* 카테고리 */}
       <div>

--- a/web/src/features/schedule/components/week-view.tsx
+++ b/web/src/features/schedule/components/week-view.tsx
@@ -279,6 +279,7 @@ function WeekSpanBar({
   const isEvent = cat?.type === 'event';
   const isDone = span.schedule.status === 'done' || span.schedule.status === 'cancelled';
   const isOverdue =
+    !isEvent &&
     !isDone &&
     span.schedule.date &&
     new Date(span.schedule.date + 'T12:00:00+09:00') <


### PR DESCRIPTION
## Summary
- 일정 수정 모달: event 타입 카테고리 선택 시 상태 변경 버튼 숨김
- ScheduleCard + WeekSpanBar: event 타입은 overdue 빨간 테두리 제외

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)