### PR TITLE
feat(reminder): 며칠마다 주기 + 유한 반복(횟수/기간) 지원

### DIFF
--- a/db/migrations/028_reminder_finite.sql
+++ b/db/migrations/028_reminder_finite.sql
@@ -1,0 +1,3 @@
+-- 리마인더 유한 반복 지원: 종료 날짜 + 남은 횟수
+ALTER TABLE reminders ADD COLUMN end_date DATE;
+ALTER TABLE reminders ADD COLUMN remaining_count INTEGER;

--- a/src/agents/life/prompt.ts
+++ b/src/agents/life/prompt.ts
@@ -198,6 +198,12 @@ sleep_records.date는 **수면을 기록하는 날짜**야. 보통 일어난 날
   - 매월 특정 날짜: frequency='매월', days_of_month=ARRAY[날짜]. 예: 매월 1,15일 → ARRAY[1,15]
   - 격주: frequency='매주', days_of_week=ARRAY[요일], repeat_interval=2, reference_date=첫 실행일
   - 격월: frequency='매월', days_of_month=ARRAY[날짜], repeat_interval=2, reference_date=첫 실행일
+  - 며칠마다: frequency='며칠마다', repeat_interval=N, reference_date=첫 실행일. 예: 3일마다 → repeat_interval=3
+  - 종료 조건 (선택, 모든 반복 패턴에 사용 가능):
+    - 횟수 제한: remaining_count=N. "5번만 반복" → remaining_count=5
+    - 기간 제한: end_date='YYYY-MM-DD'. "2주간" → end_date=2주 후 날짜 계산해서 지정
+    - 둘 다 지정 가능. 먼저 도달하는 쪽이 종료
+  - 시작일 지정: reference_date에 시작일 설정. 해당 날짜부터 발동
   - 요일 번호: 0=일, 1=월, 2=화, 3=수, 4=목, 5=금, 6=토
 
 ## 데이터 규칙

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -21,6 +21,7 @@ import {
   queryNotificationSettings,
   queryDueReminders,
   deactivateReminder,
+  decrementReminderCount,
 } from '../shared/life-queries.js';
 import { postBlockMessage, postToChannel } from '../shared/slack.js';
 import { getTodayISO, getYesterdayISO, getKSTTimeString, getKSTDayOfWeek } from '../shared/kst.js';
@@ -593,6 +594,22 @@ export class CronScheduler {
       if (reminder.date) {
         await deactivateReminder(reminder.id);
         console.warn(`[Life Cron] 일회성 리마인더 비활성화: ${reminder.title}`);
+        continue;
+      }
+
+      // remaining_count 차감 → 0이면 비활성화
+      if (reminder.remaining_count != null && reminder.remaining_count > 0) {
+        const deactivated = await decrementReminderCount(reminder.id);
+        if (deactivated) {
+          console.warn(`[Life Cron] 횟수 소진 리마인더 비활성화: ${reminder.title}`);
+          continue;
+        }
+      }
+
+      // end_date 도달 → 비활성화
+      if (reminder.end_date && today >= reminder.end_date) {
+        await deactivateReminder(reminder.id);
+        console.warn(`[Life Cron] 기간 만료 리마인더 비활성화: ${reminder.title}`);
       }
     }
 

--- a/src/shared/life-queries.ts
+++ b/src/shared/life-queries.ts
@@ -254,6 +254,8 @@ export interface ReminderRow {
   date: string | null;
   frequency: string | null;
   active: boolean;
+  end_date: string | null;
+  remaining_count: number | null;
 }
 
 /** 현재 시각에 발동할 리마인더 조회 */
@@ -264,10 +266,12 @@ export const queryDueReminders = async (
 ): Promise<ReminderRow[]> =>
   (
     await query<ReminderRow>(
-      `SELECT id, title, time_value, date::text, frequency, active
+      `SELECT id, title, time_value, date::text, frequency, active,
+              end_date::text, remaining_count
      FROM reminders
      WHERE active = true
        AND time_value = $1
+       AND (end_date IS NULL OR $2::date <= end_date)
        AND (
          (date = $2)
          OR (date IS NULL AND frequency = '매일')
@@ -284,6 +288,10 @@ export const queryDueReminders = async (
                   - (EXTRACT(YEAR FROM COALESCE(reference_date, $2::date))::int * 12
                      + EXTRACT(MONTH FROM COALESCE(reference_date, $2::date))::int))
                  % COALESCE(repeat_interval, 1) = 0)
+         OR (date IS NULL AND frequency = '며칠마다'
+             AND $2::date >= COALESCE(reference_date, $2::date)
+             AND (($2::date - COALESCE(reference_date, $2::date))::int)
+                 % COALESCE(repeat_interval, 1) = 0)
        )`,
       [currentTime, today, dow],
     )
@@ -292,6 +300,22 @@ export const queryDueReminders = async (
 /** 리마인더 비활성화 (일회성 발동 후) */
 export const deactivateReminder = async (id: number): Promise<void> => {
   await query('UPDATE reminders SET active = false WHERE id = $1', [id]);
+};
+
+/** remaining_count 차감. 0이 되면 자동 비활성화. 비활성화 여부 반환. */
+export const decrementReminderCount = async (id: number): Promise<boolean> => {
+  const result = await query<{ remaining_count: number }>(
+    `UPDATE reminders
+     SET remaining_count = remaining_count - 1
+     WHERE id = $1 AND remaining_count IS NOT NULL AND remaining_count > 0
+     RETURNING remaining_count`,
+    [id],
+  );
+  if (result.rows.length > 0 && result.rows[0].remaining_count === 0) {
+    await deactivateReminder(id);
+    return true;
+  }
+  return false;
 };
 
 export interface SleepEventRow {


### PR DESCRIPTION
## 변경 내용
- DB: `end_date`, `remaining_count` 컬럼 추가 (028_reminder_finite.sql)
- 새 frequency `'며칠마다'`: `repeat_interval=N`, `reference_date=시작일`로 N일 주기 리마인더 지원
- 유한 반복: `remaining_count`(횟수 제한) + `end_date`(기간 제한), 먼저 도달하는 쪽이 종료
- 시작일 지정: `reference_date` 미래 날짜 설정 시 해당 날짜부터 발동
- 크론: 발동 시 remaining_count 차감 → 0이면 자동 비활성화, end_date 도달 시 비활성화
- 에이전트 프롬프트: 새 패턴(며칠마다/종료조건/시작일) 안내 추가

## 사용 예시
- "3일마다 11시에 물 마시기, 5번만" → `frequency='며칠마다', repeat_interval=3, remaining_count=5`
- "앞으로 2주간 매주 월,목 11시" → `frequency='매주', days_of_week=ARRAY[1,4], end_date=2주 후`
- "이번주 토요일부터 3일마다" → `frequency='며칠마다', repeat_interval=3, reference_date=토요일`

## 코드 리뷰 결과
- [x] 보안 감사 통과 (SQL 파라미터 바인딩, 크리덴셜 없음)
- [x] 타입 안전성 확인
- [x] 컨벤션 점검 완료
- [x] 코드 품질 확인

## 테스트
- [x] vitest 258건 전체 통과
- [x] TypeScript 타입 체크 통과
- [ ] 배포 후 실제 리마인더 발동 확인