### PR TITLE
fix: 결제주기 기반 UI 개선 + 일평균 계산 수정

### DIFF
--- a/web/src/components/ui/icons.tsx
+++ b/web/src/components/ui/icons.tsx
@@ -157,6 +157,14 @@ export function ChevronDownIcon(props: IconProps) {
   );
 }
 
+export function FunnelIcon(props: IconProps) {
+  return (
+    <svg {...defaultProps(props)}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z" />
+    </svg>
+  );
+}
+
 export function XMarkIcon(props: IconProps) {
   return (
     <svg {...defaultProps(props)}>

--- a/web/src/features/budget/components/budget-page.tsx
+++ b/web/src/features/budget/components/budget-page.tsx
@@ -10,6 +10,13 @@ import { RunwayCard } from './runway-card';
 import { SettingsPanel } from './settings-panel';
 import { ChevronLeftIcon, ChevronRightIcon } from '@/components/ui/icons';
 
+/** 결제주기 날짜 범위 계산 (표시용) */
+function getBillingRangeLabel(yearMonth: string): string {
+  const [year, month] = yearMonth.split('-').map(Number);
+  const prevMonth = month === 1 ? 12 : month - 1;
+  return `${prevMonth}/16~${month}/15`;
+}
+
 function MonthNavigator({
   selectedMonth,
   onChange,
@@ -30,19 +37,22 @@ function MonthNavigator({
   };
 
   return (
-    <div className="flex items-center gap-2">
-      <button onClick={prev} className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
-        <ChevronLeftIcon size={18} />
-      </button>
-      <span className="min-w-[80px] text-center text-sm font-semibold text-gray-800">
-        {year}년 {month}월
-      </span>
-      <button
-        onClick={next}
-        className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-      >
-        <ChevronRightIcon size={18} />
-      </button>
+    <div className="flex flex-col items-end gap-0.5">
+      <div className="flex items-center gap-2">
+        <button onClick={prev} className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
+          <ChevronLeftIcon size={18} />
+        </button>
+        <span className="min-w-[80px] text-center text-sm font-semibold text-gray-800">
+          {month}월 대금
+        </span>
+        <button
+          onClick={next}
+          className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+        >
+          <ChevronRightIcon size={18} />
+        </button>
+      </div>
+      <span className="text-[10px] text-gray-400">{getBillingRangeLabel(selectedMonth)}</span>
     </div>
   );
 }

--- a/web/src/features/budget/components/expense-list.tsx
+++ b/web/src/features/budget/components/expense-list.tsx
@@ -6,7 +6,7 @@ import { ko } from 'date-fns/locale';
 import type { ExpenseRow } from '@/features/budget/lib/types';
 import { EXPENSE_CATEGORIES } from '@/features/budget/lib/types';
 import { formatAmount } from '@/lib/types';
-import { TrashIcon, TagIcon, ChevronDownIcon } from '@/components/ui/icons';
+import { TrashIcon, FunnelIcon, ChevronDownIcon } from '@/components/ui/icons';
 
 /** 카테고리별 색상 맵 */
 const CATEGORY_COLORS: Record<string, string> = {
@@ -91,8 +91,8 @@ export function ExpenseList({ expenses, onDelete, selectedCategory, onCategoryCh
               : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
           }`}
         >
-          <TagIcon size={13} />
-          {selectedCategory ?? '전체 카테고리'}
+          <FunnelIcon size={13} />
+          {selectedCategory ?? '필터'}
           <ChevronDownIcon size={13} />
         </button>
 

--- a/web/src/features/budget/components/month-summary.tsx
+++ b/web/src/features/budget/components/month-summary.tsx
@@ -33,11 +33,15 @@ export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
   const cycleStart = new Date(`${prevYear}-${String(prevMonth).padStart(2, '0')}-16T00:00:00`);
   const cycleEnd = new Date(`${year}-${String(month).padStart(2, '0')}-15T00:00:00`);
   const totalDays = Math.round((cycleEnd.getTime() - cycleStart.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  const isFutureCycle = today < cycleStart;
   const isCurrentCycle = today >= cycleStart && today <= cycleEnd;
-  const daysPassed = isCurrentCycle
-    ? Math.round((today.getTime() - cycleStart.getTime()) / (1000 * 60 * 60 * 24)) + 1
-    : totalDays;
-  const daysLeft = Math.max(totalDays - daysPassed, 0);
+  const isPastCycle = today > cycleEnd;
+  const daysPassed = isFutureCycle
+    ? 0
+    : isCurrentCycle
+      ? Math.round((today.getTime() - cycleStart.getTime()) / (1000 * 60 * 60 * 24)) + 1
+      : totalDays;
+  const daysLeft = totalDays - daysPassed;
 
   const budgetUsed = totalBudget !== null ? summary.variable_total : null;
   const budgetRemaining = totalBudget !== null && budgetUsed !== null ? totalBudget - budgetUsed : null;
@@ -49,7 +53,7 @@ export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
       <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-gray-700">{summary.year_month.replace('-', '년 ')}월 요약</h2>
+        <h2 className="text-sm font-semibold text-gray-700">{month}월 대금 요약</h2>
         {isOverBudget ? (
           <span className="flex items-center gap-1 text-xs text-red-500">
             <ExclamationTriangleIcon size={14} />

--- a/web/src/features/budget/hooks/use-budget.ts
+++ b/web/src/features/budget/hooks/use-budget.ts
@@ -3,8 +3,14 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { ExpenseRow, MonthSummary, AssetRow, FixedCostRow } from '@/features/budget/lib/types';
 
-function getCurrentYearMonth(): string {
-  return new Date().toISOString().slice(0, 7);
+/** 현재 결제주기의 대금 월 반환. 16일 이후면 다음달 대금. */
+function getCurrentBillingMonth(): string {
+  const now = new Date();
+  if (now.getDate() >= 16) {
+    const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    return `${next.getFullYear()}-${String(next.getMonth() + 1).padStart(2, '0')}`;
+  }
+  return now.toISOString().slice(0, 7);
 }
 
 /**
@@ -22,7 +28,7 @@ function getBillingRange(yearMonth: string): { from: string; to: string } {
 }
 
 export function useBudget() {
-  const [selectedMonth, setSelectedMonth] = useState(getCurrentYearMonth);
+  const [selectedMonth, setSelectedMonth] = useState(getCurrentBillingMonth);
   const [expenses, setExpenses] = useState<ExpenseRow[]>([]);
   const [summary, setSummary] = useState<MonthSummary | null>(null);
   const [assets, setAssets] = useState<AssetRow[]>([]);

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -135,17 +135,18 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
     count: Number(r.count),
   }));
 
-  // 고정비 카테고리 제외한 가변 지출
-  const FIXED_CATEGORIES = new Set(['통신비', '공과금']);
+  // 일평균/예산 계산에서 제외할 카테고리 (고정비, 사업비, 환불)
+  const EXCLUDED_CATEGORIES = new Set(['통신비', '공과금', '리커밋 사업', '리커밋 택배', '환불']);
   const variableTotal = byCategory
-    .filter((c) => !FIXED_CATEGORIES.has(c.category))
+    .filter((c) => !EXCLUDED_CATEGORIES.has(c.category))
     .reduce((s, c) => s + c.total, 0);
 
   // 결제주기 일수 계산 (전월 16일 ~ 당월 15일)
   const fromDate = new Date(`${from}T00:00:00`);
   const toDate = new Date(`${to}T00:00:00`);
   const daysInCycle = Math.round((toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-  const dailyAvg = total > 0 ? Math.round(total / daysInCycle) : 0;
+  // 일평균은 가변 지출 기준 (고정비/사업비/환불 제외)
+  const dailyAvg = variableTotal > 0 ? Math.round(variableTotal / daysInCycle) : 0;
 
   return {
     year_month: yearMonth,


### PR DESCRIPTION
## Summary
- 16일 이후 자동으로 다음달 대금 주기로 전환
- 월 표시를 "N월 대금" + 날짜 범위로 변경하여 결제주기 명확화
- 일평균 계산에서 고정비/사업비/환불 카테고리 제외
- 미래 월 남은 날 표시 수정 (0일 → 전체 일수)
- 카테고리 필터 라벨/아이콘 변경

## Test plan
- [ ] 4/16 이후 자동으로 5월 대금 표시 확인
- [ ] "N월 대금 (날짜범위)" 표시 확인
- [ ] 일평균에 리커밋/환불 미포함 확인
- [ ] 미래 월 남은 날이 전체 일수로 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)