### PR TITLE
fix(life): 순수 계산 쿼리 user_id 검증 면제 — 수면 기록 실패 수정

### DIFF
--- a/src/shared/__tests__/sql-tools.test.ts
+++ b/src/shared/__tests__/sql-tools.test.ts
@@ -131,6 +131,11 @@ describe('validateUserIdFilter', () => {
     expect(validateUserIdFilter('SELECT * FROM schedules WHERE id = 1', 1)).not.toBeNull();
   });
 
+  it('테이블 참조 없는 순수 계산 쿼리는 통과한다', () => {
+    expect(validateUserIdFilter("SELECT EXTRACT(EPOCH FROM ('08:50'::time - '01:00'::time)) / 60 AS duration_minutes", 1)).toBeNull();
+    expect(validateUserIdFilter('SELECT 470 AS duration_minutes', 1)).toBeNull();
+  });
+
   it('면제 테이블(categories)만 참조하면 통과한다', () => {
     expect(validateUserIdFilter('SELECT * FROM categories', 1)).toBeNull();
   });

--- a/src/shared/sql-tools.ts
+++ b/src/shared/sql-tools.ts
@@ -228,8 +228,11 @@ export const validateUserIdFilter = (sql: string, userId: number): string | null
   const tableMatches = stripped.matchAll(/\b(?:FROM|JOIN|INTO|UPDATE)\s+(\w+)/gi);
   const tables = [...tableMatches].map((m) => (m[1] ?? '').toLowerCase());
 
+  // 테이블 참조가 없는 순수 계산 쿼리는 OK (SELECT EXTRACT(...), SELECT 470 등)
+  if (tables.length === 0) return null;
+
   // 추출된 테이블이 모두 면제 대상이면 OK
-  if (tables.length > 0 && tables.every((t) => USER_ID_EXEMPT_TABLES.has(t))) {
+  if (tables.every((t) => USER_ID_EXEMPT_TABLES.has(t))) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- 테이블 미참조 SELECT(`SELECT EXTRACT(...)`, `SELECT 470`)가 `validateUserIdFilter`에 블로킹되어 에이전트 루프 라운드 낭비
- 수면 duration 계산에 4라운드 소진 → INSERT 에러 복구까지 합치면 10라운드 초과 → "요청이 너무 복잡해" 응답
- `FROM/JOIN/INTO/UPDATE` 없는 순수 계산 쿼리는 user_id 검증 면제 처리

## Test plan
- [x] `validateUserIdFilter` 유닛 테스트 추가 및 전체 통과 (66/66)
- [ ] 배포 후 수면 기록 메시지 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)