### PR TITLE
fix(budget): 런웨이 단축 경고 — 월 초과 시 분모 fallback 수정

### DIFF
--- a/web/src/features/budget/components/month-summary.tsx
+++ b/web/src/features/budget/components/month-summary.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { MonthSummary } from '@/features/budget/lib/types';
+import { calculateRunwayShorten } from '@/features/budget/lib/budget-calc';
 import { formatAmount } from '@/lib/types';
 import { getTodayISO } from '@/lib/kst';
 import { BanknotesIcon, ClockIcon, CheckCircleIcon } from '@/components/ui/icons';
@@ -90,11 +91,19 @@ export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
               )}
 
               {/* 하루 분석 메시지 */}
-              {todayRemaining < 0 && daysLeft > 0 && (todayBudget > 0 || (dailyBudget != null && dailyBudget > 0)) && (
-                <div className="mt-2 rounded-md bg-red-50 px-2.5 py-1.5 text-xs text-red-500">
-                  남은 {daysLeft}일 이 패턴이면 런웨이 약 {Math.floor(Math.abs(todayRemaining) * daysLeft / (todayBudget > 0 ? todayBudget : dailyBudget!))}일 단축
-                </div>
-              )}
+              {(() => {
+                const shortenDays = calculateRunwayShorten({
+                  todayRemaining, todayBudget, totalBudget, totalDays, daysLeft,
+                });
+                if (shortenDays != null && shortenDays > 0) {
+                  return (
+                    <div className="mt-2 rounded-md bg-red-50 px-2.5 py-1.5 text-xs text-red-500">
+                      남은 {daysLeft}일 이 패턴이면 런웨이 약 {shortenDays}일 단축
+                    </div>
+                  );
+                }
+                return null;
+              })()}
               {todayRemaining > 0 && todayFlexSpent > 0 && (
                 <div className="mt-2 rounded-md bg-green-50 px-2.5 py-1.5 text-xs text-green-600">
                   오늘 {formatAmount(todayRemaining)} 아꼈어!

--- a/web/src/features/budget/lib/__tests__/budget-calc.test.ts
+++ b/web/src/features/budget/lib/__tests__/budget-calc.test.ts
@@ -6,6 +6,7 @@ import {
   calcCycleDays,
   calculateBudgetAllocation,
   calculateTodayAllocation,
+  calculateRunwayShorten,
   resolveSnapshotDate,
 } from '../budget-calc';
 import type { BudgetCalcInput } from '../budget-calc';
@@ -388,5 +389,115 @@ describe('resolveSnapshotDate', () => {
     // 12:00 KST = 03:00 UTC → anchor 02:00 UTC → 11:00 KST 같은 날
     const now = new Date('2026-04-11T03:00:00Z');
     expect(resolveSnapshotDate(now)).toBe('2026-04-11');
+  });
+});
+
+// ─── calculateRunwayShorten ──────────────────────────────
+//
+// 핵심 버그 재현:
+//   - 월 예산 초과 → todayBudget=0(클램프) → 런웨이 단축 경고 미표시
+//   - 원인: 분모(todayBudget)가 0이면 division by zero 방어로 경고 안 나옴
+//   - 수정: todayBudget=0일 때 totalBudget/totalDays로 fallback
+
+describe('calculateRunwayShorten', () => {
+  test('정상 케이스: todayBudget > 0 → todayBudget을 분모로 사용', () => {
+    const result = calculateRunwayShorten({
+      todayRemaining: -20_000,
+      todayBudget: 10_000,
+      totalBudget: 300_000,
+      totalDays: 30,
+      daysLeft: 5,
+    });
+    // |(-20000)| * 5 / 10000 = 10
+    expect(result).toBe(10);
+  });
+
+  test('🐛 bug fix: todayBudget=0(월 초과 클램프) → totalBudget/totalDays fallback', () => {
+    // 실제 재현: 97500원 초과, todayBudget=0, 월예산 300000, 30일 주기, 남은 2일
+    const result = calculateRunwayShorten({
+      todayRemaining: -97_500,
+      todayBudget: 0,
+      totalBudget: 300_000,
+      totalDays: 30,
+      daysLeft: 2,
+    });
+    // fallback 분모 = round(300000/30) = 10000
+    // |(-97500)| * 2 / 10000 = 19.5 → floor → 19
+    expect(result).toBe(19);
+    expect(result).not.toBeNull(); // 핵심: null이 아니어야 경고가 표시됨
+  });
+
+  test('🐛 bug fix: todayBudget=0 + dailyBudget 음수(월 초과) → fallback으로 경고 표시', () => {
+    // dailyBudget이 음수여도 totalBudget/totalDays가 양수면 경고 나와야 함
+    const result = calculateRunwayShorten({
+      todayRemaining: -50_000,
+      todayBudget: 0,
+      totalBudget: 200_000,
+      totalDays: 31,
+      daysLeft: 3,
+    });
+    // fallback 분모 = round(200000/31) = 6452
+    // 50000 * 3 / 6452 = 23.25 → 23
+    expect(result).toBe(23);
+  });
+
+  test('todayRemaining >= 0 → null (초과 아님, 경고 불필요)', () => {
+    expect(calculateRunwayShorten({
+      todayRemaining: 5_000,
+      todayBudget: 10_000,
+      totalBudget: 300_000,
+      totalDays: 30,
+      daysLeft: 5,
+    })).toBeNull();
+  });
+
+  test('todayRemaining = 0 → null (정확히 예산대로 씀)', () => {
+    expect(calculateRunwayShorten({
+      todayRemaining: 0,
+      todayBudget: 10_000,
+      totalBudget: 300_000,
+      totalDays: 30,
+      daysLeft: 5,
+    })).toBeNull();
+  });
+
+  test('todayRemaining null → null (데이터 없음)', () => {
+    expect(calculateRunwayShorten({
+      todayRemaining: null,
+      todayBudget: 10_000,
+      totalBudget: 300_000,
+      totalDays: 30,
+      daysLeft: 5,
+    })).toBeNull();
+  });
+
+  test('daysLeft = 0 → null (주기 마지막 날, 단축 의미 없음)', () => {
+    expect(calculateRunwayShorten({
+      todayRemaining: -20_000,
+      todayBudget: 10_000,
+      totalBudget: 300_000,
+      totalDays: 30,
+      daysLeft: 0,
+    })).toBeNull();
+  });
+
+  test('totalBudget null + todayBudget=0 → null (예산 데이터 없음)', () => {
+    expect(calculateRunwayShorten({
+      todayRemaining: -20_000,
+      todayBudget: 0,
+      totalBudget: null,
+      totalDays: 30,
+      daysLeft: 5,
+    })).toBeNull();
+  });
+
+  test('totalBudget=0 + todayBudget=0 → null (예산 0)', () => {
+    expect(calculateRunwayShorten({
+      todayRemaining: -20_000,
+      todayBudget: 0,
+      totalBudget: 0,
+      totalDays: 30,
+      daysLeft: 5,
+    })).toBeNull();
   });
 });

--- a/web/src/features/budget/lib/budget-calc.ts
+++ b/web/src/features/budget/lib/budget-calc.ts
@@ -217,6 +217,48 @@ export function calculateTodayAllocation(input: TodayAllocationInput): TodayAllo
   return { todayBudget, todayRemaining };
 }
 
+// ─── 런웨이 단축 경고 계산 ──────────────────────────────────
+
+/** 런웨이 단축 경고 입력 */
+export interface RunwayShortenInput {
+  /** 오늘 남음(음수 = 초과). null이면 데이터 없음 */
+  todayRemaining: number | null;
+  /** 오늘 할당 예산 (0 = 월 초과로 클램프됨) */
+  todayBudget: number | null;
+  /** 월 자유 예산 (freePerMonth, 항상 >= 0) */
+  totalBudget: number | null;
+  /** 결제주기 총 일수 */
+  totalDays: number;
+  /** 남은 일수 (오늘 제외) */
+  daysLeft: number;
+}
+
+/**
+ * 런웨이 단축 일수 계산 (순수 함수)
+ *
+ * "오늘과 같은 패턴으로 남은 일수를 보내면 런웨이가 며칠 단축되는가"
+ *
+ * 분모 우선순위:
+ * 1. todayBudget > 0 → 오늘 할당 예산 (가장 정확)
+ * 2. totalBudget / totalDays → 월 예산 기준 일일 예산 (월 초과 시 fallback)
+ * 3. 둘 다 없으면 null (경고 표시 불가)
+ */
+export function calculateRunwayShorten(input: RunwayShortenInput): number | null {
+  const { todayRemaining, todayBudget, totalBudget, totalDays, daysLeft } = input;
+
+  if (todayRemaining == null || todayRemaining >= 0 || daysLeft <= 0) return null;
+
+  const baseDailyBudget = todayBudget != null && todayBudget > 0
+    ? todayBudget
+    : totalBudget != null && totalBudget > 0 && totalDays > 0
+      ? Math.round(totalBudget / totalDays)
+      : 0;
+
+  if (baseDailyBudget <= 0) return null;
+
+  return Math.floor(Math.abs(todayRemaining) * daysLeft / baseDailyBudget);
+}
+
 // ─── 스냅샷 날짜 결정 ──────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary
- 월 예산 초과 상태에서 런웨이 단축 경고가 표시되지 않는 버그 수정
- `calculateRunwayShorten` 순수 함수 추출로 테스트 가능하게 개선

## 근본 원인
`todayBudget=0`(월 초과 클램프) + `dailyBudget < 0`(월 초과로 음수) → 런웨이 단축 경고의 분모가 0 이하 → division by zero 가드에 걸려 경고 미표시

## 변경 내용
| 파일 | 변경 |
|------|------|
| `budget-calc.ts` | `calculateRunwayShorten()` 순수 함수 추출 |
| `month-summary.tsx` | 인라인 계산 → 순수 함수 호출로 교체 |
| `budget-calc.test.ts` | 테스트 9건 추가 (월 초과 fallback, 경계값 등) |

## Test plan
- [x] budget-calc 단위 테스트 55건 통과 (런웨이 단축 9건 포함)
- [x] 전체 프로젝트 테스트 335건 통과
- [x] TypeScript 타입 체크 통과
- [ ] 배포 후 월 예산 초과 상태에서 런웨이 단축 경고 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)