### PR TITLE
fix: 루틴 N일마다 빈도가 매일 생성되는 버그 수정 (#141)

### DIFF
--- a/src/shared/__tests__/life-queries.test.ts
+++ b/src/shared/__tests__/life-queries.test.ts
@@ -65,6 +65,11 @@ describe('shouldCreateToday', () => {
     expect(shouldCreateToday('주1회', '2026-03-03', '2026-03-08')).toBe(false);
   });
 
+  it('4일마다: 4일 이상 경과 시 true', () => {
+    expect(shouldCreateToday('4일마다', '2026-03-04', '2026-03-08')).toBe(true);
+    expect(shouldCreateToday('4일마다', '2026-03-05', '2026-03-08')).toBe(false);
+  });
+
   it('알 수 없는 빈도는 true', () => {
     expect(shouldCreateToday('unknown', '2026-03-07', '2026-03-08')).toBe(true);
   });
@@ -87,6 +92,10 @@ describe('frequencyBadge', () => {
 
   it('주1회면 배지 반환', () => {
     expect(frequencyBadge('주1회')).toContain('1주');
+  });
+
+  it('4일마다면 배지 반환', () => {
+    expect(frequencyBadge('4일마다')).toContain('4일');
   });
 });
 

--- a/src/shared/life-queries.ts
+++ b/src/shared/life-queries.ts
@@ -59,6 +59,13 @@ const daysBetween = (from: string, to: string): number => {
   return Math.round((toDate.getTime() - fromDate.getTime()) / msPerDay);
 };
 
+/** N일마다 패턴에서 일수 추출 (예: '3일마다' → 3, '격일' → 2) */
+const parseIntervalDays = (frequency: string): number | null => {
+  if (frequency === '격일') return 2;
+  const match = /^(\d+)일마다$/.exec(frequency);
+  return match ? Number(match[1]) : null;
+};
+
 /** 빈도에 따라 오늘 기록을 생성해야 하는지 판별 */
 export const shouldCreateToday = (
   frequency: string,
@@ -70,30 +77,20 @@ export const shouldCreateToday = (
 
   const gap = daysBetween(lastDate, today);
 
-  switch (frequency) {
-    case '격일':
-      return gap >= 2;
-    case '3일마다':
-      return gap >= 3;
-    case '주1회':
-      return gap >= 7;
-    default:
-      return true;
-  }
+  if (frequency === '주1회') return gap >= 7;
+
+  const intervalDays = parseIntervalDays(frequency);
+  if (intervalDays) return gap >= intervalDays;
+
+  return true;
 };
 
 /** 빈도 → 표시용 배지 텍스트 (매일은 빈 문자열) */
 export const frequencyBadge = (frequency: string): string => {
-  switch (frequency) {
-    case '격일':
-      return '_(2일 마다)_';
-    case '3일마다':
-      return '_(3일 마다)_';
-    case '주1회':
-      return '_(1주 마다)_';
-    default:
-      return '';
-  }
+  if (frequency === '주1회') return '_(1주 마다)_';
+  const intervalDays = parseIntervalDays(frequency);
+  if (intervalDays) return `_(${intervalDays}일 마다)_`;
+  return '';
 };
 
 // ─── 루틴 쿼리 ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `shouldCreateToday`가 '3일마다'만 하드코딩하여 '4일마다' 등이 default→매일 생성되는 버그 수정
- N일마다 패턴을 정규식으로 동적 파싱 (`/^(\d+)일마다$/`)
- `frequencyBadge`도 동일 패턴 적용

## Test plan
- [x] 기존 테스트 22개 통과
- [x] '4일마다' 테스트 케이스 추가
- [ ] 배포 후 파슬리 물주기(4일마다) 루틴이 매일 안 뜨는지 확인

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)