### PR TITLE
feat(web): 수면 대시보드 — 생활 페이지 통합 + 수면 시각화

### DIFF
--- a/web/src/app/api/sleep/dashboard/route.ts
+++ b/web/src/app/api/sleep/dashboard/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import {
+  querySleepRecordsWithEvents,
+  calculateSleepSummary,
+  calculateDayOfWeekPattern,
+} from '@/features/sleep/lib/queries';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const userId = await requireAuth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const from = searchParams.get('from');
+    const to = searchParams.get('to');
+
+    if (!from || !to) {
+      return NextResponse.json({ error: 'from/to 파라미터 필요' }, { status: 400 });
+    }
+
+    const records = await querySleepRecordsWithEvents(userId, from, to);
+    const summary = calculateSleepSummary(records);
+    const dayOfWeekPattern = calculateDayOfWeekPattern(records);
+
+    return NextResponse.json(
+      { data: { records, summary, dayOfWeekPattern } },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
+  } catch {
+    return NextResponse.json({ error: '수면 대시보드 조회 실패' }, { status: 500 });
+  }
+}

--- a/web/src/app/routines/page.tsx
+++ b/web/src/app/routines/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { AppShell } from '@/components/ui/app-shell';
-import { RoutinePage } from '@/features/routine/components/routine-page';
+import { LifePage } from '@/features/life/components/life-page';
 
 export default function RoutinesPageRoute() {
   return (
     <AppShell>
-      <RoutinePage />
+      <LifePage />
     </AppShell>
   );
 }

--- a/web/src/components/ui/app-shell.tsx
+++ b/web/src/components/ui/app-shell.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import {
   CalendarIcon,
-  ArrowPathIcon,
+  HeartIcon,
   WalletIcon,
   ArrowRightStartOnRectangleIcon,
   Bars3Icon,
@@ -20,7 +20,7 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { href: '/schedules', label: '일정', Icon: CalendarIcon },
-  { href: '/routines', label: '루틴', Icon: ArrowPathIcon },
+  { href: '/routines', label: '생활', Icon: HeartIcon },
   { href: '/budget', label: '지출', Icon: WalletIcon },
 ];
 

--- a/web/src/components/ui/icons.tsx
+++ b/web/src/components/ui/icons.tsx
@@ -253,3 +253,27 @@ export function Bars3Icon(props: IconProps) {
     </svg>
   );
 }
+
+export function HeartIcon(props: IconProps) {
+  return (
+    <svg {...defaultProps(props)}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"
+      />
+    </svg>
+  );
+}
+
+export function MoonIcon(props: IconProps) {
+  return (
+    <svg {...defaultProps(props)}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
+      />
+    </svg>
+  );
+}

--- a/web/src/features/life/components/life-page.tsx
+++ b/web/src/features/life/components/life-page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState } from 'react';
+import { TopTabs } from '@/components/ui/tabs';
+import { SleepDashboard } from '@/features/sleep/components/sleep-dashboard';
+import { RoutinePage } from '@/features/routine/components/routine-page';
+
+type LifeView = 'sleep' | 'routine';
+
+const LIFE_TABS: { id: LifeView; label: string }[] = [
+  { id: 'sleep', label: '수면' },
+  { id: 'routine', label: '루틴' },
+];
+
+export function LifePage() {
+  const [view, setView] = useState<LifeView>('sleep');
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <TopTabs tabs={LIFE_TABS} active={view} onChange={setView} />
+      {view === 'sleep' && <SleepDashboard />}
+      {view === 'routine' && <RoutinePage />}
+    </div>
+  );
+}

--- a/web/src/features/routine/components/routine-page.tsx
+++ b/web/src/features/routine/components/routine-page.tsx
@@ -12,7 +12,7 @@ import { RoutineForm } from './routine-form';
 import { RoutineRecordDetail } from './routine-record-detail';
 import { Modal } from '@/components/ui/modal';
 import { BottomSheet } from '@/components/ui/bottom-sheet';
-import { TopTabs } from '@/components/ui/tabs';
+import { PillTabs } from '@/components/ui/tabs';
 import { TabsSkeleton, ListSkeleton } from '@/components/ui/skeleton';
 
 const ROUTINE_TABS: { id: RoutineView; label: string }[] = [
@@ -64,7 +64,9 @@ export function RoutinePage() {
   if (loading) {
     return (
       <div className="flex flex-1 flex-col">
-        <TabsSkeleton count={3} />
+        <div className="mx-auto w-full max-w-5xl px-4 pt-4">
+          <TabsSkeleton count={3} />
+        </div>
         <div className="mx-auto w-full max-w-5xl px-4 py-4">
           <ListSkeleton rows={5} rowHeight="h-14" />
         </div>
@@ -73,8 +75,10 @@ export function RoutinePage() {
   }
   return (
     <div className="flex flex-1 flex-col">
-      {/* 탭 바 */}
-      <TopTabs tabs={ROUTINE_TABS} active={view} onChange={setView} />
+      {/* 서브 탭 */}
+      <div className="mx-auto w-full max-w-5xl px-4 pt-4">
+        <PillTabs tabs={ROUTINE_TABS} active={view} onChange={setView} />
+      </div>
 
       {/* 콘텐츠 */}
       <div className="flex-1 overflow-y-auto">

--- a/web/src/features/sleep/components/period-selector.tsx
+++ b/web/src/features/sleep/components/period-selector.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { SleepPeriod } from '../lib/types';
+
+const PERIODS: { id: SleepPeriod; label: string }[] = [
+  { id: '1w', label: '1주' },
+  { id: '2w', label: '2주' },
+  { id: '1m', label: '1개월' },
+];
+
+interface PeriodSelectorProps {
+  period: SleepPeriod;
+  onChange: (p: SleepPeriod) => void;
+}
+
+export function PeriodSelector({ period, onChange }: PeriodSelectorProps) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {PERIODS.map((p) => (
+        <button
+          key={p.id}
+          onClick={() => onChange(p.id)}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition ${
+            period === p.id
+              ? 'bg-indigo-500 text-white'
+              : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+          }`}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/features/sleep/components/sleep-dashboard.tsx
+++ b/web/src/features/sleep/components/sleep-dashboard.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useSleepDashboard } from '../hooks/use-sleep-dashboard';
+import { PeriodSelector } from './period-selector';
+import { SleepSummaryCards } from './sleep-summary-cards';
+import { SleepTimeline } from './sleep-timeline';
+import { SleepTrendChart } from './sleep-trend-chart';
+import { SleepDayPattern } from './sleep-day-pattern';
+import { CardSkeleton } from '@/components/ui/skeleton';
+
+export function SleepDashboard() {
+  const { period, data, loading, handlePeriodChange } = useSleepDashboard();
+
+  if (loading && !data) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-4 px-4 py-4">
+        <CardSkeleton className="h-10" />
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => <CardSkeleton key={i} className="h-20" />)}
+        </div>
+        <CardSkeleton className="h-64" />
+        <CardSkeleton className="h-48" />
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-5xl space-y-4 px-4 py-4 md:py-6">
+        <PeriodSelector period={period} onChange={handlePeriodChange} />
+        <SleepSummaryCards summary={data.summary} />
+        <SleepTimeline records={data.records} />
+        <SleepTrendChart records={data.records} />
+        <SleepDayPattern pattern={data.dayOfWeekPattern} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/sleep/components/sleep-day-pattern.tsx
+++ b/web/src/features/sleep/components/sleep-day-pattern.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type { DayOfWeekPattern } from '../lib/types';
+
+interface SleepDayPatternProps {
+  pattern: DayOfWeekPattern[];
+}
+
+function barColor(minutes: number): string {
+  if (minutes >= 420) return '#818cf8';
+  if (minutes >= 360) return '#fbbf24';
+  return '#f87171';
+}
+
+export function SleepDayPattern({ pattern }: SleepDayPatternProps) {
+  const ordered = [1, 2, 3, 4, 5, 6, 0].map((d) => pattern.find((p) => p.day === d)!);
+  const maxDur = Math.max(...ordered.map((p) => p.avgDuration), 1);
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <h3 className="mb-4 text-sm font-semibold text-gray-900">요일별 수면 패턴</h3>
+      <div className="flex items-end justify-between gap-2">
+        {ordered.map((p) => {
+          const h = Math.floor(p.avgDuration / 60);
+          const m = p.avgDuration % 60;
+          const heightPx = Math.max(4, (p.avgDuration / (maxDur + 60)) * 100);
+          return (
+            <div key={p.day} className="flex flex-1 flex-col items-center gap-1">
+              <span className="text-xs text-gray-500">
+                {p.count > 0 ? `${h}h${m > 0 ? m : ''}` : '—'}
+              </span>
+              <div
+                className="w-full rounded-t"
+                style={{
+                  height: heightPx,
+                  backgroundColor: p.count > 0 ? barColor(p.avgDuration) : '#e5e7eb',
+                }}
+              />
+              <span className={`text-xs font-medium ${
+                p.dayName === '일' ? 'text-red-400' : p.dayName === '토' ? 'text-blue-400' : 'text-gray-500'
+              }`}>
+                {p.dayName}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/sleep/components/sleep-summary-cards.tsx
+++ b/web/src/features/sleep/components/sleep-summary-cards.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { SleepSummary } from '../lib/types';
+
+interface SleepSummaryCardsProps {
+  summary: SleepSummary;
+}
+
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h}시간 ${m}분` : `${h}시간`;
+}
+
+function scoreColor(score: number): string {
+  if (score >= 70) return 'text-green-600';
+  if (score >= 40) return 'text-yellow-600';
+  return 'text-red-500';
+}
+
+export function SleepSummaryCards({ summary }: SleepSummaryCardsProps) {
+  const cards = [
+    {
+      label: '평균 수면',
+      value: summary.totalNights > 0 ? formatDuration(summary.avgDuration) : '-',
+      sub: `${summary.totalNights}일 기록`,
+    },
+    {
+      label: '평균 취침',
+      value: summary.avgBedtime,
+      sub: `기상 ${summary.avgWakeTime}`,
+    },
+    {
+      label: '중간 기상',
+      value: summary.totalMidWakes > 0 ? `${summary.avgMidWakesPerNight}회/일` : '없음',
+      sub: `총 ${summary.totalMidWakes}회`,
+    },
+    {
+      label: '규칙성',
+      value: `${summary.regularityScore}점`,
+      sub: '취침 시간 기준',
+      valueClass: scoreColor(summary.regularityScore),
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {cards.map((c) => (
+        <div
+          key={c.label}
+          className="rounded-xl border border-gray-200 bg-white p-4"
+        >
+          <div className="text-xs text-gray-400">{c.label}</div>
+          <div className={`mt-1 text-lg font-bold ${c.valueClass ?? 'text-gray-900'}`}>
+            {c.value}
+          </div>
+          <div className="mt-0.5 text-xs text-gray-400">{c.sub}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import type { SleepRecordWithEvents } from '../lib/types';
+
+interface SleepTimelineProps {
+  records: SleepRecordWithEvents[];
+}
+
+// 20:00(=0) ~ 12:00(=960) 범위를 Y축으로 매핑
+const Y_START_HOUR = 20;
+const Y_RANGE_MINUTES = 16 * 60; // 20:00 ~ 12:00 = 16시간 = 960분
+
+function timeToY(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  let minutesFromStart = (h * 60 + (m ?? 0)) - (Y_START_HOUR * 60);
+  if (minutesFromStart < 0) minutesFromStart += 1440;
+  return minutesFromStart;
+}
+
+function yToRatio(y: number): number {
+  return Math.max(0, Math.min(1, y / Y_RANGE_MINUTES));
+}
+
+const Y_LABELS = ['20', '22', '0', '2', '4', '6', '8', '10', '12'];
+const Y_LABEL_MINUTES = [0, 120, 240, 360, 480, 600, 720, 840, 960];
+
+export function SleepTimeline({ records }: SleepTimelineProps) {
+  const validRecords = records.filter((r) => r.bedtime && r.wake_time);
+
+  if (validRecords.length === 0) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-5">
+        <h3 className="mb-2 text-sm font-semibold text-gray-900">수면 타임라인</h3>
+        <p className="py-8 text-center text-sm text-gray-400">기간 내 수면 기록이 없어</p>
+      </div>
+    );
+  }
+
+  const chartHeight = 280;
+  const labelWidth = 28;
+  const barGap = 2;
+  const barWidth = Math.max(8, Math.min(24, (320 - labelWidth) / validRecords.length - barGap));
+  const chartWidth = labelWidth + validRecords.length * (barWidth + barGap) + 8;
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 타임라인</h3>
+      <div className="overflow-x-auto">
+        <svg
+          width={Math.max(chartWidth, 300)}
+          height={chartHeight + 36}
+          className="text-xs"
+        >
+          {/* Y축 라벨 + 그리드 */}
+          {Y_LABELS.map((label, i) => {
+            const y = ((Y_LABEL_MINUTES[i] ?? 0) / Y_RANGE_MINUTES) * chartHeight;
+            return (
+              <g key={label}>
+                <text x={labelWidth - 4} y={y + 4} textAnchor="end" className="fill-gray-400 text-[10px]">
+                  {label}
+                </text>
+                <line
+                  x1={labelWidth} y1={y} x2={chartWidth} y2={y}
+                  stroke="#f3f4f6" strokeWidth={1}
+                />
+              </g>
+            );
+          })}
+
+          {/* 바 */}
+          {validRecords.map((r, i) => {
+            const x = labelWidth + i * (barWidth + barGap);
+            const bedY = yToRatio(timeToY(r.bedtime!)) * chartHeight;
+            const wakeY = yToRatio(timeToY(r.wake_time!)) * chartHeight;
+            const barHeight = Math.max(4, wakeY - bedY);
+            const dateLabel = r.date.slice(5);
+
+            return (
+              <g key={r.id}>
+                <rect
+                  x={x} y={bedY} width={barWidth} height={barHeight}
+                  rx={3} fill="#818cf8" opacity={0.8}
+                />
+                {r.events.map((e) => {
+                  const ey = yToRatio(timeToY(e.event_time)) * chartHeight;
+                  return (
+                    <circle
+                      key={e.id}
+                      cx={x + barWidth / 2} cy={ey}
+                      r={2.5} fill="#ef4444"
+                    />
+                  );
+                })}
+                <text
+                  x={x + barWidth / 2} y={chartHeight + 14}
+                  textAnchor="middle" className="fill-gray-400 text-[9px]"
+                >
+                  {dateLabel}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-indigo-400" /> 수면
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-full bg-red-500" /> 중간 기상
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import type { SleepRecordWithEvents } from '../lib/types';
+
+interface SleepTrendChartProps {
+  records: SleepRecordWithEvents[];
+}
+
+function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
+  const valid = records.filter((r) => r.duration_minutes != null);
+  if (valid.length === 0) return null;
+
+  const maxDur = Math.max(...valid.map((r) => r.duration_minutes!));
+  const chartHeight = 120;
+  const barWidth = Math.max(6, Math.min(20, 300 / valid.length - 2));
+
+  const idealMin = 420;
+  const idealMax = 480;
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 시간 추이</h3>
+      <div className="overflow-x-auto">
+        <svg
+          width={Math.max(valid.length * (barWidth + 3) + 8, 200)}
+          height={chartHeight + 24}
+          className="text-xs"
+        >
+          {/* 적정 수면 구간 배경 */}
+          <rect
+            x={0} y={(1 - idealMax / (maxDur + 60)) * chartHeight}
+            width="100%" height={((idealMax - idealMin) / (maxDur + 60)) * chartHeight}
+            fill="#d1fae5" opacity={0.3}
+          />
+
+          {valid.map((r, i) => {
+            const x = i * (barWidth + 3) + 2;
+            const h = (r.duration_minutes! / (maxDur + 60)) * chartHeight;
+            const y = chartHeight - h;
+            const hours = Math.floor(r.duration_minutes! / 60);
+            const mins = r.duration_minutes! % 60;
+            const isLow = r.duration_minutes! < idealMin;
+            const color = isLow ? '#f87171' : '#818cf8';
+
+            return (
+              <g key={r.id}>
+                <rect x={x} y={y} width={barWidth} height={h} rx={2} fill={color} opacity={0.8} />
+                <text x={x + barWidth / 2} y={y - 3} textAnchor="middle" className="fill-gray-500 text-[8px]">
+                  {hours}h{mins > 0 ? mins : ''}
+                </text>
+                <text
+                  x={x + barWidth / 2} y={chartHeight + 12}
+                  textAnchor="middle" className="fill-gray-400 text-[9px]"
+                >
+                  {r.date.slice(8)}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="mt-2 flex items-center gap-3 text-xs text-gray-400">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-4 rounded-sm bg-green-100" /> 적정 (7\~8h)
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function TimesTrendChart({ records }: { records: SleepRecordWithEvents[] }) {
+  const valid = records.filter((r) => r.bedtime && r.wake_time);
+  if (valid.length === 0) return null;
+
+  const chartHeight = 140;
+  const chartWidth = Math.max(valid.length * 20 + 40, 200);
+  const padding = { left: 36, right: 8, top: 8, bottom: 24 };
+  const innerW = chartWidth - padding.left - padding.right;
+  const innerH = chartHeight - padding.top - padding.bottom;
+
+  const yStart = 20 * 60;
+  const yRange = 16 * 60;
+
+  function timeToNorm(time: string): number {
+    const [h, m] = time.split(':').map(Number);
+    let mins = h * 60 + (m ?? 0) - yStart;
+    if (mins < 0) mins += 1440;
+    return mins / yRange;
+  }
+
+  const bedPoints = valid.map((r, i) => ({
+    x: padding.left + (i / Math.max(1, valid.length - 1)) * innerW,
+    y: padding.top + timeToNorm(r.bedtime!) * innerH,
+  }));
+  const wakePoints = valid.map((r, i) => ({
+    x: padding.left + (i / Math.max(1, valid.length - 1)) * innerW,
+    y: padding.top + timeToNorm(r.wake_time!) * innerH,
+  }));
+
+  const bedPath = bedPoints.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
+  const wakePath = wakePoints.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
+
+  const yLabels = ['20', '0', '4', '8', '12'];
+  const yLabelNorms = [0, 240 / 960, 480 / 960, 720 / 960, 1];
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <h3 className="mb-3 text-sm font-semibold text-gray-900">취침 · 기상 시간 추이</h3>
+      <div className="overflow-x-auto">
+        <svg width={chartWidth} height={chartHeight} className="text-xs">
+          {yLabels.map((label, i) => {
+            const y = padding.top + (yLabelNorms[i] ?? 0) * innerH;
+            return (
+              <g key={label}>
+                <text x={padding.left - 4} y={y + 3} textAnchor="end" className="fill-gray-400 text-[10px]">
+                  {label}시
+                </text>
+                <line x1={padding.left} y1={y} x2={chartWidth - padding.right} y2={y} stroke="#f3f4f6" />
+              </g>
+            );
+          })}
+          <path d={bedPath} fill="none" stroke="#818cf8" strokeWidth={1.5} />
+          {bedPoints.map((p, i) => (
+            <circle key={`b${i}`} cx={p.x} cy={p.y} r={2.5} fill="#818cf8" />
+          ))}
+          <path d={wakePath} fill="none" stroke="#f59e0b" strokeWidth={1.5} />
+          {wakePoints.map((p, i) => (
+            <circle key={`w${i}`} cx={p.x} cy={p.y} r={2.5} fill="#f59e0b" />
+          ))}
+          {valid.map((r, i) => {
+            const x = padding.left + (i / Math.max(1, valid.length - 1)) * innerW;
+            const step = Math.max(1, Math.floor(valid.length / 7));
+            if (i % step !== 0 && i !== valid.length - 1) return null;
+            return (
+              <text key={r.id} x={x} y={chartHeight - 2} textAnchor="middle" className="fill-gray-400 text-[9px]">
+                {r.date.slice(5)}
+              </text>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-0.5 w-3 bg-indigo-400" /> 취침
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-0.5 w-3 bg-amber-400" /> 기상
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function SleepTrendChart({ records }: SleepTrendChartProps) {
+  return (
+    <div className="space-y-4">
+      <DurationChart records={records} />
+      <TimesTrendChart records={records} />
+    </div>
+  );
+}

--- a/web/src/features/sleep/hooks/use-sleep-dashboard.ts
+++ b/web/src/features/sleep/hooks/use-sleep-dashboard.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { getTodayISO, addDays } from '@/lib/kst';
+import type { SleepDashboardData, SleepPeriod } from '../lib/types';
+
+const PERIOD_DAYS: Record<SleepPeriod, number> = {
+  '1w': 6,
+  '2w': 13,
+  '1m': 29,
+};
+
+export function useSleepDashboard() {
+  const [period, setPeriod] = useState<SleepPeriod>('2w');
+  const [data, setData] = useState<SleepDashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = useCallback(async (p: SleepPeriod) => {
+    setLoading(true);
+    const to = getTodayISO();
+    const from = addDays(to, -PERIOD_DAYS[p]);
+    try {
+      const res = await fetch(`/api/sleep/dashboard?from=${from}&to=${to}`, {
+        cache: 'no-store',
+      });
+      if (res.status === 401) { window.location.href = '/login'; return; }
+      if (res.ok) {
+        const { data: d } = (await res.json()) as { data: SleepDashboardData };
+        setData(d);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData(period);
+  }, [period, fetchData]);
+
+  const handlePeriodChange = useCallback((p: SleepPeriod) => {
+    setPeriod(p);
+  }, []);
+
+  return { period, data, loading, handlePeriodChange };
+}

--- a/web/src/features/sleep/lib/queries.ts
+++ b/web/src/features/sleep/lib/queries.ts
@@ -1,0 +1,135 @@
+import { query } from '@/lib/db';
+import type { SleepRecord, SleepEvent, SleepRecordWithEvents, SleepSummary, DayOfWeekPattern } from './types';
+
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
+
+/** 기간별 수면 기록 + 이벤트 조회 */
+export async function querySleepRecordsWithEvents(
+  userId: number,
+  from: string,
+  to: string,
+): Promise<SleepRecordWithEvents[]> {
+  const [recordsResult, eventsResult] = await Promise.all([
+    query<SleepRecord>(
+      `SELECT id, date::text, bedtime, wake_time, duration_minutes, sleep_type, memo
+       FROM sleep_records
+       WHERE user_id = $1 AND date BETWEEN $2 AND $3 AND sleep_type = 'night'
+       ORDER BY date`,
+      [userId, from, to],
+    ),
+    query<SleepEvent>(
+      `SELECT id, date::text, event_time, memo
+       FROM sleep_events
+       WHERE user_id = $1 AND date BETWEEN $2 AND $3
+       ORDER BY date, event_time`,
+      [userId, from, to],
+    ),
+  ]);
+
+  const eventsByDate = new Map<string, SleepEvent[]>();
+  for (const e of eventsResult.rows) {
+    const list = eventsByDate.get(e.date) ?? [];
+    list.push(e);
+    eventsByDate.set(e.date, list);
+  }
+
+  return recordsResult.rows.map((r) => ({
+    ...r,
+    events: eventsByDate.get(r.date) ?? [],
+  }));
+}
+
+/** 시간 문자열(HH:MM)을 자정 기준 분으로 변환. 20:00 이후는 음수 */
+function timeToMinutesFromMidnight(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  const total = h * 60 + (m ?? 0);
+  return total >= 1200 ? total - 1440 : total;
+}
+
+/** 분(자정기준)을 HH:MM 문자열로 변환 */
+function minutesToTimeStr(minutes: number): string {
+  let m = Math.round(minutes);
+  if (m < 0) m += 1440;
+  const hh = String(Math.floor(m / 60) % 24).padStart(2, '0');
+  const mm = String(m % 60).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+/** 수면 요약 통계 계산 */
+export function calculateSleepSummary(
+  records: SleepRecordWithEvents[],
+): SleepSummary {
+  const validRecords = records.filter((r) => r.bedtime && r.wake_time && r.duration_minutes);
+
+  if (validRecords.length === 0) {
+    return {
+      avgDuration: 0, avgBedtime: '--:--', avgWakeTime: '--:--',
+      totalMidWakes: 0, avgMidWakesPerNight: 0, regularityScore: 0, totalNights: 0,
+    };
+  }
+
+  const totalDuration = validRecords.reduce((s, r) => s + (r.duration_minutes ?? 0), 0);
+  const avgDuration = totalDuration / validRecords.length;
+
+  const bedtimeMins = validRecords.map((r) => timeToMinutesFromMidnight(r.bedtime!));
+  const waketimeMins = validRecords.map((r) => timeToMinutesFromMidnight(r.wake_time!));
+  const avgBedtimeMin = bedtimeMins.reduce((a, b) => a + b, 0) / bedtimeMins.length;
+  const avgWakeTimeMin = waketimeMins.reduce((a, b) => a + b, 0) / waketimeMins.length;
+
+  const totalMidWakes = records.reduce((s, r) => s + r.events.length, 0);
+
+  const bedtimeStdDev = Math.sqrt(
+    bedtimeMins.reduce((s, m) => s + (m - avgBedtimeMin) ** 2, 0) / bedtimeMins.length,
+  );
+  const regularityScore = Math.max(0, Math.min(100, Math.round(100 - (bedtimeStdDev / 120) * 100)));
+
+  return {
+    avgDuration: Math.round(avgDuration),
+    avgBedtime: minutesToTimeStr(avgBedtimeMin),
+    avgWakeTime: minutesToTimeStr(avgWakeTimeMin),
+    totalMidWakes,
+    avgMidWakesPerNight: validRecords.length > 0
+      ? Math.round((totalMidWakes / validRecords.length) * 10) / 10
+      : 0,
+    regularityScore,
+    totalNights: validRecords.length,
+  };
+}
+
+/** 요일별 패턴 계산 */
+export function calculateDayOfWeekPattern(
+  records: SleepRecordWithEvents[],
+): DayOfWeekPattern[] {
+  const buckets = Array.from({ length: 7 }, (_, i) => ({
+    day: i,
+    dayName: DAY_NAMES[i] ?? '',
+    durations: [] as number[],
+    bedtimes: [] as number[],
+    waketimes: [] as number[],
+  }));
+
+  for (const r of records) {
+    if (!r.bedtime || !r.wake_time || !r.duration_minutes) continue;
+    const dow = new Date(r.date + 'T12:00:00+09:00').getUTCDay();
+    const bucket = buckets[dow];
+    if (!bucket) continue;
+    bucket.durations.push(r.duration_minutes);
+    bucket.bedtimes.push(timeToMinutesFromMidnight(r.bedtime));
+    bucket.waketimes.push(timeToMinutesFromMidnight(r.wake_time));
+  }
+
+  return buckets.map((b) => ({
+    day: b.day,
+    dayName: b.dayName,
+    avgDuration: b.durations.length > 0
+      ? Math.round(b.durations.reduce((a, c) => a + c, 0) / b.durations.length)
+      : 0,
+    avgBedtime: b.bedtimes.length > 0
+      ? Math.round(b.bedtimes.reduce((a, c) => a + c, 0) / b.bedtimes.length)
+      : 0,
+    avgWakeTime: b.waketimes.length > 0
+      ? Math.round(b.waketimes.reduce((a, c) => a + c, 0) / b.waketimes.length)
+      : 0,
+    count: b.durations.length,
+  }));
+}

--- a/web/src/features/sleep/lib/types.ts
+++ b/web/src/features/sleep/lib/types.ts
@@ -1,0 +1,54 @@
+/** 수면 기록 (sleep_records 테이블 매핑) */
+export interface SleepRecord {
+  id: number;
+  date: string;
+  bedtime: string | null;
+  wake_time: string | null;
+  duration_minutes: number | null;
+  sleep_type: 'night' | 'nap';
+  memo: string | null;
+}
+
+/** 수면 이벤트 — 중간 기상 (sleep_events 테이블 매핑) */
+export interface SleepEvent {
+  id: number;
+  date: string;
+  event_time: string;
+  memo: string | null;
+}
+
+/** 수면 기록 + 해당 날짜의 이벤트 조인 */
+export interface SleepRecordWithEvents extends SleepRecord {
+  events: SleepEvent[];
+}
+
+/** 요일별 패턴 집계 */
+export interface DayOfWeekPattern {
+  day: number; // 0=일, 1=월, ..., 6=토
+  dayName: string;
+  avgDuration: number; // 분
+  avgBedtime: number; // 분 (자정 기준, 예: 23:30 = -30, 00:30 = 30)
+  avgWakeTime: number; // 분 (자정 기준)
+  count: number;
+}
+
+/** 대시보드 요약 통계 */
+export interface SleepSummary {
+  avgDuration: number; // 분
+  avgBedtime: string; // HH:MM
+  avgWakeTime: string; // HH:MM
+  totalMidWakes: number;
+  avgMidWakesPerNight: number;
+  regularityScore: number; // 0~100
+  totalNights: number;
+}
+
+/** 대시보드 API 응답 */
+export interface SleepDashboardData {
+  records: SleepRecordWithEvents[];
+  summary: SleepSummary;
+  dayOfWeekPattern: DayOfWeekPattern[];
+}
+
+/** 기간 선택 타입 */
+export type SleepPeriod = '1w' | '2w' | '1m';


### PR DESCRIPTION
## 관련 이슈
Closes #265

## 변경 내용
- 네비게이션 "루틴" → "생활", 아이콘 HeartIcon으로 교체
- `/routines` 페이지에 TopTabs [수면|루틴] 구조 추가
- 루틴 탭 내부는 PillTabs [체크리스트|통계|관리]로 서브 탭 전환
- 수면 대시보드 4종 시각화 구현:
  - 요약 카드 (평균 수면시간, 취침/기상 시간, 중간 기상, 규칙성 점수)
  - 수면 타임라인 차트 (취침~기상 구간 + 중간 기상 마커)
  - 수면 시간 추이 바차트 (적정 구간 표시)
  - 취침·기상 시간 추이 선 차트
  - 요일별 평균 수면 패턴 바차트
- `GET /api/sleep/dashboard` 엔드포인트 추가
- 기존 `sleep_records`, `sleep_events` 테이블 활용 (DB 스키마 변경 없음)
- 기간 선택 (1주 / 2주 / 1개월)

## 코드 리뷰 결과
- [x] 보안 감사 통과 (SQL 파라미터화, requireAuth() 인증)
- [x] 타입 안전성 확인 (any 없음, tsc --noEmit 통과)
- [x] 컨벤션 점검 완료 (named export, kebab-case, 에러 핸들링)
- [x] 코드 품질 확인

## 테스트
- [x] TypeScript 타입 체크 통과
- [ ] 수면 기록 없는 상태에서 빈 화면 처리 확인
- [ ] 1주/2주/1개월 기간 전환 시 데이터 재조회 확인
- [ ] 중간 기상 마커 타임라인 표시 확인
- [ ] 루틴 탭 전환 시 기존 기능 정상 동작 확인