### PR TITLE
fix: 루틴 created_at 기준 달성률 분기 처리

### DIFF
--- a/src/agents/life/prompt.ts
+++ b/src/agents/life/prompt.ts
@@ -217,6 +217,9 @@ sleep_records.date는 **잠에서 깬 날짜**야. 잠든 날짜가 아님.
 ## 데이터 규칙
 - important 기본 FALSE, 명시적 요청만 TRUE. status 기본 'todo', 날짜 없으면 NULL(백로그).
 - 루틴 추가: templates INSERT + 오늘 records INSERT. 삭제: active=false.
+- 루틴 달성률 분석: routine_templates.created_at 확인 필수. 생성일 이전 기간은 달성률 계산에서 제외.
+  - 이번 주 분석인데 루틴이 어제 추가됐다면, 어제부터만 카운트.
+  - SQL 조건: AND r.date >= t.created_at::date (routine_templates t JOIN 필요)
 - 루틴 메모: routine_records.memo. "코세척 루틴에 메모 추가해줘" → 해당 날짜+루틴의 record를 찾아 UPDATE.
   - 날짜 지정 없으면 오늘. "어제 코세척에 메모" → 어제 날짜 record.
   - 덮어쓰기(replace): UPDATE SET memo = '새 메모'. 기존 메모가 있으면 교체. 추가가 아닌 교체.
@@ -234,19 +237,21 @@ sleep_records.date는 **잠에서 깬 날짜**야. 잠든 날짜가 아님.
 1. 수면 vs 루틴 상관:
 SELECT s.date, s.duration_minutes, ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric / NULLIF(COUNT(*), 0) * 100)::int AS routine_rate
 FROM sleep_records s JOIN routine_records r ON s.date = r.date
-WHERE s.sleep_type = 'night' AND s.date BETWEEN $1 AND $2
+JOIN routine_templates t ON r.template_id = t.id
+WHERE s.sleep_type = 'night' AND s.date BETWEEN $1 AND $2 AND r.date >= t.created_at::date
 GROUP BY s.date, s.duration_minutes ORDER BY s.date
 
 2. 요일별 패턴:
-SELECT EXTRACT(DOW FROM date)::int AS dow, ROUND(AVG(CASE WHEN completed THEN 1 ELSE 0 END) * 100)::int AS rate
-FROM routine_records WHERE date BETWEEN $1 AND $2
+SELECT EXTRACT(DOW FROM r.date)::int AS dow, ROUND(AVG(CASE WHEN r.completed THEN 1 ELSE 0 END) * 100)::int AS rate
+FROM routine_records r JOIN routine_templates t ON r.template_id = t.id
+WHERE r.date BETWEEN $1 AND $2 AND r.date >= t.created_at::date
 GROUP BY dow ORDER BY dow
 
 3. 시간대별 추세 (2주 비교):
 SELECT t.time_slot, ROUND(COUNT(*) FILTER (WHERE r.completed AND r.date BETWEEN ($2::date - 6) AND $2)::numeric / NULLIF(COUNT(*) FILTER (WHERE r.date BETWEEN ($2::date - 6) AND $2), 0) * 100)::int AS this_week,
 ROUND(COUNT(*) FILTER (WHERE r.completed AND r.date BETWEEN ($2::date - 13) AND ($2::date - 7))::numeric / NULLIF(COUNT(*) FILTER (WHERE r.date BETWEEN ($2::date - 13) AND ($2::date - 7)), 0) * 100)::int AS last_week
 FROM routine_records r JOIN routine_templates t ON r.template_id = t.id
-WHERE r.date BETWEEN ($2::date - 13) AND $2
+WHERE r.date BETWEEN ($2::date - 13) AND $2 AND r.date >= t.created_at::date
 GROUP BY t.time_slot
 
 ### 해석 규칙

--- a/src/cron/weekly-report.ts
+++ b/src/cron/weekly-report.ts
@@ -133,20 +133,24 @@ export const aggregateWeeklyRoutine = async (
   };
 
   try {
-    // 이번주 달성률 + 지난주 비교
+    // 이번주 달성률 + 지난주 비교 (각 루틴의 created_at 이후 기록만 집계)
     const rateResult = await query<RoutineRateRow>(
       `WITH this_week AS (
         SELECT
           COUNT(*)::int AS this_week_total,
-          COUNT(*) FILTER (WHERE completed)::int AS this_week_done,
-          ROUND(COUNT(*) FILTER (WHERE completed)::numeric
+          COUNT(*) FILTER (WHERE r.completed)::int AS this_week_done,
+          ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric
             / NULLIF(COUNT(*), 0) * 100)::int AS this_week_rate
-        FROM routine_records WHERE date BETWEEN $1 AND $2
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.date BETWEEN $1 AND $2 AND r.date >= t.created_at::date
       ),
       last_week AS (
-        SELECT ROUND(COUNT(*) FILTER (WHERE completed)::numeric
+        SELECT ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric
           / NULLIF(COUNT(*), 0) * 100)::int AS last_week_rate
-        FROM routine_records WHERE date BETWEEN ($1::date - 7) AND ($1::date - 1)
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.date BETWEEN ($1::date - 7) AND ($1::date - 1) AND r.date >= t.created_at::date
       )
       SELECT this_week_total, this_week_done, this_week_rate, last_week_rate
       FROM this_week, last_week`,
@@ -156,20 +160,20 @@ export const aggregateWeeklyRoutine = async (
     const rate = rateResult.rows[0];
     if (!rate || rate.this_week_total === 0) return empty;
 
-    // 시간대별 달성률
+    // 시간대별 달성률 (각 루틴의 created_at 이후 기록만 집계)
     const slotResult = await query<SlotBreakdownRow>(
       `SELECT t.time_slot AS slot,
         ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric
           / NULLIF(COUNT(*), 0) * 100)::int AS rate
       FROM routine_records r
       JOIN routine_templates t ON r.template_id = t.id
-      WHERE r.date BETWEEN $1 AND $2
+      WHERE r.date BETWEEN $1 AND $2 AND r.date >= t.created_at::date
       GROUP BY t.time_slot
       ORDER BY rate DESC`,
       [weekStart, weekEnd],
     );
 
-    // 루틴별 달성률 (best/worst)
+    // 루틴별 달성률 (best/worst) — 주간 시작일 이전에 생성된 루틴만 포함
     const routineResult = await query<RoutineNameRow>(
       `SELECT t.name,
         ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric
@@ -177,6 +181,7 @@ export const aggregateWeeklyRoutine = async (
       FROM routine_records r
       JOIN routine_templates t ON r.template_id = t.id
       WHERE r.date BETWEEN $1 AND $2
+        AND t.created_at::date < $1::date
       GROUP BY t.id, t.name
       HAVING COUNT(*) >= 2
       ORDER BY rate DESC`,
@@ -289,12 +294,13 @@ export const aggregateSleepRoutineCorrelation = async (
           AND duration_minutes IS NOT NULL
       ),
       daily_routine AS (
-        SELECT date,
-          ROUND(COUNT(*) FILTER (WHERE completed)::numeric
+        SELECT r.date,
+          ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric
             / NULLIF(COUNT(*), 0) * 100)::int AS rate
-        FROM routine_records
-        WHERE date BETWEEN $1 AND $2
-        GROUP BY date
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.date BETWEEN $1 AND $2 AND r.date >= t.created_at::date
+        GROUP BY r.date
       )
       SELECT
         (SELECT ROUND(AVG(r.rate))::int FROM daily_routine r

--- a/src/shared/insights.ts
+++ b/src/shared/insights.ts
@@ -146,6 +146,7 @@ export const detectSlotGap = async (today: string): Promise<Insight | null> => {
        FROM routine_records r
        JOIN routine_templates t ON r.template_id = t.id
        WHERE r.date BETWEEN ($1::date - 6) AND $1
+         AND r.date >= t.created_at::date
        GROUP BY t.time_slot
        HAVING COUNT(*) >= 3
        ORDER BY rate`,
@@ -182,14 +183,18 @@ export const detectWeekComparison = async (today: string): Promise<Insight | nul
   try {
     const result = await query<WeekCompRow>(
       `WITH this_week AS (
-        SELECT ROUND(COUNT(*) FILTER (WHERE completed)::numeric
+        SELECT ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric
           / NULLIF(COUNT(*), 0) * 100)::int AS rate
-        FROM routine_records WHERE date BETWEEN ($1::date - 6) AND $1
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.date BETWEEN ($1::date - 6) AND $1 AND r.date >= t.created_at::date
       ),
       last_week AS (
-        SELECT ROUND(COUNT(*) FILTER (WHERE completed)::numeric
+        SELECT ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric
           / NULLIF(COUNT(*), 0) * 100)::int AS rate
-        FROM routine_records WHERE date BETWEEN ($1::date - 13) AND ($1::date - 7)
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.date BETWEEN ($1::date - 13) AND ($1::date - 7) AND r.date >= t.created_at::date
       )
       SELECT this_week.rate AS this_rate, last_week.rate AS last_rate
       FROM this_week, last_week`,


### PR DESCRIPTION
## Summary
- 신규 루틴이 주간 리포트에서 과거 기간까지 포함되어 0% 달성률로 표시되는 문제 수정
- `routine_templates.created_at`을 기준으로 생성일 이전 기간은 달성률 계산에서 제외
- LLM 시스템 프롬프트에 `created_at` 확인 규칙 추가

## 변경 내용
| 파일 | 변경 |
|------|------|
| `weekly-report.ts` | 개별 루틴 best/worst: 주간 시작일 이전 생성 루틴만 표시. 전체/시간대별/상관관계 쿼리에 `AND r.date >= t.created_at::date` 필터 추가 |
| `insights.ts` | `detectSlotGap`, `detectWeekComparison`에 `created_at` 필터 추가 |
| `prompt.ts` | 데이터 규칙에 `created_at` 확인 필수 가이드 + SQL 패턴 업데이트 |

## Test plan
- [x] 기존 테스트 258개 전체 통과
- [x] 타입 체크 통과

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)