### PR TITLE
fix(life): 수면 기록 데이터 정합성 강화 (#247)

### DIFF
--- a/db/migrations/040_sleep_records_unique.sql
+++ b/db/migrations/040_sleep_records_unique.sql
@@ -1,0 +1,11 @@
+-- 040: sleep_records 데이터 정합성 — 동일 수면 레코드 중복 방지
+-- 동일 (user_id, date, sleep_type, bedtime) 조합으로 여러 건이 INSERT되는 것을
+-- DB 레벨에서 차단한다. LLM의 실수나 네트워크 재시도로 같은 수면이 중복
+-- 기록되는 리스크를 제거.
+--
+-- bedtime이 NULL인 레코드(메모 전용 INSERT)는 제외하여 메모만 기록하는
+-- 사용 패턴은 그대로 허용한다.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_sleep_records_user_date_type_bedtime
+ON sleep_records (user_id, date, sleep_type, bedtime)
+WHERE bedtime IS NOT NULL;

--- a/src/agents/life/__tests__/prompt.test.ts
+++ b/src/agents/life/__tests__/prompt.test.ts
@@ -106,6 +106,18 @@ describe('buildLifeSystemPrompt', () => {
     expect(prompt).toContain('백로그');
   });
 
+  it('수면 레코드 변경 규칙을 포함한다', async () => {
+    const prompt = await buildLifeSystemPrompt('C123', 1);
+    // UPDATE/DELETE sleep_type 필터 규칙
+    expect(prompt).toContain('sleep_type 필터');
+    // INSERT 전 중복 확인 규칙
+    expect(prompt).toContain('INSERT 전');
+    // 날짜 이동 UPDATE 규칙
+    expect(prompt).toContain('날짜 이동');
+    // 사용자 언급 없는 INSERT 금지
+    expect(prompt).toContain('직접 언급하지 않은');
+  });
+
   it('220줄 이내의 간결한 프롬프트', async () => {
     const prompt = await buildLifeSystemPrompt('C123', 1);
     const lineCount = prompt.split('\n').length;

--- a/src/agents/life/prompt.ts
+++ b/src/agents/life/prompt.ts
@@ -173,9 +173,16 @@ sleep_records.date는 **수면을 기록하는 날짜**야. 보통 일어난 날
   - "오늘 일찍 자볼게" → 기록 금지 (미래 계획임)
 - bedtime과 wake_time **둘 다 확인**된 경우에만 sleep_records INSERT.
   - 하나만 알면 나머지를 자연스럽게 물어봐: "몇 시에 일어났어?"
+- **사용자가 이 대화에서 직접 언급하지 않은 수면은 절대 INSERT 금지.** 이전 대화나 다른 날짜의 기록을 오늘 다시 써넣지 마.
 - duration_minutes는 반드시 **SQL로 계산**해. 직접 암산 금지.
   - INSERT 전에 SELECT로 계산: SELECT EXTRACT(EPOCH FROM ('wake_time'::time - 'bedtime'::time + INTERVAL '24h')) / 60 % 1440
   - 계산된 값을 duration_minutes에 넣어.
+
+### ⚠️ 수면 레코드 변경 규칙 (절대 규칙)
+- **UPDATE/DELETE sleep_records에는 반드시 sleep_type 필터 포함.** 누락하면 같은 날 밤잠과 낮잠이 함께 변경됨.
+  - 예: UPDATE sleep_records SET bedtime='02:30' WHERE user_id = ${userId} AND date = '2026-04-11' AND sleep_type = 'night'
+- **INSERT 전 동일 (user_id, date, sleep_type) 레코드 존재 여부를 SELECT로 먼저 확인.** 있으면 INSERT하지 말고 UPDATE로 처리.
+- **날짜 이동("이건 어제 기록이야"): INSERT 재생성 금지.** UPDATE SET date = '어제' WHERE id = 원본 ID 사용. 대상 날짜에 이미 동일 bedtime 레코드가 있으면 원본을 DELETE로 정리(중복 방지).
 
 ### 수면 관련 대화 → 자동 메모 기록
 사용자가 수면 습관/패턴/어려움을 언급하면 **반드시 기록**해:


### PR DESCRIPTION
## 관련 이슈
Closes #247

## 변경 내용
- `db/migrations/040_sleep_records_unique.sql`: `(user_id, date, sleep_type, bedtime)` UNIQUE 부분 인덱스 추가 — `bedtime IS NOT NULL` 조건으로 메모 전용 레코드는 허용
- `src/agents/life/prompt.ts`: 수면 섹션에 변경 규칙 추가
  - UPDATE/DELETE 시 `sleep_type` 필터 필수 규칙
  - INSERT 전 동일 레코드 존재 여부 SELECT 확인 규칙
  - 날짜 이동 시 INSERT 재생성 금지, UPDATE 사용 규칙
  - 이 대화에서 직접 언급하지 않은 수면 INSERT 금지 규칙
- `src/agents/life/__tests__/prompt.test.ts`: 신규 규칙 포함 여부 테스트 케이스 추가

## 코드 리뷰 결과
- [x] 보안 감사 통과
- [x] 타입 안전성 확인
- [x] 컨벤션 점검 완료 (마이그레이션 idempotent, 파일명 준수)
- [x] 코드 품질 확인

## 테스트
- [x] `yarn test src/agents/life/__tests__/prompt.test.ts` — 13 tests passed
- [x] `yarn test` — 332 tests passed (전체 회귀 통과)