### PR TITLE
docs: 아키텍처 다이어그램 재디자인

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,13 @@
       "cwd": "/Users/ihyewon/slack-ai-agents/web",
       "port": 3000,
       "autoPort": true
+    },
+    {
+      "name": "svg-preview",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "8765"],
+      "cwd": "/Users/ihyewon/slack-ai-agents/docs/images",
+      "port": 8765
     }
   ]
 }

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -1,157 +1,121 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 580" font-family="'Pretendard', 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 460" font-family="'Pretendard', 'Apple SD Gothic Neo', 'Noto Sans KR', -apple-system, sans-serif">
   <defs>
     <filter id="shadow" x="-4%" y="-4%" width="108%" height="108%">
-      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-opacity="0.12"/>
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.08"/>
     </filter>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#f0f4f8"/>
-      <stop offset="100%" stop-color="#dbe4ee"/>
-    </linearGradient>
-    <linearGradient id="vmGrad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ffffff"/>
-      <stop offset="100%" stop-color="#f7f9fc"/>
-    </linearGradient>
-    <linearGradient id="svcGrad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ffffff"/>
-      <stop offset="100%" stop-color="#f5f7fa"/>
-    </linearGradient>
-    <marker id="arrowR" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#6366f1"/>
+    <marker id="arrow" markerWidth="6" markerHeight="5" refX="5" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="#6366f1"/>
     </marker>
-    <marker id="arrowL" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
-      <path d="M8,0 L0,3 L8,6" fill="#6366f1"/>
+    <marker id="arrowGreen" markerWidth="6" markerHeight="5" refX="5" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="#10b981"/>
     </marker>
-    <marker id="arrowGreen" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6" fill="#16a34a"/>
+    <marker id="arrowGray" markerWidth="6" markerHeight="5" refX="5" refY="2.5" orient="auto">
+      <path d="M0,0 L5,2.5 L0,5 Z" fill="#94a3b8"/>
     </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="960" height="580" rx="16" fill="url(#bgGrad)"/>
+  <rect width="960" height="460" fill="#f8fafc"/>
 
-  <!-- ===== Slack (왼쪽) ===== -->
-  <rect x="24" y="80" width="160" height="360" rx="14" fill="url(#vmGrad)" stroke="#c8d6e5" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="24" y="80" width="160" height="44" rx="14" fill="#611f69"/>
-  <rect x="24" y="110" width="160" height="14" fill="#611f69"/>
-  <text x="42" y="108" fill="#fff" font-size="15" font-weight="700">Slack</text>
+  <!-- Title -->
+  <text x="480" y="30" text-anchor="middle" fill="#334155" font-size="14" font-weight="700">Slack AI Agent — 자연어로 라이프 데이터를 다루는 에이전트</text>
 
-  <rect x="40" y="140" width="128" height="44" rx="8" fill="#f3e8ff" stroke="#c084fc" stroke-width="1"/>
-  <text x="56" y="167" fill="#6b21a8" font-size="12" font-weight="600">자연어 대화</text>
+  <!-- Column labels -->
+  <text x="160" y="60" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="700" letter-spacing="3">CLIENT</text>
+  <text x="480" y="60" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="700" letter-spacing="3">ORACLE CLOUD VM</text>
+  <text x="820" y="60" text-anchor="middle" fill="#94a3b8" font-size="10" font-weight="700" letter-spacing="3">AI</text>
 
-  <rect x="40" y="198" width="128" height="44" rx="8" fill="#ecfdf5" stroke="#86efac" stroke-width="1"/>
-  <text x="56" y="225" fill="#166534" font-size="12" font-weight="600">크론 알림 (4회)</text>
+  <!-- ===== Slack card ===== -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="80" width="240" height="120" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+    <rect x="40" y="80" width="240" height="38" rx="12" fill="#611f69"/>
+    <rect x="40" y="106" width="240" height="12" fill="#611f69"/>
+    <text x="60" y="106" fill="#ffffff" font-size="14" font-weight="700">Slack</text>
+    <text x="230" y="106" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.8">Socket Mode</text>
+  </g>
+  <text x="60" y="142" fill="#475569" font-size="12">자연어 대화 · 크론 알림</text>
+  <text x="60" y="162" fill="#475569" font-size="12">체크리스트 · App Home</text>
+  <text x="60" y="182" fill="#475569" font-size="12">인사이트 넛지</text>
 
-  <rect x="40" y="256" width="128" height="44" rx="8" fill="#fefce8" stroke="#fbbf24" stroke-width="1"/>
-  <text x="56" y="278" fill="#92400e" font-size="11" font-weight="600">루틴 체크리스트</text>
-  <text x="56" y="292" fill="#78716c" font-size="10">(Block Kit 버튼)</text>
+  <!-- ===== Web (Vercel) card ===== -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="230" width="240" height="110" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+    <rect x="40" y="230" width="240" height="38" rx="12" fill="#171717"/>
+    <rect x="40" y="256" width="240" height="12" fill="#171717"/>
+    <text x="60" y="256" fill="#ffffff" font-size="14" font-weight="700">Web</text>
+    <text x="230" y="256" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.8">Vercel · Next.js</text>
+  </g>
+  <text x="60" y="292" fill="#475569" font-size="12">캘린더 · 백로그 · 루틴</text>
+  <text x="60" y="312" fill="#475569" font-size="12">지출 · 카테고리 · DnD</text>
 
-  <rect x="40" y="314" width="128" height="44" rx="8" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="56" y="341" fill="#1e40af" font-size="12" font-weight="600">App Home 탭</text>
+  <!-- ===== Oracle Cloud VM (center) ===== -->
+  <g>
+    <rect x="310" y="76" width="340" height="320" rx="14" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5" stroke-dasharray="6,4"/>
+  </g>
 
-  <rect x="40" y="372" width="128" height="44" rx="8" fill="#fef2f2" stroke="#fca5a5" stroke-width="1"/>
-  <text x="56" y="394" fill="#991b1b" font-size="11" font-weight="600">인사이트 넛지</text>
-  <text x="56" y="408" fill="#78716c" font-size="10">(Pure SQL 감지)</text>
+  <!-- Slack Bolt App -->
+  <g filter="url(#shadow)">
+    <rect x="334" y="100" width="292" height="120" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  </g>
+  <text x="354" y="126" fill="#1e3a8a" font-size="13" font-weight="700">Slack Bolt App</text>
+  <text x="354" y="148" fill="#475569" font-size="11">• Agent Loop — LLM ↔ SQL 도구 자율 반복</text>
+  <text x="354" y="167" fill="#475569" font-size="11">• node-cron — 아침/밤/주간 알림 (KST)</text>
+  <text x="354" y="186" fill="#475569" font-size="11">• Fast path — 정규식 → Block Kit (\~1초)</text>
+  <text x="354" y="205" fill="#475569" font-size="11">• Rate Limit · userId 격리 · 인젝션 차단</text>
 
-  <!-- ===== Slack → VM 화살표 ===== -->
-  <line x1="188" y1="200" x2="238" y2="200" stroke="#6366f1" stroke-width="2" marker-end="url(#arrowR)"/>
-  <line x1="238" y1="220" x2="188" y2="220" stroke="#6366f1" stroke-width="2" marker-end="url(#arrowL)"/>
-  <text x="192" y="195" fill="#4338ca" font-size="9" font-weight="600">Socket Mode</text>
+  <!-- DB Proxy API -->
+  <g filter="url(#shadow)">
+    <rect x="334" y="240" width="292" height="58" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  </g>
+  <text x="354" y="266" fill="#14532d" font-size="13" font-weight="700">DB Proxy API</text>
+  <text x="608" y="266" text-anchor="end" fill="#166534" font-size="10" font-weight="600">:3100 · Bearer</text>
+  <text x="354" y="286" fill="#475569" font-size="11">SQL 화이트리스트 · TLS 종료 (Caddy)</text>
 
-  <!-- ===== Oracle Cloud VM (중앙) ===== -->
-  <rect x="244" y="30" width="330" height="520" rx="14" fill="url(#vmGrad)" stroke="#c8d6e5" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="244" y="30" width="330" height="44" rx="14" fill="#7c3aed"/>
-  <rect x="244" y="60" width="330" height="14" fill="#7c3aed"/>
-  <text x="262" y="58" fill="#fff" font-size="14" font-weight="700">Oracle Cloud VM (Docker)</text>
+  <!-- PostgreSQL -->
+  <g filter="url(#shadow)">
+    <rect x="334" y="316" width="292" height="58" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  </g>
+  <text x="354" y="342" fill="#1e3a8a" font-size="13" font-weight="700">PostgreSQL</text>
+  <text x="608" y="342" text-anchor="end" fill="#1e40af" font-size="10" font-weight="600">내부 전용 · Docker</text>
+  <text x="354" y="362" fill="#475569" font-size="11">일정 · 루틴 · 지출 · 일기 · 사주</text>
 
-  <!-- Node.js + Slack Bolt -->
-  <rect x="262" y="90" width="294" height="36" rx="8" fill="#e8f4fd" stroke="#93c5fd" stroke-width="1"/>
-  <text x="280" y="113" fill="#1e40af" font-size="13" font-weight="600">Node.js + Slack Bolt (TypeScript)</text>
+  <!-- VM 내부 수직 연결 (점선) -->
+  <line x1="480" y1="220" x2="480" y2="240" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrowGray)"/>
+  <line x1="480" y1="298" x2="480" y2="316" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrowGray)"/>
 
-  <!-- Agent Loop -->
-  <rect x="262" y="140" width="294" height="90" rx="10" fill="#fefce8" stroke="#fbbf24" stroke-width="1"/>
-  <text x="280" y="164" fill="#92400e" font-size="13" font-weight="700">Agent Loop</text>
-  <text x="280" y="184" fill="#78716c" font-size="11">LLM ↔ SQL 도구 자율 반복 (tool use)</text>
-  <text x="280" y="202" fill="#78716c" font-size="11">query_db · modify_db · get_schema</text>
-  <text x="280" y="220" fill="#78716c" font-size="11">SQL 감사 로그 + user_id 검증 + 10s 타임아웃</text>
+  <!-- ===== Claude Sonnet card ===== -->
+  <g filter="url(#shadow)">
+    <rect x="680" y="130" width="240" height="140" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+    <rect x="680" y="130" width="240" height="38" rx="12" fill="#d97706"/>
+    <rect x="680" y="156" width="240" height="12" fill="#d97706"/>
+    <text x="700" y="156" fill="#ffffff" font-size="14" font-weight="700">Claude Sonnet</text>
+    <text x="910" y="156" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.85">Anthropic API</text>
+  </g>
+  <text x="700" y="192" fill="#475569" font-size="12">자연어 이해 · SQL 생성</text>
+  <text x="700" y="212" fill="#475569" font-size="12">크로스 분석 · 인사이트</text>
+  <text x="700" y="232" fill="#475569" font-size="12">크론/주간 리포트 작성</text>
+  <text x="700" y="256" fill="#b45309" font-size="10" font-weight="600">Tool Use: query_db · modify_db</text>
 
-  <!-- Cron -->
-  <rect x="262" y="244" width="294" height="58" rx="10" fill="#ecfdf5" stroke="#86efac" stroke-width="1"/>
-  <text x="280" y="268" fill="#166534" font-size="13" font-weight="700">node-cron (Asia/Seoul)</text>
-  <text x="280" y="288" fill="#78716c" font-size="11">프로액티브 인사이트 (5 SQL 패턴 감지)</text>
+  <!-- ===== Connections ===== -->
 
-  <!-- Security Layer -->
-  <rect x="262" y="316" width="294" height="68" rx="10" fill="#fef2f2" stroke="#f87171" stroke-width="1"/>
-  <text x="280" y="340" fill="#991b1b" font-size="13" font-weight="700">Security Layer</text>
-  <text x="280" y="358" fill="#78716c" font-size="11">Rate Limiter (슬라이딩 윈도우 5req/min)</text>
-  <text x="280" y="374" fill="#78716c" font-size="11">메시지 크기 제한 · 프롬프트 인젝션 차단</text>
+  <!-- Slack ↔ Bolt (양방향) -->
+  <line x1="280" y1="135" x2="334" y2="135" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="334" y1="151" x2="280" y2="151" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="287" y="124" fill="#4338ca" font-size="9" font-weight="600">Socket Mode</text>
 
-  <!-- DB Proxy -->
-  <rect x="262" y="398" width="294" height="60" rx="10" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="280" y="422" fill="#166534" font-size="13" font-weight="700">DB Proxy API (:3100)</text>
-  <text x="280" y="440" fill="#78716c" font-size="11">Bearer 인증 · 1MB 제한 · /health 헬스체크</text>
+  <!-- Web → DB Proxy (HTTPS) -->
+  <line x1="280" y1="282" x2="334" y2="269" stroke="#10b981" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <text x="286" y="258" fill="#059669" font-size="9" font-weight="600">HTTPS</text>
 
-  <!-- PostgreSQL (VM 내부) -->
-  <rect x="262" y="472" width="294" height="60" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="280" y="496" fill="#1e40af" font-size="13" font-weight="700">PostgreSQL (Docker — 내부 전용)</text>
-  <text x="280" y="516" fill="#78716c" font-size="11">TLS 암호화 · expose:5432 (외부 미노출)</text>
+  <!-- Bolt ↔ Claude (tool use) -->
+  <line x1="626" y1="158" x2="680" y2="158" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="680" y1="174" x2="626" y2="174" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="636" y="147" fill="#4338ca" font-size="9" font-weight="600">Tool Use</text>
 
-  <!-- DB Proxy → PostgreSQL 내부 연결 -->
-  <line x1="409" y1="458" x2="409" y2="472" stroke="#3b82f6" stroke-width="2" marker-end="url(#arrowR)"/>
-  <text x="416" y="468" fill="#2563eb" font-size="8" font-weight="600">localhost</text>
-
-  <!-- ===== VM → AI 화살표 ===== -->
-  <line x1="578" y1="150" x2="622" y2="110" stroke="#6366f1" stroke-width="2" marker-end="url(#arrowR)"/>
-  <text x="580" y="142" fill="#4338ca" font-size="9" font-weight="600">Tool Use</text>
-
-  <!-- ===== 외부 서비스 (오른쪽) ===== -->
-
-  <!-- Claude Sonnet -->
-  <rect x="628" y="50" width="304" height="100" rx="12" fill="url(#svcGrad)" stroke="#c8d6e5" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="628" y="50" width="304" height="36" rx="12" fill="#d97706"/>
-  <rect x="628" y="74" width="304" height="12" fill="#d97706"/>
-  <text x="646" y="74" fill="#fff" font-size="13" font-weight="700">Claude Sonnet (단일 LLM)</text>
-  <text x="646" y="110" fill="#78716c" font-size="11">자연어 이해 · SQL 생성 · 크로스 분석 · 인사이트</text>
-  <text x="646" y="128" fill="#78716c" font-size="11">크론 메시지 생성 · 주간 리포트 · Pure SQL 비용 최적화</text>
-
-  <!-- Caddy + TLS -->
-  <rect x="628" y="170" width="304" height="70" rx="12" fill="url(#svcGrad)" stroke="#c8d6e5" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="628" y="170" width="304" height="36" rx="12" fill="#16a34a"/>
-  <rect x="628" y="194" width="304" height="12" fill="#16a34a"/>
-  <text x="646" y="194" fill="#fff" font-size="13" font-weight="700">Caddy (리버스 프록시)</text>
-  <text x="646" y="224" fill="#78716c" font-size="11">Let's Encrypt 자동 TLS · HTTPS → :3100 프록시</text>
-
-  <!-- Caddy → DB Proxy 화살표 -->
-  <line x1="628" y1="220" x2="560" y2="428" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowGreen)"/>
-  <text x="574" y="330" fill="#16a34a" font-size="9" font-weight="600" transform="rotate(-55, 574, 330)">HTTPS → :3100</text>
-
-  <!-- Vercel -->
-  <rect x="628" y="260" width="304" height="100" rx="12" fill="url(#svcGrad)" stroke="#c8d6e5" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="628" y="260" width="304" height="36" rx="12" fill="#171717"/>
-  <rect x="628" y="284" width="304" height="12" fill="#171717"/>
-  <text x="646" y="284" fill="#fff" font-size="13" font-weight="700">Vercel (Next.js 웹 대시보드)</text>
-  <text x="646" y="316" fill="#78716c" font-size="11">캘린더 · 백로그 · 카테고리 뷰 · DnD</text>
-  <text x="646" y="334" fill="#78716c" font-size="11">반응형 UI + PWA · GitHub push 자동 배포</text>
-  <text x="646" y="350" fill="#16a34a" font-size="11" font-weight="600">→ DB Proxy API (HTTPS) 경유</text>
-
-  <!-- Vercel → Caddy 화살표 -->
-  <line x1="780" y1="260" x2="780" y2="240" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowGreen)"/>
-  <text x="786" y="254" fill="#16a34a" font-size="9" font-weight="600">HTTPS</text>
-
-  <!-- CI/CD -->
-  <rect x="628" y="380" width="304" height="68" rx="12" fill="url(#svcGrad)" stroke="#c8d6e5" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="628" y="380" width="304" height="36" rx="12" fill="#4f46e5"/>
-  <rect x="628" y="404" width="304" height="12" fill="#4f46e5"/>
-  <text x="646" y="404" fill="#fff" font-size="13" font-weight="700">CI/CD</text>
-  <text x="646" y="432" fill="#78716c" font-size="11">GitHub Actions (lint + type-check + test)</text>
-  <text x="646" y="448" fill="#78716c" font-size="10">yarn deploy (VM) · Vercel 자동 배포 (웹)</text>
-
-  <!-- 보안 범례 -->
-  <rect x="628" y="468" width="304" height="82" rx="12" fill="#fef2f2" stroke="#f87171" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="646" y="490" fill="#991b1b" font-size="12" font-weight="700">보안 아키텍처</text>
-  <text x="646" y="508" fill="#78716c" font-size="10">DB 포트 외부 미노출 · Bearer API Key 인증</text>
-  <text x="646" y="522" fill="#78716c" font-size="10">TLS 암호화 (DB + HTTPS) · SQL 감사 로그</text>
-  <text x="646" y="536" fill="#78716c" font-size="10">Rate Limiting · user_id 격리 · 프롬프트 인젝션 차단</text>
-
-  <!-- 타이틀 -->
-  <text x="480" y="18" fill="#334155" font-size="11" font-weight="600" text-anchor="middle">Slack AI Agent — 개인 라이프 데이터 에이전트 아키텍처 (v3)</text>
+  <!-- ===== Security Footer ===== -->
+  <g>
+    <rect x="40" y="410" width="880" height="32" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+    <text x="58" y="431" fill="#991b1b" font-size="11" font-weight="700">🛡 보안</text>
+    <text x="108" y="431" fill="#64748b" font-size="11">DB 포트 외부 미노출 · Bearer + 전 구간 TLS · SQL 화이트리스트 · userId 테넌트 격리 · Rate Limit · SQL 감사 로그 · 커밋 전 시크릿 스캔</text>
+  </g>
 </svg>


### PR DESCRIPTION
## 요약

README의 "어떻게 동작하나" 섹션 아키텍처 SVG를 재디자인. 기존 다이어그램이 복잡해 한눈에 들어오지 않던 문제 해결.

## 변경

| | 기존 | 새 버전 |
|---|---|---|
| 박스 수 | 16개 | 7개 |
| 컬럼 구조 | 혼재 | Client / VM / AI 3컬럼 |
| 흐름 방향 | 다방향 | 좌→우 (VM 내부만 상→하) |
| 색상 수 | 10+ | 4 (Slack 보라 / Vercel 검정 / Claude 주황 / 중립) |
| 보안 정보 | 별도 범례 박스 | 하단 1줄 footer |
| 화살표 머리 | 큼 | 축소 + `orient="auto"`로 양방향 자동 회전 |

## 부가 변경

- `.claude/launch.json`에 SVG 미리보기용 static server(`svg-preview`) 설정 추가 — 향후 SVG/이미지 수정 시 빠른 시각 검증용

## 테스트

- [x] Claude Preview로 렌더링 확인
- [ ] GitHub에서 README 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)