### PR TITLE
fix(insight): 일기 저장 안정화 — LLM 경로 제거 + 날짜 경계 5시 적용

### DIFF
--- a/src/agents/insight/diary-fast-path.ts
+++ b/src/agents/insight/diary-fast-path.ts
@@ -5,7 +5,7 @@
  */
 
 import { query } from '../../shared/db.js';
-import { getTodayISO } from '../../shared/kst.js';
+import { getEffectiveTodayISO } from '../../shared/kst.js';
 
 /** 응답 전 자연스러운 딜레이 (1~2초 랜덤) */
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -50,15 +50,6 @@ export const pickDiaryConfirmation = (): string => {
   return DIARY_CONFIRMATIONS[idx] ?? DIARY_CONFIRMATIONS[0];
 };
 
-// ─── 명령 패턴 감지 ──────────────────────────────────────
-
-/**
- * LLM 에이전트 루프가 필요한 명령 패턴.
- * 매칭되면 일기 fast path를 건너뛰고 LLM으로 전달.
- */
-export const INSIGHT_COMMAND_RE =
-  /(?:테마|프로필|패턴|원국|격국|용신|사주|대운|일기\s*(?:보여|읽어|확인|분석|삭제)|분석|해석|설명\s*해|알려\s*줘|뭐야|어떻게\s*(?:봐|생각|돼|되는)|어때|삭제|추가해\s*줘)/;
-
 // ─── DB 저장 ─────────────────────────────────────────────
 
 /**
@@ -69,7 +60,7 @@ export const saveDiaryEntry = async (
   userId: number,
   content: string,
 ): Promise<void> => {
-  const date = getTodayISO();
+  const date = getEffectiveTodayISO();
 
   const existing = await query<{ id: number }>(
     `SELECT id FROM diary_entries WHERE user_id = $1 AND date = $2 LIMIT 1`,

--- a/src/agents/insight/index.ts
+++ b/src/agents/insight/index.ts
@@ -1,15 +1,10 @@
 import type { AgentHandler } from '../../router.js';
 import type { LLMClient } from '../../shared/llm.js';
-import { runAgentLoop } from '../../shared/agent-loop.js';
 import { sendMessage } from '../../shared/slack.js';
-import { SQL_TOOLS, executeSQLTool } from '../../shared/sql-tools.js';
-import { ChatHistory } from '../../shared/chat-history.js';
-import { buildInsightSystemPrompt } from './prompt.js';
 import { queryOne } from '../../shared/db.js';
-import { getTodayISO, addDays } from '../../shared/kst.js';
+import { getTodayISO, getEffectiveTodayISO, addDays } from '../../shared/kst.js';
 import { resolveUserId, DEFAULT_USER_ID } from '../../shared/user-resolver.js';
 import {
-  INSIGHT_COMMAND_RE,
   saveDiaryEntry,
   pickDiaryConfirmation,
   naturalDelay,
@@ -27,6 +22,8 @@ const YEARLY_FORTUNE_RE = /^(올해\s*)?세운(\s*(보여줘|보여|알려줘|�
 const TOMORROW_FORTUNE_RE = /^내일\s*일운(\s*(보여줘|보여|알려줘|뭐야))?[.?!]?$/;
 /** 대운 조회 */
 const MAJOR_FORTUNE_RE = /^(내\s*)?대운(\s*(보여줘|보여|알려줘|뭐야))?[.?!]?$/;
+/** 오늘 일기 조회 */
+const TODAY_DIARY_RE = /^오늘\s*일기/;
 
 interface FortuneRow {
   date: string;
@@ -106,24 +103,43 @@ const tryFortuneFastPath = async (
   return true;
 };
 
+/** 오늘 일기 조회 fast path */
+const showTodayDiary = async (
+  say: Parameters<AgentHandler>[1],
+  userId: number,
+): Promise<void> => {
+  const today = getEffectiveTodayISO();
+  try {
+    const row = await queryOne<{ content: string }>(
+      `SELECT content FROM diary_entries WHERE user_id = $1 AND date = $2`,
+      [userId, today],
+    );
+    if (!row) {
+      await sendMessage(say, '아직 오늘 일기가 없어.');
+    } else {
+      await sendMessage(say, `*오늘의 일기 (${today})*\n${row.content}`);
+    }
+  } catch (error: unknown) {
+    console.error('[Insight Agent] 일기 조회 오류:', error);
+    await sendMessage(say, '일기 조회 중 오류가 발생했어.');
+  }
+};
+
 // ─── 에이전트 ─────────────────────────────────────────
 
 /**
  * Insight 에이전트 생성.
- * 명리학 일운 분석 조회 + 일기/고민 자동 기록 + 삶의 테마 관리.
- * 운세 조회(일운/월운/세운/대운)는 fast path로 즉시 응답.
+ * 일기 자동 저장 + 운세 조회 fast path + 오늘 일기 조회.
+ * LLM 에이전트 루프 없음 — 모든 비명령 메시지는 일기로 저장.
  */
-export const createInsightAgent = (llmClient: LLMClient): AgentHandler => {
-  const history = new ChatHistory({ maxPairs: 5, maxUserChars: 1500, maxAssistantChars: 500 });
-
+export const createInsightAgent = (_llmClient: LLMClient): AgentHandler => {
   return async (message, say) => {
     const text = 'text' in message ? (message.text ?? '') : '';
     if (!text.trim()) return;
 
-    const channelId = message.channel;
     const trimmed = text.trim();
 
-    // Slack user → DB userId 해석 (미등록이면 DEFAULT_USER_ID 폴백)
+    // Slack user → DB userId 해석
     const slackUserId = ('user' in message ? message.user : undefined) ?? '';
     const resolvedUserId = slackUserId ? await resolveUserId(slackUserId) : null;
     if (resolvedUserId === null && slackUserId) {
@@ -134,38 +150,20 @@ export const createInsightAgent = (llmClient: LLMClient): AgentHandler => {
     // ── fast path: 운세 조회 ──
     if (await tryFortuneFastPath(trimmed, say, userId)) return;
 
-    // ── fast path: 일기 저장 (명령 패턴이 아닌 모든 메시지) ──
-    if (!INSIGHT_COMMAND_RE.test(trimmed)) {
-      try {
-        await saveDiaryEntry(userId, text.trim());
-        await naturalDelay();
-        await sendMessage(say, pickDiaryConfirmation());
-      } catch (error: unknown) {
-        console.error('[Insight Agent] 일기 저장 실패:', error);
-        await sendMessage(say, '일기 저장 중 오류가 발생했어. 다시 한번 말해줘.');
-      }
+    // ── fast path: 오늘 일기 조회 ──
+    if (TODAY_DIARY_RE.test(trimmed)) {
+      await showTodayDiary(say, userId);
       return;
     }
 
-    // ── LLM 에이전트 루프 (명령 패턴 매칭 시) ──
+    // ── 기본: 일기 저장 (어떤 단어든 무조건 일기로 저장) ──
     try {
-      const result = await runAgentLoop(
-        llmClient,
-        text,
-        {
-          label: 'Insight Agent',
-          buildSystemPrompt: () => buildInsightSystemPrompt(userId),
-          getTools: async () => SQL_TOOLS,
-          executeToolCall: (name, args) => executeSQLTool(name, args, userId),
-          historyMessages: history.toMessages(channelId),
-        },
-      );
-
-      await sendMessage(say, result.text);
-      history.add(channelId, text, result.text);
+      await saveDiaryEntry(userId, text.trim());
+      await naturalDelay();
+      await sendMessage(say, pickDiaryConfirmation());
     } catch (error: unknown) {
-      console.error('[Insight Agent] 오류:', error);
-      await sendMessage(say, '오류가 발생했어. 다시 한번 말해줘.');
+      console.error('[Insight Agent] 일기 저장 실패:', error);
+      await sendMessage(say, '일기 저장 중 오류가 발생했어. 다시 한번 말해줘.');
     }
   };
 };

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -24,7 +24,7 @@ import {
   decrementReminderCount,
 } from '../shared/life-queries.js';
 import { postBlockMessage, postToChannel } from '../shared/slack.js';
-import { getTodayISO, getKSTTimeString, getKSTDayOfWeek } from '../shared/kst.js';
+import { getTodayISO, getEffectiveTodayISO, getKSTTimeString, getKSTDayOfWeek } from '../shared/kst.js';
 import {
   DEFAULT_USER_ID,
   queryAllUserMappings,
@@ -367,7 +367,7 @@ const insightMorningTask = async (app: App, config: LifeCronConfig): Promise<voi
 /** 밤 일기 리뷰 → insight 채널.
  * 오늘 일기가 있으면 LLM 1회로 하루 코멘트, 없으면 간단 리마인더 전송. */
 const insightNightTask = async (app: App, config: LifeCronConfig): Promise<void> => {
-  const today = getTodayISO();
+  const today = getEffectiveTodayISO();
 
   await forEachUser(config, 'insight', '일기 리뷰', async (userId, channelId) => {
     const diaryResult = await query<{ content: string }>(


### PR DESCRIPTION
## Summary
- LLM 에이전트 루프 제거 — 인사이트 채널 일기 전용으로 단순화
- 일기 날짜 기준을 `getEffectiveTodayISO()` (새벽 5시 경계)로 변경
- "오늘 일기" 조회 fast path 추가, 운세 fast path 유지

## Test plan
- [ ] "오늘 일기" 입력 시 오늘 일기 조회 확인
- [ ] 일반 메시지 입력 시 일기 저장 + 확인 문구 응답
- [ ] 일운/월운/세운/대운 fast path 정상 동작 확인
- [ ] 밤 크론(insightNight) 일기 리뷰 정상 전송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)