### PR TITLE
fix(budget): 일별 현황 탭 카드 래퍼 추가

### DIFF
--- a/web/src/features/budget/components/daily-budget-log.tsx
+++ b/web/src/features/budget/components/daily-budget-log.tsx
@@ -70,7 +70,7 @@ export function DailyBudgetLogView({ yearMonth, todayBudget }: DailyBudgetLogPro
       : null;
 
   return (
-    <div>
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
       {/* 누적 요약 카드 */}
       <div className="mb-4 rounded-xl bg-gray-50 p-4">
         <div className="mb-1 text-xs text-gray-500">이번 달 현황</div>
@@ -131,16 +131,22 @@ function formatAmount(amount: number): string {
 
 function LoadingSkeleton() {
   return (
-    <div className="space-y-2">
-      {[...Array(5)].map((_, i) => (
-        <div key={i} className="h-10 animate-pulse rounded-lg bg-gray-100" />
-      ))}
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="space-y-2">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className="h-10 animate-pulse rounded-lg bg-gray-100" />
+        ))}
+      </div>
     </div>
   );
 }
 
 function EmptyState() {
   return (
-    <div className="py-12 text-center text-sm text-gray-400">아직 기록된 예산 현황이 없어</div>
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="py-12 text-center text-sm text-gray-400">
+        아직 기록된 예산 현황이 없어
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

관리 탭의 "일별 현황" 서브탭이 배경·테두리 없이 텍스트만 떠 있던 문제를 수정. loading/empty/normal 3개 state 모두 프로젝트 카드 컨벤션(`rounded-xl border border-gray-200 bg-white p-4 shadow-sm`)으로 래핑해 `MonthSummaryCard`와 시각적 일관성 확보.

## Before / After

- Before: `<div>` 루트 → 상위 페이지 배경 위에 바로 리스트
- After: 흰색 카드 컨테이너 안에 누적 요약(gray-50 inner card)과 일별 로그 리스트 배치 → 중첩된 시각적 위계

## Test plan

- [ ] `/budget` → 관리 탭 → 일별 현황 서브탭에서 카드 스타일 확인
- [ ] 로딩 중 스켈레톤도 카드 안에 표시되는지 확인
- [ ] 기록이 없을 때 empty state도 카드 안에 표시되는지 확인