### PR TITLE
fix(budget): 크론 경로 미들웨어 화이트리스트 추가 (#251)

### DIFF
--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { unsealData } from 'iron-session';
 
-const PUBLIC_PATHS = ['/login', '/api/auth'];
+const PUBLIC_PATHS = ['/login', '/api/auth', '/api/cron'];
 const SESSION_COOKIE = 'life-dashboard-session';
 
 /** Next.js 16 — middleware는 기본 Node.js 런타임에서 동작 */


### PR DESCRIPTION
## Summary

- 미들웨어 `PUBLIC_PATHS`에 `/api/cron` 추가 — Vercel cron 요청이 세션 검증 단계에서 `/login`으로 리다이렉트되던 문제 수정
- 라우트 핸들러 자체가 `Bearer CRON_SECRET` 검증을 수행하므로 공개 경로 처리해도 안전
- 결과적으로 `daily_budget_logs` 스냅샷이 적재되지 못하던 현상 해소

Closes #251

## Test plan

- [ ] 배포 후 `/api/cron/daily-budget-log`에 Bearer 토큰으로 수동 호출 → 200 응답
- [ ] `daily_budget_logs` 테이블에 오늘 날짜 row 생성 확인
- [ ] 다음 스케줄 실행(23:50 KST) 후 자동 적재 확인
- [ ] 웹 관리탭 "이번 달 현황"에 당일 기록 표시 확인