### PR TITLE
feat(web): 가입 제한 조정 + Slack 신규 가입 알림

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,4 +36,7 @@ POSTGRES_PASSWORD=...              # docker-compose PostgreSQL 비밀번호
 # KAKAO_CLIENT_ID=...             # Kakao REST API 키
 # NEXT_PUBLIC_KAKAO_CLIENT_ID=... # 클라이언트용 (KAKAO_CLIENT_ID와 동일 값)
 # KAKAO_CLIENT_SECRET=...         # optional: Kakao 보안 설정 시
-# KAKAO_ALLOWED_IDS=...           # 가입 허용 카카오 ID (콤마 구분, 미설정 시 가입 불가)
+
+# 신규 가입 알림 (Vercel 환경변수)
+# SLACK_BOT_TOKEN=...              # Slack Bot User OAuth Token (chat:write 스코프 필요)
+# SIGNUP_NOTIFY_CHANNEL_ID=...     # 가입 알림 채널 ID

--- a/web/src/app/api/auth/kakao/callback/route.ts
+++ b/web/src/app/api/auth/kakao/callback/route.ts
@@ -49,9 +49,6 @@ export async function GET(request: Request) {
     if (message === 'MAX_USERS_REACHED') {
       return NextResponse.redirect(new URL('/login?error=max_users', request.url));
     }
-    if (message === 'NOT_ALLOWED') {
-      return NextResponse.redirect(new URL('/login?error=not_allowed', request.url));
-    }
 
     return NextResponse.redirect(new URL('/login?error=auth_failed', request.url));
   }

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -5,7 +5,6 @@ import { Suspense } from 'react';
 
 const ERROR_MESSAGES: Record<string, string> = {
   max_users: '현재 가입 인원이 가득 찼어요',
-  not_allowed: '가입이 허용되지 않은 계정이에요',
   auth_failed: '로그인에 실패했어요. 다시 시도해주세요',
   invalid_state: '잘못된 요청이에요. 다시 시도해주세요',
   invalid_request: '잘못된 요청이에요',

--- a/web/src/lib/kakao.ts
+++ b/web/src/lib/kakao.ts
@@ -3,7 +3,7 @@
 const KAKAO_CLIENT_ID = process.env.KAKAO_CLIENT_ID ?? '';
 const KAKAO_CLIENT_SECRET = process.env.KAKAO_CLIENT_SECRET;
 
-const MAX_USERS = 10;
+const MAX_USERS = 5;
 
 export const getKakaoAuthUrl = (redirectUri: string, state: string): string => {
   const params = new URLSearchParams({

--- a/web/src/lib/slack.ts
+++ b/web/src/lib/slack.ts
@@ -1,0 +1,83 @@
+/** Slack Web API 클라이언트 — 웹에서 알림용 메시지 전송 */
+
+const SLACK_API = 'https://slack.com/api/chat.postMessage';
+
+interface PostMessageOptions {
+  channel: string;
+  text: string;
+  blocks?: unknown[];
+}
+
+/**
+ * Slack 채널에 메시지 전송. 실패해도 throw 하지 않음 (fire-and-forget).
+ * SLACK_BOT_TOKEN 미설정 시 아무 동작 안 함.
+ */
+export const postSlackMessage = async (options: PostMessageOptions): Promise<void> => {
+  const token = process.env['SLACK_BOT_TOKEN'];
+  if (!token) {
+    console.warn('[slack] SLACK_BOT_TOKEN 미설정 — 알림 건너뜀');
+    return;
+  }
+
+  try {
+    const res = await fetch(SLACK_API, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify(options),
+    });
+
+    if (!res.ok) {
+      console.error(`[slack] HTTP ${res.status}: ${res.statusText}`);
+      return;
+    }
+
+    const data = (await res.json()) as { ok: boolean; error?: string };
+    if (!data.ok) {
+      console.error(`[slack] API 오류: ${data.error ?? 'unknown'}`);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[slack] 요청 실패: ${message}`);
+  }
+};
+
+/** 신규 가입자 알림 */
+export const notifyNewSignup = async (params: {
+  nickname: string | null;
+  email: string | null;
+  totalUsers: number;
+  maxUsers: number;
+}): Promise<void> => {
+  const channel = process.env['SIGNUP_NOTIFY_CHANNEL_ID'];
+  if (!channel) {
+    console.warn('[slack] SIGNUP_NOTIFY_CHANNEL_ID 미설정 — 알림 건너뜀');
+    return;
+  }
+
+  const nickname = params.nickname ?? '(닉네임 없음)';
+  const email = params.email ?? '(이메일 비공개)';
+  const now = new Date().toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
+
+  await postSlackMessage({
+    channel,
+    text: `신규 가입자 알림 — ${nickname}`,
+    blocks: [
+      {
+        type: 'header',
+        text: { type: 'plain_text', text: '🚨 새 가입자 발생', emoji: true },
+      },
+      {
+        type: 'section',
+        fields: [
+          { type: 'mrkdwn', text: `*닉네임*\n${nickname}` },
+          { type: 'mrkdwn', text: `*이메일*\n${email}` },
+          { type: 'mrkdwn', text: `*가입 시각*\n${now}` },
+          { type: 'mrkdwn', text: `*총 유저*\n${params.totalUsers} / ${params.maxUsers}` },
+        ],
+      },
+    ],
+  });
+};

--- a/web/src/lib/users.ts
+++ b/web/src/lib/users.ts
@@ -1,17 +1,7 @@
 import { query, queryOne } from '@/lib/db';
 import type { KakaoUserInfo } from '@/lib/kakao';
 import { MAX_USERS } from '@/lib/kakao';
-
-/**
- * 가입 허용 카카오 ID 목록 (환경변수 KAKAO_ALLOWED_IDS, 콤마 구분).
- * 미설정 시 가입 차단 (기존 유저만 로그인 가능).
- */
-const ALLOWED_KAKAO_IDS = new Set(
-  (process.env['KAKAO_ALLOWED_IDS'] ?? '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0),
-);
+import { notifyNewSignup } from '@/lib/slack';
 
 export interface UserRow {
   id: number;
@@ -48,11 +38,6 @@ export const findOrCreateUser = async (info: KakaoUserInfo): Promise<UserRow> =>
     return existing;
   }
 
-  // 가입 허용 목록 검증 (allowlist)
-  if (!ALLOWED_KAKAO_IDS.has(String(info.kakaoId))) {
-    throw new Error('NOT_ALLOWED');
-  }
-
   // 가입 제한 확인
   const count = await getUserCount();
   if (count >= MAX_USERS) {
@@ -77,5 +62,17 @@ export const findOrCreateUser = async (info: KakaoUserInfo): Promise<UserRow> =>
 
   const user = result.rows[0];
   if (!user) throw new Error('유저 생성 실패');
+
+  // Slack 알림 (fire-and-forget — 실패해도 가입은 성공)
+  notifyNewSignup({
+    nickname: user.nickname,
+    email: user.email,
+    totalUsers: count + 1,
+    maxUsers: MAX_USERS,
+  }).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[users] 가입 알림 전송 실패:', message);
+  });
+
   return user;
 };


### PR DESCRIPTION
## Summary
- MAX_USERS 10 → 5 로 조정
- Kakao allowlist 제거 — MAX_USERS 단독 운용으로 단순화
- 신규 가입 시 Slack 채널로 알림 전송 (fire-and-forget)

## 알림 구현
- \`web/src/lib/slack.ts\`: chat.postMessage 호출 헬퍼
- Block Kit 메시지: 닉네임 / 이메일 / 가입 시각 / 총 유저 수
- 실패해도 가입 자체는 성공 (silent log)

## 환경변수 (Vercel 추가 필요)
- \`SLACK_BOT_TOKEN\` — \`chat:write\` 스코프
- \`SIGNUP_NOTIFY_CHANNEL_ID\` — 알림 채널 ID

## Test plan
- [x] \`yarn test\` (320 passed)
- [x] \`yarn build\` (web)
- [ ] Vercel 환경변수 추가 후 수동 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)