### PR TITLE
fix(docker): BuildKit cache mount + yarn cache clean 충돌 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ WORKDIR /app
 
 COPY package.json yarn.lock ./
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,sharing=locked \
-    yarn install --frozen-lockfile --production \
-    && yarn cache clean
+    yarn install --frozen-lockfile --production
 
 COPY --from=builder /app/dist ./dist
 COPY db/ ./db/


### PR DESCRIPTION
## 관련 이슈
#227 후속 hotfix (PR #228 배포 파이프라인 재시도)

## 배경
PR #228 머지 후 첫 `build-image` job 실행에서 실패.

```
error Error: EBUSY: resource busy or locked, rmdir '/usr/local/share/.cache/yarn'
ERROR: failed to build: process "/bin/sh -c yarn install --frozen-lockfile --production && yarn cache clean"
       did not complete successfully: exit code: 1
```

## 원인
프로덕션 스테이지에서 `yarn cache clean`이 BuildKit cache mount 디렉토리(`/usr/local/share/.cache/yarn`)를 rmdir 시도. 해당 경로는 BuildKit이 관리하는 마운트 포인트이므로 컨테이너 내부에서 삭제 불가 → EBUSY.

## 수정
- 프로덕션 스테이지에서 `&& yarn cache clean` 제거
- cache mount는 최종 이미지 레이어에 포함되지 않으므로 clean 자체가 불필요 (이미지 bloat 없음)

## 테스트
- [ ] build-image job 성공 확인
- [ ] deploy job pull + up -d 성공 확인