### PR TITLE
fix(budget): 사업 카테고리를 일 예산 계산에 포함

### DIFF
--- a/web/src/features/budget/lib/types.ts
+++ b/web/src/features/budget/lib/types.ts
@@ -104,11 +104,11 @@ export interface MonthProjection {
   remaining: number;      // 남은 가용자금
 }
 
-/** 예산 계산에서 제외할 카테고리 (고정비/사업비 — 자유 지출에 포함 안 됨) */
-export const EXCLUDED_CATEGORIES = new Set(['통신비', '공과금', '리커밋 사업', '리커밋 택배']);
+/** 예산 계산에서 제외할 카테고리 (고정비 — 자유 지출에 포함 안 됨) */
+export const EXCLUDED_CATEGORIES = new Set(['통신비', '공과금']);
 
 /** 예산 계산에서 제외할 카테고리 SQL 조건 */
-export const EXCLUDED_CATEGORIES_SQL = "'통신비', '공과금', '리커밋 사업', '리커밋 택배'";
+export const EXCLUDED_CATEGORIES_SQL = "'통신비', '공과금'";
 
 /** 하루 최소 자유 예산 경고 기준 (원) */
 export const MIN_DAILY_BUDGET = 10000;


### PR DESCRIPTION
## 관련 이슈
예산 일 예산 계산 개선

## 변경 내용
- `리커밋 사업`, `리커밋 택배` 카테고리를 `EXCLUDED_CATEGORIES`에서 제거
- 사업 관련 지출이 자유 지출로 일 예산에 반영되도록 변경
- 사업비 정산은 수입 입력으로 처리

## 테스트
- [x] EXCLUDED_CATEGORIES에서 사업 카테고리 제거 확인
- [x] EXCLUDED_CATEGORIES_SQL 동기화 확인