### PR TITLE
fix(ci): 배포 대상 아키텍처를 linux/amd64로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
   build-image:
     name: Build and Push Image
     needs: ci
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -68,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## 관련 이슈
#227 hotfix 2 (PR #228, #229 후속)

## 배경
PR #229 머지 후 배포는 성공했으나 VM에서 컨테이너가 재시작 루프:

```
exec /usr/local/bin/docker-entrypoint.sh: exec format error
```

## 원인
빌드 플랫폼(`linux/arm64`)과 실제 서버 아키텍처(`x86_64`) 불일치.

## 수정
- `runs-on: ubuntu-24.04-arm` → `ubuntu-latest` (네이티브 amd64 러너)
- `platforms: linux/arm64` → `linux/amd64`

## 테스트
- [ ] build-image job 성공 (amd64 이미지 푸시)
- [ ] deploy job 성공
- [ ] VM 컨테이너 정상 기동 (`docker compose ps` healthy)
- [ ] `/health` 200 응답