### PR TITLE
feat(web): 예산 설정 페이지 분리 + 고정비 자동 기록

### DIFF
--- a/web/src/app/api/expenses/summary/route.ts
+++ b/web/src/app/api/expenses/summary/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { queryMonthSummary } from '@/features/budget/lib/queries';
+import { queryMonthSummary, ensureFixedCostExpenses } from '@/features/budget/lib/queries';
 
 export async function GET(request: Request) {
   const userId = await requireAuth();
@@ -13,6 +13,9 @@ export async function GET(request: Request) {
     if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
       return NextResponse.json({ error: 'yearMonth 형식이 올바르지 않습니다 (YYYY-MM)' }, { status: 400 });
     }
+
+    // 고정비 자동 기록 (결제일 지난 건)
+    await ensureFixedCostExpenses(userId, yearMonth);
 
     const data = await queryMonthSummary(userId, yearMonth);
     return NextResponse.json({ data });

--- a/web/src/app/budget/settings/page.tsx
+++ b/web/src/app/budget/settings/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { AppShell } from '@/components/ui/app-shell';
+import { BudgetSettingsPage } from '@/features/budget/components/budget-settings-page';
+
+export default function Page() {
+  return (
+    <AppShell>
+      <BudgetSettingsPage />
+    </AppShell>
+  );
+}

--- a/web/src/components/ui/app-shell.tsx
+++ b/web/src/components/ui/app-shell.tsx
@@ -21,7 +21,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { href: '/schedules', label: '일정', Icon: CalendarIcon, activeOn: ['/backlog', '/categories'] },
   { href: '/routines', label: '루틴', Icon: ArrowPathIcon },
-  { href: '/budget', label: '지출', Icon: WalletIcon },
+  { href: '/budget', label: '지출', Icon: WalletIcon, activeOn: ['/budget/settings'] },
 ];
 
 export function AppShell({ children }: { children: React.ReactNode }) {

--- a/web/src/features/budget/components/budget-page.tsx
+++ b/web/src/features/budget/components/budget-page.tsx
@@ -9,8 +9,7 @@ import { ExpenseList } from './expense-list';
 import { ExpenseEditModal } from './expense-edit-modal';
 import { CategoryChart } from './category-chart';
 import { RunwayCard } from './runway-card';
-import { SettingsPanel } from './settings-panel';
-import { ChevronLeftIcon, ChevronRightIcon } from '@/components/ui/icons';
+import { ChevronLeftIcon, ChevronRightIcon, Bars3Icon } from '@/components/ui/icons';
 
 /** 결제주기 날짜 범위 계산 (표시용) */
 function getBillingRangeLabel(yearMonth: string): string {
@@ -59,14 +58,14 @@ function MonthNavigator({
   );
 }
 
-type TabId = 'list' | 'chart' | 'runway' | 'settings';
+type TabId = 'list' | 'chart' | 'runway';
 
 export function BudgetPage() {
   const {
     selectedMonth, setSelectedMonth,
-    expenses, summary, fixedCosts, assets,
+    expenses, summary,
     loading, error,
-    addExpense, deleteExpense, updateExpense, updateAssetBalance,
+    addExpense, deleteExpense, updateExpense,
   } = useBudget();
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>('list');
@@ -76,14 +75,22 @@ export function BudgetPage() {
     { id: 'list', label: '지출 목록' },
     { id: 'chart', label: '카테고리' },
     { id: 'runway', label: '분석' },
-    { id: 'settings', label: '설정' },
   ];
 
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-4">
       {/* 헤더 */}
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-base font-bold text-gray-900">지출 관리</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-base font-bold text-gray-900">지출 관리</h1>
+          <a
+            href="/budget/settings"
+            className="rounded-lg p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
+            title="예산 설정"
+          >
+            <Bars3Icon size={18} />
+          </a>
+        </div>
         <MonthNavigator selectedMonth={selectedMonth} onChange={setSelectedMonth} />
       </div>
 
@@ -140,14 +147,6 @@ export function BudgetPage() {
       )}
 
       {activeTab === 'runway' && <RunwayCard />}
-
-      {activeTab === 'settings' && (
-        <SettingsPanel
-          fixedCosts={fixedCosts}
-          assets={assets}
-          onUpdateAsset={updateAssetBalance}
-        />
-      )}
 
       {/* 수정 모달 */}
       {editingExpense && (

--- a/web/src/features/budget/components/budget-settings-page.tsx
+++ b/web/src/features/budget/components/budget-settings-page.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { FixedCostRow, AssetRow, BudgetRow } from '@/features/budget/lib/types';
+import { formatAmount } from '@/lib/types';
+import { ChevronLeftIcon, PencilIcon, CheckCircleIcon, XMarkIcon } from '@/components/ui/icons';
+
+/** 현재 결제주기의 대금 월 */
+function getCurrentBillingMonth(): string {
+  const now = new Date();
+  if (now.getDate() >= 16) {
+    const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    return `${next.getFullYear()}-${String(next.getMonth() + 1).padStart(2, '0')}`;
+  }
+  return now.toISOString().slice(0, 7);
+}
+
+// ─── 자산 수정 아이템 ─────────────────────────────────
+
+function AssetItem({
+  asset,
+  onUpdate,
+}: {
+  asset: AssetRow;
+  onUpdate: (id: number, balance: number, available_amount: number) => Promise<void>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [balance, setBalance] = useState(String(asset.balance));
+  const [available, setAvailable] = useState(String(asset.available_amount ?? asset.balance));
+
+  const handleSave = async () => {
+    const b = Number(balance);
+    const a = Number(available);
+    if (isNaN(b) || isNaN(a)) return;
+    setSaving(true);
+    try {
+      await onUpdate(asset.id, b, a);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="px-4 py-2.5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-700">{asset.name}</span>
+          <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">{asset.type}</span>
+          {asset.is_emergency && (
+            <span className="rounded bg-amber-50 px-1.5 py-0.5 text-xs text-amber-600">비상금</span>
+          )}
+        </div>
+        {!editing && (
+          <button
+            onClick={() => { setBalance(String(asset.balance)); setAvailable(String(asset.available_amount ?? asset.balance)); setEditing(true); }}
+            className="rounded-md p-1 text-gray-300 hover:bg-gray-100 hover:text-gray-500"
+          >
+            <PencilIcon size={14} />
+          </button>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="mt-2 space-y-2">
+          <div className="flex items-center gap-2">
+            <label className="w-16 text-xs text-gray-400">잔액</label>
+            <input type="number" value={balance} onChange={(e) => setBalance(e.target.value)}
+              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none" />
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="w-16 text-xs text-gray-400">사용가능</label>
+            <input type="number" value={available} onChange={(e) => setAvailable(e.target.value)}
+              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none" />
+          </div>
+          <div className="flex justify-end gap-1.5">
+            <button onClick={() => setEditing(false)} disabled={saving} className="rounded-md p-1 text-gray-400 hover:bg-gray-100"><XMarkIcon size={16} /></button>
+            <button onClick={() => void handleSave()} disabled={saving} className="rounded-md p-1 text-blue-500 hover:bg-blue-50"><CheckCircleIcon size={16} /></button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-1 flex items-center gap-4 text-sm">
+          <span><span className="text-xs text-gray-400">잔액 </span><span className="font-semibold text-gray-800">{formatAmount(asset.balance)}</span></span>
+          {asset.available_amount !== null && asset.available_amount !== asset.balance && (
+            <span><span className="text-xs text-gray-400">사용가능 </span><span className="font-semibold text-gray-800">{formatAmount(asset.available_amount)}</span></span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── 메인 설정 페이지 ─────────────────────────────────
+
+export function BudgetSettingsPage() {
+  const [fixedCosts, setFixedCosts] = useState<FixedCostRow[]>([]);
+  const [assets, setAssets] = useState<AssetRow[]>([]);
+  const [budget, setBudget] = useState<BudgetRow | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // 예산 수정 상태
+  const [editingBudget, setEditingBudget] = useState(false);
+  const [budgetInput, setBudgetInput] = useState('');
+  const [savingBudget, setSavingBudget] = useState(false);
+
+  const yearMonth = getCurrentBillingMonth();
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [fixedRes, assetsRes, budgetRes] = await Promise.all([
+        fetch('/api/budget/fixed-costs'),
+        fetch('/api/budget/assets'),
+        fetch(`/api/budget?yearMonth=${yearMonth}`),
+      ]);
+      if (fixedRes.ok) {
+        const d = (await fixedRes.json()) as { data: FixedCostRow[] };
+        setFixedCosts(d.data);
+      }
+      if (assetsRes.ok) {
+        const d = (await assetsRes.json()) as { data: AssetRow[] };
+        setAssets(d.data);
+      }
+      if (budgetRes.ok) {
+        const d = (await budgetRes.json()) as { data: BudgetRow | null };
+        setBudget(d.data);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [yearMonth]);
+
+  useEffect(() => { void fetchAll(); }, [fetchAll]);
+
+  const handleUpdateAsset = async (id: number, balance: number, available_amount: number) => {
+    const res = await fetch(`/api/budget/assets/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ balance, available_amount }),
+    });
+    if (!res.ok) throw new Error('자산 수정 실패');
+    const { data } = (await res.json()) as { data: AssetRow };
+    setAssets((prev) => prev.map((a) => (a.id === id ? data : a)));
+  };
+
+  const handleSaveBudget = async () => {
+    const amount = parseInt(budgetInput.replace(/,/g, ''), 10);
+    if (isNaN(amount) || amount <= 0) return;
+    setSavingBudget(true);
+    try {
+      const res = await fetch('/api/budget', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ year_month: yearMonth, total_budget: amount }),
+      });
+      if (res.ok) {
+        const { data } = (await res.json()) as { data: BudgetRow };
+        setBudget(data);
+        setEditingBudget(false);
+      }
+    } finally {
+      setSavingBudget(false);
+    }
+  };
+
+  const activeCosts = fixedCosts.filter((c) => c.active);
+  const inactiveCosts = fixedCosts.filter((c) => !c.active);
+  const totalFixed = activeCosts.reduce((s, c) => s + c.amount, 0);
+
+  if (loading) {
+    return (
+      <div className="mx-auto w-full max-w-2xl px-4 py-4">
+        <div className="h-8 w-32 animate-pulse rounded bg-gray-100 mb-4" />
+        <div className="h-40 animate-pulse rounded-xl bg-gray-100 mb-4" />
+        <div className="h-40 animate-pulse rounded-xl bg-gray-100" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-4">
+      {/* 헤더 */}
+      <div className="mb-4 flex items-center gap-2">
+        <a href="/budget" className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
+          <ChevronLeftIcon size={18} />
+        </a>
+        <h1 className="text-base font-bold text-gray-900">예산 설정</h1>
+      </div>
+
+      <div className="space-y-4">
+        {/* 월 예산 */}
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-sm font-semibold text-gray-700">월 가변 예산</h2>
+            {!editingBudget && (
+              <button
+                onClick={() => { setBudgetInput(String(budget?.total_budget ?? '')); setEditingBudget(true); }}
+                className="rounded-md p-1 text-gray-300 hover:bg-gray-100 hover:text-gray-500"
+              >
+                <PencilIcon size={14} />
+              </button>
+            )}
+          </div>
+
+          {editingBudget ? (
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                inputMode="numeric"
+                value={budgetInput}
+                onChange={(e) => {
+                  const raw = e.target.value.replace(/[^0-9]/g, '');
+                  const num = parseInt(raw, 10);
+                  setBudgetInput(raw ? num.toLocaleString('ko-KR') : '');
+                }}
+                placeholder="월 예산 입력"
+                className="flex-1 rounded-lg border border-gray-200 px-2.5 py-2 text-sm focus:border-blue-400 focus:outline-none"
+              />
+              <button onClick={() => setEditingBudget(false)} className="rounded-md p-1 text-gray-400 hover:bg-gray-100"><XMarkIcon size={16} /></button>
+              <button onClick={() => void handleSaveBudget()} disabled={savingBudget} className="rounded-md p-1 text-blue-500 hover:bg-blue-50"><CheckCircleIcon size={16} /></button>
+            </div>
+          ) : (
+            <div>
+              <span className="text-2xl font-bold text-gray-900">
+                {budget?.total_budget ? formatAmount(budget.total_budget) : '미설정'}
+              </span>
+              <p className="mt-1 text-xs text-gray-400">고정비/할부 제외, 자유롭게 쓸 수 있는 월 예산</p>
+            </div>
+          )}
+        </div>
+
+        {/* 고정 지출 */}
+        <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-t-xl">
+            <h2 className="text-sm font-semibold text-gray-700">고정 지출</h2>
+            <span className="text-xs text-gray-500">합계 {formatAmount(totalFixed)}</span>
+          </div>
+
+          {activeCosts.length === 0 && inactiveCosts.length === 0 ? (
+            <div className="py-8 text-center text-sm text-gray-400">등록된 고정 지출이 없습니다.</div>
+          ) : (
+            <div className="divide-y divide-gray-100">
+              {activeCosts.map((cost) => (
+                <div key={cost.id} className="flex items-center justify-between px-4 py-2.5">
+                  <div className="flex items-center gap-2 min-w-0 flex-wrap">
+                    <span className="text-sm font-medium text-gray-700">{cost.name}</span>
+                    {cost.category && (
+                      <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">{cost.category}</span>
+                    )}
+                    {cost.is_variable && (
+                      <span className="rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-500">변동</span>
+                    )}
+                    {cost.day_of_month && (
+                      <span className="text-xs text-gray-400">매월 {cost.day_of_month}일</span>
+                    )}
+                  </div>
+                  <span className="shrink-0 text-sm font-semibold text-gray-800 ml-2">
+                    {formatAmount(cost.amount)}
+                  </span>
+                </div>
+              ))}
+
+              {inactiveCosts.length > 0 && (
+                <>
+                  <div className="bg-gray-50 px-4 py-1.5">
+                    <span className="text-xs font-medium text-gray-400">비활성</span>
+                  </div>
+                  {inactiveCosts.map((cost) => (
+                    <div key={cost.id} className="flex items-center justify-between px-4 py-2.5 opacity-50">
+                      <span className="text-sm text-gray-500">{cost.name}</span>
+                      <span className="text-sm text-gray-500">{formatAmount(cost.amount)}</span>
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          )}
+
+          <div className="border-t border-gray-100 px-4 py-2.5">
+            <p className="text-xs text-gray-400">
+              결제일이 설정된 고정 지출은 해당 날짜에 자동으로 지출 내역에 기록됩니다.
+            </p>
+          </div>
+        </div>
+
+        {/* 자산/자금 */}
+        <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="bg-gray-50 px-4 py-2 rounded-t-xl">
+            <h2 className="text-sm font-semibold text-gray-700">자산/자금 현황</h2>
+          </div>
+
+          {assets.length === 0 ? (
+            <div className="py-8 text-center text-sm text-gray-400">등록된 자산이 없습니다.</div>
+          ) : (
+            <div className="divide-y divide-gray-100">
+              {assets.map((asset) => (
+                <AssetItem key={asset.id} asset={asset} onUpdate={handleUpdateAsset} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -183,6 +183,71 @@ export async function queryFixedCosts(userId: number): Promise<FixedCostRow[]> {
   return rows;
 }
 
+/**
+ * 고정비 자동 기록: 결제일(day_of_month)이 설정된 활성 고정비에 대해
+ * 해당 결제주기 내에 지출 기록이 없으면 자동 생성.
+ * - 미래 날짜는 생성하지 않음 (오늘까지만)
+ * - source='fixed'로 구분, 삭제 후에도 기록은 유지
+ */
+export async function ensureFixedCostExpenses(userId: number, yearMonth: string): Promise<number> {
+  const [year, month] = yearMonth.split('-').map(Number);
+  const prevMonth = month === 1 ? 12 : month - 1;
+  const prevYear = month === 1 ? year - 1 : year;
+
+  const fixedCosts = await queryFixedCosts(userId);
+  const activeCostsWithDay = fixedCosts.filter((fc) => fc.active && fc.day_of_month);
+
+  if (activeCostsWithDay.length === 0) return 0;
+
+  const today = new Date();
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+
+  let created = 0;
+
+  for (const fc of activeCostsWithDay) {
+    const day = fc.day_of_month!;
+
+    // 결제주기 내 실제 날짜 계산
+    // day >= 16 → 전월 (결제주기 시작 쪽), day <= 15 → 당월 (결제주기 끝 쪽)
+    let expenseYear: number, expenseMonth: number;
+    if (day >= 16) {
+      expenseYear = prevYear;
+      expenseMonth = prevMonth;
+    } else {
+      expenseYear = year;
+      expenseMonth = month;
+    }
+
+    // 해당 월의 실제 마지막 일자 확인 (31일이 없는 달 처리)
+    const lastDay = new Date(expenseYear, expenseMonth, 0).getDate();
+    const actualDay = Math.min(day, lastDay);
+    const expenseDate = `${expenseYear}-${String(expenseMonth).padStart(2, '0')}-${String(actualDay).padStart(2, '0')}`;
+
+    // 미래 날짜는 스킵
+    if (expenseDate > todayStr) continue;
+
+    // 이미 기록된 건이 있는지 확인 (source='fixed', 같은 날짜, 같은 이름)
+    const existing = await queryOne<{ id: number }>(
+      `SELECT id FROM expenses
+       WHERE user_id = $1 AND source = 'fixed' AND date = $2 AND description = $3`,
+      [userId, expenseDate, fc.name],
+    );
+
+    if (existing) continue;
+
+    // 자동 생성
+    await queryOne(
+      `INSERT INTO expenses (user_id, date, amount, category, description, payment_method, source, memo)
+       VALUES ($1, $2, $3, $4, $5, '카드', 'fixed', $6)
+       RETURNING id`,
+      [userId, expenseDate, fc.amount, fc.category ?? '기타', fc.name, `고정비 자동 기록 (fixed_cost_id: ${fc.id})`],
+    );
+    created++;
+  }
+
+  return created;
+}
+
 // ─── 예산 ─────────────────────────────────────────────
 
 /** 월 예산 조회 */


### PR DESCRIPTION
## Summary
- 예산 설정을 월별 탭에서 분리하여 독립 페이지(`/budget/settings`)로 이동
- 월 가변 예산, 고정 지출 목록, 자산/자금 현황을 한 페이지에서 관리
- 결제일이 설정된 고정비는 해당 날짜에 자동으로 지출 내역에 기록 (`source='fixed'`)
- 고정비를 나중에 삭제하더라도 이미 기록된 지출은 유지

## Test plan
- [ ] `/budget/settings` 페이지 접근 및 렌더링 확인
- [ ] 월 예산 수정 후 저장 확인
- [ ] 자산 잔액/사용가능 금액 수정 확인
- [ ] 고정비 자동 기록: 결제일 지난 고정비가 지출 목록에 자동 생성되는지 확인
- [ ] 고정비 자동 기록 중복 방지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)