### PR TITLE
fix(web): 수면 차트 바 너비 채우기 + 틸드 표시 수정

### DIFF
--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -49,10 +49,9 @@ export function SleepTimeline({ records }: SleepTimelineProps) {
   const chartHeight = 280;
   const labelWidth = 28;
   const barGap = 2;
-  const availableWidth = Math.max(cw, 300) - labelWidth - 8;
-  const barWidth = Math.min(28, Math.max(8, availableWidth / validRecords.length - barGap));
-  const dataWidth = labelWidth + validRecords.length * (barWidth + barGap) + 8;
-  const chartWidth = Math.max(dataWidth, cw, 300);
+  const chartWidth = Math.max(cw, 300);
+  const availableWidth = chartWidth - labelWidth - 8;
+  const barWidth = Math.max(8, availableWidth / validRecords.length - barGap);
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -23,10 +23,9 @@ function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
 
   const maxDur = Math.max(...valid.map((r) => r.duration_minutes!));
   const chartHeight = 120;
-  const availableWidth = Math.max(cw, 200);
-  const barWidth = Math.min(24, Math.max(6, availableWidth / valid.length - 3));
-  const dataWidth = valid.length * (barWidth + 3) + 8;
-  const chartWidth = Math.max(dataWidth, cw, 200);
+  const chartWidth = Math.max(cw, 200);
+  const barGap = 3;
+  const barWidth = Math.max(6, (chartWidth - 8) / valid.length - barGap);
 
   const idealMin = 420;
   const idealMax = 480;
@@ -76,7 +75,7 @@ function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
       </div>
       <div className="mt-2 flex items-center gap-3 text-xs text-gray-400">
         <span className="flex items-center gap-1">
-          <span className="inline-block h-2 w-4 rounded-sm bg-green-100" /> 적정 (7\~8h)
+          <span className="inline-block h-2 w-4 rounded-sm bg-green-100" /> 적정 (7~8h)
         </span>
       </div>
     </div>


### PR DESCRIPTION
## 관련 이슈
#265 후속 수정

## 변경 내용
- 타임라인/수면시간추이: barWidth max 제한 제거로 바가 컨테이너 전체를 채움
- 1주/2주 등 데이터가 적을 때도 바가 고르게 분포
- JSX에서 불필요한 백슬래시 이스케이프 제거 (`7\~8h` → `7~8h`)