### PR TITLE
feat: 지출/예산 관리 기능 추가

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "web-dev",
       "runtimeExecutable": "/opt/homebrew/Cellar/node/22.5.1/bin/node",
-      "runtimeArgs": ["/Users/ihyewon/slack-ai-agents/web/node_modules/.bin/next", "dev", "--no-turbopack"],
+      "runtimeArgs": ["/Users/ihyewon/slack-ai-agents/web/node_modules/.bin/next", "dev", "--webpack"],
       "cwd": "/Users/ihyewon/slack-ai-agents/web",
       "port": 3000,
       "autoPort": true

--- a/web/src/components/ui/icons.tsx
+++ b/web/src/components/ui/icons.tsx
@@ -149,6 +149,14 @@ export function ChevronRightIcon(props: IconProps) {
   );
 }
 
+export function ChevronDownIcon(props: IconProps) {
+  return (
+    <svg {...defaultProps(props)}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+    </svg>
+  );
+}
+
 export function XMarkIcon(props: IconProps) {
   return (
     <svg {...defaultProps(props)}>

--- a/web/src/features/budget/components/budget-page.tsx
+++ b/web/src/features/budget/components/budget-page.tsx
@@ -28,8 +28,6 @@ function MonthNavigator({
     onChange(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`);
   };
 
-  const isCurrentMonth = selectedMonth === new Date().toISOString().slice(0, 7);
-
   return (
     <div className="flex items-center gap-2">
       <button onClick={prev} className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
@@ -40,8 +38,7 @@ function MonthNavigator({
       </span>
       <button
         onClick={next}
-        disabled={isCurrentMonth}
-        className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 disabled:opacity-30"
+        className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
       >
         <ChevronRightIcon size={18} />
       </button>

--- a/web/src/features/budget/components/expense-form.tsx
+++ b/web/src/features/budget/components/expense-form.tsx
@@ -121,9 +121,9 @@ export function ExpenseForm({ onAdd }: ExpenseFormProps) {
       <button
         type="submit"
         disabled={loading}
-        className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+        className="mt-3 ml-auto flex items-center gap-1 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
       >
-        <PlusIcon size={16} />
+        <PlusIcon size={13} />
         {loading ? '추가 중...' : '추가'}
       </button>
     </form>

--- a/web/src/features/budget/components/expense-list.tsx
+++ b/web/src/features/budget/components/expense-list.tsx
@@ -6,7 +6,35 @@ import { ko } from 'date-fns/locale';
 import type { ExpenseRow } from '@/features/budget/lib/types';
 import { EXPENSE_CATEGORIES } from '@/features/budget/lib/types';
 import { formatAmount } from '@/lib/types';
-import { TrashIcon, TagIcon } from '@/components/ui/icons';
+import { TrashIcon, TagIcon, ChevronDownIcon } from '@/components/ui/icons';
+
+/** 카테고리별 색상 맵 */
+const CATEGORY_COLORS: Record<string, string> = {
+  식재료: '#22c55e',
+  배달음식: '#f97316',
+  외식비: '#ef4444',
+  카페: '#92400e',
+  생필품: '#06b6d4',
+  쇼핑: '#a855f7',
+  미용: '#ec4899',
+  교통비: '#3b82f6',
+  '의료/건강': '#14b8a6',
+  구독료: '#6366f1',
+  통신비: '#64748b',
+  공과금: '#78716c',
+  문화생활: '#f59e0b',
+  여행: '#0ea5e9',
+  경조사: '#d946ef',
+  고양이: '#fb923c',
+  '리커밋 사업': '#84cc16',
+  '리커밋 택배': '#65a30d',
+  환불: '#10b981',
+  기타: '#9ca3af',
+};
+
+function getCategoryColor(category: string): string {
+  return CATEGORY_COLORS[category] ?? '#9ca3af';
+}
 
 interface ExpenseListProps {
   expenses: ExpenseRow[];
@@ -28,6 +56,7 @@ function groupByDate(expenses: ExpenseRow[]): Map<string, ExpenseRow[]> {
 
 export function ExpenseList({ expenses, onDelete, selectedCategory, onCategoryChange }: ExpenseListProps) {
   const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [filterOpen, setFilterOpen] = useState(false);
 
   const filtered = selectedCategory
     ? expenses.filter((e) => e.category === selectedCategory)
@@ -46,31 +75,59 @@ export function ExpenseList({ expenses, onDelete, selectedCategory, onCategoryCh
     }
   };
 
+  // 현재 expenses에 실제 존재하는 카테고리만 필터에 표시
+  const activeCategories = [...new Set(expenses.map((e) => e.category))];
+  const sortedCategories = EXPENSE_CATEGORIES.filter((c) => activeCategories.includes(c));
+
   return (
     <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
-      {/* 카테고리 필터 */}
-      <div className="overflow-x-auto border-b border-gray-100 px-4 py-2">
-        <div className="flex gap-1.5">
-          <button
-            onClick={() => onCategoryChange(null)}
-            className={`shrink-0 rounded-full px-3 py-1 text-xs font-medium transition ${
-              selectedCategory === null ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-            }`}
-          >
-            전체
-          </button>
-          {EXPENSE_CATEGORIES.map((cat) => (
-            <button
-              key={cat}
-              onClick={() => onCategoryChange(cat === selectedCategory ? null : cat)}
-              className={`shrink-0 rounded-full px-3 py-1 text-xs font-medium transition ${
-                selectedCategory === cat ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-              }`}
-            >
-              {cat}
-            </button>
-          ))}
-        </div>
+      {/* 카테고리 필터 버튼 */}
+      <div className="relative border-b border-gray-100 px-4 py-2">
+        <button
+          onClick={() => setFilterOpen(!filterOpen)}
+          className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition ${
+            selectedCategory
+              ? 'bg-blue-50 text-blue-700'
+              : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
+          }`}
+        >
+          <TagIcon size={13} />
+          {selectedCategory ?? '전체 카테고리'}
+          <ChevronDownIcon size={13} />
+        </button>
+
+        {filterOpen && (
+          <>
+            <div className="fixed inset-0 z-40" onClick={() => setFilterOpen(false)} />
+            <div className="absolute left-4 top-full z-50 mt-1 max-h-64 w-48 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+              <button
+                onClick={() => { onCategoryChange(null); setFilterOpen(false); }}
+                className={`flex w-full items-center gap-2 px-3 py-2 text-xs ${
+                  selectedCategory === null ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                전체
+              </button>
+              {sortedCategories.map((cat) => {
+                const color = getCategoryColor(cat);
+                const count = expenses.filter((e) => e.category === cat).length;
+                return (
+                  <button
+                    key={cat}
+                    onClick={() => { onCategoryChange(cat); setFilterOpen(false); }}
+                    className={`flex w-full items-center gap-2 px-3 py-2 text-xs ${
+                      selectedCategory === cat ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+                    <span className="flex-1 text-left">{cat}</span>
+                    <span className="text-gray-400">{count}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        )}
       </div>
 
       {/* 지출 목록 */}
@@ -95,41 +152,46 @@ export function ExpenseList({ expenses, onDelete, selectedCategory, onCategoryCh
                 </div>
 
                 {/* 해당 날 지출 */}
-                {dayExpenses.map((expense) => (
-                  <div key={expense.id} className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50">
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-1.5">
-                        <span className="flex items-center gap-0.5 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
-                          <TagIcon size={11} />
-                          {expense.category}
-                        </span>
-                        {expense.is_installment && expense.installment_num !== null && expense.installment_total !== null && (
-                          <span className="rounded bg-amber-50 px-1.5 py-0.5 text-xs text-amber-600">
-                            {expense.installment_num}/{expense.installment_total}
+                {dayExpenses.map((expense) => {
+                  const color = getCategoryColor(expense.category);
+                  return (
+                    <div key={expense.id} className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <span
+                            className="flex items-center gap-0.5 rounded px-1.5 py-0.5 text-xs font-medium"
+                            style={{
+                              backgroundColor: `${color}15`,
+                              color,
+                            }}
+                          >
+                            {expense.category}
                           </span>
+                          {expense.is_installment && expense.installment_num !== null && expense.installment_total !== null && (
+                            <span className="rounded bg-amber-50 px-1.5 py-0.5 text-xs text-amber-600">
+                              {expense.installment_num}/{expense.installment_total}
+                            </span>
+                          )}
+                        </div>
+                        {expense.description && (
+                          <p className="mt-0.5 truncate text-xs text-gray-500">{expense.description}</p>
                         )}
                       </div>
-                      {expense.description && (
-                        <p className="mt-0.5 truncate text-xs text-gray-500">{expense.description}</p>
+                      <div className="shrink-0 text-right">
+                        <div className="text-sm font-semibold text-gray-800">{formatAmount(expense.amount)}</div>
+                      </div>
+                      {expense.source !== 'import' && (
+                        <button
+                          onClick={() => void handleDelete(expense.id)}
+                          disabled={deletingId === expense.id}
+                          className="shrink-0 rounded-md p-1 text-gray-300 transition hover:bg-red-50 hover:text-red-400 disabled:opacity-50"
+                        >
+                          <TrashIcon size={15} />
+                        </button>
                       )}
                     </div>
-                    <div className="shrink-0 text-right">
-                      <div className="text-sm font-semibold text-gray-800">{formatAmount(expense.amount)}</div>
-                      {expense.source === 'import' && (
-                        <div className="text-xs text-gray-300">위플</div>
-                      )}
-                    </div>
-                    {expense.source !== 'import' && (
-                      <button
-                        onClick={() => void handleDelete(expense.id)}
-                        disabled={deletingId === expense.id}
-                        className="shrink-0 rounded-md p-1 text-gray-300 transition hover:bg-red-50 hover:text-red-400 disabled:opacity-50"
-                      >
-                        <TrashIcon size={15} />
-                      </button>
-                    )}
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             );
           })}

--- a/web/src/features/budget/hooks/use-budget.ts
+++ b/web/src/features/budget/hooks/use-budget.ts
@@ -7,10 +7,17 @@ function getCurrentYearMonth(): string {
   return new Date().toISOString().slice(0, 7);
 }
 
-function getMonthRange(yearMonth: string): { from: string; to: string } {
+/**
+ * 카드 결제주기 기준 날짜 범위 계산.
+ * "N월" = 전월 16일 ~ 당월 15일.
+ * 예: 2026-04 → 2026-03-16 ~ 2026-04-15
+ */
+function getBillingRange(yearMonth: string): { from: string; to: string } {
   const [year, month] = yearMonth.split('-').map(Number);
-  const from = `${yearMonth}-01`;
-  const to = new Date(year, month, 0).toISOString().slice(0, 10);
+  const prevMonth = month === 1 ? 12 : month - 1;
+  const prevYear = month === 1 ? year - 1 : year;
+  const from = `${prevYear}-${String(prevMonth).padStart(2, '0')}-16`;
+  const to = `${year}-${String(month).padStart(2, '0')}-15`;
   return { from, to };
 }
 
@@ -27,7 +34,7 @@ export function useBudget() {
     setLoading(true);
     setError(null);
     try {
-      const { from, to } = getMonthRange(month);
+      const { from, to } = getBillingRange(month);
       const [expensesRes, summaryRes, assetsRes, fixedRes] = await Promise.all([
         fetch(`/api/expenses?from=${from}&to=${to}`),
         fetch(`/api/expenses/summary?yearMonth=${month}`),
@@ -79,8 +86,9 @@ export function useBudget() {
         throw new Error(err.error ?? '지출 추가 실패');
       }
       const { data: newExpense } = (await res.json()) as { data: ExpenseRow };
-      // 현재 보고 있는 달이면 목록에 추가
-      if (data.date.startsWith(selectedMonth)) {
+      // 현재 보고 있는 결제주기에 해당하면 목록에 추가
+      const { from, to } = getBillingRange(selectedMonth);
+      if (data.date >= from && data.date <= to) {
         setExpenses((prev) => [newExpense, ...prev]);
         // 요약 재조회
         void fetch(`/api/expenses/summary?yearMonth=${selectedMonth}`)

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -101,12 +101,16 @@ export async function deleteExpense(userId: number, id: number): Promise<boolean
 
 // ─── 월간 요약 ────────────────────────────────────────
 
-/** 월간 요약: 총 지출, 카테고리별, 예산 대비 */
+/**
+ * 월간 요약: 총 지출, 카테고리별, 예산 대비.
+ * 카드 결제주기 기준: 전월 16일 ~ 당월 15일.
+ */
 export async function queryMonthSummary(userId: number, yearMonth: string): Promise<MonthSummary> {
-  const from = `${yearMonth}-01`;
-  // 월 마지막일 계산
   const [year, month] = yearMonth.split('-').map(Number);
-  const to = new Date(year, month, 0).toISOString().slice(0, 10);
+  const prevMonth = month === 1 ? 12 : month - 1;
+  const prevYear = month === 1 ? year - 1 : year;
+  const from = `${prevYear}-${String(prevMonth).padStart(2, '0')}-16`;
+  const to = `${year}-${String(month).padStart(2, '0')}-15`;
 
   const [totalResult, categoryResult, budget, fixedCosts] = await Promise.all([
     query<{ total: string }>(
@@ -137,9 +141,11 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
     .filter((c) => !FIXED_CATEGORIES.has(c.category))
     .reduce((s, c) => s + c.total, 0);
 
-  // 이 달 실제 날짜 수
-  const daysInMonth = new Date(year, month, 0).getDate();
-  const dailyAvg = total > 0 ? Math.round(total / daysInMonth) : 0;
+  // 결제주기 일수 계산 (전월 16일 ~ 당월 15일)
+  const fromDate = new Date(`${from}T00:00:00`);
+  const toDate = new Date(`${to}T00:00:00`);
+  const daysInCycle = Math.round((toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  const dailyAvg = total > 0 ? Math.round(total / daysInCycle) : 0;
 
   return {
     year_month: yearMonth,


### PR DESCRIPTION
## Summary
- 지출/예산 관리를 위한 DB 스키마, Slack 봇 에이전트, 웹 대시보드, API 엔드포인트 추가
- 웹 대시보드: 월간 요약, 지출 목록(카테고리 필터/색상), 카테고리 차트, 지출 분석
- 카드 결제주기(16일~15일) 기반 월간 조회
- 위플 CSV 마이그레이션 스크립트 포함

## Test plan
- [ ] 지출 추가/삭제 동작 확인
- [ ] 월 이동 네비게이션 (과거/미래) 확인
- [ ] 카테고리 필터 드롭다운 동작 확인
- [ ] 결제주기(16일~15일) 기준 데이터 조회 확인
- [ ] Slack #money 채널에서 지출 에이전트 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)