### PR TITLE
fix(web): 통계 뷰 히트맵 복원 + days_active 수정

### DIFF
--- a/web/src/features/routine/components/routine-page.tsx
+++ b/web/src/features/routine/components/routine-page.tsx
@@ -95,6 +95,7 @@ export function RoutinePage() {
           {view === 'stats' && (
             <RoutineStats
               stats={stats}
+              yearlyStats={yearlyStats}
               fetchStats={fetchStats}
               selectedDate={selectedDate}
             />

--- a/web/src/features/routine/components/routine-stats.tsx
+++ b/web/src/features/routine/components/routine-stats.tsx
@@ -4,15 +4,17 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import type { RoutineDayStat, RoutinePerStat } from '@/lib/types';
 import { getTodayISO, addDays, getDayName } from '@/lib/kst';
 import { MonthlyHeatmap } from './monthly-heatmap';
+import { YearlyHeatmap } from './yearly-heatmap';
 
 interface RoutineStatsProps {
   stats: RoutineDayStat[];
+  yearlyStats: RoutineDayStat[];
   fetchStats: (from: string, to: string) => Promise<void>;
   selectedDate: string;
 }
 
 /** 달성률 통계 뷰 */
-export function RoutineStats({ stats, fetchStats, selectedDate }: RoutineStatsProps) {
+export function RoutineStats({ stats, yearlyStats, fetchStats, selectedDate }: RoutineStatsProps) {
   const today = getTodayISO();
   const weekStart = addDays(today, -6);
 
@@ -23,6 +25,7 @@ export function RoutineStats({ stats, fetchStats, selectedDate }: RoutineStatsPr
 
   return (
     <div className="space-y-6">
+      <YearlyHeatmap stats={yearlyStats} />
       <PerRoutineSection />
       <WeeklyChart stats={stats} from={weekStart} to={today} />
       <MonthlyHeatmap stats={stats} selectedDate={selectedDate} />

--- a/web/src/features/routine/lib/queries.ts
+++ b/web/src/features/routine/lib/queries.ts
@@ -212,7 +212,10 @@ export async function queryRoutinePerStats(
               THEN ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric / COUNT(*) * 100)::int
               ELSE 0
             END AS rate,
-            GREATEST(1, (CURRENT_DATE - t.created_at::date) + 1)::int AS days_active
+            GREATEST(1, (CURRENT_DATE - COALESCE(
+              (SELECT MIN(date) FROM routine_records WHERE template_id = t.id),
+              t.created_at::date
+            )) + 1)::int AS days_active
      FROM routine_records r
      JOIN routine_templates t ON r.template_id = t.id
      WHERE r.user_id = $1 AND t.deleted_at IS NULL


### PR DESCRIPTION
## 변경 내용
- 통계 뷰 최상단에 1년치 YearlyHeatmap 복원 (이전 머지에서 누락)
- `days_active` 계산: `created_at` → `MIN(routine_records.date)` (첫 기록 날짜 기준)
  - 3월부터 내내 했던 루틴이 5일째로 표시되던 버그 수정