### PR TITLE
feat(budget): 월별 시뮬레이션 기반 예산 재설계

### DIFF
--- a/web/src/features/budget/components/runway-card.tsx
+++ b/web/src/features/budget/components/runway-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import type { RunwayResult } from '@/features/budget/lib/queries';
+import type { MonthProjection } from '@/features/budget/lib/types';
 import { formatAmount } from '@/lib/types';
 import { ArrowTrendingDownIcon, ExclamationTriangleIcon, CheckCircleIcon, PencilIcon, XMarkIcon } from '@/components/ui/icons';
 
@@ -12,11 +13,18 @@ function getStoredTargetDate(): string {
   return localStorage.getItem(STORAGE_KEY) ?? '';
 }
 
+/** 프로젝션 바 높이 (remaining 기준 0~100%) */
+function barHeight(projection: MonthProjection, maxRemaining: number): number {
+  if (maxRemaining <= 0) return 0;
+  return Math.max(2, Math.round((projection.remaining / maxRemaining) * 100));
+}
+
 export function RunwayCard() {
   const [runway, setRunway] = useState<RunwayResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [editingTarget, setEditingTarget] = useState(false);
   const [targetInput, setTargetInput] = useState('');
+  const [showProjections, setShowProjections] = useState(false);
 
   const fetchRunway = useCallback((targetDate?: string) => {
     setLoading(true);
@@ -57,9 +65,17 @@ export function RunwayCard() {
     );
   }
 
-  const isOverBudget = runway.over_budget > 0;
-  const budgetMonths = runway.budget_runway_months;
-  const actualMonths = runway.actual_runway_months;
+  const isSaved = runway.cumulative_saved >= 0;
+  const projections = runway.projections;
+  const maxRemaining = projections.length > 0 ? projections[0].remaining : 0;
+
+  // 할부가 줄어드는 월 찾기 (이전 월 대비 할부 감소)
+  const installmentDropMonths = new Set<string>();
+  for (let i = 1; i < projections.length; i++) {
+    if (projections[i].installments < projections[i - 1].installments) {
+      installmentDropMonths.add(projections[i].month);
+    }
+  }
 
   return (
     <div className="space-y-3">
@@ -94,10 +110,41 @@ export function RunwayCard() {
         )}
       </div>
 
-      {/* 예산 추천 */}
+      {/* 일일 목표 + 누적 절약/초과 */}
+      {runway.daily_target !== null && (
+        <div className={`rounded-xl border p-4 shadow-sm ${isSaved ? 'border-green-100 bg-green-50' : 'border-red-100 bg-red-50'}`}>
+          <div className="flex items-center justify-between mb-2">
+            <div className="text-xs text-gray-500">일일 자유 예산 목표</div>
+            <span className="text-lg font-bold text-gray-800">{formatAmount(runway.daily_target)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="text-xs text-gray-500">
+              {runway.cycle_elapsed}일 경과 / {runway.cycle_days}일
+            </div>
+            <div className={`text-sm font-semibold ${isSaved ? 'text-green-700' : 'text-red-600'}`}>
+              {isSaved
+                ? `${formatAmount(runway.cumulative_saved)} 절약`
+                : `${formatAmount(Math.abs(runway.cumulative_saved))} 초과`}
+            </div>
+          </div>
+          {/* 진행 바 */}
+          <div className="mt-2 h-1.5 rounded-full bg-gray-200 overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all ${isSaved ? 'bg-green-500' : 'bg-red-400'}`}
+              style={{ width: `${Math.min(100, (runway.cycle_elapsed / runway.cycle_days) * 100)}%` }}
+            />
+          </div>
+          <div className="mt-1.5 flex justify-between text-[10px] text-gray-400">
+            <span>지출: {formatAmount(runway.flexible_spent)}</span>
+            <span>목표: {formatAmount(runway.daily_target * runway.cycle_elapsed)}</span>
+          </div>
+        </div>
+      )}
+
+      {/* 추천 월 자유 예산 */}
       {runway.recommended_budget !== null && runway.target_date && (
         <div className="rounded-xl border border-blue-100 bg-blue-50 p-4 shadow-sm">
-          <div className="text-xs text-blue-600 mb-1">추천 월 가변 예산</div>
+          <div className="text-xs text-blue-600 mb-1">추천 월 자유 예산</div>
           <div className="flex items-end gap-2">
             <span className="text-2xl font-bold text-blue-700">
               {formatAmount(runway.recommended_budget)}
@@ -106,6 +153,9 @@ export function RunwayCard() {
           </div>
           <p className="mt-1.5 text-xs text-blue-500">
             가용 자금 {formatAmount(runway.total_available)} 기준, {runway.target_date}까지 유지
+            {runway.recommended_daily !== null && (
+              <> (일 {formatAmount(runway.recommended_daily)})</>
+            )}
           </p>
           {runway.monthly_budget !== null && runway.recommended_budget !== runway.monthly_budget && (
             <p className="mt-1 text-xs text-blue-600 font-medium">
@@ -125,40 +175,86 @@ export function RunwayCard() {
             <ArrowTrendingDownIcon size={16} />
             지출 분석
           </h2>
-          {isOverBudget ? (
-            <span className="flex items-center gap-1 text-xs text-red-500">
-              <ExclamationTriangleIcon size={14} />
-              예산 초과 중
-            </span>
-          ) : runway.monthly_budget !== null ? (
-            <span className="flex items-center gap-1 text-xs text-green-600">
-              <CheckCircleIcon size={14} />
-              예산 내
-            </span>
-          ) : null}
         </div>
 
-        {/* 예산 기준 런웨이 (메인) */}
+        {/* 런웨이 */}
         <div className="mb-3">
           <div className="text-xs text-gray-400 mb-1">예산대로 살면</div>
           <div className="flex items-end gap-1">
             <span className="text-3xl font-bold text-gray-900">
-              {budgetMonths}개월
+              {runway.budget_runway_months}개월
             </span>
             <span className="mb-0.5 text-sm text-gray-500">({runway.budget_runway_date}까지)</span>
           </div>
         </div>
 
-        {/* 실제 런웨이 (비교) */}
-        {isOverBudget && (
-          <div className="mb-3 rounded-lg bg-red-50 px-3 py-2">
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-red-600">현재 소비 패턴 유지 시</span>
-              <span className="font-semibold text-red-700">{actualMonths}개월 ({runway.actual_runway_date}까지)</span>
-            </div>
-            <div className="mt-1 text-xs text-red-500">
-              매달 {formatAmount(runway.over_budget)} 초과 → 런웨이 {Math.round((budgetMonths - actualMonths) * 10) / 10}개월 단축
-            </div>
+        {/* 미니 프로젝션 바 차트 */}
+        {projections.length > 0 && (
+          <div className="mb-3">
+            <button
+              onClick={() => setShowProjections(!showProjections)}
+              className="mb-2 text-xs text-gray-400 hover:text-gray-600"
+            >
+              월별 시뮬레이션 {showProjections ? '접기' : '펼치기'} ({projections.length}개월)
+            </button>
+            {!showProjections && (
+              <div className="flex items-end gap-px h-12">
+                {projections.map((p) => (
+                  <div
+                    key={p.month}
+                    className={`flex-1 rounded-t-sm ${installmentDropMonths.has(p.month) ? 'bg-blue-400' : 'bg-gray-300'}`}
+                    style={{ height: `${barHeight(p, maxRemaining)}%` }}
+                    title={`${p.month}: 잔액 ${formatAmount(p.remaining)}`}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 상세 프로젝션 테이블 */}
+        {showProjections && projections.length > 0 && (
+          <div className="mb-3 max-h-60 overflow-y-auto rounded-lg border border-gray-100">
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 bg-gray-50">
+                <tr className="text-gray-400">
+                  <th className="px-2 py-1.5 text-left font-normal">월</th>
+                  <th className="px-2 py-1.5 text-right font-normal">잠긴돈</th>
+                  <th className="px-2 py-1.5 text-right font-normal">자유</th>
+                  <th className="px-2 py-1.5 text-right font-normal">잔액</th>
+                </tr>
+              </thead>
+              <tbody>
+                {projections.map((p) => (
+                  <tr
+                    key={p.month}
+                    className={`border-t border-gray-50 ${installmentDropMonths.has(p.month) ? 'bg-blue-50' : ''}`}
+                  >
+                    <td className="px-2 py-1.5 text-gray-600">
+                      {p.month.slice(2)}
+                      {installmentDropMonths.has(p.month) && (
+                        <span className="ml-1 text-blue-500">*</span>
+                      )}
+                    </td>
+                    <td className="px-2 py-1.5 text-right text-gray-500">
+                      {formatAmount(p.locked)}
+                      {p.installments > 0 && (
+                        <span className="text-[10px] text-gray-400 ml-0.5">
+                          (할부 {formatAmount(p.installments)})
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-2 py-1.5 text-right text-gray-500">{formatAmount(p.free_budget)}</td>
+                    <td className="px-2 py-1.5 text-right font-medium text-gray-700">{formatAmount(p.remaining)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {installmentDropMonths.size > 0 && (
+              <div className="px-2 py-1.5 text-[10px] text-blue-500 bg-gray-50 border-t border-gray-100">
+                * 할부 종료로 잠긴돈 감소
+              </div>
+            )}
           </div>
         )}
 
@@ -173,14 +269,14 @@ export function RunwayCard() {
             <div className="font-medium text-gray-700">{formatAmount(runway.fixed_monthly)}</div>
           </div>
           <div>
-            <div className="text-gray-400">월 가변 예산</div>
+            <div className="text-gray-400">월 자유 예산</div>
             <div className="font-medium text-gray-700">
               {runway.monthly_budget !== null ? formatAmount(runway.monthly_budget) : '미설정'}
             </div>
           </div>
           <div>
             <div className="text-gray-400">실제 월 평균</div>
-            <div className={`font-medium ${isOverBudget ? 'text-red-600' : 'text-gray-700'}`}>
+            <div className="font-medium text-gray-700">
               {formatAmount(runway.avg_variable_monthly)}
             </div>
           </div>

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -6,6 +6,7 @@ import type {
   AssetRow,
   MonthSummary,
   CategoryStat,
+  MonthProjection,
 } from './types';
 
 // ─── 지출 CRUD ───────────────────────────────────────
@@ -335,34 +336,92 @@ export async function updateAsset(
   );
 }
 
-// ─── 런웨이 계산 ──────────────────────────────────────
+// ─── 런웨이 계산 (월별 시뮬레이션) ──────────────────────
 
 export interface RunwayResult {
-  total_available: number;         // 총 가용 자금 (비상금 제외)
-  fixed_monthly: number;           // 월 고정비 합계
-  monthly_budget: number | null;   // 월 가변 예산 (설정값)
-  avg_variable_monthly: number;    // 최근 3개월 평균 가변 지출
-  budget_monthly_burn: number;     // 예산 기준 월 소진액 (고정비 + 가변예산 - 수입)
-  actual_monthly_burn: number;     // 실제 월 소진액 (고정비 + 실제지출 - 수입)
-  budget_runway_months: number;    // 예산대로 살 때 런웨이
-  actual_runway_months: number;    // 실제 지출 기준 런웨이
-  budget_runway_date: string;      // 예산 기준 종료일
-  actual_runway_date: string;      // 실제 기준 종료일
-  over_budget: number;             // 예산 초과분 누적 (양수 = 초과)
-  recommended_budget: number | null; // 목표 기간 기반 추천 가변 예산
-  target_date: string | null;       // 목표 생존 기간 (YYYY-MM)
+  total_available: number;           // 총 가용 자금 (비상금 제외)
+  fixed_monthly: number;             // 월 고정비 합계
+  monthly_budget: number | null;     // 월 가변 예산 (설정값)
+  avg_variable_monthly: number;      // 최근 3개월 평균 가변 지출
+  projections: MonthProjection[];    // 월별 시뮬레이션 결과
+  budget_runway_months: number;      // 시뮬레이션 기반 런웨이 (개월)
+  budget_runway_date: string;        // 런웨이 종료월
+  target_date: string | null;        // 목표 기간 (YYYY-MM)
+  recommended_budget: number | null; // 목표 기간 기반 추천 자유 예산
+  recommended_daily: number | null;  // 추천 일일 자유 예산
+  // 현재 결제주기 추적
+  daily_target: number | null;       // 일일 목표 (자유 예산 / 결제주기 일수)
+  cycle_days: number;                // 결제주기 일수
+  cycle_elapsed: number;             // 경과 일수
+  flexible_spent: number;            // 현재 주기 자유 지출
+  cumulative_saved: number;          // (일일목표 × 경과일) - 실제 자유지출
+}
+
+/** 결제주기 기준 billing month 오프셋 계산 */
+function addBillingMonths(yearMonth: string, offset: number): string {
+  const [y, m] = yearMonth.split('-').map(Number);
+  const d = new Date(y, m - 1 + offset, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+/** 현재 결제주기의 billing month (16일 이후면 다음달) */
+function getCurrentBillingMonth(now: Date): string {
+  if (now.getDate() >= 16) {
+    const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    return `${next.getFullYear()}-${String(next.getMonth() + 1).padStart(2, '0')}`;
+  }
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+/** 결제주기 날짜 범위 (전월 16일 ~ 당월 15일) */
+function getBillingRange(yearMonth: string): { from: string; to: string } {
+  const [year, month] = yearMonth.split('-').map(Number);
+  const prevMonth = month === 1 ? 12 : month - 1;
+  const prevYear = month === 1 ? year - 1 : year;
+  return {
+    from: `${prevYear}-${String(prevMonth).padStart(2, '0')}-16`,
+    to: `${year}-${String(month).padStart(2, '0')}-15`,
+  };
 }
 
 export async function queryRunway(userId: number, targetDate?: string): Promise<RunwayResult> {
   const now = new Date();
-  const currentYearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const billingMonth = getCurrentBillingMonth(now);
 
-  const [assets, fixedCosts, currentBudget] = await Promise.all([
+  const [assets, fixedCosts, currentBudget, installmentRows, variableRows] = await Promise.all([
     queryAssets(userId),
     queryFixedCosts(userId),
-    queryBudget(userId, currentYearMonth),
+    queryBudget(userId, billingMonth),
+    // 할부 그룹별 최신 레코드 (남은 회차 계산용)
+    query<{
+      installment_group: string;
+      installment_num: number;
+      installment_total: number;
+      amount: number;
+    }>(
+      `SELECT DISTINCT ON (installment_group)
+         installment_group, installment_num, installment_total, amount
+       FROM expenses
+       WHERE user_id = $1 AND is_installment = true AND installment_group IS NOT NULL
+       ORDER BY installment_group, date DESC, created_at DESC`,
+      [userId],
+    ),
+    // 최근 3개월 가변 지출 평균 (고정비/사업비/환불 제외)
+    query<{ avg_monthly: string }>(
+      `SELECT COALESCE(AVG(monthly_total), 0) as avg_monthly
+       FROM (
+         SELECT DATE_TRUNC('month', date) as month, SUM(amount) as monthly_total
+         FROM expenses
+         WHERE user_id = $1
+           AND date >= NOW() - INTERVAL '3 months'
+           AND category NOT IN ('통신비', '공과금', '리커밋 사업', '리커밋 택배', '환불')
+         GROUP BY 1
+       ) sub`,
+      [userId],
+    ),
   ]);
 
+  // 기본 수치
   const totalAvailable = assets
     .filter((a) => !a.is_emergency)
     .reduce((s, a) => s + (a.available_amount ?? a.balance), 0);
@@ -372,66 +431,137 @@ export async function queryRunway(userId: number, targetDate?: string): Promise<
     .reduce((s, fc) => s + fc.amount, 0);
 
   const monthlyBudget = currentBudget?.total_budget ?? null;
-
-  // 최근 3개월 가변 지출 평균 (리커밋/환불 제외)
-  const { rows: variableRows } = await query<{ avg_monthly: string }>(
-    `SELECT COALESCE(AVG(monthly_total), 0) as avg_monthly
-     FROM (
-       SELECT DATE_TRUNC('month', date) as month, SUM(amount) as monthly_total
-       FROM expenses
-       WHERE user_id = $1
-         AND date >= NOW() - INTERVAL '3 months'
-         AND category NOT IN ('통신비', '공과금', '리커밋 사업', '리커밋 택배', '환불')
-       GROUP BY 1
-     ) sub`,
-    [userId],
-  );
-
-  const avgVariableMonthly = Math.round(Number(variableRows[0]?.avg_monthly ?? 0));
+  const avgVariableMonthly = Math.round(Number(variableRows.rows[0]?.avg_monthly ?? 0));
   const estimatedIncome = Number(process.env.ESTIMATED_MONTHLY_INCOME ?? '0');
-
-  // 예산 기준 런웨이: 예산대로 살면 얼마나 버틸 수 있는지
   const budgetVariable = monthlyBudget ?? avgVariableMonthly;
-  const budgetMonthlyBurn = Math.max(fixedMonthly + budgetVariable - estimatedIncome, 1);
-  const budgetRunwayMonths = totalAvailable / budgetMonthlyBurn;
 
-  // 실제 기준 런웨이: 최근 소비 패턴 유지 시
-  const actualMonthlyBurn = Math.max(fixedMonthly + avgVariableMonthly - estimatedIncome, 1);
-  const actualRunwayMonths = totalAvailable / actualMonthlyBurn;
+  // 할부 프로젝션: 그룹별 남은 회차와 월 금액
+  const installments = installmentRows.rows
+    .filter((r) => r.installment_total > r.installment_num)
+    .map((r) => ({
+      amount: r.amount,
+      remaining: r.installment_total - r.installment_num,
+    }));
 
-  // 예산 초과분: 실제 평균 - 예산 (양수면 초과)
-  const overBudget = monthlyBudget !== null ? avgVariableMonthly - monthlyBudget : 0;
+  // ─── 월별 시뮬레이션 ───
+  const projections: MonthProjection[] = [];
+  let remaining = totalAvailable;
+  const maxMonths = 120;
 
-  const toDateStr = (months: number) => {
-    const target = new Date(now.getFullYear(), now.getMonth() + Math.floor(months), 1);
-    return `${target.getFullYear()}-${String(target.getMonth() + 1).padStart(2, '0')}`;
-  };
+  for (let i = 1; i <= maxMonths && remaining > 0; i++) {
+    const month = addBillingMonths(billingMonth, i);
+    // 해당 월의 할부 합계 (남은 회차가 i 이상인 그룹만)
+    const installmentSum = installments
+      .filter((inst) => inst.remaining >= i)
+      .reduce((s, inst) => s + inst.amount, 0);
 
-  // 목표 기간 기반 추천 예산: (가용자금 / 남은개월) - 고정비 + 수입
+    const locked = fixedMonthly + installmentSum;
+    const freeBudget = budgetVariable;
+    const netBurn = locked + freeBudget - estimatedIncome;
+
+    remaining -= netBurn;
+
+    projections.push({
+      month,
+      fixed: fixedMonthly,
+      installments: installmentSum,
+      locked,
+      free_budget: freeBudget,
+      income: estimatedIncome,
+      net_burn: netBurn,
+      remaining: Math.max(remaining, 0),
+    });
+
+    if (remaining <= 0) break;
+  }
+
+  const budgetRunwayMonths = projections.length > 0
+    ? projections.length - 1 + (remaining <= 0
+        ? (projections.at(-1)!.remaining + projections.at(-1)!.net_burn) / projections.at(-1)!.net_burn
+        : projections.length)
+    : 0;
+  const budgetRunwayDate = projections.length > 0
+    ? (remaining <= 0 ? projections.at(-1)!.month : addBillingMonths(billingMonth, maxMonths))
+    : billingMonth;
+
+  // ─── 목표 기간 기반 추천 예산 (할부 차등 반영) ───
   const validTarget = targetDate && /^\d{4}-\d{2}$/.test(targetDate) ? targetDate : null;
   let recommendedBudget: number | null = null;
+  let recommendedDaily: number | null = null;
+
   if (validTarget) {
     const [ty, tm] = validTarget.split('-').map(Number);
     const targetMonths = (ty - now.getFullYear()) * 12 + (tm - now.getMonth() - 1);
     if (targetMonths > 0) {
-      const monthlyAllowance = totalAvailable / targetMonths;
-      recommendedBudget = Math.max(Math.round(monthlyAllowance - fixedMonthly + estimatedIncome), 0);
+      // 목표까지 각 월의 잠긴 돈 합계 (고정비 + 할부)
+      let totalLocked = 0;
+      for (let i = 1; i <= targetMonths; i++) {
+        const installmentSum = installments
+          .filter((inst) => inst.remaining >= i)
+          .reduce((s, inst) => s + inst.amount, 0);
+        totalLocked += fixedMonthly + installmentSum;
+      }
+      const totalIncome = estimatedIncome * targetMonths;
+      const availableForFree = totalAvailable - totalLocked + totalIncome;
+      recommendedBudget = Math.max(Math.round(availableForFree / targetMonths), 0);
+
+      // 추천 일일 예산 (결제주기 일수 기준)
+      const { from, to } = getBillingRange(billingMonth);
+      const cycleDays = Math.round(
+        (new Date(`${to}T00:00:00`).getTime() - new Date(`${from}T00:00:00`).getTime()) / 86400000,
+      ) + 1;
+      recommendedDaily = cycleDays > 0 ? Math.round(recommendedBudget / cycleDays) : null;
     }
   }
+
+  // ─── 현재 결제주기 추적 ───
+  const { from: cycleFrom, to: cycleTo } = getBillingRange(billingMonth);
+  const cycleFromDate = new Date(`${cycleFrom}T00:00:00`);
+  const cycleToDate = new Date(`${cycleTo}T00:00:00`);
+  const cycleDays = Math.round((cycleToDate.getTime() - cycleFromDate.getTime()) / 86400000) + 1;
+
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const todayDate = new Date(`${todayStr}T00:00:00`);
+  const cycleElapsed = Math.max(
+    0,
+    Math.min(
+      cycleDays,
+      Math.round((todayDate.getTime() - cycleFromDate.getTime()) / 86400000) + 1,
+    ),
+  );
+
+  // 현재 주기 자유 지출 (가변 - 할부 - 제외 카테고리 - 환불)
+  const flexResult = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(amount), 0) as total FROM expenses
+     WHERE user_id = $1 AND date >= $2 AND date <= $3
+       AND is_installment = false
+       AND category NOT IN ('통신비', '공과금', '리커밋 사업', '리커밋 택배', '환불')`,
+    [userId, cycleFrom, todayStr < cycleTo ? todayStr : cycleTo],
+  );
+  const flexibleSpent = Number(flexResult.rows[0]?.total ?? 0);
+
+  // 일일 목표: 추천예산 > 설정예산 > 평균 순으로 사용
+  const freeBudgetForDaily = recommendedBudget ?? monthlyBudget ?? avgVariableMonthly;
+  const dailyTarget = cycleDays > 0 ? Math.round(freeBudgetForDaily / cycleDays) : null;
+  const cumulativeSaved = dailyTarget !== null
+    ? Math.round(dailyTarget * cycleElapsed - flexibleSpent)
+    : 0;
 
   return {
     total_available: totalAvailable,
     fixed_monthly: fixedMonthly,
     monthly_budget: monthlyBudget,
     avg_variable_monthly: avgVariableMonthly,
-    budget_monthly_burn: budgetMonthlyBurn,
-    actual_monthly_burn: actualMonthlyBurn,
+    projections,
     budget_runway_months: Math.round(budgetRunwayMonths * 10) / 10,
-    actual_runway_months: Math.round(actualRunwayMonths * 10) / 10,
-    budget_runway_date: toDateStr(budgetRunwayMonths),
-    actual_runway_date: toDateStr(actualRunwayMonths),
-    over_budget: overBudget,
-    recommended_budget: recommendedBudget,
+    budget_runway_date: budgetRunwayDate,
     target_date: validTarget,
+    recommended_budget: recommendedBudget,
+    recommended_daily: recommendedDaily,
+    daily_target: dailyTarget,
+    cycle_days: cycleDays,
+    cycle_elapsed: cycleElapsed,
+    flexible_spent: flexibleSpent,
+    cumulative_saved: cumulativeSaved,
   };
 }

--- a/web/src/features/budget/lib/types.ts
+++ b/web/src/features/budget/lib/types.ts
@@ -66,6 +66,18 @@ export interface MonthSummary {
   daily_avg: number;
 }
 
+/** 월별 시뮬레이션 프로젝션 */
+export interface MonthProjection {
+  month: string;          // YYYY-MM (결제주기 기준)
+  fixed: number;          // 고정비
+  installments: number;   // 할부 합계
+  locked: number;         // fixed + installments (줄일 수 없는 돈)
+  free_budget: number;    // 자유 예산
+  income: number;         // 수입
+  net_burn: number;       // locked + free_budget - income
+  remaining: number;      // 남은 가용자금
+}
+
 /** 지출 카테고리 목록 */
 export const EXPENSE_CATEGORIES = [
   '식재료',


### PR DESCRIPTION
## Summary
- 예산 시뮬레이션 계산을 단순 나눗셈에서 월별 순차 차감 시뮬레이션으로 전환
- 할부 종료 시점 반영으로 정확도 향상 (할부 끝나는 월부터 소진액 감소)
- 일일 자유 예산 목표 + 누적 절약/초과 추적 추가

## Test plan
- [ ] 예산 시뮬레이션 카드 렌더링 확인 (목표 기간 설정 + 일일 목표 + 프로젝션)
- [ ] 할부 데이터 있을 때 월별 프로젝션 정확성 확인
- [ ] 목표 기간 변경 시 추천 예산 재계산 확인
- [ ] 프로젝션 테이블 접기/펼치기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)