### PR TITLE
feat(budget): 일일 목표/예산 시뮬레이션 재설계

### DIFF
--- a/web/src/features/budget/components/budget-page.tsx
+++ b/web/src/features/budget/components/budget-page.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from 'react';
 import { useBudget } from '@/features/budget/hooks/use-budget';
+import type { ExpenseRow } from '@/features/budget/lib/types';
 import { MonthSummaryCard } from './month-summary';
 import { ExpenseForm } from './expense-form';
 import { ExpenseList } from './expense-list';
+import { ExpenseEditModal } from './expense-edit-modal';
 import { CategoryChart } from './category-chart';
 import { RunwayCard } from './runway-card';
 import { SettingsPanel } from './settings-panel';
@@ -12,7 +14,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@/components/ui/icons';
 
 /** 결제주기 날짜 범위 계산 (표시용) */
 function getBillingRangeLabel(yearMonth: string): string {
-  const [year, month] = yearMonth.split('-').map(Number);
+  const [, month] = yearMonth.split('-').map(Number);
   const prevMonth = month === 1 ? 12 : month - 1;
   return `${prevMonth}/16~${month}/15`;
 }
@@ -64,10 +66,11 @@ export function BudgetPage() {
     selectedMonth, setSelectedMonth,
     expenses, summary, fixedCosts, assets,
     loading, error,
-    addExpense, deleteExpense, updateAssetBalance,
+    addExpense, deleteExpense, updateExpense, updateAssetBalance,
   } = useBudget();
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>('list');
+  const [editingExpense, setEditingExpense] = useState<ExpenseRow | null>(null);
 
   const tabs: { id: TabId; label: string }[] = [
     { id: 'list', label: '지출 목록' },
@@ -125,6 +128,7 @@ export function BudgetPage() {
           <ExpenseList
             expenses={expenses}
             onDelete={deleteExpense}
+            onEdit={setEditingExpense}
             selectedCategory={selectedCategory}
             onCategoryChange={setSelectedCategory}
           />
@@ -142,6 +146,15 @@ export function BudgetPage() {
           fixedCosts={fixedCosts}
           assets={assets}
           onUpdateAsset={updateAssetBalance}
+        />
+      )}
+
+      {/* 수정 모달 */}
+      {editingExpense && (
+        <ExpenseEditModal
+          expense={editingExpense}
+          onSave={updateExpense}
+          onClose={() => setEditingExpense(null)}
         />
       )}
     </div>

--- a/web/src/features/budget/components/expense-edit-modal.tsx
+++ b/web/src/features/budget/components/expense-edit-modal.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useState } from 'react';
+import type { ExpenseRow } from '@/features/budget/lib/types';
+import { EXPENSE_CATEGORIES } from '@/features/budget/lib/types';
+import { XMarkIcon } from '@/components/ui/icons';
+
+interface ExpenseEditModalProps {
+  expense: ExpenseRow;
+  onSave: (id: number, updates: { date: string; amount: number; category: string; description: string | null }) => Promise<void>;
+  onClose: () => void;
+}
+
+export function ExpenseEditModal({ expense, onSave, onClose }: ExpenseEditModalProps) {
+  const [date, setDate] = useState(expense.date);
+  const [amountStr, setAmountStr] = useState(expense.amount.toLocaleString('ko-KR'));
+  const [category, setCategory] = useState(expense.category);
+  const [description, setDescription] = useState(expense.description ?? '');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.replace(/[^0-9]/g, '');
+    const num = parseInt(raw, 10);
+    setAmountStr(raw ? num.toLocaleString('ko-KR') : '');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const amount = parseInt(amountStr.replace(/,/g, ''), 10);
+    if (isNaN(amount) || amount <= 0) {
+      setError('금액을 올바르게 입력해주세요');
+      return;
+    }
+    setLoading(true);
+    try {
+      await onSave(expense.id, {
+        date,
+        amount,
+        category,
+        description: description || null,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '수정 실패');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={handleBackdropClick}
+    >
+      <div className="w-full max-w-md rounded-xl bg-white p-5 shadow-lg">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-700">지출 수정</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 transition hover:text-gray-600"
+          >
+            <XMarkIcon size={18} />
+          </button>
+        </div>
+
+        {/* Installment badge */}
+        {expense.is_installment && expense.installment_num != null && expense.installment_total != null && (
+          <div className="mb-3">
+            <span className="inline-block rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-600">
+              {expense.installment_num}/{expense.installment_total} 할부
+            </span>
+          </div>
+        )}
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3">
+          {/* 날짜 */}
+          <div>
+            <label className="mb-1 block text-xs text-gray-500">날짜</label>
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="w-full rounded-lg border border-gray-200 px-2.5 py-2 text-sm focus:border-blue-400 focus:outline-none"
+              required
+            />
+          </div>
+
+          {/* 금액 */}
+          <div>
+            <label className="mb-1 block text-xs text-gray-500">금액 (원)</label>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={amountStr}
+              onChange={handleAmountChange}
+              placeholder="0"
+              className="w-full rounded-lg border border-gray-200 px-2.5 py-2 text-sm focus:border-blue-400 focus:outline-none"
+              required
+            />
+          </div>
+
+          {/* 카테고리 */}
+          <div>
+            <label className="mb-1 block text-xs text-gray-500">카테고리</label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full rounded-lg border border-gray-200 px-2.5 py-2 text-sm focus:border-blue-400 focus:outline-none"
+            >
+              {EXPENSE_CATEGORIES.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* 내역 */}
+          <div>
+            <label className="mb-1 block text-xs text-gray-500">내역</label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="메모"
+              className="w-full rounded-lg border border-gray-200 px-2.5 py-2 text-sm focus:border-blue-400 focus:outline-none"
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-center gap-1 text-xs text-red-500">
+              <XMarkIcon size={13} />
+              {error}
+            </div>
+          )}
+
+          {/* Buttons */}
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition hover:text-gray-700"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+            >
+              {loading ? '저장 중...' : '저장'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/budget/components/expense-list.tsx
+++ b/web/src/features/budget/components/expense-list.tsx
@@ -39,6 +39,7 @@ function getCategoryColor(category: string): string {
 interface ExpenseListProps {
   expenses: ExpenseRow[];
   onDelete: (id: number) => Promise<void>;
+  onEdit: (expense: ExpenseRow) => void;
   selectedCategory: string | null;
   onCategoryChange: (cat: string | null) => void;
 }
@@ -54,7 +55,7 @@ function groupByDate(expenses: ExpenseRow[]): Map<string, ExpenseRow[]> {
   return map;
 }
 
-export function ExpenseList({ expenses, onDelete, selectedCategory, onCategoryChange }: ExpenseListProps) {
+export function ExpenseList({ expenses, onDelete, onEdit, selectedCategory, onCategoryChange }: ExpenseListProps) {
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [filterOpen, setFilterOpen] = useState(false);
 
@@ -155,7 +156,7 @@ export function ExpenseList({ expenses, onDelete, selectedCategory, onCategoryCh
                 {dayExpenses.map((expense) => {
                   const color = getCategoryColor(expense.category);
                   return (
-                    <div key={expense.id} className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50">
+                    <div key={expense.id} className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 cursor-pointer" onClick={() => onEdit(expense)}>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-1.5">
                           <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
@@ -177,7 +178,7 @@ export function ExpenseList({ expenses, onDelete, selectedCategory, onCategoryCh
                       </div>
                       {expense.source !== 'import' && (
                         <button
-                          onClick={() => void handleDelete(expense.id)}
+                          onClick={(e) => { e.stopPropagation(); void handleDelete(expense.id); }}
                           disabled={deletingId === expense.id}
                           className="shrink-0 rounded-md p-1 text-gray-300 transition hover:bg-red-50 hover:text-red-400 disabled:opacity-50"
                         >

--- a/web/src/features/budget/components/month-summary.tsx
+++ b/web/src/features/budget/components/month-summary.tsx
@@ -23,7 +23,6 @@ function ProgressBar({ value, max, danger }: { value: number; max: number; dange
 export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
   const budget = summary.budget;
   const totalBudget = budget?.total_budget ?? null;
-  const dailyBudget = budget?.daily_budget ?? null;
 
   // 결제주기: 전월 16일 ~ 당월 15일
   const today = new Date();
@@ -35,7 +34,6 @@ export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
   const totalDays = Math.round((cycleEnd.getTime() - cycleStart.getTime()) / (1000 * 60 * 60 * 24)) + 1;
   const isFutureCycle = today < cycleStart;
   const isCurrentCycle = today >= cycleStart && today <= cycleEnd;
-  const isPastCycle = today > cycleEnd;
   const daysPassed = isFutureCycle
     ? 0
     : isCurrentCycle
@@ -43,86 +41,116 @@ export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
       : totalDays;
   const daysLeft = totalDays - daysPassed;
 
-  const budgetUsed = totalBudget !== null ? summary.variable_total : null;
-  const budgetRemaining = totalBudget !== null && budgetUsed !== null ? totalBudget - budgetUsed : null;
-  const isOverBudget = budgetRemaining !== null && budgetRemaining < 0;
+  // 예산 계산
+  // 자유 예산 = 총 예산 - 할부(이미 확정)
+  // 남은 자유 예산 = 자유 예산 - 이미 쓴 자유 지출
+  // 일일 목표 = 남은 자유 예산 / 남은 날
+  const flexibleBudget = totalBudget !== null ? totalBudget - summary.installment_total : null;
+  const flexibleRemaining = flexibleBudget !== null ? flexibleBudget - summary.flexible_spent : null;
+  const dailyTarget = flexibleRemaining !== null && daysLeft > 0
+    ? Math.round(flexibleRemaining / daysLeft)
+    : null;
 
-  const todaySpent = summary.by_category.reduce((s, c) => s + c.total, 0); // 오늘 지출은 별도 API 필요, 여기선 월 일평균
-  const dailyLeft = dailyBudget !== null ? dailyBudget - Math.round(summary.daily_avg) : null;
+  const isOverBudget = totalBudget !== null && summary.variable_total > totalBudget;
+  const budgetRemaining = totalBudget !== null ? totalBudget - summary.variable_total : null;
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-sm font-semibold text-gray-700">{month}월 대금 요약</h2>
-        {isOverBudget ? (
-          <span className="flex items-center gap-1 text-xs text-red-500">
-            <ExclamationTriangleIcon size={14} />
-            예산 초과
-          </span>
-        ) : (
-          <span className="flex items-center gap-1 text-xs text-green-600">
-            <CheckCircleIcon size={14} />
-            절약 중
-          </span>
-        )}
-      </div>
-
-      {/* 총 지출 */}
-      <div className="mb-4">
-        <div className="mb-1 flex items-end justify-between">
-          <span className="flex items-center gap-1 text-xs text-gray-500">
-            <BanknotesIcon size={13} />
-            가변 지출
-          </span>
-          <span className="text-lg font-bold text-gray-900">{formatAmount(summary.variable_total)}</span>
-        </div>
         {totalBudget !== null && (
-          <>
-            <ProgressBar value={summary.variable_total} max={totalBudget} danger={isOverBudget} />
-            <div className="mt-1 flex justify-between text-xs text-gray-400">
-              <span>예산 {formatAmount(totalBudget)}</span>
-              <span className={isOverBudget ? 'font-medium text-red-500' : 'text-gray-500'}>
-                {isOverBudget ? `${formatAmount(Math.abs(budgetRemaining ?? 0))} 초과` : `${formatAmount(budgetRemaining ?? 0)} 남음`}
-              </span>
-            </div>
-          </>
+          isOverBudget ? (
+            <span className="flex items-center gap-1 text-xs text-red-500">
+              <ExclamationTriangleIcon size={14} />
+              예산 초과
+            </span>
+          ) : (
+            <span className="flex items-center gap-1 text-xs text-green-600">
+              <CheckCircleIcon size={14} />
+              예산 내
+            </span>
+          )
         )}
       </div>
 
-      {/* 일일 현황 */}
+      {/* 예산 진행 */}
+      {totalBudget !== null && (
+        <div className="mb-4">
+          <div className="mb-1 flex items-end justify-between">
+            <span className="flex items-center gap-1 text-xs text-gray-500">
+              <BanknotesIcon size={13} />
+              가변 지출
+            </span>
+            <span className="text-lg font-bold text-gray-900">{formatAmount(summary.variable_total)}</span>
+          </div>
+          <ProgressBar value={summary.variable_total} max={totalBudget} danger={isOverBudget} />
+          <div className="mt-1 flex justify-between text-xs text-gray-400">
+            <span>예산 {formatAmount(totalBudget)}</span>
+            <span className={isOverBudget ? 'font-medium text-red-500' : 'text-gray-500'}>
+              {isOverBudget
+                ? `${formatAmount(Math.abs(budgetRemaining ?? 0))} 초과`
+                : `${formatAmount(budgetRemaining ?? 0)} 남음`}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* 예산 미설정 시 */}
+      {totalBudget === null && (
+        <div className="mb-4">
+          <div className="mb-1 flex items-end justify-between">
+            <span className="text-xs text-gray-500">가변 지출</span>
+            <span className="text-lg font-bold text-gray-900">{formatAmount(summary.variable_total)}</span>
+          </div>
+          <div className="rounded-lg bg-amber-50 px-3 py-1.5 text-xs text-amber-600">
+            월 예산을 설정하면 일일 목표를 계산해줘요
+          </div>
+        </div>
+      )}
+
+      {/* 핵심 지표 */}
       <div className="grid grid-cols-3 gap-2 border-t border-gray-100 pt-3">
+        {/* 일일 목표 */}
         <div className="text-center">
-          <div className="text-xs text-gray-400">일평균</div>
-          <div className="text-sm font-semibold text-gray-800">{formatAmount(summary.daily_avg)}</div>
-          {dailyBudget !== null && (
-            <div className={`text-xs ${dailyLeft !== null && dailyLeft < 0 ? 'text-red-400' : 'text-gray-400'}`}>
-              목표 {formatAmount(dailyBudget)}
-            </div>
+          <div className="text-xs text-gray-400">오늘 목표</div>
+          {dailyTarget !== null ? (
+            <>
+              <div className={`text-sm font-semibold ${dailyTarget < 0 ? 'text-red-500' : 'text-gray-800'}`}>
+                {dailyTarget < 0 ? '-' : ''}{formatAmount(Math.abs(dailyTarget))}
+              </div>
+              <div className="text-[10px] text-gray-400">할부 제외</div>
+            </>
+          ) : (
+            <div className="text-sm text-gray-300">-</div>
           )}
         </div>
+
+        {/* 남은 날 */}
         <div className="text-center">
           <div className="flex items-center justify-center gap-0.5 text-xs text-gray-400">
             <ClockIcon size={12} />
             남은 날
           </div>
           <div className="text-sm font-semibold text-gray-800">{daysLeft}일</div>
-          {dailyBudget !== null && daysLeft > 0 && budgetRemaining !== null && (
-            <div className="text-xs text-gray-400">
-              하루 {formatAmount(Math.max(Math.round(budgetRemaining / daysLeft), 0))}
+          {flexibleRemaining !== null && daysLeft > 0 && (
+            <div className="text-[10px] text-gray-400">
+              남은 예산 {formatAmount(Math.max(flexibleRemaining, 0))}
             </div>
           )}
         </div>
+
+        {/* 할부 확정분 */}
         <div className="text-center">
-          <div className="text-xs text-gray-400">총 지출</div>
-          <div className="text-sm font-semibold text-gray-800">{formatAmount(summary.total)}</div>
-          <div className="text-xs text-gray-400">고정비 포함</div>
+          <div className="text-xs text-gray-400">할부 확정</div>
+          <div className="text-sm font-semibold text-gray-800">{formatAmount(summary.installment_total)}</div>
+          <div className="text-[10px] text-gray-400">이번 주기</div>
         </div>
       </div>
 
       {/* 고정비 */}
       {summary.fixed_total > 0 && (
         <div className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs text-gray-500">
-          월 고정비 {formatAmount(summary.fixed_total)} (주담대·관리비·보험·통신·구독)
+          총 지출 {formatAmount(summary.total)} (고정비 {formatAmount(summary.fixed_total)} 포함)
         </div>
       )}
     </div>

--- a/web/src/features/budget/components/runway-card.tsx
+++ b/web/src/features/budget/components/runway-card.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import type { RunwayResult } from '@/features/budget/lib/queries';
 import { formatAmount } from '@/lib/types';
-import { ArrowTrendingDownIcon, ExclamationTriangleIcon } from '@/components/ui/icons';
+import { ArrowTrendingDownIcon, ExclamationTriangleIcon, CheckCircleIcon } from '@/components/ui/icons';
 
 export function RunwayCard() {
   const [runway, setRunway] = useState<RunwayResult | null>(null);
@@ -33,49 +33,76 @@ export function RunwayCard() {
     );
   }
 
-  const runwayMonths = runway.runway_months;
-  const isDanger = runwayMonths < 3;
-  const isWarning = runwayMonths < 5;
+  const isOverBudget = runway.over_budget > 0;
+  const budgetMonths = runway.budget_runway_months;
+  const actualMonths = runway.actual_runway_months;
+  const isDanger = actualMonths < 3;
 
   return (
-    <div className={`rounded-xl border p-4 shadow-sm ${isDanger ? 'border-red-200 bg-red-50' : isWarning ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}`}>
-      <div className="mb-2 flex items-center justify-between">
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
         <h2 className="flex items-center gap-1.5 text-sm font-semibold text-gray-700">
           <ArrowTrendingDownIcon size={16} />
           지출 분석
         </h2>
-        {isDanger && (
-          <span className="flex items-center gap-1 text-xs font-medium text-red-600">
+        {isOverBudget ? (
+          <span className="flex items-center gap-1 text-xs text-red-500">
             <ExclamationTriangleIcon size={14} />
-            주의
+            예산 초과 중
+          </span>
+        ) : (
+          <span className="flex items-center gap-1 text-xs text-green-600">
+            <CheckCircleIcon size={14} />
+            예산 내
           </span>
         )}
       </div>
 
-      <div className="mb-3 flex items-end gap-1">
-        <span className={`text-3xl font-bold ${isDanger ? 'text-red-600' : isWarning ? 'text-amber-600' : 'text-gray-900'}`}>
-          {runwayMonths}개월
-        </span>
-        <span className="mb-0.5 text-sm text-gray-500">({runway.runway_date}까지)</span>
+      {/* 예산 기준 런웨이 (메인) */}
+      <div className="mb-3">
+        <div className="text-xs text-gray-400 mb-1">예산대로 살면</div>
+        <div className="flex items-end gap-1">
+          <span className="text-3xl font-bold text-gray-900">
+            {budgetMonths}개월
+          </span>
+          <span className="mb-0.5 text-sm text-gray-500">({runway.budget_runway_date}까지)</span>
+        </div>
       </div>
 
+      {/* 실제 런웨이 (비교) */}
+      {isOverBudget && (
+        <div className="mb-3 rounded-lg bg-red-50 px-3 py-2">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-red-600">현재 소비 패턴 유지 시</span>
+            <span className="font-semibold text-red-700">{actualMonths}개월 ({runway.actual_runway_date}까지)</span>
+          </div>
+          <div className="mt-1 text-xs text-red-500">
+            매달 {formatAmount(runway.over_budget)} 초과 → 런웨이 {Math.round((budgetMonths - actualMonths) * 10) / 10}개월 단축
+          </div>
+        </div>
+      )}
+
       {/* 상세 */}
-      <div className="grid grid-cols-2 gap-2 text-xs text-gray-500">
+      <div className="grid grid-cols-2 gap-2 border-t border-gray-100 pt-3 text-xs text-gray-500">
         <div>
           <div className="text-gray-400">총 가용 자금</div>
           <div className="font-medium text-gray-700">{formatAmount(runway.total_available)}</div>
-        </div>
-        <div>
-          <div className="text-gray-400">월 순지출 추정</div>
-          <div className="font-medium text-gray-700">{formatAmount(runway.estimated_monthly_net)}</div>
         </div>
         <div>
           <div className="text-gray-400">월 고정비</div>
           <div className="font-medium text-gray-700">{formatAmount(runway.fixed_monthly)}</div>
         </div>
         <div>
-          <div className="text-gray-400">평균 가변 지출</div>
-          <div className="font-medium text-gray-700">{formatAmount(runway.avg_variable_monthly)}</div>
+          <div className="text-gray-400">월 가변 예산</div>
+          <div className="font-medium text-gray-700">
+            {runway.monthly_budget !== null ? formatAmount(runway.monthly_budget) : '미설정'}
+          </div>
+        </div>
+        <div>
+          <div className="text-gray-400">실제 월 평균</div>
+          <div className={`font-medium ${isOverBudget ? 'text-red-600' : 'text-gray-700'}`}>
+            {formatAmount(runway.avg_variable_monthly)}
+          </div>
         </div>
       </div>
     </div>

--- a/web/src/features/budget/hooks/use-budget.ts
+++ b/web/src/features/budget/hooks/use-budget.ts
@@ -121,6 +121,26 @@ export function useBudget() {
       .then((d: { data: MonthSummary }) => setSummary(d.data));
   }, [selectedMonth]);
 
+  const updateExpense = useCallback(
+    async (id: number, updates: { date: string; amount: number; category: string; description: string | null }): Promise<void> => {
+      const res = await fetch(`/api/expenses/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      });
+      if (!res.ok) {
+        const err = (await res.json()) as { error?: string };
+        throw new Error(err.error ?? '지출 수정 실패');
+      }
+      const { data } = (await res.json()) as { data: ExpenseRow };
+      setExpenses((prev) => prev.map((e) => (e.id === id ? data : e)));
+      void fetch(`/api/expenses/summary?yearMonth=${selectedMonth}`)
+        .then((r) => r.json())
+        .then((d: { data: MonthSummary }) => setSummary(d.data));
+    },
+    [selectedMonth],
+  );
+
   const updateAssetBalance = useCallback(
     async (id: number, balance: number, available_amount: number): Promise<void> => {
       const res = await fetch(`/api/budget/assets/${id}`, {
@@ -146,6 +166,7 @@ export function useBudget() {
     error,
     addExpense,
     deleteExpense,
+    updateExpense,
     updateAssetBalance,
     refresh: () => void fetchAll(selectedMonth),
   };

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -141,11 +141,21 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
     .filter((c) => !EXCLUDED_CATEGORIES.has(c.category))
     .reduce((s, c) => s + c.total, 0);
 
+  // 할부 합계 (가변 카테고리 중 is_installment=true)
+  const installmentResult = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(amount), 0) as total FROM expenses
+     WHERE user_id = $1 AND date >= $2 AND date <= $3
+       AND is_installment = true
+       AND category NOT IN ('통신비', '공과금', '리커밋 사업', '리커밋 택배', '환불')`,
+    [userId, from, to],
+  );
+  const installmentTotal = Number(installmentResult.rows[0]?.total ?? 0);
+  const flexibleSpent = variableTotal - installmentTotal;
+
   // 결제주기 일수 계산 (전월 16일 ~ 당월 15일)
   const fromDate = new Date(`${from}T00:00:00`);
   const toDate = new Date(`${to}T00:00:00`);
   const daysInCycle = Math.round((toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-  // 일평균은 가변 지출 기준 (고정비/사업비/환불 제외)
   const dailyAvg = variableTotal > 0 ? Math.round(variableTotal / daysInCycle) : 0;
 
   return {
@@ -154,6 +164,8 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
     budget,
     fixed_total: fixedTotal,
     variable_total: variableTotal,
+    installment_total: installmentTotal,
+    flexible_spent: flexibleSpent,
     by_category: byCategory,
     daily_avg: dailyAvg,
   };
@@ -235,32 +247,40 @@ export async function updateAsset(
 // ─── 런웨이 계산 ──────────────────────────────────────
 
 export interface RunwayResult {
-  total_available: number;       // 총 가용 자금 (비상금 제외)
-  emergency_available: number;   // 비상금 포함 총액
-  fixed_monthly: number;         // 월 고정비 합계
-  avg_variable_monthly: number;  // 최근 3개월 평균 가변 지출
-  estimated_monthly_net: number; // 월 순지출 추정
-  runway_months: number;         // 런웨이 (개월)
-  runway_date: string;           // 런웨이 종료 예상일 (YYYY-MM)
+  total_available: number;         // 총 가용 자금 (비상금 제외)
+  fixed_monthly: number;           // 월 고정비 합계
+  monthly_budget: number | null;   // 월 가변 예산 (설정값)
+  avg_variable_monthly: number;    // 최근 3개월 평균 가변 지출
+  budget_monthly_burn: number;     // 예산 기준 월 소진액 (고정비 + 가변예산 - 수입)
+  actual_monthly_burn: number;     // 실제 월 소진액 (고정비 + 실제지출 - 수입)
+  budget_runway_months: number;    // 예산대로 살 때 런웨이
+  actual_runway_months: number;    // 실제 지출 기준 런웨이
+  budget_runway_date: string;      // 예산 기준 종료일
+  actual_runway_date: string;      // 실제 기준 종료일
+  over_budget: number;             // 예산 초과분 누적 (양수 = 초과)
 }
 
 export async function queryRunway(userId: number): Promise<RunwayResult> {
-  const [assets, fixedCosts] = await Promise.all([
+  const now = new Date();
+  const currentYearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+
+  const [assets, fixedCosts, currentBudget] = await Promise.all([
     queryAssets(userId),
     queryFixedCosts(userId),
+    queryBudget(userId, currentYearMonth),
   ]);
 
   const totalAvailable = assets
     .filter((a) => !a.is_emergency)
     .reduce((s, a) => s + (a.available_amount ?? a.balance), 0);
 
-  const emergencyAvailable = assets.reduce((s, a) => s + (a.available_amount ?? a.balance), 0);
-
   const fixedMonthly = fixedCosts
     .filter((fc) => fc.active)
     .reduce((s, fc) => s + fc.amount, 0);
 
-  // 최근 3개월 가변 지출 평균
+  const monthlyBudget = currentBudget?.total_budget ?? null;
+
+  // 최근 3개월 가변 지출 평균 (리커밋/환불 제외)
   const { rows: variableRows } = await query<{ avg_monthly: string }>(
     `SELECT COALESCE(AVG(monthly_total), 0) as avg_monthly
      FROM (
@@ -268,31 +288,43 @@ export async function queryRunway(userId: number): Promise<RunwayResult> {
        FROM expenses
        WHERE user_id = $1
          AND date >= NOW() - INTERVAL '3 months'
-         AND category NOT IN ('통신비', '공과금', '환불')
+         AND category NOT IN ('통신비', '공과금', '리커밋 사업', '리커밋 택배', '환불')
        GROUP BY 1
      ) sub`,
     [userId],
   );
 
   const avgVariableMonthly = Math.round(Number(variableRows[0]?.avg_monthly ?? 0));
-  // 월 예상 수입은 환경변수로 관리 (코드에 금액 노출 금지)
   const estimatedIncome = Number(process.env.ESTIMATED_MONTHLY_INCOME ?? '0');
-  const estimatedMonthlyNet = Math.max(fixedMonthly + avgVariableMonthly - estimatedIncome, 1);
-  const runwayMonths = totalAvailable / estimatedMonthlyNet;
 
-  const runwayDate = (() => {
-    const now = new Date();
-    const target = new Date(now.getFullYear(), now.getMonth() + Math.floor(runwayMonths), 1);
+  // 예산 기준 런웨이: 예산대로 살면 얼마나 버틸 수 있는지
+  const budgetVariable = monthlyBudget ?? avgVariableMonthly;
+  const budgetMonthlyBurn = Math.max(fixedMonthly + budgetVariable - estimatedIncome, 1);
+  const budgetRunwayMonths = totalAvailable / budgetMonthlyBurn;
+
+  // 실제 기준 런웨이: 최근 소비 패턴 유지 시
+  const actualMonthlyBurn = Math.max(fixedMonthly + avgVariableMonthly - estimatedIncome, 1);
+  const actualRunwayMonths = totalAvailable / actualMonthlyBurn;
+
+  // 예산 초과분: 실제 평균 - 예산 (양수면 초과)
+  const overBudget = monthlyBudget !== null ? avgVariableMonthly - monthlyBudget : 0;
+
+  const toDateStr = (months: number) => {
+    const target = new Date(now.getFullYear(), now.getMonth() + Math.floor(months), 1);
     return `${target.getFullYear()}-${String(target.getMonth() + 1).padStart(2, '0')}`;
-  })();
+  };
 
   return {
     total_available: totalAvailable,
-    emergency_available: emergencyAvailable,
     fixed_monthly: fixedMonthly,
+    monthly_budget: monthlyBudget,
     avg_variable_monthly: avgVariableMonthly,
-    estimated_monthly_net: estimatedMonthlyNet,
-    runway_months: Math.round(runwayMonths * 10) / 10,
-    runway_date: runwayDate,
+    budget_monthly_burn: budgetMonthlyBurn,
+    actual_monthly_burn: actualMonthlyBurn,
+    budget_runway_months: Math.round(budgetRunwayMonths * 10) / 10,
+    actual_runway_months: Math.round(actualRunwayMonths * 10) / 10,
+    budget_runway_date: toDateStr(budgetRunwayMonths),
+    actual_runway_date: toDateStr(actualRunwayMonths),
+    over_budget: overBudget,
   };
 }

--- a/web/src/features/budget/lib/types.ts
+++ b/web/src/features/budget/lib/types.ts
@@ -56,6 +56,10 @@ export interface MonthSummary {
   budget: BudgetRow | null;
   fixed_total: number;
   variable_total: number;
+  /** 할부 합계 (이미 확정된 지출, 가변 카테고리 중 is_installment=true) */
+  installment_total: number;
+  /** 자유 지출 (가변 지출 중 할부 제외 = 내가 직접 쓴 돈) */
+  flexible_spent: number;
   by_category: CategoryStat[];
   daily_avg: number;
 }


### PR DESCRIPTION
## Summary
- 일일 목표를 예산 기반으로 재설계 (예산 - 할부확정 - 기지출) / 남은날
- 예산 시뮬레이션를 예산 기준 vs 실제 소비 비교 방식으로 변경
- 지출 항목 클릭 시 수정 모달 추가
- 분석 패널 색상 통일 (노란색 제거)

## Test plan
- [ ] 일일 목표가 할부 제외 후 남은 예산 기준으로 계산되는지 확인
- [ ] 예산 시뮬레이션가 예산 기준으로 표시되고, 초과 시에만 실제 예산 시뮬레이션 비교 표시
- [ ] 지출 항목 클릭 → 수정 모달 → 저장 동작 확인
- [ ] 분석 패널 색상이 흰색인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)