### PR TITLE
fix(ci): 배포 SSH 액션 타임아웃 30분으로 확장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          command_timeout: 30m
           script: bash ~/deploy.sh
 
       - name: Notify deploy success


### PR DESCRIPTION
## Summary
\`appleboy/ssh-action\`의 기본 \`command_timeout\`이 10분인데, VM의 \`yarn install\`(~5분) + \`docker build\`(~3분) + up 재시작까지 합치면 10분을 초과해서 타임아웃 발생.

## 변경
- \`command_timeout: 30m\` 추가

## 참고
PR #225 배포 시 이 문제 발생 — 이미지는 정상 빌드됐으나 SSH 액션이 타임아웃으로 잘림. 수동 \`docker compose up -d\`로 반영 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)