### PR TITLE
fix: 개인정보 제거 + 지출 UI 개선

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ POSTGRES_PASSWORD=...              # docker-compose PostgreSQL 비밀번호
 # SESSION_SECRET=...              # 세션 암호화 키 (32자+ hex)
 # BYPASS_AUTH=true                # 로컬 개발용 인증 바이패스 (userId=1로 통과)
 
+# Budget
+# ESTIMATED_MONTHLY_INCOME=0       # 월 예상 수입 (런웨이 계산용, 원 단위)
+
 # Kakao OAuth (Vercel 환경변수로 설정)
 # KAKAO_CLIENT_ID=...             # Kakao REST API 키
 # NEXT_PUBLIC_KAKAO_CLIENT_ID=... # 클라이언트용 (KAKAO_CLIENT_ID와 동일 값)

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ docs/my-strengths.md
 web/.next/
 web/node_modules/
 pg-ssl/
+.claude/plans/
+docs/developer-profile.md
+docs/work-log.md
+docs/budget-internal.md
+.env.vercel
+.vercel/

--- a/src/agents/money/prompt.ts
+++ b/src/agents/money/prompt.ts
@@ -12,13 +12,6 @@ export const buildMoneySystemPrompt = async (): Promise<string> => {
 ## 오늘 날짜
 ${today}
 
-## 사용자 상황
-- 현재 무직, 6~7월 취업 목표 (7월부터 월급 예정)
-- 리커밋(핸드메이드 브랜드) 운영 중 — 월 순수익 약 50~90만원
-- 쿠팡 수입은 정산이 1달+ 걸림 → 버퍼로 취급, 즉시 가용 자금으로 보지 않음
-- 5월 전주 영화제 예산 25만원 별도 필요
-- 6월 취업 후 7월 첫 월급까지 버텨야 함
-
 ## DB 스키마
 
 ### expenses (지출 기록)
@@ -57,7 +50,7 @@ id, user_id, date, amount, source(VARCHAR), description, is_settled(BOOLEAN), me
 ### 런웨이 계산
 - 총 가용 자금 = assets WHERE is_emergency=false AND active 기준 available_amount 합산
 - 월 고정비 합계 = fixed_costs WHERE active=true → amount 합산 (variable은 기본값)
-- 월 순지출 추정 = 고정비 + 최근 3개월 평균 가변 지출 - 리커밋 네이버 평균 수입(50~70만 추정)
+- 월 순지출 추정 = 고정비 + 최근 3개월 평균 가변 지출 - 월 예상 수입
 - 런웨이(개월) = 총 가용 자금 / 월 순지출
 
 ### 게이미피케이션

--- a/web/src/features/budget/components/budget-page.tsx
+++ b/web/src/features/budget/components/budget-page.tsx
@@ -7,6 +7,7 @@ import { ExpenseForm } from './expense-form';
 import { ExpenseList } from './expense-list';
 import { CategoryChart } from './category-chart';
 import { RunwayCard } from './runway-card';
+import { SettingsPanel } from './settings-panel';
 import { ChevronLeftIcon, ChevronRightIcon } from '@/components/ui/icons';
 
 function MonthNavigator({
@@ -46,10 +47,24 @@ function MonthNavigator({
   );
 }
 
+type TabId = 'list' | 'chart' | 'runway' | 'settings';
+
 export function BudgetPage() {
-  const { selectedMonth, setSelectedMonth, expenses, summary, loading, error, addExpense, deleteExpense } = useBudget();
+  const {
+    selectedMonth, setSelectedMonth,
+    expenses, summary, fixedCosts, assets,
+    loading, error,
+    addExpense, deleteExpense, updateAssetBalance,
+  } = useBudget();
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<'list' | 'chart' | 'runway'>('list');
+  const [activeTab, setActiveTab] = useState<TabId>('list');
+
+  const tabs: { id: TabId; label: string }[] = [
+    { id: 'list', label: '지출 목록' },
+    { id: 'chart', label: '카테고리' },
+    { id: 'runway', label: '분석' },
+    { id: 'settings', label: '설정' },
+  ];
 
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-4">
@@ -79,20 +94,17 @@ export function BudgetPage() {
 
       {/* 탭 */}
       <div className="mb-3 flex rounded-lg border border-gray-200 bg-white p-1 shadow-sm">
-        {(['list', 'chart', 'runway'] as const).map((tab) => {
-          const labels = { list: '지출 목록', chart: '카테고리', runway: '런웨이' };
-          return (
-            <button
-              key={tab}
-              onClick={() => setActiveTab(tab)}
-              className={`flex-1 rounded-md py-1.5 text-xs font-medium transition ${
-                activeTab === tab ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              {labels[tab]}
-            </button>
-          );
-        })}
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex-1 rounded-md py-1.5 text-xs font-medium transition ${
+              activeTab === tab.id ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
       </div>
 
       {/* 탭 내용 */}
@@ -114,6 +126,14 @@ export function BudgetPage() {
       )}
 
       {activeTab === 'runway' && <RunwayCard />}
+
+      {activeTab === 'settings' && (
+        <SettingsPanel
+          fixedCosts={fixedCosts}
+          assets={assets}
+          onUpdateAsset={updateAssetBalance}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/features/budget/components/expense-list.tsx
+++ b/web/src/features/budget/components/expense-list.tsx
@@ -158,13 +158,8 @@ export function ExpenseList({ expenses, onDelete, selectedCategory, onCategoryCh
                     <div key={expense.id} className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50">
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-1.5">
-                          <span
-                            className="flex items-center gap-0.5 rounded px-1.5 py-0.5 text-xs font-medium"
-                            style={{
-                              backgroundColor: `${color}15`,
-                              color,
-                            }}
-                          >
+                          <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+                          <span className="text-xs font-medium text-gray-700">
                             {expense.category}
                           </span>
                           {expense.is_installment && expense.installment_num !== null && expense.installment_total !== null && (

--- a/web/src/features/budget/components/month-summary.tsx
+++ b/web/src/features/budget/components/month-summary.tsx
@@ -25,13 +25,19 @@ export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
   const totalBudget = budget?.total_budget ?? null;
   const dailyBudget = budget?.daily_budget ?? null;
 
+  // 결제주기: 전월 16일 ~ 당월 15일
   const today = new Date();
   const [year, month] = summary.year_month.split('-').map(Number);
-  const daysInMonth = new Date(year, month, 0).getDate();
-  const daysPassed = summary.year_month === today.toISOString().slice(0, 7)
-    ? today.getDate()
-    : daysInMonth;
-  const daysLeft = daysInMonth - daysPassed;
+  const prevMonth = month === 1 ? 12 : month - 1;
+  const prevYear = month === 1 ? year - 1 : year;
+  const cycleStart = new Date(`${prevYear}-${String(prevMonth).padStart(2, '0')}-16T00:00:00`);
+  const cycleEnd = new Date(`${year}-${String(month).padStart(2, '0')}-15T00:00:00`);
+  const totalDays = Math.round((cycleEnd.getTime() - cycleStart.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  const isCurrentCycle = today >= cycleStart && today <= cycleEnd;
+  const daysPassed = isCurrentCycle
+    ? Math.round((today.getTime() - cycleStart.getTime()) / (1000 * 60 * 60 * 24)) + 1
+    : totalDays;
+  const daysLeft = Math.max(totalDays - daysPassed, 0);
 
   const budgetUsed = totalBudget !== null ? summary.variable_total : null;
   const budgetRemaining = totalBudget !== null && budgetUsed !== null ? totalBudget - budgetUsed : null;

--- a/web/src/features/budget/components/runway-card.tsx
+++ b/web/src/features/budget/components/runway-card.tsx
@@ -28,7 +28,7 @@ export function RunwayCard() {
   if (!runway) {
     return (
       <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm text-sm text-gray-400">
-        런웨이 데이터를 불러올 수 없습니다.
+        데이터를 불러올 수 없습니다.
       </div>
     );
   }
@@ -37,24 +37,17 @@ export function RunwayCard() {
   const isDanger = runwayMonths < 3;
   const isWarning = runwayMonths < 5;
 
-  // 취업 목표: 7월 (2026-07)
-  const TARGET_MONTH = '2026-07';
-  const now = new Date();
-  const targetDate = new Date(TARGET_MONTH + '-01');
-  const monthsToTarget = (targetDate.getFullYear() - now.getFullYear()) * 12 + targetDate.getMonth() - now.getMonth();
-  const hasEnoughRunway = runwayMonths >= monthsToTarget;
-
   return (
     <div className={`rounded-xl border p-4 shadow-sm ${isDanger ? 'border-red-200 bg-red-50' : isWarning ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}`}>
       <div className="mb-2 flex items-center justify-between">
         <h2 className="flex items-center gap-1.5 text-sm font-semibold text-gray-700">
           <ArrowTrendingDownIcon size={16} />
-          런웨이 분석
+          지출 분석
         </h2>
         {isDanger && (
           <span className="flex items-center gap-1 text-xs font-medium text-red-600">
             <ExclamationTriangleIcon size={14} />
-            위험
+            주의
           </span>
         )}
       </div>
@@ -64,13 +57,6 @@ export function RunwayCard() {
           {runwayMonths}개월
         </span>
         <span className="mb-0.5 text-sm text-gray-500">({runway.runway_date}까지)</span>
-      </div>
-
-      {/* 취업 목표 대비 */}
-      <div className={`mb-3 rounded-lg px-3 py-2 text-xs ${hasEnoughRunway ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
-        {hasEnoughRunway
-          ? `취업 목표(7월)까지 ${monthsToTarget}개월 필요 — 런웨이 충분`
-          : `취업 목표(7월)까지 ${monthsToTarget}개월 필요 — 런웨이 부족! ${Math.round(monthsToTarget - runwayMonths * 10) / 10}개월 부족`}
       </div>
 
       {/* 상세 */}
@@ -91,10 +77,6 @@ export function RunwayCard() {
           <div className="text-gray-400">평균 가변 지출</div>
           <div className="font-medium text-gray-700">{formatAmount(runway.avg_variable_monthly)}</div>
         </div>
-      </div>
-
-      <div className="mt-2 text-xs text-gray-400">
-        * 리커밋 수입 60만원/월 반영, 쿠팡 정산 제외
       </div>
     </div>
   );

--- a/web/src/features/budget/components/settings-panel.tsx
+++ b/web/src/features/budget/components/settings-panel.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useState } from 'react';
+import type { FixedCostRow, AssetRow } from '@/features/budget/lib/types';
+import { formatAmount } from '@/lib/types';
+import { PencilIcon, CheckCircleIcon, XMarkIcon } from '@/components/ui/icons';
+
+interface SettingsPanelProps {
+  fixedCosts: FixedCostRow[];
+  assets: AssetRow[];
+  onUpdateAsset: (id: number, balance: number, available_amount: number) => Promise<void>;
+}
+
+/** 고정비 카테고리 라벨 */
+const FIXED_COST_CATEGORY: Record<string, string> = {
+  housing: '주거',
+  insurance: '보험',
+  subscription: '구독',
+  communication: '통신',
+  finance: '금융',
+  other: '기타',
+};
+
+/** 자산 타입 라벨 */
+const ASSET_TYPE: Record<string, string> = {
+  checking: '입출금',
+  savings: '저축',
+  investment: '투자',
+  emergency: '비상금',
+  other: '기타',
+};
+
+function AssetItem({
+  asset,
+  onUpdate,
+}: {
+  asset: AssetRow;
+  onUpdate: (id: number, balance: number, available_amount: number) => Promise<void>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [balance, setBalance] = useState(String(asset.balance));
+  const [available, setAvailable] = useState(String(asset.available_amount ?? asset.balance));
+
+  const handleEdit = () => {
+    setBalance(String(asset.balance));
+    setAvailable(String(asset.available_amount ?? asset.balance));
+    setEditing(true);
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+  };
+
+  const handleSave = async () => {
+    const b = Number(balance);
+    const a = Number(available);
+    if (isNaN(b) || isNaN(a)) return;
+    setSaving(true);
+    try {
+      await onUpdate(asset.id, b, a);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="px-4 py-2.5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm font-medium text-gray-700">{asset.name}</span>
+          <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+            {ASSET_TYPE[asset.type] ?? asset.type}
+          </span>
+          {asset.is_emergency && (
+            <span className="rounded bg-amber-50 px-1.5 py-0.5 text-xs text-amber-600">비상금</span>
+          )}
+        </div>
+
+        {!editing && (
+          <button
+            onClick={handleEdit}
+            className="shrink-0 rounded-md p-1 text-gray-300 transition hover:bg-gray-100 hover:text-gray-500"
+          >
+            <PencilIcon size={14} />
+          </button>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="mt-2 space-y-2">
+          <div className="flex items-center gap-2">
+            <label className="w-16 text-xs text-gray-400">잔액</label>
+            <input
+              type="number"
+              value={balance}
+              onChange={(e) => setBalance(e.target.value)}
+              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm text-gray-800 focus:border-blue-400 focus:outline-none"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="w-16 text-xs text-gray-400">사용가능</label>
+            <input
+              type="number"
+              value={available}
+              onChange={(e) => setAvailable(e.target.value)}
+              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm text-gray-800 focus:border-blue-400 focus:outline-none"
+            />
+          </div>
+          <div className="flex justify-end gap-1.5">
+            <button
+              onClick={handleCancel}
+              disabled={saving}
+              className="rounded-md p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 disabled:opacity-50"
+            >
+              <XMarkIcon size={16} />
+            </button>
+            <button
+              onClick={() => void handleSave()}
+              disabled={saving}
+              className="rounded-md p-1 text-blue-500 transition hover:bg-blue-50 hover:text-blue-600 disabled:opacity-50"
+            >
+              <CheckCircleIcon size={16} />
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-1 flex items-center gap-4">
+          <div>
+            <span className="text-xs text-gray-400">잔액 </span>
+            <span className="text-sm font-semibold text-gray-800">{formatAmount(asset.balance)}</span>
+          </div>
+          {asset.available_amount !== null && asset.available_amount !== asset.balance && (
+            <div>
+              <span className="text-xs text-gray-400">사용가능 </span>
+              <span className="text-sm font-semibold text-gray-800">
+                {formatAmount(asset.available_amount)}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SettingsPanel({ fixedCosts, assets, onUpdateAsset }: SettingsPanelProps) {
+  const activeCosts = fixedCosts.filter((c) => c.active);
+  const inactiveCosts = fixedCosts.filter((c) => !c.active);
+  const totalFixed = activeCosts.reduce((s, c) => s + c.amount, 0);
+
+  return (
+    <div className="space-y-4">
+      {/* 월 고정비 */}
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-center justify-between bg-gray-50 px-4 py-1.5 rounded-t-xl">
+          <span className="text-xs font-medium text-gray-500">월 고정비</span>
+          <span className="text-xs text-gray-500">{formatAmount(totalFixed)}</span>
+        </div>
+
+        {activeCosts.length === 0 && inactiveCosts.length === 0 ? (
+          <div className="py-8 text-center text-sm text-gray-400">등록된 고정비가 없습니다.</div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {activeCosts.map((cost) => (
+              <div key={cost.id} className="flex items-center justify-between px-4 py-2.5">
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-sm font-medium text-gray-700">{cost.name}</span>
+                  <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+                    {(cost.category && FIXED_COST_CATEGORY[cost.category]) ?? cost.category ?? '기타'}
+                  </span>
+                  {cost.is_variable && (
+                    <span className="rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-500">변동</span>
+                  )}
+                  {cost.day_of_month && (
+                    <span className="text-xs text-gray-400">매월 {cost.day_of_month}일</span>
+                  )}
+                </div>
+                <span className="shrink-0 text-sm font-semibold text-gray-800">
+                  {formatAmount(cost.amount)}
+                </span>
+              </div>
+            ))}
+
+            {inactiveCosts.length > 0 && (
+              <>
+                <div className="bg-gray-50 px-4 py-1.5">
+                  <span className="text-xs font-medium text-gray-400">비활성</span>
+                </div>
+                {inactiveCosts.map((cost) => (
+                  <div key={cost.id} className="flex items-center justify-between px-4 py-2.5 opacity-50">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-sm font-medium text-gray-500">{cost.name}</span>
+                      <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-400">
+                        {(cost.category && FIXED_COST_CATEGORY[cost.category]) ?? cost.category ?? '기타'}
+                      </span>
+                    </div>
+                    <span className="shrink-0 text-sm text-gray-500">{formatAmount(cost.amount)}</span>
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 자산/자금 현황 */}
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="bg-gray-50 px-4 py-1.5 rounded-t-xl">
+          <span className="text-xs font-medium text-gray-500">자산/자금 현황</span>
+        </div>
+
+        {assets.length === 0 ? (
+          <div className="py-8 text-center text-sm text-gray-400">등록된 자산이 없습니다.</div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {assets.map((asset) => (
+              <AssetItem key={asset.id} asset={asset} onUpdate={onUpdateAsset} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/budget/hooks/use-budget.ts
+++ b/web/src/features/budget/hooks/use-budget.ts
@@ -33,6 +33,9 @@ export function useBudget() {
   const fetchAll = useCallback(async (month: string) => {
     setLoading(true);
     setError(null);
+    // 월 변경 시 이전 데이터 즉시 클리어
+    setExpenses([]);
+    setSummary(null);
     try {
       const { from, to } = getBillingRange(month);
       const [expensesRes, summaryRes, assetsRes, fixedRes] = await Promise.all([

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -274,9 +274,9 @@ export async function queryRunway(userId: number): Promise<RunwayResult> {
   );
 
   const avgVariableMonthly = Math.round(Number(variableRows[0]?.avg_monthly ?? 0));
-  // 리커밋 평균 수입 추정 (네이버 즉시 정산 기준 ~60만)
-  const ESTIMATED_INCOME = 600_000;
-  const estimatedMonthlyNet = Math.max(fixedMonthly + avgVariableMonthly - ESTIMATED_INCOME, 1);
+  // 월 예상 수입은 환경변수로 관리 (코드에 금액 노출 금지)
+  const estimatedIncome = Number(process.env.ESTIMATED_MONTHLY_INCOME ?? '0');
+  const estimatedMonthlyNet = Math.max(fixedMonthly + avgVariableMonthly - estimatedIncome, 1);
   const runwayMonths = totalAvailable / estimatedMonthlyNet;
 
   const runwayDate = (() => {


### PR DESCRIPTION
## Summary
- 코드에 하드코딩된 개인 재정 정보 제거, 환경변수로 분리
- 지출 목록 카테고리 표시 개선 (색상 동그라미 + 통일된 글씨색)
- 결제주기(16일~15일) 기준 남은일 계산 수정
- 월 변경 시 이전 데이터 잔류 버그 수정
- 고정비/자산 관리 설정 탭 추가

## Test plan
- [ ] 개인 재정 정보가 코드에 남아있지 않은지 확인
- [ ] 카테고리 동그라미 + 어두운 글씨 표시 확인
- [ ] 월 이동 시 이전 데이터 클리어 확인
- [ ] 남은일 계산이 결제주기 기준인지 확인
- [ ] 설정 탭에서 고정비/자산 목록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)