### PR TITLE
fix(sleep): 차트 너비 복원 + 스켈레톤 레이아웃 개선

### DIFF
--- a/web/src/features/sleep/components/sleep-dashboard.tsx
+++ b/web/src/features/sleep/components/sleep-dashboard.tsx
@@ -13,13 +13,17 @@ export function SleepDashboard() {
 
   if (loading && !data) {
     return (
-      <div className="mx-auto max-w-5xl space-y-4 px-4 py-4">
-        <CardSkeleton className="h-10" />
-        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-          {[1, 2, 3, 4].map((i) => <CardSkeleton key={i} className="h-20" />)}
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-5xl space-y-4 px-4 py-4 md:py-6">
+          <CardSkeleton className="h-10 w-48" />
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            {[1, 2, 3, 4].map((i) => <CardSkeleton key={i} className="h-24" />)}
+          </div>
+          <CardSkeleton className="h-80" />
+          <CardSkeleton className="h-48" />
+          <CardSkeleton className="h-48" />
+          <CardSkeleton className="h-36" />
         </div>
-        <CardSkeleton className="h-64" />
-        <CardSkeleton className="h-48" />
       </div>
     );
   }

--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -28,7 +28,6 @@ const Y_LABEL_MINUTES = [0, 120, 240, 360, 480, 600, 720, 840, 960];
 
 export function SleepTimeline({ records }: SleepTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const scrollRef = useRef<HTMLDivElement>(null);
   const [cw, setCw] = useState(0);
 
   useEffect(() => {
@@ -39,7 +38,7 @@ export function SleepTimeline({ records }: SleepTimelineProps) {
 
   // 스크롤을 오른쪽(최신)으로 이동
   useEffect(() => {
-    const el = scrollRef.current;
+    const el = containerRef.current;
     if (el && cw > 0) {
       el.scrollLeft = el.scrollWidth;
     }
@@ -68,71 +67,69 @@ export function SleepTimeline({ records }: SleepTimelineProps) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 타임라인</h3>
-      <div ref={containerRef}>
-        <div ref={scrollRef} className="overflow-x-auto">
-          {cw > 0 && (
-            <svg
-              width={chartWidth}
-              height={topPadding + chartHeight + dateAreaHeight}
-              className="text-xs"
-            >
-              {Y_LABELS.map((label, i) => {
-                const y = topPadding + ((Y_LABEL_MINUTES[i] ?? 0) / Y_RANGE_MINUTES) * chartHeight;
-                return (
-                  <g key={label}>
-                    <text x={labelWidth - 4} y={y + 4} textAnchor="end" className="fill-gray-400 text-[10px]">
-                      {label}
-                    </text>
-                    <line
-                      x1={labelWidth} y1={y} x2={chartWidth} y2={y}
-                      stroke="#f3f4f6" strokeWidth={1}
-                    />
-                  </g>
-                );
-              })}
+      <div ref={containerRef} className="overflow-x-auto">
+        {cw > 0 && (
+          <svg
+            width={chartWidth}
+            height={topPadding + chartHeight + dateAreaHeight}
+            className="text-xs"
+          >
+            {Y_LABELS.map((label, i) => {
+              const y = topPadding + ((Y_LABEL_MINUTES[i] ?? 0) / Y_RANGE_MINUTES) * chartHeight;
+              return (
+                <g key={label}>
+                  <text x={labelWidth - 4} y={y + 4} textAnchor="end" className="fill-gray-400 text-[10px]">
+                    {label}
+                  </text>
+                  <line
+                    x1={labelWidth} y1={y} x2={chartWidth} y2={y}
+                    stroke="#f3f4f6" strokeWidth={1}
+                  />
+                </g>
+              );
+            })}
 
-              {validRecords.map((r, i) => {
-                const x = labelWidth + i * (barWidth + barGap);
-                const bedY = topPadding + yToRatio(timeToY(r.bedtime!)) * chartHeight;
-                const wakeY = topPadding + yToRatio(timeToY(r.wake_time!)) * chartHeight;
-                const barHeight = Math.max(4, wakeY - bedY);
-                const dateLabel = formatDateLabel(r.date);
-                const dayLabel = getDayOfWeek(r.date);
+            {validRecords.map((r, i) => {
+              const x = labelWidth + i * (barWidth + barGap);
+              const bedY = topPadding + yToRatio(timeToY(r.bedtime!)) * chartHeight;
+              const wakeY = topPadding + yToRatio(timeToY(r.wake_time!)) * chartHeight;
+              const barHeight = Math.max(4, wakeY - bedY);
+              const dateLabel = formatDateLabel(r.date);
+              const dayLabel = getDayOfWeek(r.date);
 
-                return (
-                  <g key={r.id}>
-                    <rect
-                      x={x} y={bedY} width={barWidth} height={barHeight}
-                      rx={3} fill="#818cf8" opacity={0.8}
-                    />
-                    {r.events.map((e) => {
-                      const ey = topPadding + yToRatio(timeToY(e.event_time)) * chartHeight;
-                      return (
-                        <circle
-                          key={e.id}
-                          cx={x + barWidth / 2} cy={ey}
-                          r={2.5} fill="#ef4444"
-                        />
-                      );
-                    })}
-                    <text
-                      x={x + barWidth / 2} y={topPadding + chartHeight + 12}
-                      textAnchor="middle" className="fill-gray-500 text-[9px]"
-                    >
-                      {dateLabel}
-                    </text>
-                    <text
-                      x={x + barWidth / 2} y={topPadding + chartHeight + 24}
-                      textAnchor="middle" className="fill-gray-400 text-[8px]"
-                    >
-                      {dayLabel}
-                    </text>
-                  </g>
-                );
-              })}
-            </svg>
-          )}
-        </div>
+              return (
+                <g key={r.id}>
+                  <rect
+                    x={x} y={bedY} width={barWidth} height={barHeight}
+                    rx={3} fill="#818cf8" opacity={0.8}
+                  />
+                  {r.events.map((e) => {
+                    const ey = topPadding + yToRatio(timeToY(e.event_time)) * chartHeight;
+                    return (
+                      <circle
+                        key={e.id}
+                        cx={x + barWidth / 2} cy={ey}
+                        r={2.5} fill="#ef4444"
+                      />
+                    );
+                  })}
+                  <text
+                    x={x + barWidth / 2} y={topPadding + chartHeight + 12}
+                    textAnchor="middle" className="fill-gray-500 text-[9px]"
+                  >
+                    {dateLabel}
+                  </text>
+                  <text
+                    x={x + barWidth / 2} y={topPadding + chartHeight + 24}
+                    textAnchor="middle" className="fill-gray-400 text-[8px]"
+                  >
+                    {dayLabel}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        )}
       </div>
       <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
         <span className="flex items-center gap-1">

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -10,21 +10,20 @@ interface SleepTrendChartProps {
 
 function useContainerWidth() {
   const ref = useRef<HTMLDivElement>(null);
-  const scrollRef = useRef<HTMLDivElement>(null);
   const [w, setW] = useState(0);
   useEffect(() => {
     if (ref.current) setW(ref.current.clientWidth);
   }, []);
-  return { ref, scrollRef, w };
+  return { ref, w };
 }
 
 function useScrollToEnd(
-  scrollRef: React.RefObject<HTMLDivElement | null>,
+  ref: React.RefObject<HTMLDivElement | null>,
   w: number,
   deps: unknown[],
 ) {
   useEffect(() => {
-    const el = scrollRef.current;
+    const el = ref.current;
     if (el && w > 0) {
       el.scrollLeft = el.scrollWidth;
     }
@@ -33,9 +32,9 @@ function useScrollToEnd(
 }
 
 function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
-  const { ref, scrollRef, w: cw } = useContainerWidth();
+  const { ref, w: cw } = useContainerWidth();
   const valid = records.filter((r) => r.duration_minutes != null);
-  useScrollToEnd(scrollRef, cw, [valid.length]);
+  useScrollToEnd(ref, cw, [valid.length]);
   if (valid.length === 0) return null;
 
   const maxDur = Math.max(...valid.map((r) => r.duration_minutes!));
@@ -51,55 +50,53 @@ function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 시간 추이</h3>
-      <div ref={ref}>
-        <div ref={scrollRef} className="overflow-x-auto">
-          {cw > 0 && (
-            <svg
-              width={chartWidth}
-              height={chartHeight + 24 + dateAreaHeight}
-              className="text-xs"
-            >
-              <rect
-                x={0} y={(1 - idealMax / (maxDur + 60)) * chartHeight}
-                width={chartWidth} height={((idealMax - idealMin) / (maxDur + 60)) * chartHeight}
-                fill="#d1fae5" opacity={0.3}
-              />
+      <div ref={ref} className="overflow-x-auto">
+        {cw > 0 && (
+          <svg
+            width={chartWidth}
+            height={chartHeight + 24 + dateAreaHeight}
+            className="text-xs"
+          >
+            <rect
+              x={0} y={(1 - idealMax / (maxDur + 60)) * chartHeight}
+              width={chartWidth} height={((idealMax - idealMin) / (maxDur + 60)) * chartHeight}
+              fill="#d1fae5" opacity={0.3}
+            />
 
-              {valid.map((r, i) => {
-                const x = i * (barWidth + 3) + 2;
-                const h = (r.duration_minutes! / (maxDur + 60)) * chartHeight;
-                const y = chartHeight - h;
-                const hours = Math.floor(r.duration_minutes! / 60);
-                const mins = r.duration_minutes! % 60;
-                const isLow = r.duration_minutes! < idealMin;
-                const color = isLow ? '#f87171' : '#818cf8';
-                const dateLabel = formatDateLabel(r.date);
-                const dayLabel = getDayOfWeek(r.date);
+            {valid.map((r, i) => {
+              const x = i * (barWidth + 3) + 2;
+              const h = (r.duration_minutes! / (maxDur + 60)) * chartHeight;
+              const y = chartHeight - h;
+              const hours = Math.floor(r.duration_minutes! / 60);
+              const mins = r.duration_minutes! % 60;
+              const isLow = r.duration_minutes! < idealMin;
+              const color = isLow ? '#f87171' : '#818cf8';
+              const dateLabel = formatDateLabel(r.date);
+              const dayLabel = getDayOfWeek(r.date);
 
-                return (
-                  <g key={r.id}>
-                    <rect x={x} y={y} width={barWidth} height={h} rx={2} fill={color} opacity={0.8} />
-                    <text x={x + barWidth / 2} y={y - 3} textAnchor="middle" className="fill-gray-500 text-[8px]">
-                      {hours}h{mins > 0 ? mins : ''}
-                    </text>
-                    <text
-                      x={x + barWidth / 2} y={chartHeight + 12}
-                      textAnchor="middle" className="fill-gray-500 text-[9px]"
-                    >
-                      {dateLabel}
-                    </text>
-                    <text
-                      x={x + barWidth / 2} y={chartHeight + 24}
-                      textAnchor="middle" className="fill-gray-400 text-[8px]"
-                    >
-                      {dayLabel}
-                    </text>
-                  </g>
-                );
-              })}
-            </svg>
-          )}
-        </div>
+              return (
+                <g key={r.id}>
+                  <rect x={x} y={y} width={barWidth} height={h} rx={2} fill={color} opacity={0.8} />
+                  <text x={x + barWidth / 2} y={y - 3} textAnchor="middle" className="fill-gray-500 text-[8px]">
+                    {hours}h{mins > 0 ? mins : ''}
+                  </text>
+                  <text
+                    x={x + barWidth / 2} y={chartHeight + 12}
+                    textAnchor="middle" className="fill-gray-500 text-[9px]"
+                  >
+                    {dateLabel}
+                  </text>
+                  <text
+                    x={x + barWidth / 2} y={chartHeight + 24}
+                    textAnchor="middle" className="fill-gray-400 text-[8px]"
+                  >
+                    {dayLabel}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        )}
       </div>
       <div className="mt-2 flex items-center gap-3 text-xs text-gray-400">
         <span className="flex items-center gap-1">
@@ -111,9 +108,9 @@ function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
 }
 
 function TimesTrendChart({ records }: { records: SleepRecordWithEvents[] }) {
-  const { ref, scrollRef, w: cw } = useContainerWidth();
+  const { ref, w: cw } = useContainerWidth();
   const valid = records.filter((r) => r.bedtime && r.wake_time);
-  useScrollToEnd(scrollRef, cw, [valid.length]);
+  useScrollToEnd(ref, cw, [valid.length]);
   if (valid.length === 0) return null;
 
   const chartHeight = 140;
@@ -150,49 +147,47 @@ function TimesTrendChart({ records }: { records: SleepRecordWithEvents[] }) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-3 text-sm font-semibold text-gray-900">취침 · 기상 시간 추이</h3>
-      <div ref={ref}>
-        <div ref={scrollRef} className="overflow-x-auto">
-          {cw > 0 && (
-            <svg width={chartWidth} height={chartHeight + 12} className="text-xs">
-              {yLabels.map((label, i) => {
-                const y = padding.top + (yLabelNorms[i] ?? 0) * innerH;
-                return (
-                  <g key={label}>
-                    <text x={padding.left - 4} y={y + 3} textAnchor="end" className="fill-gray-400 text-[10px]">
-                      {label}시
-                    </text>
-                    <line x1={padding.left} y1={y} x2={chartWidth - padding.right} y2={y} stroke="#f3f4f6" />
-                  </g>
-                );
-              })}
-              <path d={bedPath} fill="none" stroke="#818cf8" strokeWidth={1.5} />
-              {bedPoints.map((p, i) => (
-                <circle key={`b${i}`} cx={p.x} cy={p.y} r={2.5} fill="#818cf8" />
-              ))}
-              <path d={wakePath} fill="none" stroke="#f59e0b" strokeWidth={1.5} />
-              {wakePoints.map((p, i) => (
-                <circle key={`w${i}`} cx={p.x} cy={p.y} r={2.5} fill="#f59e0b" />
-              ))}
-              {valid.map((r, i) => {
-                const x = padding.left + (i / Math.max(1, valid.length - 1)) * innerW;
-                const step = Math.max(1, Math.floor(valid.length / 7));
-                if (i % step !== 0 && i !== valid.length - 1) return null;
-                const dateLabel = formatDateLabel(r.date);
-                const dayLabel = getDayOfWeek(r.date);
-                return (
-                  <g key={r.id}>
-                    <text x={x} y={chartHeight - padding.bottom + 14} textAnchor="middle" className="fill-gray-500 text-[9px]">
-                      {dateLabel}
-                    </text>
-                    <text x={x} y={chartHeight - padding.bottom + 26} textAnchor="middle" className="fill-gray-400 text-[8px]">
-                      {dayLabel}
-                    </text>
-                  </g>
-                );
-              })}
-            </svg>
-          )}
-        </div>
+      <div ref={ref} className="overflow-x-auto">
+        {cw > 0 && (
+          <svg width={chartWidth} height={chartHeight + 12} className="text-xs">
+            {yLabels.map((label, i) => {
+              const y = padding.top + (yLabelNorms[i] ?? 0) * innerH;
+              return (
+                <g key={label}>
+                  <text x={padding.left - 4} y={y + 3} textAnchor="end" className="fill-gray-400 text-[10px]">
+                    {label}시
+                  </text>
+                  <line x1={padding.left} y1={y} x2={chartWidth - padding.right} y2={y} stroke="#f3f4f6" />
+                </g>
+              );
+            })}
+            <path d={bedPath} fill="none" stroke="#818cf8" strokeWidth={1.5} />
+            {bedPoints.map((p, i) => (
+              <circle key={`b${i}`} cx={p.x} cy={p.y} r={2.5} fill="#818cf8" />
+            ))}
+            <path d={wakePath} fill="none" stroke="#f59e0b" strokeWidth={1.5} />
+            {wakePoints.map((p, i) => (
+              <circle key={`w${i}`} cx={p.x} cy={p.y} r={2.5} fill="#f59e0b" />
+            ))}
+            {valid.map((r, i) => {
+              const x = padding.left + (i / Math.max(1, valid.length - 1)) * innerW;
+              const step = Math.max(1, Math.floor(valid.length / 7));
+              if (i % step !== 0 && i !== valid.length - 1) return null;
+              const dateLabel = formatDateLabel(r.date);
+              const dayLabel = getDayOfWeek(r.date);
+              return (
+                <g key={r.id}>
+                  <text x={x} y={chartHeight - padding.bottom + 14} textAnchor="middle" className="fill-gray-500 text-[9px]">
+                    {dateLabel}
+                  </text>
+                  <text x={x} y={chartHeight - padding.bottom + 26} textAnchor="middle" className="fill-gray-400 text-[8px]">
+                    {dayLabel}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        )}
       </div>
       <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
         <span className="flex items-center gap-1">


### PR DESCRIPTION
## 변경 내용
- ref 분리(containerRef + scrollRef)로 인한 차트 너비 축소 버그 수정 — 단일 ref로 복원
- 스크롤 자동 오른쪽 이동은 동일 ref에서 처리
- 스켈레톤 로딩 시 실제 차트와 유사한 크기/개수로 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)