### PR TITLE
fix(budget): 일별 로그 드리프트 방어 + 오늘 예산 클램프

### DIFF
--- a/web/src/app/api/cron/daily-budget-log/route.ts
+++ b/web/src/app/api/cron/daily-budget-log/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { saveDailyBudgetLog } from '@/features/budget/lib/queries';
+import { resolveSnapshotDate } from '@/features/budget/lib/budget-calc';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
@@ -13,7 +14,10 @@ export async function GET(request: Request) {
   }
 
   try {
-    const result = await saveDailyBudgetLog(1); // user_id = 1 (단일 사용자)
+    // Vercel cron 드리프트 방어: 발화 시각에서 1시간 버퍼를 차감한 KST 날짜로 저장
+    // (cron 14:50 UTC 예약 → 15:xx 드리프트해도 KST 당일을 올바르게 반환)
+    const targetDate = resolveSnapshotDate(new Date());
+    const result = await saveDailyBudgetLog(1, { targetDate });
     return NextResponse.json({ ok: true, data: result });
   } catch (err) {
     console.error('[daily-budget-log] 스냅샷 실패:', err);

--- a/web/src/features/budget/lib/__tests__/budget-calc.test.ts
+++ b/web/src/features/budget/lib/__tests__/budget-calc.test.ts
@@ -5,6 +5,8 @@ import {
   getBillingRange,
   calcCycleDays,
   calculateBudgetAllocation,
+  calculateTodayAllocation,
+  resolveSnapshotDate,
 } from '../budget-calc';
 import type { BudgetCalcInput } from '../budget-calc';
 
@@ -194,5 +196,132 @@ describe('calculateBudgetAllocation', () => {
     expect(result.monthlyLocked[1].days).toBe(30);
     // month 2 = '2026-06': 5/16 ~ 6/15 → 31일
     expect(result.monthlyLocked[2].days).toBe(31);
+  });
+});
+
+// ─── calculateTodayAllocation ──────────────────────────────
+//
+// 핵심 버그 재현:
+//   - 이번 달이 이미 초과된 상태(monthBudgetRemaining < 0)에서
+//     오늘 예산이 음수로 나와 "오늘 초과 = 오늘 지출 + 이전 누적 빚"이 되어버림.
+//   - 사용자는 오늘 49680원 썼는데 오늘 초과 53103원으로 표시됨 (-3423 carry-over 포함).
+//   - 카피라이트: 오늘 예산은 0원으로 클램프하고, 오늘 초과는 순수하게 오늘 지출만 반영.
+
+describe('calculateTodayAllocation', () => {
+  test('정상 케이스: 남은 예산 양수 → 균등 분배', () => {
+    const result = calculateTodayAllocation({
+      monthBudgetRemaining: 40_000,
+      todayFlexSpent: 10_000,
+      cycleRemainingDays: 3, // 오늘 포함 4일
+    });
+    // budgetBeforeToday = 40000 + 10000 = 50000
+    // todayBudget = 50000 / 4 = 12500
+    expect(result.todayBudget).toBe(12_500);
+    expect(result.todayRemaining).toBe(2_500); // 12500 - 10000
+  });
+
+  test('오늘 아직 지출 없음 → 예산 = 남은예산 / 남은일수', () => {
+    const result = calculateTodayAllocation({
+      monthBudgetRemaining: 40_000,
+      todayFlexSpent: 0,
+      cycleRemainingDays: 3,
+    });
+    expect(result.todayBudget).toBe(10_000);
+    expect(result.todayRemaining).toBe(10_000);
+  });
+
+  test('주기 마지막 날(cycleRemainingDays=0) → todayIncludedDays=1', () => {
+    const result = calculateTodayAllocation({
+      monthBudgetRemaining: 20_000,
+      todayFlexSpent: 5_000,
+      cycleRemainingDays: 0,
+    });
+    // budgetBeforeToday = 25000, 1일에 전부
+    expect(result.todayBudget).toBe(25_000);
+    expect(result.todayRemaining).toBe(20_000);
+  });
+
+  test('🐛 bug fix: 이번 달이 이미 초과된 상태에서 오늘 예산은 0으로 클램프', () => {
+    // 실제 재현 값: monthRemaining=-63372, todayFlexSpent=49680, cycleRemainingDays=3
+    // budgetBeforeToday = -63372 + 49680 = -13692 → 예전엔 -3423원/day → today_remaining -53103
+    const result = calculateTodayAllocation({
+      monthBudgetRemaining: -63_372,
+      todayFlexSpent: 49_680,
+      cycleRemainingDays: 3,
+    });
+    expect(result.todayBudget).toBe(0);
+    // 오늘 초과 = 오늘 지출 그대로 (이전 누적 빚은 분리)
+    expect(result.todayRemaining).toBe(-49_680);
+  });
+
+  test('🐛 bug fix: 월 초과 + 오늘 미지출 → 오늘 예산 0, 남음 0', () => {
+    const result = calculateTodayAllocation({
+      monthBudgetRemaining: -13_692,
+      todayFlexSpent: 0,
+      cycleRemainingDays: 3,
+    });
+    expect(result.todayBudget).toBe(0);
+    expect(result.todayRemaining).toBe(0);
+  });
+
+  test('cycleRemainingDays 음수 방어 → 에러 안 나고 0 또는 양수', () => {
+    const result = calculateTodayAllocation({
+      monthBudgetRemaining: 10_000,
+      todayFlexSpent: 0,
+      cycleRemainingDays: -1,
+    });
+    // todayIncludedDays 방어: 최소 1
+    expect(result.todayBudget).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ─── resolveSnapshotDate ──────────────────────────────
+//
+// 핵심 버그 재현:
+//   - Vercel cron `50 14 * * *` (14:50 UTC = 23:50 KST) 로 예약했지만
+//     실제 fire는 15:03:19 UTC (드리프트 13분) → KST 00:03 → getTodayISO()가
+//     다음날 반환 → 스냅샷이 다음날 date로 저장되는 문제.
+//   - 해결: nowUtc에서 1시간 버퍼를 뺀 anchor 시점의 KST 날짜를 반환.
+
+describe('resolveSnapshotDate', () => {
+  test('정시 발화 (14:50 UTC) → KST 23:50 → 당일(KST)', () => {
+    const now = new Date('2026-04-11T14:50:00Z');
+    expect(resolveSnapshotDate(now)).toBe('2026-04-11');
+  });
+
+  test('🐛 실제 재현: 14:50 예약 → 15:03 UTC fire → 여전히 KST 당일(4/11)', () => {
+    const now = new Date('2026-04-11T15:03:19Z');
+    expect(resolveSnapshotDate(now)).toBe('2026-04-11');
+  });
+
+  test('드리프트 30분 → 여전히 당일', () => {
+    const now = new Date('2026-04-11T15:20:00Z');
+    expect(resolveSnapshotDate(now)).toBe('2026-04-11');
+  });
+
+  test('드리프트 50분 → 여전히 당일 (1시간 버퍼 내)', () => {
+    const now = new Date('2026-04-11T15:40:00Z');
+    expect(resolveSnapshotDate(now)).toBe('2026-04-11');
+  });
+
+  test('월말 경계: 4/30 23:50 KST 예약 → 정상 발화 → 4/30', () => {
+    const now = new Date('2026-04-30T14:50:00Z');
+    expect(resolveSnapshotDate(now)).toBe('2026-04-30');
+  });
+
+  test('월말 경계: 4/30 14:50 예약 → 15:10 드리프트 → 여전히 4/30', () => {
+    const now = new Date('2026-04-30T15:10:00Z');
+    expect(resolveSnapshotDate(now)).toBe('2026-04-30');
+  });
+
+  test('연말 경계: 12/31 23:50 KST 정시 발화 → 12/31', () => {
+    const now = new Date('2026-12-31T14:50:00Z');
+    expect(resolveSnapshotDate(now)).toBe('2026-12-31');
+  });
+
+  test('명시적 KST 정오 → 당일 그대로 (버퍼 차감해도 같은 날)', () => {
+    // 12:00 KST = 03:00 UTC → anchor 02:00 UTC → 11:00 KST 같은 날
+    const now = new Date('2026-04-11T03:00:00Z');
+    expect(resolveSnapshotDate(now)).toBe('2026-04-11');
   });
 });

--- a/web/src/features/budget/lib/budget-calc.ts
+++ b/web/src/features/budget/lib/budget-calc.ts
@@ -165,3 +165,79 @@ export function calculateBudgetAllocation(input: BudgetCalcInput): BudgetCalcRes
 
   return { budgetBase, freePerMonth, dailyFree, totalLocked, monthlyLocked };
 }
+
+// ─── 오늘 할당 계산 ──────────────────────────────────────
+
+/** 오늘 할당 계산 입력 */
+export interface TodayAllocationInput {
+  /** 이번 주기 남은 자유 예산 (음수 = 이미 초과) */
+  monthBudgetRemaining: number;
+  /** 오늘 자유 지출 (today 날짜의 expense 합) */
+  todayFlexSpent: number;
+  /** 오늘 제외한 남은 일수 */
+  cycleRemainingDays: number;
+}
+
+/** 오늘 할당 계산 결과 */
+export interface TodayAllocationResult {
+  /** 오늘 쓸 수 있는 예산 (누적 빚과 분리, 0 이상으로 클램프) */
+  todayBudget: number;
+  /** 오늘 남음(양수) / 초과(음수) — 오늘 지출만 반영 */
+  todayRemaining: number;
+}
+
+/**
+ * 오늘 할당 예산/남음 계산 (순수 함수)
+ *
+ * 핵심 원리:
+ * - budgetBeforeToday = 이번 주기 남은 예산에 오늘 지출을 복원한 값
+ *   (오늘 시작 시점의 가용 예산)
+ * - todayBudget = budgetBeforeToday / (오늘 포함 남은 일수)
+ * - 🔧 budgetBeforeToday가 음수면 (이미 이번 달 초과) 오늘 예산 0으로 클램프
+ *   → 오늘 "초과"가 오늘 지출만 반영하도록 분리. 누적 빚은
+ *     monthBudgetRemaining으로 별도 표시.
+ */
+export function calculateTodayAllocation(input: TodayAllocationInput): TodayAllocationResult {
+  const { monthBudgetRemaining, todayFlexSpent, cycleRemainingDays } = input;
+
+  const budgetBeforeToday = monthBudgetRemaining + todayFlexSpent;
+  const todayIncludedDays = Math.max(1, cycleRemainingDays + 1);
+
+  // 이미 이번 달 초과 상태면 오늘 예산 0으로 클램프
+  const todayBudget = budgetBeforeToday > 0
+    ? Math.round(budgetBeforeToday / todayIncludedDays)
+    : 0;
+
+  const todayRemaining = todayBudget - todayFlexSpent;
+
+  return { todayBudget, todayRemaining };
+}
+
+// ─── 스냅샷 날짜 결정 ──────────────────────────────────────
+
+/**
+ * Vercel cron 드리프트를 흡수하는 스냅샷 대상 날짜 계산 (순수 함수)
+ *
+ * 배경:
+ * - 일별 예산 로그 cron은 KST 23:50 (14:50 UTC)에 예약되어 있지만
+ *   Vercel cron은 수 분\~수십 분 드리프트가 발생한다.
+ * - 드리프트가 KST 자정을 넘어가면 `getTodayISO()`가 다음날을 반환해
+ *   스냅샷이 엉뚱한 날짜로 저장되는 문제가 있었다.
+ *
+ * 해결:
+ * - 입력 시각에서 1시간 버퍼를 빼고 KST 날짜로 환산.
+ * - 예: 14:50 UTC 정시 발화 → 13:50 UTC → 22:50 KST → 당일
+ *       15:03 UTC 드리프트 → 14:03 UTC → 23:03 KST → 당일
+ *       15:40 UTC 드리프트 → 14:40 UTC → 23:40 KST → 당일
+ * - 최대 ~1시간 드리프트까지 안전.
+ */
+export function resolveSnapshotDate(nowUtc: Date, driftBufferMs = 3600_000): string {
+  const anchorMs = nowUtc.getTime() - driftBufferMs;
+  // KST로 환산 (UTC+9)
+  const kstMs = anchorMs + 9 * 3600 * 1000;
+  const kst = new Date(kstMs);
+  const yyyy = kst.getUTCFullYear();
+  const mm = String(kst.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(kst.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -6,6 +6,8 @@ import {
   getBillingRange,
   calcCycleDays,
   calculateBudgetAllocation,
+  calculateTodayAllocation,
+  resolveSnapshotDate,
 } from './budget-calc';
 import type { InstallmentProjection } from './budget-calc';
 import type {
@@ -928,12 +930,13 @@ export async function queryRunway(userId: number, targetDate?: string): Promise<
   }
 
   // 오늘 할당 예산 (B방식 — 하루 고정)
-  // "오늘 시작 시점 남은 예산 / 오늘 포함 남은 일수" 로 역산
-  // cycleRemainingDays는 오늘 제외 남은 일수이므로 +1하면 오늘 포함
-  const budgetBeforeToday = monthBudgetRemaining + todayFlexSpent;
-  const todayIncludedDays = cycleRemainingDays + 1;
-  const todayBudget = todayIncludedDays > 0 ? Math.round(budgetBeforeToday / todayIncludedDays) : 0;
-  const todayRemaining = todayBudget - todayFlexSpent;
+  // calculateTodayAllocation: monthBudgetRemaining이 음수면 0으로 클램프
+  // → 오늘 "초과"는 오늘 지출만 반영. 누적 빚은 monthBudgetRemaining으로 별도 표시.
+  const { todayBudget, todayRemaining } = calculateTodayAllocation({
+    monthBudgetRemaining,
+    todayFlexSpent,
+    cycleRemainingDays,
+  });
 
   // ─── 월별 시뮬레이션 (실제 런웨이) ───
   const projections: MonthProjection[] = [];
@@ -1019,11 +1022,18 @@ export interface DailyBudgetLogSummary {
   avg_daily_saved: number; // 일평균 세이브
 }
 
-/** 오늘의 예산 스냅샷 저장 (Vercel cron에서 호출) */
+/**
+ * 오늘의 예산 스냅샷 저장 (Vercel cron에서 호출)
+ *
+ * @param userId
+ * @param opts.targetDate 스냅샷 대상 날짜 (생략 시 KST 오늘).
+ *   Vercel cron 드리프트 방지용으로 cron 핸들러에서 `resolveSnapshotDate(new Date())` 를 넘긴다.
+ */
 export async function saveDailyBudgetLog(
   userId: number,
+  opts?: { targetDate?: string },
 ): Promise<{ date: string; budget: number; spent: number; saved: number }> {
-  const today = getTodayISO();
+  const targetDate = opts?.targetDate ?? getTodayISO();
 
   // 목표 기간 조회 → queryRunway에 전달
   const settings = await queryOne<{ target_date: string | null }>(
@@ -1032,10 +1042,28 @@ export async function saveDailyBudgetLog(
   );
   const runway = await queryRunway(userId, settings?.target_date ?? undefined);
 
+  // targetDate의 자유 지출을 DB에서 직접 조회 (runway의 today_flex_spent는 'live today' 기준이라 드리프트 시 0이 될 수 있음)
+  // 조건은 queryRunway의 today_flex 쿼리와 동일하게 맞춤
+  const budgetStartRow = await queryOne<{ updated_at: string }>(
+    'SELECT updated_at::text FROM budget_settings WHERE user_id = $1',
+    [userId],
+  );
+  const budgetStartAtParam = budgetStartRow?.updated_at ?? '9999-12-31T00:00:00Z';
+  const targetSpentRow = await queryOne<{ spent: string }>(
+    `SELECT COALESCE(SUM(amount), 0)::text as spent
+     FROM expenses
+     WHERE user_id=$1 AND date=$2
+       AND (is_installment=false OR (is_installment=true AND created_at>=$3))
+       AND exclude_from_budget = false
+       AND COALESCE(type,'expense')='expense'
+       AND planned_expense_id IS NULL`,
+    [userId, targetDate, budgetStartAtParam],
+  );
+  const spent = Number(targetSpentRow?.spent ?? 0);
+
   const budget = runway.today_budget;
-  const spent = runway.today_flex_spent;
   const saved = budget - spent;
-  const now = new Date(`${today}T12:00:00`);
+  const now = new Date(`${targetDate}T12:00:00`);
   const billingMonth = getCurrentBillingMonth(now);
 
   // UPSERT: 같은 날 다시 실행해도 최신 값으로 갱신
@@ -1044,10 +1072,10 @@ export async function saveDailyBudgetLog(
      VALUES ($1, $2, $3, $4, $5, $6)
      ON CONFLICT (user_id, date)
      DO UPDATE SET budget = $4, spent = $5, saved = $6, billing_month = $3`,
-    [userId, today, billingMonth, budget, spent, saved],
+    [userId, targetDate, billingMonth, budget, spent, saved],
   );
 
-  return { date: today, budget, spent, saved };
+  return { date: targetDate, budget, spent, saved };
 }
 
 /** billing_month 기준 일별 예산 로그 조회 */


### PR DESCRIPTION
## Summary
- 일별 예산 로그 스냅샷이 잘못된 날짜로 저장되던 문제 수정 — cron 드리프트 흡수 로직 추가
- 월 예산 초과 상태에서 "오늘 초과" 금액이 실제 오늘 지출과 맞지 않던 문제 수정 — 오늘 예산 0으로 클램프
- 예산 계산 순수 함수 2개 추출 + TDD 테스트 14개 추가

## 배경
일별 현황 탭에서 오늘 지출이 없는데도 초과로 기록되거나, 오늘 지출 금액과 "오늘 초과" 금액이 맥락상 불일치하는 문제가 있었음.

### 버그 1: 스냅샷 날짜 엉킴
Vercel cron은 최대 수십 분 드리프트가 발생하는데, 23:50 KST 예약이 자정을 넘어 발화하면 `getTodayISO()`가 다음날을 반환해 엉뚱한 날짜로 저장되는 문제.

### 버그 2: 오늘 초과 ≠ 오늘 지출
월 예산이 이미 초과된 상태에서 오늘 예산이 음수로 계산돼, 오늘 초과 금액에 이전 누적 분까지 섞여 표시되던 문제.

## 변경 내역

### 순수 함수 추가 (\`budget-calc.ts\`)
- \`resolveSnapshotDate(nowUtc, driftBufferMs=3600_000)\` — 발화 시각에서 1시간 버퍼 차감 후 KST 날짜 환산. ~60분 드리프트 흡수.
- \`calculateTodayAllocation({ monthBudgetRemaining, todayFlexSpent, cycleRemainingDays })\` — 누적이 음수면 오늘 예산 0으로 클램프. 오늘 초과는 오늘 지출만 반영, 누적 초과는 월간 지표로 별도 표시.

### 쿼리/핸들러 정리
- \`queryRunway\`는 새 순수 함수를 호출해 오늘 할당을 계산
- \`saveDailyBudgetLog\`는 \`opts.targetDate\` 받도록 확장, 해당 날짜의 지출을 DB에서 직접 SUM
- cron 핸들러는 \`resolveSnapshotDate(new Date())\`를 명시적으로 전달

## 테스트
- \`budget-calc.test.ts\`: 기존 28개 → 42개
  - \`calculateTodayAllocation\` 6개 (정상/경계/클램프 재현)
  - \`resolveSnapshotDate\` 8개 (정시/드리프트/월말/연말)
- TDD로 진행: 14개 실패 확인 → 구현 → 전부 통과
- 전체 스위트 84개 모두 통과, \`tsc --noEmit\` 클린

## Test plan
- [x] \`yarn vitest run\` — 84개 통과
- [x] \`yarn tsc --noEmit\` — 타입 에러 없음
- [ ] 머지 후 오늘 밤 cron 정상 발화 확인 — 일별 현황 탭에 오늘 날짜 행이 올바른 값으로 들어오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)