### PR TITLE
fix(web): yearlyStats destructuring 누락 — Vercel 빌드 실패 수정

### DIFF
--- a/web/src/features/routine/components/routine-page.tsx
+++ b/web/src/features/routine/components/routine-page.tsx
@@ -15,7 +15,7 @@ import { BottomSheet } from '@/components/ui/bottom-sheet';
 
 export function RoutinePage() {
   const {
-    view, selectedDate, templates, records, stats, loading,
+    view, selectedDate, templates, records, stats, yearlyStats, loading,
     showForm, editingTemplate, editingRecord,
     setView, setShowForm, setEditingTemplate, setEditingRecord,
     handlePrevDate, handleNextDate, handleToday,


### PR DESCRIPTION
routine-page.tsx에서 yearlyStats를 RoutineStats에 전달하지만 훅 destructuring에 빠져있어서 빌드 에러. 추가.