### PR TITLE
fix: 탭 복귀 시 일정 추가 기본 날짜 갱신 (#140)

### DIFF
--- a/web/src/features/schedule/hooks/use-schedules.ts
+++ b/web/src/features/schedule/hooks/use-schedules.ts
@@ -97,7 +97,22 @@ export function useSchedules() {
         fetchData();
       }
     }, 15_000);
-    return () => clearInterval(id);
+
+    // 탭 복귀 시 날짜가 바뀌었으면 currentDate 갱신
+    const handleVisibility = () => {
+      if (document.visibilityState !== 'visible') return;
+      const now = new Date();
+      if (format(now, 'yyyy-MM-dd') !== format(currentDate, 'yyyy-MM-dd')) {
+        setCurrentDate(now);
+        setSelectedDate(null);
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      clearInterval(id);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
   }, [fetchData]);
 
   // 필터링


### PR DESCRIPTION
## Summary
- 대시보드 탭을 띄워놓고 다음 날 복귀하면 일정 추가 모달의 기본 날짜가 어제로 남는 버그 수정
- `visibilitychange` 이벤트에서 날짜 변경 감지 → `currentDate` 갱신

## Test plan
- [ ] 탭 띄워놓고 자정 이후 복귀 → 일정 추가 기본 날짜가 오늘인지 확인
- [ ] 오늘 버튼 클릭 시 기존 동작 정상 동작 확인

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)