### PR TITLE
fix: SET statement_timeout 파라미터 바인딩 오류 수정

### DIFF
--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -65,11 +65,11 @@ export const queryWithClient = async <T extends pg.QueryResultRow = pg.QueryResu
   const p = getPool();
   const client = await p.connect();
   try {
-    await client.query('SET statement_timeout = $1', [String(timeoutMs)]);
+    await client.query(`SET statement_timeout = ${Number(timeoutMs)}`);
     const result = await client.query<T>(text);
     return result;
   } finally {
-    await client.query('SET statement_timeout = $1', ['0']).catch(() => {/* 무시 */});
+    await client.query('SET statement_timeout = 0').catch(() => {/* 무시 */});
     client.release();
   }
 };
@@ -83,7 +83,7 @@ export const queryWithRowLimit = async <T extends pg.QueryResultRow = pg.QueryRe
   const p = getPool();
   const client = await p.connect();
   try {
-    await client.query('SET statement_timeout = $1', [String(timeoutMs)]);
+    await client.query(`SET statement_timeout = ${Number(timeoutMs)}`);
     await client.query('BEGIN');
     const result = await client.query<T>(text);
     if (result.rowCount !== null && result.rowCount > maxRows) {
@@ -98,7 +98,7 @@ export const queryWithRowLimit = async <T extends pg.QueryResultRow = pg.QueryRe
     await client.query('ROLLBACK').catch(() => {/* 무시 */});
     throw err;
   } finally {
-    await client.query('SET statement_timeout = $1', ['0']).catch(() => {/* 무시 */});
+    await client.query('SET statement_timeout = 0').catch(() => {/* 무시 */});
     client.release();
   }
 };


### PR DESCRIPTION
## Summary
- PostgreSQL `SET` 명령은 `$1` 파라미터 바인딩을 지원하지 않아 `query_db`/`modify_db` 도구가 모두 실패하던 버그 수정
- 리터럴 값 삽입으로 변경 (`Number()` 캐스팅으로 안전성 확보)

## Test plan
- [x] 296 테스트 전체 통과
- [ ] Slack #insight 채널에서 일기 기록 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)