### PR TITLE
fix(sleep): 수면 차트 UX 개선 — 기간·날짜·스크롤·카드

### DIFF
--- a/web/src/features/sleep/components/period-selector.tsx
+++ b/web/src/features/sleep/components/period-selector.tsx
@@ -3,9 +3,9 @@
 import type { SleepPeriod } from '../lib/types';
 
 const PERIODS: { id: SleepPeriod; label: string }[] = [
-  { id: '1w', label: '1주' },
-  { id: '2w', label: '2주' },
   { id: '1m', label: '1개월' },
+  { id: '2w', label: '2주' },
+  { id: '1w', label: '1주' },
 ];
 
 interface PeriodSelectorProps {

--- a/web/src/features/sleep/components/sleep-summary-cards.tsx
+++ b/web/src/features/sleep/components/sleep-summary-cards.tsx
@@ -19,44 +19,45 @@ function scoreColor(score: number): string {
 }
 
 export function SleepSummaryCards({ summary }: SleepSummaryCardsProps) {
-  const cards = [
-    {
-      label: '평균 수면',
-      value: summary.totalNights > 0 ? formatDuration(summary.avgDuration) : '-',
-      sub: `${summary.totalNights}일 기록`,
-    },
-    {
-      label: '평균 취침',
-      value: summary.avgBedtime,
-      sub: `기상 ${summary.avgWakeTime}`,
-    },
-    {
-      label: '중간 기상',
-      value: summary.totalMidWakes > 0 ? `${summary.avgMidWakesPerNight}회/일` : '없음',
-      sub: `총 ${summary.totalMidWakes}회`,
-    },
-    {
-      label: '규칙성',
-      value: `${summary.regularityScore}점`,
-      sub: '취침 시간 기준',
-      valueClass: scoreColor(summary.regularityScore),
-    },
-  ];
-
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-      {cards.map((c) => (
-        <div
-          key={c.label}
-          className="rounded-xl border border-gray-200 bg-white p-4"
-        >
-          <div className="text-xs text-gray-400">{c.label}</div>
-          <div className={`mt-1 text-lg font-bold ${c.valueClass ?? 'text-gray-900'}`}>
-            {c.value}
-          </div>
-          <div className="mt-0.5 text-xs text-gray-400">{c.sub}</div>
+      {/* 평균 수면 */}
+      <div className="rounded-xl border border-gray-200 bg-white p-4">
+        <div className="text-xs text-gray-400">평균 수면</div>
+        <div className="mt-1 text-lg font-bold text-gray-900">
+          {summary.totalNights > 0 ? formatDuration(summary.avgDuration) : '-'}
         </div>
-      ))}
+        <div className="mt-0.5 text-xs text-gray-400">{summary.totalNights}일 기록</div>
+      </div>
+
+      {/* 취침 · 기상 */}
+      <div className="rounded-xl border border-gray-200 bg-white p-4">
+        <div className="text-xs text-gray-400">취침 · 기상</div>
+        <div className="mt-1 flex items-baseline gap-2">
+          <span className="text-lg font-bold text-gray-900">{summary.avgBedtime}</span>
+          <span className="text-sm text-gray-400">/</span>
+          <span className="text-lg font-bold text-gray-900">{summary.avgWakeTime}</span>
+        </div>
+        <div className="mt-0.5 text-xs text-gray-400">평균 취침 / 기상</div>
+      </div>
+
+      {/* 중간 기상 */}
+      <div className="rounded-xl border border-gray-200 bg-white p-4">
+        <div className="text-xs text-gray-400">중간 기상</div>
+        <div className="mt-1 text-lg font-bold text-gray-900">
+          {summary.totalMidWakes > 0 ? `${summary.avgMidWakesPerNight}회/일` : '없음'}
+        </div>
+        <div className="mt-0.5 text-xs text-gray-400">총 {summary.totalMidWakes}회</div>
+      </div>
+
+      {/* 규칙성 */}
+      <div className="rounded-xl border border-gray-200 bg-white p-4">
+        <div className="text-xs text-gray-400">규칙성</div>
+        <div className={`mt-1 text-lg font-bold ${scoreColor(summary.regularityScore)}`}>
+          {summary.regularityScore}점
+        </div>
+        <div className="mt-0.5 text-xs text-gray-400">취침 시간 기준</div>
+      </div>
     </div>
   );
 }

--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useEffect } from 'react';
 import type { SleepRecordWithEvents } from '../lib/types';
+import { formatDateLabel, getDayOfWeek } from '../lib/chart-utils';
 
 interface SleepTimelineProps {
   records: SleepRecordWithEvents[];
@@ -27,6 +28,7 @@ const Y_LABEL_MINUTES = [0, 120, 240, 360, 480, 600, 720, 840, 960];
 
 export function SleepTimeline({ records }: SleepTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const [cw, setCw] = useState(0);
 
   useEffect(() => {
@@ -34,6 +36,14 @@ export function SleepTimeline({ records }: SleepTimelineProps) {
     if (!el) return;
     setCw(el.clientWidth);
   }, []);
+
+  // 스크롤을 오른쪽(최신)으로 이동
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && cw > 0) {
+      el.scrollLeft = el.scrollWidth;
+    }
+  }, [cw, records]);
 
   const validRecords = records.filter((r) => r.bedtime && r.wake_time);
 
@@ -49,69 +59,80 @@ export function SleepTimeline({ records }: SleepTimelineProps) {
   const chartHeight = 280;
   const labelWidth = 28;
   const barGap = 2;
+  const topPadding = 12;
   const chartWidth = Math.max(cw, 300);
   const availableWidth = chartWidth - labelWidth - 8;
   const barWidth = Math.max(8, availableWidth / validRecords.length - barGap);
+  const dateAreaHeight = 32;
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 타임라인</h3>
-      <div ref={containerRef} className="overflow-x-auto">
-        {cw > 0 && (
-          <svg
-            width={chartWidth}
-            height={chartHeight + 36}
-            className="text-xs"
-          >
-            {Y_LABELS.map((label, i) => {
-              const y = ((Y_LABEL_MINUTES[i] ?? 0) / Y_RANGE_MINUTES) * chartHeight;
-              return (
-                <g key={label}>
-                  <text x={labelWidth - 4} y={y + 4} textAnchor="end" className="fill-gray-400 text-[10px]">
-                    {label}
-                  </text>
-                  <line
-                    x1={labelWidth} y1={y} x2={chartWidth} y2={y}
-                    stroke="#f3f4f6" strokeWidth={1}
-                  />
-                </g>
-              );
-            })}
+      <div ref={containerRef}>
+        <div ref={scrollRef} className="overflow-x-auto">
+          {cw > 0 && (
+            <svg
+              width={chartWidth}
+              height={topPadding + chartHeight + dateAreaHeight}
+              className="text-xs"
+            >
+              {Y_LABELS.map((label, i) => {
+                const y = topPadding + ((Y_LABEL_MINUTES[i] ?? 0) / Y_RANGE_MINUTES) * chartHeight;
+                return (
+                  <g key={label}>
+                    <text x={labelWidth - 4} y={y + 4} textAnchor="end" className="fill-gray-400 text-[10px]">
+                      {label}
+                    </text>
+                    <line
+                      x1={labelWidth} y1={y} x2={chartWidth} y2={y}
+                      stroke="#f3f4f6" strokeWidth={1}
+                    />
+                  </g>
+                );
+              })}
 
-            {validRecords.map((r, i) => {
-              const x = labelWidth + i * (barWidth + barGap);
-              const bedY = yToRatio(timeToY(r.bedtime!)) * chartHeight;
-              const wakeY = yToRatio(timeToY(r.wake_time!)) * chartHeight;
-              const barHeight = Math.max(4, wakeY - bedY);
-              const dateLabel = r.date.slice(5);
+              {validRecords.map((r, i) => {
+                const x = labelWidth + i * (barWidth + barGap);
+                const bedY = topPadding + yToRatio(timeToY(r.bedtime!)) * chartHeight;
+                const wakeY = topPadding + yToRatio(timeToY(r.wake_time!)) * chartHeight;
+                const barHeight = Math.max(4, wakeY - bedY);
+                const dateLabel = formatDateLabel(r.date);
+                const dayLabel = getDayOfWeek(r.date);
 
-              return (
-                <g key={r.id}>
-                  <rect
-                    x={x} y={bedY} width={barWidth} height={barHeight}
-                    rx={3} fill="#818cf8" opacity={0.8}
-                  />
-                  {r.events.map((e) => {
-                    const ey = yToRatio(timeToY(e.event_time)) * chartHeight;
-                    return (
-                      <circle
-                        key={e.id}
-                        cx={x + barWidth / 2} cy={ey}
-                        r={2.5} fill="#ef4444"
-                      />
-                    );
-                  })}
-                  <text
-                    x={x + barWidth / 2} y={chartHeight + 14}
-                    textAnchor="middle" className="fill-gray-400 text-[9px]"
-                  >
-                    {dateLabel}
-                  </text>
-                </g>
-              );
-            })}
-          </svg>
-        )}
+                return (
+                  <g key={r.id}>
+                    <rect
+                      x={x} y={bedY} width={barWidth} height={barHeight}
+                      rx={3} fill="#818cf8" opacity={0.8}
+                    />
+                    {r.events.map((e) => {
+                      const ey = topPadding + yToRatio(timeToY(e.event_time)) * chartHeight;
+                      return (
+                        <circle
+                          key={e.id}
+                          cx={x + barWidth / 2} cy={ey}
+                          r={2.5} fill="#ef4444"
+                        />
+                      );
+                    })}
+                    <text
+                      x={x + barWidth / 2} y={topPadding + chartHeight + 12}
+                      textAnchor="middle" className="fill-gray-500 text-[9px]"
+                    >
+                      {dateLabel}
+                    </text>
+                    <text
+                      x={x + barWidth / 2} y={topPadding + chartHeight + 24}
+                      textAnchor="middle" className="fill-gray-400 text-[8px]"
+                    >
+                      {dayLabel}
+                    </text>
+                  </g>
+                );
+              })}
+            </svg>
+          )}
+        </div>
       </div>
       <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
         <span className="flex items-center gap-1">

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useEffect } from 'react';
 import type { SleepRecordWithEvents } from '../lib/types';
+import { formatDateLabel, getDayOfWeek } from '../lib/chart-utils';
 
 interface SleepTrendChartProps {
   records: SleepRecordWithEvents[];
@@ -9,16 +10,32 @@ interface SleepTrendChartProps {
 
 function useContainerWidth() {
   const ref = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const [w, setW] = useState(0);
   useEffect(() => {
     if (ref.current) setW(ref.current.clientWidth);
   }, []);
-  return { ref, w };
+  return { ref, scrollRef, w };
+}
+
+function useScrollToEnd(
+  scrollRef: React.RefObject<HTMLDivElement | null>,
+  w: number,
+  deps: unknown[],
+) {
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && w > 0) {
+      el.scrollLeft = el.scrollWidth;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [w, ...deps]);
 }
 
 function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
-  const { ref, w: cw } = useContainerWidth();
+  const { ref, scrollRef, w: cw } = useContainerWidth();
   const valid = records.filter((r) => r.duration_minutes != null);
+  useScrollToEnd(scrollRef, cw, [valid.length]);
   if (valid.length === 0) return null;
 
   const maxDur = Math.max(...valid.map((r) => r.duration_minutes!));
@@ -26,6 +43,7 @@ function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
   const chartWidth = Math.max(cw, 200);
   const barGap = 3;
   const barWidth = Math.max(6, (chartWidth - 8) / valid.length - barGap);
+  const dateAreaHeight = 32;
 
   const idealMin = 420;
   const idealMax = 480;
@@ -33,45 +51,55 @@ function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 시간 추이</h3>
-      <div ref={ref} className="overflow-x-auto">
-        {cw > 0 && (
-          <svg
-            width={chartWidth}
-            height={chartHeight + 24}
-            className="text-xs"
-          >
-            <rect
-              x={0} y={(1 - idealMax / (maxDur + 60)) * chartHeight}
-              width={chartWidth} height={((idealMax - idealMin) / (maxDur + 60)) * chartHeight}
-              fill="#d1fae5" opacity={0.3}
-            />
+      <div ref={ref}>
+        <div ref={scrollRef} className="overflow-x-auto">
+          {cw > 0 && (
+            <svg
+              width={chartWidth}
+              height={chartHeight + 24 + dateAreaHeight}
+              className="text-xs"
+            >
+              <rect
+                x={0} y={(1 - idealMax / (maxDur + 60)) * chartHeight}
+                width={chartWidth} height={((idealMax - idealMin) / (maxDur + 60)) * chartHeight}
+                fill="#d1fae5" opacity={0.3}
+              />
 
-            {valid.map((r, i) => {
-              const x = i * (barWidth + 3) + 2;
-              const h = (r.duration_minutes! / (maxDur + 60)) * chartHeight;
-              const y = chartHeight - h;
-              const hours = Math.floor(r.duration_minutes! / 60);
-              const mins = r.duration_minutes! % 60;
-              const isLow = r.duration_minutes! < idealMin;
-              const color = isLow ? '#f87171' : '#818cf8';
+              {valid.map((r, i) => {
+                const x = i * (barWidth + 3) + 2;
+                const h = (r.duration_minutes! / (maxDur + 60)) * chartHeight;
+                const y = chartHeight - h;
+                const hours = Math.floor(r.duration_minutes! / 60);
+                const mins = r.duration_minutes! % 60;
+                const isLow = r.duration_minutes! < idealMin;
+                const color = isLow ? '#f87171' : '#818cf8';
+                const dateLabel = formatDateLabel(r.date);
+                const dayLabel = getDayOfWeek(r.date);
 
-              return (
-                <g key={r.id}>
-                  <rect x={x} y={y} width={barWidth} height={h} rx={2} fill={color} opacity={0.8} />
-                  <text x={x + barWidth / 2} y={y - 3} textAnchor="middle" className="fill-gray-500 text-[8px]">
-                    {hours}h{mins > 0 ? mins : ''}
-                  </text>
-                  <text
-                    x={x + barWidth / 2} y={chartHeight + 12}
-                    textAnchor="middle" className="fill-gray-400 text-[9px]"
-                  >
-                    {r.date.slice(8)}
-                  </text>
-                </g>
-              );
-            })}
-          </svg>
-        )}
+                return (
+                  <g key={r.id}>
+                    <rect x={x} y={y} width={barWidth} height={h} rx={2} fill={color} opacity={0.8} />
+                    <text x={x + barWidth / 2} y={y - 3} textAnchor="middle" className="fill-gray-500 text-[8px]">
+                      {hours}h{mins > 0 ? mins : ''}
+                    </text>
+                    <text
+                      x={x + barWidth / 2} y={chartHeight + 12}
+                      textAnchor="middle" className="fill-gray-500 text-[9px]"
+                    >
+                      {dateLabel}
+                    </text>
+                    <text
+                      x={x + barWidth / 2} y={chartHeight + 24}
+                      textAnchor="middle" className="fill-gray-400 text-[8px]"
+                    >
+                      {dayLabel}
+                    </text>
+                  </g>
+                );
+              })}
+            </svg>
+          )}
+        </div>
       </div>
       <div className="mt-2 flex items-center gap-3 text-xs text-gray-400">
         <span className="flex items-center gap-1">
@@ -83,13 +111,14 @@ function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
 }
 
 function TimesTrendChart({ records }: { records: SleepRecordWithEvents[] }) {
-  const { ref, w: cw } = useContainerWidth();
+  const { ref, scrollRef, w: cw } = useContainerWidth();
   const valid = records.filter((r) => r.bedtime && r.wake_time);
+  useScrollToEnd(scrollRef, cw, [valid.length]);
   if (valid.length === 0) return null;
 
   const chartHeight = 140;
   const chartWidth = Math.max(cw, 200);
-  const padding = { left: 36, right: 8, top: 8, bottom: 24 };
+  const padding = { left: 36, right: 12, top: 8, bottom: 36 };
   const innerW = chartWidth - padding.left - padding.right;
   const innerH = chartHeight - padding.top - padding.bottom;
 
@@ -121,40 +150,49 @@ function TimesTrendChart({ records }: { records: SleepRecordWithEvents[] }) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-3 text-sm font-semibold text-gray-900">취침 · 기상 시간 추이</h3>
-      <div ref={ref} className="overflow-x-auto">
-        {cw > 0 && (
-          <svg width={chartWidth} height={chartHeight} className="text-xs">
-            {yLabels.map((label, i) => {
-              const y = padding.top + (yLabelNorms[i] ?? 0) * innerH;
-              return (
-                <g key={label}>
-                  <text x={padding.left - 4} y={y + 3} textAnchor="end" className="fill-gray-400 text-[10px]">
-                    {label}시
-                  </text>
-                  <line x1={padding.left} y1={y} x2={chartWidth - padding.right} y2={y} stroke="#f3f4f6" />
-                </g>
-              );
-            })}
-            <path d={bedPath} fill="none" stroke="#818cf8" strokeWidth={1.5} />
-            {bedPoints.map((p, i) => (
-              <circle key={`b${i}`} cx={p.x} cy={p.y} r={2.5} fill="#818cf8" />
-            ))}
-            <path d={wakePath} fill="none" stroke="#f59e0b" strokeWidth={1.5} />
-            {wakePoints.map((p, i) => (
-              <circle key={`w${i}`} cx={p.x} cy={p.y} r={2.5} fill="#f59e0b" />
-            ))}
-            {valid.map((r, i) => {
-              const x = padding.left + (i / Math.max(1, valid.length - 1)) * innerW;
-              const step = Math.max(1, Math.floor(valid.length / 7));
-              if (i % step !== 0 && i !== valid.length - 1) return null;
-              return (
-                <text key={r.id} x={x} y={chartHeight - 2} textAnchor="middle" className="fill-gray-400 text-[9px]">
-                  {r.date.slice(5)}
-                </text>
-              );
-            })}
-          </svg>
-        )}
+      <div ref={ref}>
+        <div ref={scrollRef} className="overflow-x-auto">
+          {cw > 0 && (
+            <svg width={chartWidth} height={chartHeight + 12} className="text-xs">
+              {yLabels.map((label, i) => {
+                const y = padding.top + (yLabelNorms[i] ?? 0) * innerH;
+                return (
+                  <g key={label}>
+                    <text x={padding.left - 4} y={y + 3} textAnchor="end" className="fill-gray-400 text-[10px]">
+                      {label}시
+                    </text>
+                    <line x1={padding.left} y1={y} x2={chartWidth - padding.right} y2={y} stroke="#f3f4f6" />
+                  </g>
+                );
+              })}
+              <path d={bedPath} fill="none" stroke="#818cf8" strokeWidth={1.5} />
+              {bedPoints.map((p, i) => (
+                <circle key={`b${i}`} cx={p.x} cy={p.y} r={2.5} fill="#818cf8" />
+              ))}
+              <path d={wakePath} fill="none" stroke="#f59e0b" strokeWidth={1.5} />
+              {wakePoints.map((p, i) => (
+                <circle key={`w${i}`} cx={p.x} cy={p.y} r={2.5} fill="#f59e0b" />
+              ))}
+              {valid.map((r, i) => {
+                const x = padding.left + (i / Math.max(1, valid.length - 1)) * innerW;
+                const step = Math.max(1, Math.floor(valid.length / 7));
+                if (i % step !== 0 && i !== valid.length - 1) return null;
+                const dateLabel = formatDateLabel(r.date);
+                const dayLabel = getDayOfWeek(r.date);
+                return (
+                  <g key={r.id}>
+                    <text x={x} y={chartHeight - padding.bottom + 14} textAnchor="middle" className="fill-gray-500 text-[9px]">
+                      {dateLabel}
+                    </text>
+                    <text x={x} y={chartHeight - padding.bottom + 26} textAnchor="middle" className="fill-gray-400 text-[8px]">
+                      {dayLabel}
+                    </text>
+                  </g>
+                );
+              })}
+            </svg>
+          )}
+        </div>
       </div>
       <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
         <span className="flex items-center gap-1">

--- a/web/src/features/sleep/hooks/use-sleep-dashboard.ts
+++ b/web/src/features/sleep/hooks/use-sleep-dashboard.ts
@@ -11,7 +11,7 @@ const PERIOD_DAYS: Record<SleepPeriod, number> = {
 };
 
 export function useSleepDashboard() {
-  const [period, setPeriod] = useState<SleepPeriod>('2w');
+  const [period, setPeriod] = useState<SleepPeriod>('1m');
   const [data, setData] = useState<SleepDashboardData | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/web/src/features/sleep/lib/chart-utils.ts
+++ b/web/src/features/sleep/lib/chart-utils.ts
@@ -1,0 +1,21 @@
+/** 요일 한글 약자 (일~토) */
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
+
+/**
+ * 차트용 날짜 라벨 생성
+ * - 기본: 일(day)만 표시  (예: "02")
+ * - 1일이면 월-일 표시    (예: "04-01")
+ */
+export function formatDateLabel(dateStr: string): string {
+  const day = dateStr.slice(8, 10);
+  if (day === '01') {
+    return `${dateStr.slice(5, 7)}-${day}`;
+  }
+  return day;
+}
+
+/** 날짜 문자열 → 요일 한글 1글자 */
+export function getDayOfWeek(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  return DAY_NAMES[d.getDay()];
+}


### PR DESCRIPTION
## 변경 내용
- 기본 기간 1개월로 변경, 탭 순서 1개월→2주→1주
- 스크롤 오버플로 시 오른쪽(최신 기록)으로 자동 이동
- 수면 타임라인 상단 잘림 수정 (상단 패딩 추가)
- 날짜 표시 3개 차트 통일: 기본 일(day)만, 1일에 월 포함, 요일 한글 1글자 추가
- 취침·기상 추이 마지막 날짜 잘림 수정 (우측 패딩 증가)
- 취침/기상 요약 카드를 같은 크기로 한 카드에 통합 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)