### PR TITLE
fix(web): 예산 계산 버그 수정 및 날짜 KST 통일

### DIFF
--- a/web/src/app/api/budget/route.ts
+++ b/web/src/app/api/budget/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
 import { queryBudget, upsertBudget } from '@/features/budget/lib/queries';
+import { getTodayISO } from '@/lib/kst';
 
 export async function GET(request: Request) {
   const userId = await requireAuth();
@@ -8,7 +9,7 @@ export async function GET(request: Request) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const yearMonth = searchParams.get('yearMonth') ?? new Date().toISOString().slice(0, 7);
+    const yearMonth = searchParams.get('yearMonth') ?? getTodayISO().slice(0, 7);
 
     if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
       return NextResponse.json({ error: 'yearMonth 형식이 올바르지 않습니다 (YYYY-MM)' }, { status: 400 });

--- a/web/src/app/api/expenses/[id]/route.ts
+++ b/web/src/app/api/expenses/[id]/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
 import { updateExpense, deleteExpense } from '@/features/budget/lib/queries';
-import { EXPENSE_CATEGORIES } from '@/features/budget/lib/types';
+import { EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/features/budget/lib/types';
 
-const VALID_CATEGORIES = new Set<string>(EXPENSE_CATEGORIES);
+const VALID_CATEGORIES = new Set<string>([...EXPENSE_CATEGORIES, ...INCOME_CATEGORIES]);
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const userId = await requireAuth();

--- a/web/src/app/api/expenses/route.ts
+++ b/web/src/app/api/expenses/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
 import { queryExpenses, createExpense, createInstallmentExpenses } from '@/features/budget/lib/queries';
 import { EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/features/budget/lib/types';
+import { getTodayISO } from '@/lib/kst';
 
 const VALID_EXPENSE_CATEGORIES = new Set<string>(EXPENSE_CATEGORIES);
 const VALID_INCOME_CATEGORIES = new Set<string>(INCOME_CATEGORIES);
@@ -13,8 +14,9 @@ export async function GET(request: Request) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const from = searchParams.get('from') ?? new Date().toISOString().slice(0, 7) + '-01';
-    const to = searchParams.get('to') ?? new Date().toISOString().slice(0, 10);
+    const today = getTodayISO();
+    const from = searchParams.get('from') ?? today.slice(0, 7) + '-01';
+    const to = searchParams.get('to') ?? today;
     const category = searchParams.get('category') ?? undefined;
 
     if (!/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {

--- a/web/src/app/api/expenses/summary/route.ts
+++ b/web/src/app/api/expenses/summary/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
 import { queryMonthSummary, ensureFixedCostExpenses } from '@/features/budget/lib/queries';
+import { getTodayISO } from '@/lib/kst';
 
 export async function GET(request: Request) {
   const userId = await requireAuth();
@@ -8,7 +9,7 @@ export async function GET(request: Request) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const yearMonth = searchParams.get('yearMonth') ?? new Date().toISOString().slice(0, 7);
+    const yearMonth = searchParams.get('yearMonth') ?? getTodayISO().slice(0, 7);
 
     if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
       return NextResponse.json({ error: 'yearMonth 형식이 올바르지 않습니다 (YYYY-MM)' }, { status: 400 });

--- a/web/src/features/budget/components/budget-page.tsx
+++ b/web/src/features/budget/components/budget-page.tsx
@@ -7,6 +7,7 @@ import { MonthSummaryCard } from './month-summary';
 import { ExpenseForm } from './expense-form';
 import { ExpenseList } from './expense-list';
 import { ExpenseEditModal } from './expense-edit-modal';
+import { IncomeEditModal } from './income-edit-modal';
 import { CategoryChart } from './category-chart';
 import { RunwayCard } from './runway-card';
 import { BudgetSettingsPage } from './budget-settings-page';
@@ -166,8 +167,16 @@ export function BudgetPage() {
         </div>
       )}
 
-      {/* 수정 모달 */}
-      {editingExpense && (
+      {/* 수정 모달: 수입/지출 타입에 따라 분기 */}
+      {editingExpense && editingExpense.type === 'income' && (
+        <IncomeEditModal
+          income={editingExpense}
+          onSave={updateExpense}
+          onDelete={deleteExpense}
+          onClose={() => setEditingExpense(null)}
+        />
+      )}
+      {editingExpense && editingExpense.type !== 'income' && (
         <ExpenseEditModal
           expense={editingExpense}
           onSave={updateExpense}

--- a/web/src/features/budget/components/expense-form.tsx
+++ b/web/src/features/budget/components/expense-form.tsx
@@ -6,6 +6,7 @@ import { EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/features/budget/lib/typ
 import { PlusIcon, XMarkIcon } from '@/components/ui/icons';
 import { formatAmount } from '@/lib/types';
 import { Input, Select } from '@/components/ui/input';
+import { getTodayISO } from '@/lib/kst';
 
 interface ExpenseFormProps {
   onAdd: (data: {
@@ -25,7 +26,7 @@ interface ExpenseFormProps {
 const INSTALLMENT_OPTIONS = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
 export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
-  const today = new Date().toISOString().slice(0, 10);
+  const today = getTodayISO();
   const [entryType, setEntryType] = useState<'expense' | 'income'>('expense');
   const [date, setDate] = useState(today);
   const [amountStr, setAmountStr] = useState('');

--- a/web/src/features/budget/components/income-edit-modal.tsx
+++ b/web/src/features/budget/components/income-edit-modal.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import type { ExpenseRow } from '@/features/budget/lib/types';
+import { INCOME_CATEGORIES } from '@/features/budget/lib/types';
+import { XMarkIcon } from '@/components/ui/icons';
+import { Button } from '@/components/ui/button';
+import { Input, Select } from '@/components/ui/input';
+
+interface IncomeEditModalProps {
+  income: ExpenseRow;
+  onSave: (id: number, updates: { date: string; amount: number; category: string; description: string | null }) => Promise<void>;
+  onDelete: (id: number) => Promise<void>;
+  onClose: () => void;
+}
+
+export function IncomeEditModal({ income, onSave, onDelete, onClose }: IncomeEditModalProps) {
+  const [deleting, setDeleting] = useState(false);
+  const [date, setDate] = useState(income.date);
+  const [amountStr, setAmountStr] = useState(income.amount.toLocaleString('ko-KR'));
+  const [category, setCategory] = useState(income.category);
+  const [description, setDescription] = useState(income.description ?? '');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.replace(/[^0-9]/g, '');
+    const num = parseInt(raw, 10);
+    setAmountStr(raw ? num.toLocaleString('ko-KR') : '');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const amount = parseInt(amountStr.replace(/,/g, ''), 10);
+    if (isNaN(amount) || amount <= 0) {
+      setError('금액을 올바르게 입력해주세요');
+      return;
+    }
+    setLoading(true);
+    try {
+      await onSave(income.id, {
+        date,
+        amount,
+        category,
+        description: description || null,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '수정 실패');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={handleBackdropClick}
+    >
+      <div className="w-full max-w-md rounded-xl bg-white p-5 shadow-lg">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-green-700">수입 수정</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 transition hover:text-gray-600"
+          >
+            <XMarkIcon size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3">
+          {/* 날짜 */}
+          <Input
+            label="날짜"
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            required
+          />
+
+          {/* 금액 */}
+          <Input
+            label="금액 (원)"
+            type="text"
+            inputMode="numeric"
+            value={amountStr}
+            onChange={handleAmountChange}
+            placeholder="0"
+            required
+          />
+
+          {/* 카테고리 */}
+          <Select
+            label="카테고리"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            {INCOME_CATEGORIES.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </Select>
+
+          {/* 내역 */}
+          <Input
+            label="내역"
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="메모"
+          />
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-center gap-1 text-xs text-red-500">
+              <XMarkIcon size={13} />
+              {error}
+            </div>
+          )}
+
+          {/* Buttons */}
+          <div className="flex items-center justify-between pt-1">
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deleting}
+              onClick={() => {
+                if (!confirm('이 수입을 삭제할까요?')) return;
+                setDeleting(true);
+                void onDelete(income.id).then(onClose).finally(() => setDeleting(false));
+              }}
+            >
+              {deleting ? '삭제 중...' : '삭제'}
+            </Button>
+            <div className="flex items-center gap-2">
+              <Button type="button" variant="ghost" onClick={onClose}>
+                취소
+              </Button>
+              <Button type="submit" disabled={loading}>
+                {loading ? '저장 중...' : '저장'}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/budget/hooks/use-budget.ts
+++ b/web/src/features/budget/hooks/use-budget.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import type { ExpenseRow, MonthSummary, AssetRow, FixedCostRow } from '@/features/budget/lib/types';
+import { getTodayISO } from '@/lib/kst';
 
 const FETCH_TIMEOUT_MS = 8000;
 
@@ -18,12 +19,14 @@ async function fetchWithTimeout(url: string, options?: RequestInit): Promise<Res
 
 /** 현재 결제주기의 대금 월 반환. 16일 이후면 다음달 대금. */
 function getCurrentBillingMonth(): string {
-  const now = new Date();
-  if (now.getDate() >= 16) {
-    const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
-    return `${next.getFullYear()}-${String(next.getMonth() + 1).padStart(2, '0')}`;
+  const today = getTodayISO();
+  const [year, month, day] = today.split('-').map(Number);
+  if (day >= 16) {
+    const nextMonth = month === 12 ? 1 : month + 1;
+    const nextYear = month === 12 ? year + 1 : year;
+    return `${nextYear}-${String(nextMonth).padStart(2, '0')}`;
   }
-  return now.toISOString().slice(0, 7);
+  return `${year}-${String(month).padStart(2, '0')}`;
 }
 
 /**

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -844,7 +844,12 @@ export async function queryRunway(userId: number, targetDate?: string): Promise<
   // flexibleSpent는 예산 시작일(budget_settings.updated_at) 이후만 추적
   // 미래 월 예산 안정화: 이번 달 자유 지출을 더해서 "이번 달 시작 시점" 가용자금으로 복원
   // 이번 달 지출은 "이번 달 예산을 소비한 것"이지, 전체 가용자금을 영구적으로 깎은 것이 아님
-  const budgetBase = totalAvailable + flexibleSpent;
+  //
+  // 수입 이중 반영 방지:
+  // totalAvailable에 이미 incomeSince로 수입이 포함되어 있으므로,
+  // currentMonthIncome을 빼서 전체 월 분배에서 제외한다.
+  // 수입은 thisMonthFree에서 이번 달에만 직접 반영된다. (line 909)
+  const budgetBase = totalAvailable + flexibleSpent - currentMonthIncome;
 
   if (validTarget) {
     const [ty, tm] = validTarget.split('-').map(Number);

--- a/web/src/features/schedule/components/backlog-panel.tsx
+++ b/web/src/features/schedule/components/backlog-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from 'react';
 import { getCategoryStyle } from '@/lib/types';
+import { getTodayISO } from '@/lib/kst';
 import { useBacklog } from '@/features/schedule/hooks/use-backlog';
 import { Modal } from '@/components/ui/modal';
 import { ScheduleForm } from '@/features/schedule/components/schedule-form';
@@ -31,8 +32,7 @@ export function BacklogPanel() {
   );
 
   const handleAddToToday = (id: number) => {
-    const today = new Date().toISOString().slice(0, 10);
-    handleAssignDate(id, today);
+    handleAssignDate(id, getTodayISO());
   };
 
   if (loading) {

--- a/web/src/features/schedule/components/schedule-card.tsx
+++ b/web/src/features/schedule/components/schedule-card.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import type { ScheduleRow } from '@/features/schedule/lib/types';
 import type { CategoryRow } from '@/lib/types';
 import { getCategoryStyle } from '@/lib/types';
+import { getTodayISO } from '@/lib/kst';
 import { StatusBadge } from './status-badge';
 
 interface ScheduleCardProps {
@@ -77,7 +78,7 @@ export function ScheduleCard({
     <div
       onClick={handleCardClick}
       className={`cursor-pointer rounded-lg border p-3 transition hover:shadow-sm ${STATUS_BG[schedule.status] ?? 'bg-white'} ${
-        !isDone && schedule.date && new Date(schedule.date + 'T12:00:00+09:00') < new Date(new Date().toISOString().slice(0, 10) + 'T12:00:00+09:00') && schedule.status === 'todo'
+        !isDone && schedule.date && new Date(schedule.date + 'T12:00:00+09:00') < new Date(getTodayISO() + 'T12:00:00+09:00') && schedule.status === 'todo'
           ? 'border-red-300'
           : 'border-gray-200'
       }`}

--- a/web/src/features/schedule/components/week-view.tsx
+++ b/web/src/features/schedule/components/week-view.tsx
@@ -8,6 +8,7 @@ import type { ScheduleRow } from '@/features/schedule/lib/types';
 import { compareSchedulePriority } from '@/features/schedule/lib/types';
 import type { CategoryRow } from '@/lib/types';
 import { getCategoryStyle } from '@/lib/types';
+import { getTodayISO } from '@/lib/kst';
 import { computeWeekLayout, WEEK_START, type WeekSpan } from '@/features/schedule/lib/calendar-utils';
 import { StatusBadge } from './status-badge';
 import { DroppableDay } from './droppable-day';
@@ -320,7 +321,7 @@ function WeekSpanBar({
     !isDone &&
     span.schedule.date &&
     new Date(span.schedule.date + 'T12:00:00+09:00') <
-      new Date(new Date().toISOString().slice(0, 10) + 'T12:00:00+09:00') &&
+      new Date(getTodayISO() + 'T12:00:00+09:00') &&
     span.schedule.status === 'todo';
 
   const handleStatusClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- 수입 이중 반영 버그 수정 (budgetBase에서 currentMonthIncome 차감)
- 수입 전용 수정 모달 추가 (수입 카테고리 표시, 초록 테마)
- PATCH API 수입 카테고리 validation 누락 수정
- 날짜 기본값 8곳 `new Date()` → `getTodayISO()` KST 통일
- 설정탭 월별 일일 예산을 각 달 주기 일수로 계산
- 지출 추가/삭제/수정 후 분석 데이터 즉시 재조회

## Test plan
- [ ] 수입 입력 후 일일 예산이 이중 반영 없이 정상 반영되는지 확인
- [ ] 수입 항목 클릭 시 수입 수정 모달이 열리는지 확인
- [ ] 지출 추가 폼 날짜 기본값이 KST 오늘인지 확인
- [ ] 설정탭 월별 일일 예산 표시 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)