### PR TITLE
feat(budget): Phase 3 — Repository / Facade 레이어

### DIFF
--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -20,6 +20,25 @@
 
 ---
 
+## 2026-04-15: 지출/예산 계산 엔진 재설계 Phase 2 (#285, PR #286)
+
+`monthly_budget_snapshots` 테이블 신설 (DB 마이그레이션 041).
+과거 월 불변 스냅샷 구조 준비. Phase 3 Repository/Facade 레이어 추가 예정.
+
+---
+
+## 2026-04-15: 지출/예산 계산 엔진 재설계 Phase 3 (#287, PR #288)
+
+Repository / Snapshot / Facade 레이어 신설.
+
+**Repository 레이어** (7개): assets / expenses / fixed-costs / incomes / installments / planned / settings  
+**Snapshot 레이어**: `monthly_budget_snapshots` CRUD (ON CONFLICT DO NOTHING — idempotent)  
+**Facade 레이어**: `getMonthlyAllocation`, `getTodayAllocation`, `runSettlementIfDue` 3개 공개 API
+
+기존 `queries.ts` 미변경 (Phase 5 cutover 예정). `budget_settings.updated_at` 신규 facade 미사용 (의미 전환).
+
+---
+
 ## 2026-04-13: API 비용 최적화 (#261, PR #262)
 
 월 LLM API 비용 절감을 위한 3가지 최적화 적용.

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./snapshot/monthly-snapshot-repo', () => ({
+  readLatestSnapshot: vi.fn(),
+  readSnapshotByMonth: vi.fn(),
+  saveSnapshotIfAbsent: vi.fn(),
+}));
+vi.mock('./repository/assets-repo', () => ({ readTotalAssetBalance: vi.fn() }));
+vi.mock('./repository/fixed-costs-repo', () => ({ readFixedCostsMonthlyTotal: vi.fn() }));
+vi.mock('./repository/installments-repo', () => ({ readActiveInstallments: vi.fn() }));
+vi.mock('./repository/planned-repo', () => ({ readPlannedExpenses: vi.fn() }));
+vi.mock('./repository/incomes-repo', () => ({ readIncomeTotal: vi.fn() }));
+vi.mock('./repository/expenses-repo', () => ({
+  readFlexibleSpent: vi.fn(),
+  readExcludedSpent: vi.fn(),
+  readTodayFlexSpent: vi.fn(),
+}));
+vi.mock('./repository/settings-repo', () => ({ readTargetMonth: vi.fn() }));
+
+import { getMonthlyAllocation, runSettlementIfDue } from './facade';
+import { readLatestSnapshot, saveSnapshotIfAbsent } from './snapshot/monthly-snapshot-repo';
+import { readTotalAssetBalance } from './repository/assets-repo';
+import { readFixedCostsMonthlyTotal } from './repository/fixed-costs-repo';
+import { readActiveInstallments } from './repository/installments-repo';
+import { readPlannedExpenses } from './repository/planned-repo';
+import { readIncomeTotal } from './repository/incomes-repo';
+import { readFlexibleSpent, readExcludedSpent } from './repository/expenses-repo';
+import { readTargetMonth } from './repository/settings-repo';
+
+// April 10 21:00 KST — billing cycle: 2026-04 (Mar 16 ~ Apr 15)
+const DEFAULT_NOW = new Date('2026-04-10T12:00:00Z');
+
+function setupCommonMocks() {
+  vi.mocked(readLatestSnapshot).mockResolvedValue(null);
+  vi.mocked(readTotalAssetBalance).mockResolvedValue(0);
+  vi.mocked(readFixedCostsMonthlyTotal).mockResolvedValue(0);
+  vi.mocked(readActiveInstallments).mockResolvedValue([]);
+  vi.mocked(readTargetMonth).mockResolvedValue('2026-04');
+  vi.mocked(readPlannedExpenses).mockResolvedValue([]);
+  vi.mocked(readFlexibleSpent).mockResolvedValue(0);
+  vi.mocked(readExcludedSpent).mockResolvedValue(0);
+  vi.mocked(readIncomeTotal).mockResolvedValue(0);
+  vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: false });
+}
+
+describe('getMonthlyAllocation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    setupCommonMocks();
+  });
+
+  it('스냅샷 없을 때 → 자산 합계를 totalAvailable로 사용', async () => {
+    vi.mocked(readLatestSnapshot).mockResolvedValue(null);
+    vi.mocked(readTotalAssetBalance).mockResolvedValue(1_000_000);
+
+    const result = await getMonthlyAllocation(1, DEFAULT_NOW);
+
+    expect(readTotalAssetBalance).toHaveBeenCalledWith(1);
+    expect(result.monthlyBudgets.length).toBeGreaterThan(0);
+  });
+
+  it('스냅샷 있을 때 → available_at_end + 이후 변동으로 totalAvailable 계산', async () => {
+    vi.mocked(readLatestSnapshot).mockResolvedValue({
+      id: 1, user_id: 1, year_month: '2026-03', sealed_at: '2026-03-16T00:00:00Z',
+      allocated_budget: 500_000, fixed_total: 0, installment_total: 0,
+      planned_total: 0, flexible_spent: 0, excluded_spent: 0, income_total: 0,
+      available_at_start: 1_000_000, available_at_end: 900_000,
+    });
+    vi.mocked(readIncomeTotal).mockResolvedValue(100_000);
+    vi.mocked(readFlexibleSpent).mockResolvedValue(50_000);
+    vi.mocked(readExcludedSpent).mockResolvedValue(0);
+    // readTotalAssetBalance은 호출되지 않아야 함 (별도로 확인)
+    vi.mocked(readTotalAssetBalance).mockResolvedValue(999_999);
+
+    const result = await getMonthlyAllocation(1, DEFAULT_NOW);
+
+    // totalAvailable = 900_000 + 100_000 - 50_000 - 0 = 950_000 → assets(999_999)와 다른 값
+    expect(result.monthlyBudgets.length).toBeGreaterThan(0);
+    // freePerMonth은 totalAvailable 950_000 기준 계산 (≠ 999_999 기준)
+    expect(result.freePerMonth).not.toBeNull();
+  });
+});
+
+describe('runSettlementIfDue', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    setupCommonMocks();
+  });
+
+  it('정산일(16일)이 아니면 settled=false', async () => {
+    const result = await runSettlementIfDue(1, DEFAULT_NOW); // April 10
+
+    expect(result.settled).toBe(false);
+    expect(saveSnapshotIfAbsent).not.toHaveBeenCalled();
+  });
+
+  it('정산일(16일)이고 스냅샷 신규 → settled=true + 스냅샷 반환', async () => {
+    // April 16 12:00 UTC = April 16 21:00 KST → yesterday=April 15 → shouldSettle=true, targetMonth='2026-04'...
+    // wait: targetMonth = '2026-04-15'.slice(0,7) = '2026-04', range.to = '2026-04-15'
+    // targetEnd = new Date('2026-04-15T12:00:00Z') = Apr 15 21:00 KST → billing cycle '2026-04' ✓
+    const settlementNow = new Date('2026-04-16T12:00:00Z');
+
+    vi.mocked(readLatestSnapshot).mockResolvedValue(null);
+    vi.mocked(readTotalAssetBalance).mockResolvedValue(5_000_000);
+    vi.mocked(readFlexibleSpent).mockResolvedValue(300_000);
+    vi.mocked(readExcludedSpent).mockResolvedValue(50_000);
+    vi.mocked(readIncomeTotal).mockResolvedValue(2_000_000);
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
+
+    const result = await runSettlementIfDue(1, settlementNow);
+
+    expect(result.settled).toBe(true);
+    expect(result.snapshot).toBeDefined();
+    expect(result.snapshot?.year_month).toBe('2026-04');
+  });
+});

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -1,0 +1,131 @@
+import { getBillingCycle, getBillingRange } from './billing/cycle';
+import { calcAllocatedDays } from './allocator/proration';
+import { allocateMonthlyBudgets } from './allocator/month-allocator';
+import { allocateTodayBudget } from './allocator/day-allocator';
+import { detectSettlementTrigger, buildSettlementSnapshot } from './settlement/settle';
+
+import { readTotalAssetBalance } from './repository/assets-repo';
+import { readFixedCostsMonthlyTotal } from './repository/fixed-costs-repo';
+import { readActiveInstallments } from './repository/installments-repo';
+import { readPlannedExpenses } from './repository/planned-repo';
+import { readIncomeTotal } from './repository/incomes-repo';
+import { readFlexibleSpent, readExcludedSpent, readTodayFlexSpent } from './repository/expenses-repo';
+import { readTargetMonth } from './repository/settings-repo';
+import { readLatestSnapshot, saveSnapshotIfAbsent } from './snapshot/monthly-snapshot-repo';
+
+import type { MonthAllocatorResult, DayAllocatorResult, SettlementSnapshot } from './types-v2';
+
+function formatKSTDate(d: Date): string {
+  const kst = new Date(d.getTime() + 9 * 3600 * 1000);
+  return kst.toISOString().slice(0, 10);
+}
+
+function addOneDay(dateStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+/** 최신 스냅샷 기준 가용자금 계산 (없으면 전체 자산 합계 fallback) */
+async function computeTotalAvailable(userId: number, today: string): Promise<number> {
+  const snapshot = await readLatestSnapshot(userId);
+  if (!snapshot) {
+    return readTotalAssetBalance(userId);
+  }
+  const snapshotEnd = getBillingRange(snapshot.year_month).to;
+  const fromDate = addOneDay(snapshotEnd);
+  const [income, flex, excluded] = await Promise.all([
+    readIncomeTotal(userId, fromDate, today),
+    readFlexibleSpent(userId, fromDate, today),
+    readExcludedSpent(userId, fromDate, today),
+  ]);
+  return snapshot.available_at_end + income - flex - excluded;
+}
+
+/** 월 예산 배분 */
+export async function getMonthlyAllocation(
+  userId: number,
+  now: Date,
+): Promise<MonthAllocatorResult> {
+  const cycle = getBillingCycle(now);
+  const todayStr = formatKSTDate(now);
+  const [totalAvailable, fixedMonthly, installments, targetMonth] = await Promise.all([
+    computeTotalAvailable(userId, todayStr),
+    readFixedCostsMonthlyTotal(userId),
+    readActiveInstallments(userId, cycle.from),
+    readTargetMonth(userId),
+  ]);
+  const planned = await readPlannedExpenses(
+    userId, cycle.yearMonth, targetMonth ?? cycle.yearMonth,
+  );
+  return allocateMonthlyBudgets({
+    totalAvailable, fixedMonthly, installments,
+    plannedExpenses: planned,
+    currentBillingMonth: cycle.yearMonth,
+    targetMonth, today: todayStr,
+  });
+}
+
+/** 일 예산 배분 */
+export async function getTodayAllocation(
+  userId: number,
+  now: Date,
+): Promise<DayAllocatorResult> {
+  const cycle = getBillingCycle(now);
+  const monthly = await getMonthlyAllocation(userId, now);
+  const currentMonth = monthly.monthlyBudgets.find((m) => m.isCurrent);
+  if (!currentMonth) {
+    return { todayBudget: 0, todayRemaining: 0, monthBudgetRemaining: 0 };
+  }
+  const todayStr = formatKSTDate(now);
+  const { remaining } = calcAllocatedDays(todayStr, cycle);
+  const [flex, todayFlex] = await Promise.all([
+    readFlexibleSpent(userId, cycle.from, todayStr),
+    readTodayFlexSpent(userId, todayStr),
+  ]);
+  return allocateTodayBudget({
+    monthBudget: currentMonth.free,
+    flexibleSpent: flex,
+    todayFlexSpent: todayFlex,
+    cycleRemainingDays: remaining,
+  });
+}
+
+/** 월 경계 정산 (Phase 4 cron 진입점) */
+export async function runSettlementIfDue(
+  userId: number,
+  now: Date,
+): Promise<{ settled: boolean; snapshot?: SettlementSnapshot }> {
+  const trigger = detectSettlementTrigger(now);
+  if (!trigger.shouldSettle || !trigger.targetMonth) {
+    return { settled: false };
+  }
+  const targetMonth = trigger.targetMonth;
+  const range = getBillingRange(targetMonth);
+
+  const [flex, excluded, income] = await Promise.all([
+    readFlexibleSpent(userId, range.from, range.to),
+    readExcludedSpent(userId, range.from, range.to),
+    readIncomeTotal(userId, range.from, range.to),
+  ]);
+
+  // 정산 대상 월 기준 allocator 재실행 — T12:00:00Z = KST 21:00 (15일 이내)
+  const targetEnd = new Date(`${range.to}T12:00:00Z`);
+  const alloc = await getMonthlyAllocation(userId, targetEnd);
+  const monthlyBudget = alloc.monthlyBudgets.find((m) => m.yearMonth === targetMonth);
+  if (!monthlyBudget) {
+    return { settled: false };
+  }
+
+  const prevSnapshot = await readLatestSnapshot(userId);
+  const availableAtStart = prevSnapshot?.available_at_end ?? await readTotalAssetBalance(userId);
+  const availableAtEnd = await computeTotalAvailable(userId, formatKSTDate(now));
+
+  const snapshot = buildSettlementSnapshot({
+    yearMonth: targetMonth, monthlyBudget,
+    actualFlexibleSpent: flex, actualExcludedSpent: excluded, actualIncome: income,
+    availableAtStart, availableAtEnd,
+  });
+  const result = await saveSnapshotIfAbsent(userId, snapshot);
+  return { settled: result.saved, snapshot };
+}

--- a/web/src/features/budget/lib/repository/assets-repo.ts
+++ b/web/src/features/budget/lib/repository/assets-repo.ts
@@ -1,0 +1,10 @@
+import { query } from '@/lib/db';
+
+export async function readTotalAssetBalance(userId: number): Promise<number> {
+  const result = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(balance), 0)::text AS total
+     FROM assets WHERE user_id = $1`,
+    [userId],
+  );
+  return Number(result.rows[0]?.total ?? 0);
+}

--- a/web/src/features/budget/lib/repository/expenses-repo.ts
+++ b/web/src/features/budget/lib/repository/expenses-repo.ts
@@ -1,0 +1,53 @@
+import { query } from '@/lib/db';
+
+export async function readFlexibleSpent(
+  userId: number,
+  from: string,
+  to: string,
+): Promise<number> {
+  const result = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(amount), 0)::text AS total
+     FROM expenses
+     WHERE user_id = $1
+       AND COALESCE(type, 'expense') = 'expense'
+       AND exclude_from_budget = false
+       AND is_installment = false
+       AND date BETWEEN $2 AND $3`,
+    [userId, from, to],
+  );
+  return Number(result.rows[0]?.total ?? 0);
+}
+
+export async function readExcludedSpent(
+  userId: number,
+  from: string,
+  to: string,
+): Promise<number> {
+  const result = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(amount), 0)::text AS total
+     FROM expenses
+     WHERE user_id = $1
+       AND COALESCE(type, 'expense') = 'expense'
+       AND exclude_from_budget = true
+       AND date BETWEEN $2 AND $3`,
+    [userId, from, to],
+  );
+  return Number(result.rows[0]?.total ?? 0);
+}
+
+export async function readTodayFlexSpent(
+  userId: number,
+  today: string,
+): Promise<number> {
+  const result = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(amount), 0)::text AS total
+     FROM expenses
+     WHERE user_id = $1
+       AND COALESCE(type, 'expense') = 'expense'
+       AND exclude_from_budget = false
+       AND is_installment = false
+       AND date = $2::date`,
+    [userId, today],
+  );
+  return Number(result.rows[0]?.total ?? 0);
+}

--- a/web/src/features/budget/lib/repository/fixed-costs-repo.ts
+++ b/web/src/features/budget/lib/repository/fixed-costs-repo.ts
@@ -1,0 +1,11 @@
+import { query } from '@/lib/db';
+
+export async function readFixedCostsMonthlyTotal(userId: number): Promise<number> {
+  const result = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(amount), 0)::text AS total
+     FROM fixed_costs
+     WHERE user_id = $1 AND COALESCE(active, true) = true`,
+    [userId],
+  );
+  return Number(result.rows[0]?.total ?? 0);
+}

--- a/web/src/features/budget/lib/repository/incomes-repo.ts
+++ b/web/src/features/budget/lib/repository/incomes-repo.ts
@@ -1,0 +1,20 @@
+import { query } from '@/lib/db';
+
+// incomes 테이블 + expenses.type='income' 양쪽 통합 (레거시 병존 구조)
+export async function readIncomeTotal(
+  userId: number,
+  from: string,
+  to: string,
+): Promise<number> {
+  const result = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(amount), 0)::text AS total FROM (
+       SELECT amount FROM incomes
+        WHERE user_id = $1 AND date BETWEEN $2 AND $3
+       UNION ALL
+       SELECT amount FROM expenses
+        WHERE user_id = $1 AND type = 'income' AND date BETWEEN $2 AND $3
+     ) AS combined`,
+    [userId, from, to],
+  );
+  return Number(result.rows[0]?.total ?? 0);
+}

--- a/web/src/features/budget/lib/repository/installments-repo.ts
+++ b/web/src/features/budget/lib/repository/installments-repo.ts
@@ -1,0 +1,33 @@
+import { query } from '@/lib/db';
+import type { InstallmentInput } from '../types-v2';
+
+export async function readActiveInstallments(
+  userId: number,
+  currentBillingFrom: string,
+): Promise<InstallmentInput[]> {
+  const result = await query<{
+    group: string;
+    monthly_amount: number;
+    remaining_count: number;
+    is_new: boolean;
+  }>(
+    `SELECT
+       installment_group AS group,
+       MAX(amount)::int AS monthly_amount,
+       COUNT(*) FILTER (WHERE date >= $2::date)::int AS remaining_count,
+       (MIN(date) FILTER (WHERE installment_num = 1) >= $2::date) AS is_new
+     FROM expenses
+     WHERE user_id = $1
+       AND is_installment = true
+       AND installment_group IS NOT NULL
+     GROUP BY installment_group
+     HAVING COUNT(*) FILTER (WHERE date >= $2::date) > 0`,
+    [userId, currentBillingFrom],
+  );
+
+  return result.rows.map((r) => ({
+    monthlyAmount: r.monthly_amount,
+    remainingCount: r.remaining_count,
+    isNew: r.is_new,
+  }));
+}

--- a/web/src/features/budget/lib/repository/planned-repo.ts
+++ b/web/src/features/budget/lib/repository/planned-repo.ts
@@ -1,0 +1,17 @@
+import { query } from '@/lib/db';
+import type { PlannedInput } from '../types-v2';
+
+export async function readPlannedExpenses(
+  userId: number,
+  fromYearMonth: string,
+  toYearMonth: string,
+): Promise<PlannedInput[]> {
+  const result = await query<{ year_month: string; amount: number }>(
+    `SELECT year_month, SUM(amount)::int AS amount
+     FROM planned_expenses
+     WHERE user_id = $1 AND year_month BETWEEN $2 AND $3
+     GROUP BY year_month`,
+    [userId, fromYearMonth, toYearMonth],
+  );
+  return result.rows.map((r) => ({ yearMonth: r.year_month, amount: r.amount }));
+}

--- a/web/src/features/budget/lib/repository/settings-repo.ts
+++ b/web/src/features/budget/lib/repository/settings-repo.ts
@@ -1,0 +1,10 @@
+import { query } from '@/lib/db';
+
+// updated_at 미사용 — 신규 facade는 target_date만 읽는다 (Section 3.3)
+export async function readTargetMonth(userId: number): Promise<string | null> {
+  const result = await query<{ target_date: string | null }>(
+    'SELECT target_date FROM budget_settings WHERE user_id = $1',
+    [userId],
+  );
+  return result.rows[0]?.target_date ?? null;
+}

--- a/web/src/features/budget/lib/snapshot/monthly-snapshot-repo.ts
+++ b/web/src/features/budget/lib/snapshot/monthly-snapshot-repo.ts
@@ -1,0 +1,53 @@
+import { query } from '@/lib/db';
+import type { SettlementSnapshot } from '../types-v2';
+
+export interface StoredSnapshot extends SettlementSnapshot {
+  id: number;
+  user_id: number;
+  sealed_at: string;
+}
+
+export async function readLatestSnapshot(userId: number): Promise<StoredSnapshot | null> {
+  const result = await query<StoredSnapshot>(
+    `SELECT * FROM monthly_budget_snapshots
+     WHERE user_id = $1
+     ORDER BY year_month DESC
+     LIMIT 1`,
+    [userId],
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function readSnapshotByMonth(
+  userId: number,
+  yearMonth: string,
+): Promise<StoredSnapshot | null> {
+  const result = await query<StoredSnapshot>(
+    `SELECT * FROM monthly_budget_snapshots
+     WHERE user_id = $1 AND year_month = $2`,
+    [userId, yearMonth],
+  );
+  return result.rows[0] ?? null;
+}
+
+/** idempotent: UNIQUE(user_id, year_month) 충돌 시 no-op */
+export async function saveSnapshotIfAbsent(
+  userId: number,
+  snapshot: SettlementSnapshot,
+): Promise<{ saved: boolean }> {
+  const result = await query(
+    `INSERT INTO monthly_budget_snapshots (
+       user_id, year_month, allocated_budget, fixed_total, installment_total,
+       planned_total, flexible_spent, excluded_spent, income_total,
+       available_at_start, available_at_end, sealed_at
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
+     ON CONFLICT (user_id, year_month) DO NOTHING`,
+    [
+      userId, snapshot.year_month, snapshot.allocated_budget,
+      snapshot.fixed_total, snapshot.installment_total, snapshot.planned_total,
+      snapshot.flexible_spent, snapshot.excluded_spent, snapshot.income_total,
+      snapshot.available_at_start, snapshot.available_at_end,
+    ],
+  );
+  return { saved: (result.rowCount ?? 0) > 0 };
+}


### PR DESCRIPTION
## 관련 이슈
Closes #287

## 변경 내용
- Repository 레이어 신설 (7개): assets / expenses / fixed-costs / incomes / installments / planned / settings
- Snapshot 레이어 신설: `monthly_budget_snapshots` CRUD (idempotent INSERT)
- Facade 레이어 신설: `getMonthlyAllocation`, `getTodayAllocation`, `runSettlementIfDue` 3개 API
- 기존 `queries.ts`, `budget-calc.ts`, API 라우트 미변경 (Phase 5 cutover 예정)

## 코드 리뷰 결과
- [x] 보안 감사 통과 (모든 SQL 파라미터화, user_id 명시적 필터)
- [x] 타입 안전성 확인 (`any` 없음, TypeScript strict 빌드 통과)
- [x] 컨벤션 점검 완료 (named export, kebab-case, 200/30줄 이내)
- [x] `budget_settings.updated_at` 신규 facade 미사용 확인

## 테스트
- [x] facade 단위 테스트 4개 통과 (`yarn test facade`)
- [x] 전체 테스트 149개 회귀 없음 (`yarn test`)
- [x] TypeScript strict 빌드 통과 (`yarn build`)