### PR TITLE
fix(sleep): 모바일 1주/2주 차트 스크롤 제거

### DIFF
--- a/web/src/features/sleep/components/sleep-dashboard.tsx
+++ b/web/src/features/sleep/components/sleep-dashboard.tsx
@@ -35,8 +35,8 @@ export function SleepDashboard() {
       <div className="mx-auto max-w-5xl space-y-4 px-4 py-4 md:py-6">
         <PeriodSelector period={period} onChange={handlePeriodChange} />
         <SleepSummaryCards summary={data.summary} />
-        <SleepTimeline records={data.records} />
-        <SleepTrendChart records={data.records} />
+        <SleepTimeline records={data.records} period={period} />
+        <SleepTrendChart records={data.records} period={period} />
         <SleepDayPattern pattern={data.dayOfWeekPattern} />
       </div>
     </div>

--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useRef, useState, useEffect } from 'react';
-import type { SleepRecordWithEvents } from '../lib/types';
+import type { SleepRecordWithEvents, SleepPeriod } from '../lib/types';
 import { formatDateLabel, getDayOfWeek } from '../lib/chart-utils';
 
 interface SleepTimelineProps {
   records: SleepRecordWithEvents[];
+  period: SleepPeriod;
 }
 
 // 20:00(=0) ~ 12:00(=960) 범위를 Y축으로 매핑
@@ -26,7 +27,7 @@ function yToRatio(y: number): number {
 const Y_LABELS = ['20', '22', '0', '2', '4', '6', '8', '10', '12'];
 const Y_LABEL_MINUTES = [0, 120, 240, 360, 480, 600, 720, 840, 960];
 
-export function SleepTimeline({ records }: SleepTimelineProps) {
+export function SleepTimeline({ records, period }: SleepTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [cw, setCw] = useState(0);
 
@@ -36,13 +37,15 @@ export function SleepTimeline({ records }: SleepTimelineProps) {
     setCw(el.clientWidth);
   }, []);
 
-  // 스크롤을 오른쪽(최신)으로 이동
+  const allowScroll = period === '1m';
+
+  // 1개월일 때만 스크롤을 오른쪽(최신)으로 이동
   useEffect(() => {
     const el = containerRef.current;
-    if (el && cw > 0) {
+    if (el && cw > 0 && allowScroll) {
       el.scrollLeft = el.scrollWidth;
     }
-  }, [cw, records]);
+  }, [cw, records, allowScroll]);
 
   const validRecords = records.filter((r) => r.bedtime && r.wake_time);
 
@@ -67,7 +70,7 @@ export function SleepTimeline({ records }: SleepTimelineProps) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 타임라인</h3>
-      <div ref={containerRef} className="overflow-x-auto">
+      <div ref={containerRef} className={allowScroll ? 'overflow-x-auto' : ''}>
         {cw > 0 && (
           <svg
             width={chartWidth}

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useRef, useState, useEffect } from 'react';
-import type { SleepRecordWithEvents } from '../lib/types';
+import type { SleepRecordWithEvents, SleepPeriod } from '../lib/types';
 import { formatDateLabel, getDayOfWeek } from '../lib/chart-utils';
 
 interface SleepTrendChartProps {
   records: SleepRecordWithEvents[];
+  period: SleepPeriod;
 }
 
 function useContainerWidth() {
@@ -21,20 +22,21 @@ function useScrollToEnd(
   ref: React.RefObject<HTMLDivElement | null>,
   w: number,
   deps: unknown[],
+  enabled: boolean,
 ) {
   useEffect(() => {
     const el = ref.current;
-    if (el && w > 0) {
+    if (el && w > 0 && enabled) {
       el.scrollLeft = el.scrollWidth;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [w, ...deps]);
+  }, [w, enabled, ...deps]);
 }
 
-function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
+function DurationChart({ records, allowScroll }: { records: SleepRecordWithEvents[]; allowScroll: boolean }) {
   const { ref, w: cw } = useContainerWidth();
   const valid = records.filter((r) => r.duration_minutes != null);
-  useScrollToEnd(ref, cw, [valid.length]);
+  useScrollToEnd(ref, cw, [valid.length], allowScroll);
   if (valid.length === 0) return null;
 
   const maxDur = Math.max(...valid.map((r) => r.duration_minutes!));
@@ -50,7 +52,7 @@ function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 시간 추이</h3>
-      <div ref={ref} className="overflow-x-auto">
+      <div ref={ref} className={allowScroll ? 'overflow-x-auto' : ''}>
         {cw > 0 && (
           <svg
             width={chartWidth}
@@ -107,10 +109,10 @@ function DurationChart({ records }: { records: SleepRecordWithEvents[] }) {
   );
 }
 
-function TimesTrendChart({ records }: { records: SleepRecordWithEvents[] }) {
+function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEvents[]; allowScroll: boolean }) {
   const { ref, w: cw } = useContainerWidth();
   const valid = records.filter((r) => r.bedtime && r.wake_time);
-  useScrollToEnd(ref, cw, [valid.length]);
+  useScrollToEnd(ref, cw, [valid.length], allowScroll);
   if (valid.length === 0) return null;
 
   const chartHeight = 140;
@@ -147,7 +149,7 @@ function TimesTrendChart({ records }: { records: SleepRecordWithEvents[] }) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-3 text-sm font-semibold text-gray-900">취침 · 기상 시간 추이</h3>
-      <div ref={ref} className="overflow-x-auto">
+      <div ref={ref} className={allowScroll ? 'overflow-x-auto' : ''}>
         {cw > 0 && (
           <svg width={chartWidth} height={chartHeight + 12} className="text-xs">
             {yLabels.map((label, i) => {
@@ -201,11 +203,12 @@ function TimesTrendChart({ records }: { records: SleepRecordWithEvents[] }) {
   );
 }
 
-export function SleepTrendChart({ records }: SleepTrendChartProps) {
+export function SleepTrendChart({ records, period }: SleepTrendChartProps) {
+  const allowScroll = period === '1m';
   return (
     <div className="space-y-4">
-      <DurationChart records={records} />
-      <TimesTrendChart records={records} />
+      <DurationChart records={records} allowScroll={allowScroll} />
+      <TimesTrendChart records={records} allowScroll={allowScroll} />
     </div>
   );
 }


### PR DESCRIPTION
## 변경 내용
- period prop을 차트 컴포넌트에 전달
- 1주/2주 기간: overflow-x-auto 제거 → 스크롤 없이 컨테이너에 맞춤
- 1개월: 기존대로 스크롤 허용 + 자동 오른쪽(최신) 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)