### PR TITLE
fix(web): useSearchParams Suspense 래핑 추가

### DIFF
--- a/web/src/app/life/sleep/page.tsx
+++ b/web/src/app/life/sleep/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useSleepDashboard } from '@/features/sleep/hooks/use-sleep-dashboard';
 import { PeriodSelector } from '@/features/sleep/components/period-selector';
@@ -12,7 +13,29 @@ import type { SleepPeriod } from '@/features/sleep/lib/types';
 
 const VALID_PERIODS: SleepPeriod[] = ['1w', '2w', '1m'];
 
+function SleepFallback() {
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-5xl space-y-4 px-4 py-4 md:py-6">
+        <CardSkeleton className="h-10 w-48" />
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => <CardSkeleton key={i} className="h-24" />)}
+        </div>
+        <CardSkeleton className="h-80" />
+      </div>
+    </div>
+  );
+}
+
 export default function SleepPage() {
+  return (
+    <Suspense fallback={<SleepFallback />}>
+      <SleepContent />
+    </Suspense>
+  );
+}
+
+function SleepContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const rangeParam = searchParams.get('range') as SleepPeriod | null;

--- a/web/src/app/schedules/calendar/page.tsx
+++ b/web/src/app/schedules/calendar/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { Suspense, useState, useCallback } from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { startOfWeek, endOfWeek } from 'date-fns';
@@ -42,6 +42,14 @@ function getTitle(view: string, currentDate: Date): string {
 }
 
 export default function CalendarPage() {
+  return (
+    <Suspense fallback={<div className="flex-1 p-4"><div className="mx-auto max-w-3xl"><ListSkeleton rows={5} rowHeight="h-20" /></div></div>}>
+      <CalendarContent />
+    </Suspense>
+  );
+}
+
+function CalendarContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const viewParam = searchParams.get('view') as CalendarView | null;


### PR DESCRIPTION
## 관련 이슈
#277 후속 수정

## 변경 내용
- `useSearchParams()` 사용하는 페이지에 `<Suspense>` 래핑 추가
- `/schedules/calendar`, `/life/sleep` 두 페이지 해당
- Next.js 빌드 시 prerender 에러로 배포 실패하던 문제 수정