### PR TITLE
fix(db): 마이그레이션 039 idempotent 처리

### DIFF
--- a/db/migrations/039_slack_user_mappings_channels.sql
+++ b/db/migrations/039_slack_user_mappings_channels.sql
@@ -3,5 +3,5 @@
 -- 둘 다 nullable이며, NULL이면 slack_user_id로 DM 전송 폴백.
 
 ALTER TABLE slack_user_mappings
-  ADD COLUMN life_channel_id TEXT,
-  ADD COLUMN insight_channel_id TEXT;
+  ADD COLUMN IF NOT EXISTS life_channel_id TEXT,
+  ADD COLUMN IF NOT EXISTS insight_channel_id TEXT;


### PR DESCRIPTION
## 배경

마이그레이션 039가 `ADD COLUMN`을 사용해 재실행 시 중복 컬럼 에러로 마이그레이션 러너가 중단되는 문제가 있었다.

## 변경

- `ADD COLUMN` → `ADD COLUMN IF NOT EXISTS`
- 이후 마이그레이션 파일 작성 시 동일한 가드 패턴을 기본으로 적용할 것

## 테스트

- 실제 DB에 동일 마이그레이션 재실행 시 에러 없이 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)