### PR TITLE
fix: reminders 테이블 user_id 면제 누락 수정

### DIFF
--- a/src/agents/life/prompt.ts
+++ b/src/agents/life/prompt.ts
@@ -102,7 +102,7 @@ ${lifeContext}
 - SELECT: WHERE user_id = ${userId} AND ...
 - INSERT: user_id 컬럼에 ${userId} 포함
 - UPDATE/DELETE: WHERE user_id = ${userId} AND ...
-이 규칙은 sleep_events, notification_settings, reminders를 제외한 모든 테이블에 적용.
+이 규칙은 sleep_events, notification_settings, categories, reminders를 제외한 모든 테이블에 적용.
 
 ## 일정 조회 SQL — 3대 필수 규칙
 

--- a/src/shared/__tests__/sql-tools.test.ts
+++ b/src/shared/__tests__/sql-tools.test.ts
@@ -143,6 +143,10 @@ describe('validateUserIdFilter', () => {
     expect(validateUserIdFilter('INSERT INTO sleep_events (date, event_time) VALUES ($1, $2)', 1)).toBeNull();
   });
 
+  it('면제 테이블(reminders)만 참조하면 통과한다', () => {
+    expect(validateUserIdFilter("UPDATE reminders SET active = false WHERE title LIKE '%파슬리%'", 1)).toBeNull();
+  });
+
   it('information_schema 쿼리는 통과한다', () => {
     expect(validateUserIdFilter('SELECT * FROM information_schema.columns WHERE table_schema = \'public\'', 1)).toBeNull();
   });

--- a/src/shared/sql-tools.ts
+++ b/src/shared/sql-tools.ts
@@ -208,6 +208,7 @@ const USER_ID_EXEMPT_TABLES = new Set([
   'sleep_events',
   'notification_settings',
   'categories',
+  'reminders',
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- `USER_ID_EXEMPT_TABLES`에 `reminders` 추가 — user_id 컬럼이 없는 테이블이 면제 목록에서 빠져있어 리마인더 수정/삭제 요청 시 검증 거부 → 10라운드 소진 → "요청이 너무 복잡해" 응답 발생
- 시스템 프롬프트 면제 목록에 `categories` 추가하여 코드와 동기화
- reminders 면제 검증 테스트 추가

## Test plan
- [x] 기존 sql-tools 테스트 65개 전체 통과
- [ ] 배포 후 라이프 채널에서 리마인더 삭제/수정 요청 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)