### PR TITLE
chore(web): middleware를 proxy로 리네임 — Next.js 16 대응 (#253)

### DIFF
--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -5,13 +5,13 @@ import { unsealData } from 'iron-session';
 const PUBLIC_PATHS = ['/login', '/api/auth', '/api/cron'];
 const SESSION_COOKIE = 'life-dashboard-session';
 
-/** Next.js 16 — middleware는 기본 Node.js 런타임에서 동작 */
+/** Next.js 16 — proxy는 기본 Node.js 런타임에서 동작 */
 export const config = {
   matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
 };
 
-/** 미들웨어 — 세션 쿠키 서명 검증 + 보안 헤더 */
-export async function middleware(request: NextRequest) {
+/** Proxy — 세션 쿠키 서명 검증 + 보안 헤더 */
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // 보안 헤더 (모든 응답에 적용)


### PR DESCRIPTION
## Summary

- Next.js 16에서 `middleware` 파일 규약이 `proxy`로 리네임됨에 따라 파일·함수명 마이그레이션
- `web/src/middleware.ts` → `web/src/proxy.ts`
- `export async function middleware` → `export async function proxy`
- 내부 로직(세션 검증·보안 헤더·공개 경로 화이트리스트) 변경 없음
- 로컬 빌드에서 deprecation 경고 사라진 것 확인 — 빌드 출력에서 `ƒ Proxy (Middleware)`로 정상 인식
- 공식 마이그레이션 가이드: https://nextjs.org/docs/messages/middleware-to-proxy

> Base를 `fix/251-cron-middleware-whitelist`로 지정 — #252 머지 후 main으로 자동 재타깃됨.

Closes #253

## Test plan

- [ ] 프리뷰 배포 빌드 로그에서 middleware deprecation 경고 사라진 것 확인
- [ ] 인증 필요 경로 접근 시 `/login` 리다이렉트 정상 동작
- [ ] `/api/cron/daily-budget-log` Bearer 토큰 요청 200 응답
- [ ] 보안 헤더(X-Frame-Options, CSP 등) 응답에 포함 확인