### PR TITLE
feat(insight): 밤 알림에 오늘 일기 내용 포함

### DIFF
--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -408,7 +408,10 @@ const insightNightTask = async (app: App, config: LifeCronConfig): Promise<void>
       '오늘도 수고했어. 내일도 좋은 하루 보내자.',
     );
 
-    await postToChannel(app.client, channelId, comment);
+    const diaryBlock = `*오늘의 일기*\n${diary.content}`;
+    const message = `${diaryBlock}\n\n---\n\n${comment}`;
+
+    await postToChannel(app.client, channelId, message);
     console.warn(`[Life Cron] 일기 리뷰 전송 완료 (유저=${userId})`);
   });
 };


### PR DESCRIPTION
## Summary
- 인사이트 밤 크론 알림에서 LLM 코멘트만 전송하던 것을 일기 전문 + 코멘트 조합으로 변경
- 상단에 오늘 기록한 일기 전체, 하단에 LLM 리뷰 코멘트 배치

## Test plan
- [ ] 인사이트 밤 크론 알림 확인 — 일기 있는 날: 일기 + 구분선 + 코멘트
- [ ] 일기 없는 날: 기존 리마인더 메시지 그대로 전송

🤖 Generated with [Claude Code](https://claude.com/claude-code)