### PR TITLE
fix(web): 루틴 UX 개선 — 관리 탭 분리, 삭제/비활성화 구분, 히트맵 너비

### DIFF
--- a/db/migrations/029_routine_soft_delete.sql
+++ b/db/migrations/029_routine_soft_delete.sql
@@ -1,0 +1,5 @@
+-- 루틴 소프트 딜리트: 삭제(숨김) vs 비활성화(일시정지) 분리
+-- deleted_at이 NULL이 아니면 UI에서 완전히 숨김, DB에는 보존
+
+ALTER TABLE routine_templates
+ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ DEFAULT NULL;

--- a/web/src/features/routine/components/routine-page.tsx
+++ b/web/src/features/routine/components/routine-page.tsx
@@ -54,15 +54,13 @@ export function RoutinePage() {
     [handleUpdateTemplate],
   );
 
-  if (loading) {
-    return <LoadingSkeleton />;
-  }
+  if (loading) return <LoadingSkeleton />;
 
   return (
     <div className="flex flex-1 flex-col">
       {/* 헤더 */}
       <div className="border-b border-gray-200 bg-white px-4 py-3">
-        <div className="mx-auto flex max-w-3xl items-center justify-between gap-3">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3">
           <h1 className="text-lg font-bold text-gray-900 md:text-xl">루틴</h1>
           <div className="flex items-center gap-2">
             <button
@@ -78,8 +76,8 @@ export function RoutinePage() {
 
       {/* 콘텐츠 */}
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-3xl px-4 py-4 md:py-6">
-          {view === 'checklist' ? (
+        <div className="mx-auto max-w-5xl px-4 py-4 md:py-6">
+          {view === 'checklist' && (
             <div className="space-y-5">
               <YearlyHeatmap stats={yearlyStats} />
               <DateNav
@@ -94,17 +92,28 @@ export function RoutinePage() {
                 onMemoClick={handleMemoClick}
                 onEditTemplate={handleEditTemplate}
               />
-              {/* 루틴 관리 */}
-              <div className="border-t border-gray-200 pt-5">
-                <RoutineList
-                  templates={templates}
-                  onEdit={setEditingTemplate}
-                  onToggleActive={handleToggleActive}
-                />
-              </div>
             </div>
-          ) : (
+          )}
+          {view === 'stats' && (
             <RoutineStats stats={stats} fetchStats={fetchStats} selectedDate={selectedDate} />
+          )}
+          {view === 'manage' && (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-base font-semibold text-gray-900">루틴 관리</h2>
+                <button
+                  onClick={() => setShowForm(true)}
+                  className="rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600"
+                >
+                  + 추가
+                </button>
+              </div>
+              <RoutineList
+                templates={templates}
+                onEdit={setEditingTemplate}
+                onToggleActive={handleToggleActive}
+              />
+            </div>
           )}
         </div>
       </div>
@@ -170,12 +179,12 @@ function LoadingSkeleton() {
   return (
     <div className="flex flex-1 flex-col">
       <div className="border-b border-gray-200 bg-white px-4 py-3">
-        <div className="mx-auto flex max-w-3xl items-center justify-between">
+        <div className="mx-auto flex max-w-5xl items-center justify-between">
           <div className="h-7 w-20 animate-pulse rounded bg-gray-200" />
           <div className="h-8 w-32 animate-pulse rounded bg-gray-200" />
         </div>
       </div>
-      <div className="mx-auto w-full max-w-3xl space-y-3 p-4">
+      <div className="mx-auto w-full max-w-5xl space-y-3 p-4">
         {[1, 2, 3, 4, 5].map((i) => (
           <div key={i} className="h-14 animate-pulse rounded-lg bg-gray-100" />
         ))}

--- a/web/src/features/routine/components/view-toggle.tsx
+++ b/web/src/features/routine/components/view-toggle.tsx
@@ -7,20 +7,21 @@ interface ViewToggleProps {
   onChange: (view: RoutineView) => void;
 }
 
-/** 체크리스트/통계 뷰 전환 토글 */
-export function ViewToggle({ view, onChange }: ViewToggleProps) {
-  const tabs: { key: RoutineView; label: string }[] = [
-    { key: 'checklist', label: '체크리스트' },
-    { key: 'stats', label: '통계' },
-  ];
+const TABS: { key: RoutineView; label: string }[] = [
+  { key: 'checklist', label: '체크리스트' },
+  { key: 'stats', label: '통계' },
+  { key: 'manage', label: '관리' },
+];
 
+/** 체크리스트/통계/관리 뷰 전환 토글 */
+export function ViewToggle({ view, onChange }: ViewToggleProps) {
   return (
     <div className="flex rounded-lg bg-gray-100">
-      {tabs.map((tab) => (
+      {TABS.map((tab) => (
         <button
           key={tab.key}
           onClick={() => onChange(tab.key)}
-          className={`rounded-lg px-3.5 py-1.5 text-sm font-medium transition ${
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition ${
             view === tab.key
               ? 'bg-blue-500 text-white'
               : 'text-gray-500 hover:text-gray-700'

--- a/web/src/features/routine/components/yearly-heatmap.tsx
+++ b/web/src/features/routine/components/yearly-heatmap.tsx
@@ -71,25 +71,24 @@ export function YearlyHeatmap({ stats }: YearlyHeatmapProps) {
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-4">
-      <div className="mb-2 flex items-baseline justify-between">
+      <div className="mb-2">
         <span className="text-xs font-medium text-gray-500">
           지난 1년간 {totalCompleted}일 달성
         </span>
       </div>
 
-      {/* 모바일: 가로 스크롤, 데스크탑: 꽉 차게 */}
       <div ref={scrollRef} className="overflow-x-auto md:overflow-visible">
-        <div className="inline-block md:w-full">
+        <div className="inline-flex flex-col md:w-full">
           {/* 월 라벨 */}
-          <div className="flex md:pl-[24px]" style={{ paddingLeft: 28 }}>
+          <div className="mb-0.5 flex" style={{ paddingLeft: 28 }}>
             {monthLabels.map((m, i) => {
               const nextCol = monthLabels[i + 1]?.col ?? weeks.length;
               const span = nextCol - m.col;
               return (
                 <div
                   key={`${m.label}-${m.col}`}
-                  className="text-xs text-gray-400"
-                  style={{ width: span * 15, minWidth: span * 15 }}
+                  className="shrink-0 text-xs text-gray-400 md:shrink md:basis-0"
+                  style={{ flexGrow: span }}
                 >
                   {span >= 3 ? m.label : ''}
                 </div>
@@ -99,7 +98,6 @@ export function YearlyHeatmap({ stats }: YearlyHeatmapProps) {
 
           {/* 그리드 */}
           <div className="flex gap-[2px]">
-            {/* 요일 라벨 */}
             <div className="flex shrink-0 flex-col gap-[2px] pr-[2px]" style={{ width: 24 }}>
               {DAY_LABELS.map((label, i) => (
                 <div key={i} className="flex h-[13px] items-center text-[10px] text-gray-400 md:h-auto md:aspect-square">
@@ -108,7 +106,6 @@ export function YearlyHeatmap({ stats }: YearlyHeatmapProps) {
               ))}
             </div>
 
-            {/* 모바일: 고정 크기, 데스크탑: flex-1 */}
             {weeks.map((week, wi) => (
               <div key={wi} className="flex shrink-0 flex-col gap-[2px] md:flex-1 md:shrink">
                 {Array.from({ length: 7 }, (_, di) => {

--- a/web/src/features/routine/hooks/use-routines.ts
+++ b/web/src/features/routine/hooks/use-routines.ts
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { getTodayISO, addDays } from '@/lib/kst';
 import type { RoutineTemplateRow, RoutineRecordRow, RoutineDayStat } from '@/lib/types';
 
-export type RoutineView = 'checklist' | 'stats';
+export type RoutineView = 'checklist' | 'stats' | 'manage';
 
 export function useRoutines() {
   const [view, setView] = useState<RoutineView>('checklist');

--- a/web/src/features/routine/lib/queries.ts
+++ b/web/src/features/routine/lib/queries.ts
@@ -3,12 +3,12 @@ import type { RoutineTemplateRow, RoutineRecordRow, RoutineDayStat } from '@/lib
 
 // ─── 템플릿 CRUD ─────────────────────────────────────
 
-/** 모든 템플릿 조회 (active 먼저 정렬) */
+/** 모든 템플릿 조회 (삭제된 항목 제외, active 먼저 정렬) */
 export async function queryRoutineTemplates(userId: number): Promise<RoutineTemplateRow[]> {
   const { rows } = await query<RoutineTemplateRow>(
     `SELECT id, name, time_slot, frequency, active, created_at::text
      FROM routine_templates
-     WHERE user_id = $1
+     WHERE user_id = $1 AND deleted_at IS NULL
      ORDER BY active DESC, time_slot, name`,
     [userId],
   );
@@ -53,10 +53,10 @@ export async function updateRoutineTemplate(
   );
 }
 
-/** 템플릿 삭제 (soft delete → active=false) */
+/** 템플릿 삭제 (soft delete — UI에서 완전히 숨김, DB에는 보존) */
 export async function deleteRoutineTemplate(userId: number, id: number): Promise<boolean> {
   const result = await query(
-    `UPDATE routine_templates SET active = false WHERE id = $1 AND user_id = $2`,
+    `UPDATE routine_templates SET active = false, deleted_at = NOW() WHERE id = $1 AND user_id = $2`,
     [id, userId],
   );
   return (result.rowCount ?? 0) > 0;
@@ -137,7 +137,7 @@ function shouldCreateToday(frequency: string | null, lastDate: string | null, to
 /** 오늘 기록 자동 생성 (아직 없는 active 템플릿만) */
 export async function ensureTodayRecords(userId: number, date: string): Promise<number> {
   const { rows: templates } = await query<{ id: number; frequency: string | null }>(
-    `SELECT id, frequency FROM routine_templates WHERE active = true AND user_id = $1`,
+    `SELECT id, frequency FROM routine_templates WHERE active = true AND deleted_at IS NULL AND user_id = $1`,
     [userId],
   );
 


### PR DESCRIPTION
## 변경 내용
- **관리 탭 분리**: 활성/비활성 루틴 목록을 체크리스트 아래에서 별도 '관리' 탭으로 이동
- **삭제 vs 비활성화 분리**: 삭제 → `deleted_at` 설정하여 UI 완전히 숨김 (DB 보존), 비활성화 → `active=false`만 (관리 탭에서 재활성화 가능)
- **컨테이너 너비 확대**: `max-w-3xl` → `max-w-5xl` (히트맵이 잘 보이도록)
- **히트맵 월 라벨 수정**: `flexGrow` 기반으로 변경하여 데스크탑에서 삐져나오지 않음
- **DB 마이그레이션**: `routine_templates.deleted_at` 컬럼 추가