### PR TITLE
fix(budget): 예산 제외 지출이 자유예산을 깎는 버그 수정

### DIFF
--- a/web/src/features/budget/components/month-summary.tsx
+++ b/web/src/features/budget/components/month-summary.tsx
@@ -90,9 +90,9 @@ export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
               )}
 
               {/* 하루 분석 메시지 */}
-              {todayRemaining < 0 && daysLeft > 0 && todayBudget > 0 && (
+              {todayRemaining < 0 && daysLeft > 0 && (todayBudget > 0 || (dailyBudget != null && dailyBudget > 0)) && (
                 <div className="mt-2 rounded-md bg-red-50 px-2.5 py-1.5 text-xs text-red-500">
-                  남은 {daysLeft}일 이 패턴이면 런웨이 약 {Math.floor(Math.abs(todayRemaining) * daysLeft / todayBudget)}일 단축
+                  남은 {daysLeft}일 이 패턴이면 런웨이 약 {Math.floor(Math.abs(todayRemaining) * daysLeft / (todayBudget > 0 ? todayBudget : dailyBudget!))}일 단축
                 </div>
               )}
               {todayRemaining > 0 && todayFlexSpent > 0 && (

--- a/web/src/features/budget/lib/__tests__/budget-calc.test.ts
+++ b/web/src/features/budget/lib/__tests__/budget-calc.test.ts
@@ -99,11 +99,12 @@ describe('calculateBudgetAllocation', () => {
     cycleDays: 31,      // 3/16 ~ 4/15
     flexibleSpent: 30_000,
     currentMonthIncome: 40_000,
+    excludedSpent: 0,
   };
 
-  test('budgetBase = totalAvailable + flexibleSpent - currentMonthIncome', () => {
+  test('budgetBase = totalAvailable + flexibleSpent + excludedSpent - currentMonthIncome', () => {
     const result = calculateBudgetAllocation(baseInput);
-    expect(result.budgetBase).toBe(1_000_000 + 30_000 - 40_000); // 990_000
+    expect(result.budgetBase).toBe(1_000_000 + 30_000 + 0 - 40_000); // 990_000
   });
 
   test('targetDate null → freePerMonth null, 나머지 0', () => {
@@ -196,6 +197,70 @@ describe('calculateBudgetAllocation', () => {
     expect(result.monthlyLocked[1].days).toBe(30);
     // month 2 = '2026-06': 5/16 ~ 6/15 → 31일
     expect(result.monthlyLocked[2].days).toBe(31);
+  });
+
+  // ─── excludedSpent 관련 테스트 ───
+
+  test('🐛 bug fix: excludedSpent가 budgetBase에 복원되어 자유예산에 영향 안 줌', () => {
+    // 시나리오: 리커밋 택배 3500원이 예산 제외인데 자유예산을 깎았던 버그
+    // 은행 잔고가 3500원 줄었지만(totalAvailable), excludedSpent로 복원해야 함
+    const withExcluded = calculateBudgetAllocation({
+      ...baseInput,
+      totalAvailable: 996_500,   // 은행에서 3500 이미 빠진 상태
+      excludedSpent: 3_500,       // 예산 제외 지출 3500
+    });
+    const withoutExcluded = calculateBudgetAllocation({
+      ...baseInput,
+      totalAvailable: 1_000_000, // 예산 제외 지출이 없었을 때
+      excludedSpent: 0,
+    });
+    // budgetBase가 같아야 함 (996500 + 3500 = 1000000)
+    expect(withExcluded.budgetBase).toBe(withoutExcluded.budgetBase);
+    // freePerMonth도 같아야 함
+    expect(withExcluded.freePerMonth).toBe(withoutExcluded.freePerMonth);
+    expect(withExcluded.dailyFree).toBe(withoutExcluded.dailyFree);
+  });
+
+  test('excludedSpent가 크면 budgetBase가 더 높아짐 → 자유예산 증가', () => {
+    const noExcluded = calculateBudgetAllocation({ ...baseInput, excludedSpent: 0 });
+    const bigExcluded = calculateBudgetAllocation({ ...baseInput, excludedSpent: 50_000 });
+    expect(bigExcluded.budgetBase).toBe(noExcluded.budgetBase + 50_000);
+    expect(bigExcluded.freePerMonth!).toBeGreaterThan(noExcluded.freePerMonth!);
+  });
+
+  test('고정비 자동기록 + excludedSpent: locked과 이중 차감 안 됨', () => {
+    // 시나리오: 고정비 100,000이 자동 기록됨 (exclude_from_budget=true)
+    // 은행 잔고가 100,000 줄었고, excludedSpent에 100,000 포함
+    // fixedMonthly=100,000이 locked에도 있음
+    // → budgetBase에서 복원되고, locked에서 차감되므로 정확히 1번만 차감
+    const withFixed = calculateBudgetAllocation({
+      ...baseInput,
+      totalAvailable: 900_000,   // 고정비 100,000 납부 후
+      excludedSpent: 100_000,    // 고정비가 excluded 지출에 포함
+      fixedMonthly: 100_000,
+    });
+    const idealCase = calculateBudgetAllocation({
+      ...baseInput,
+      totalAvailable: 1_000_000, // 아직 미납부
+      excludedSpent: 0,
+      fixedMonthly: 100_000,
+    });
+    // budgetBase는 같아야 함 (900000+100000 = 1000000)
+    expect(withFixed.budgetBase).toBe(idealCase.budgetBase);
+    // freePerMonth도 같아야 함 (locked 배분 동일)
+    expect(withFixed.freePerMonth).toBe(idealCase.freePerMonth);
+  });
+
+  test('excludedSpent + 수입: 수입 격리와 독립적으로 작동', () => {
+    const result = calculateBudgetAllocation({
+      ...baseInput,
+      totalAvailable: 946_500,     // 3500 excluded + 50000 spent
+      flexibleSpent: 50_000,
+      currentMonthIncome: 20_000,
+      excludedSpent: 3_500,
+    });
+    // budgetBase = 946500 + 50000 + 3500 - 20000 = 980000
+    expect(result.budgetBase).toBe(980_000);
   });
 });
 

--- a/web/src/features/budget/lib/budget-calc.ts
+++ b/web/src/features/budget/lib/budget-calc.ts
@@ -62,6 +62,7 @@ export interface BudgetCalcInput {
   cycleDays: number;            // 전체 주기 일수
   flexibleSpent: number;        // 이번 주기 자유 지출
   currentMonthIncome: number;   // 이번 달 수입
+  excludedSpent: number;        // 이번 주기 예산 제외 지출 (exclude_from_budget=true)
 }
 
 /** 월별 잠긴 돈 상세 */
@@ -87,9 +88,11 @@ export interface BudgetCalcResult {
  * 예산 배분 계산 (순수 함수)
  *
  * 핵심 원리:
- * - budgetBase = totalAvailable + flexibleSpent - currentMonthIncome
- *   (이번 달 자유 지출을 복원해 "주기 시작 시점" 가용자금으로 맞추고,
+ * - budgetBase = totalAvailable + flexibleSpent + excludedSpent - currentMonthIncome
+ *   (이번 달 자유 지출 + 예산 제외 지출을 복원해 "주기 시작 시점" 가용자금으로 맞추고,
  *    수입은 이번 달에만 반영해 미래 월 예산 부풀림 방지)
+ * - excludedSpent: 예산 제외 지출(고정비 자동기록 포함)도 은행 잔고를 줄이므로 복원 필요.
+ *   고정비는 totalLocked에서 별도 차감되므로 이중 계산 아님.
  * - 현재 달 locked는 budgetDays/cycleDays 비율로 프로레이션
  * - 신규 할부(isNew)는 month 0에서 locked 제외 (자유 지출로 이미 반영)
  * - freePerMonth = dailyFree * cycleDays (월 기준 일관성)
@@ -98,11 +101,12 @@ export function calculateBudgetAllocation(input: BudgetCalcInput): BudgetCalcRes
   const {
     totalAvailable, fixedMonthly, installments, plannedExpenses,
     billingMonth, targetDate, budgetDays, cycleDays,
-    flexibleSpent, currentMonthIncome,
+    flexibleSpent, currentMonthIncome, excludedSpent,
   } = input;
 
-  // 1. budgetBase: 자유 지출 복원 + 수입 격리
-  const budgetBase = totalAvailable + flexibleSpent - currentMonthIncome;
+  // 1. budgetBase: 자유 지출 + 예산 제외 지출 복원 + 수입 격리
+  // excludedSpent를 더해야 예산 제외 지출이 자유 예산을 깎지 않음
+  const budgetBase = totalAvailable + flexibleSpent + excludedSpent - currentMonthIncome;
 
   // 2. 목표 기간 유효성 확인
   if (!targetDate || !/^\d{4}-\d{2}$/.test(targetDate)) {

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -703,7 +703,7 @@ export async function calcBudgetPreview(
   // 이번 달 자유 지출 + 수입 조회
   const endDate = todayISOStr < cycleTo ? todayISOStr : cycleTo;
   const budgetStartAtParam = previewBudgetStartAt ?? '9999-12-31T00:00:00Z';
-  const cycleMetrics = await queryOne<{ flex: string; overflow: string; income: string }>(
+  const cycleMetrics = await queryOne<{ flex: string; overflow: string; income: string; excluded: string }>(
     `SELECT
        COALESCE((SELECT SUM(amount) FROM expenses
          WHERE user_id=$1 AND date>=$2 AND date<=$3
@@ -719,11 +719,17 @@ export async function calcBudgetPreview(
        COALESCE((SELECT SUM(amount) FROM expenses
          WHERE user_id=$1 AND date>=$4 AND date<=$5 AND COALESCE(type,'expense')='income'
            AND COALESCE(distribute_to_budget, false) = false
-       ), 0)::text as income`,
+       ), 0)::text as income,
+       COALESCE((SELECT SUM(amount) FROM expenses
+         WHERE user_id=$1 AND date>=$2 AND date<=$3
+           AND exclude_from_budget = true
+           AND COALESCE(type,'expense')='expense'
+       ), 0)::text as excluded`,
     [userId, trackingFrom, endDate, cycleFrom, cycleTo, budgetStartAtParam],
   );
   const flexibleSpent = Number(cycleMetrics?.flex ?? 0) + Number(cycleMetrics?.overflow ?? 0);
   const currentMonthIncome = Number(cycleMetrics?.income ?? 0);
+  const excludedSpent = Number(cycleMetrics?.excluded ?? 0);
 
   const installments: InstallmentProjection[] = installmentRows.rows
     .filter((r) => r.installment_total > r.installment_num)
@@ -745,6 +751,7 @@ export async function calcBudgetPreview(
     cycleDays,
     flexibleSpent,
     currentMonthIncome,
+    excludedSpent,
   });
 
   if (calcResult.freePerMonth === null) return null;
@@ -857,7 +864,7 @@ export async function queryRunway(userId: number, targetDate?: string): Promise<
   // budgetStartAt이 null이면 '9999-12-31T00:00:00Z'로 폴백 → 모든 할부가 구 할부로 처리됨
   const endDate = todayStr < cycleTo ? todayStr : cycleTo;
   const budgetStartAtParam = budgetStartAt ?? '9999-12-31T00:00:00Z';
-  const cycleMetrics = await queryOne<{ flex: string; overflow: string; income: string; today_flex: string }>(
+  const cycleMetrics = await queryOne<{ flex: string; overflow: string; income: string; today_flex: string; excluded: string }>(
     `SELECT
        COALESCE((SELECT SUM(amount) FROM expenses
          WHERE user_id=$1 AND date>=$2 AND date<=$3
@@ -879,12 +886,18 @@ export async function queryRunway(userId: number, targetDate?: string): Promise<
            AND (is_installment=false OR (is_installment=true AND created_at>=$7))
            AND exclude_from_budget = false
            AND COALESCE(type,'expense')='expense' AND planned_expense_id IS NULL
-       ), 0)::text as today_flex`,
+       ), 0)::text as today_flex,
+       COALESCE((SELECT SUM(amount) FROM expenses
+         WHERE user_id=$1 AND date>=$2 AND date<=$3
+           AND exclude_from_budget = true
+           AND COALESCE(type,'expense')='expense'
+       ), 0)::text as excluded`,
     [userId, trackingFrom, endDate, cycleFrom, cycleTo, todayStr, budgetStartAtParam],
   );
   const flexibleSpent = Number(cycleMetrics?.flex ?? 0) + Number(cycleMetrics?.overflow ?? 0);
   const currentMonthIncome = Number(cycleMetrics?.income ?? 0);
   const todayFlexSpent = Number(cycleMetrics?.today_flex ?? 0);
+  const excludedSpent = Number(cycleMetrics?.excluded ?? 0);
 
   // ─── 예산 배분 계산 (공통 함수) ───
   // budgetBase 보정, 월별 locked, freePerMonth, dailyFree 산출
@@ -899,6 +912,7 @@ export async function queryRunway(userId: number, targetDate?: string): Promise<
     cycleDays,
     flexibleSpent,
     currentMonthIncome,
+    excludedSpent,
   });
   freePerMonth = calcResult.freePerMonth;
 


### PR DESCRIPTION
## Summary
- 예산 제외(`exclude_from_budget=true`) 지출이 자유예산/오늘예산을 깎는 구조적 결함 수정
- `budgetBase` 복원 공식에 `excludedSpent` 추가하여 예산 제외 지출이 자유예산에 영향 안 주도록 개선
- `todayBudget=0`(월 예산 초과 상태)일 때 런웨이 단축 경고 미표시 버그 수정

## 변경 내용
| 파일 | 변경 |
|------|------|
| `budget-calc.ts` | `BudgetCalcInput.excludedSpent` 추가, budgetBase 공식 수정 |
| `queries.ts` | `queryRunway`, `calcBudgetPreview`에 excluded 지출 서브쿼리 추가 |
| `month-summary.tsx` | 런웨이 단축 경고 조건에 `dailyBudget` fallback 추가 |
| `budget-calc.test.ts` | 테스트 4건 추가 |

## 근본 원인
기존 공식 `budgetBase = totalAvailable + flexibleSpent - income`에서 예산 제외 지출이 은행 잔고(`totalAvailable`)를 줄이지만, `flexibleSpent`에는 포함되지 않아 복원되지 않음. 결과적으로 예산 제외 지출이 자유예산을 깎는 효과 발생.

## Test plan
- [x] budget-calc 단위 테스트 46건 통과
- [x] 전체 프로젝트 테스트 335건 통과
- [x] TypeScript 타입 체크 통과
- [ ] 배포 후 예산 제외 지출 추가 시 자유예산 변동 없음 확인
- [ ] 월 예산 초과 상태에서 런웨이 단축 경고 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)