### PR TITLE
fix(sleep): 1개월 모바일 스크롤 복원

### DIFF
--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -62,9 +62,11 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
   const labelWidth = 28;
   const barGap = 2;
   const topPadding = 12;
-  const chartWidth = Math.max(cw, 300);
+  const minBarWidth = allowScroll ? 16 : 8;
+  const minContentWidth = labelWidth + 8 + validRecords.length * (minBarWidth + barGap);
+  const chartWidth = allowScroll ? Math.max(cw, minContentWidth) : Math.max(cw, 300);
   const availableWidth = chartWidth - labelWidth - 8;
-  const barWidth = Math.max(8, availableWidth / validRecords.length - barGap);
+  const barWidth = Math.max(minBarWidth, availableWidth / validRecords.length - barGap);
   const dateAreaHeight = 32;
 
   return (

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -41,9 +41,11 @@ function DurationChart({ records, allowScroll }: { records: SleepRecordWithEvent
 
   const maxDur = Math.max(...valid.map((r) => r.duration_minutes!));
   const chartHeight = 120;
-  const chartWidth = Math.max(cw, 200);
   const barGap = 3;
-  const barWidth = Math.max(6, (chartWidth - 8) / valid.length - barGap);
+  const minBarWidth = allowScroll ? 16 : 6;
+  const minContentWidth = 8 + valid.length * (minBarWidth + barGap);
+  const chartWidth = allowScroll ? Math.max(cw, minContentWidth) : Math.max(cw, 200);
+  const barWidth = Math.max(minBarWidth, (chartWidth - 8) / valid.length - barGap);
   const dateAreaHeight = 32;
 
   const idealMin = 420;
@@ -116,7 +118,9 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
   if (valid.length === 0) return null;
 
   const chartHeight = 140;
-  const chartWidth = Math.max(cw, 200);
+  const minPointGap = allowScroll ? 18 : 0;
+  const minContentWidth = 48 + valid.length * minPointGap;
+  const chartWidth = allowScroll ? Math.max(cw, minContentWidth) : Math.max(cw, 200);
   const padding = { left: 36, right: 12, top: 8, bottom: 36 };
   const innerW = chartWidth - padding.left - padding.right;
   const innerH = chartHeight - padding.top - padding.bottom;


### PR DESCRIPTION
## 변경 내용
- 1개월 기간에서 바/포인트 최소 폭을 보장하여 모바일에서 스크롤 가능하도록 수정
  - 타임라인/수면 시간: 바 최소 16px
  - 취침·기상 추이: 포인트 간격 최소 18px
- 1주/2주는 기존대로 스크롤 없이 컨테이너에 맞춤

🤖 Generated with [Claude Code](https://claude.com/claude-code)