### PR TITLE
feat(budget): Phase 4 — API 라우트 + 월 경계 정산 cron

### DIFF
--- a/web/src/app/api/budget/v2/monthly/route.ts
+++ b/web/src/app/api/budget/v2/monthly/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import { getMonthlyAllocation } from '@/features/budget/lib/facade';
+
+export async function GET() {
+  const userId = await requireAuth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const data = await getMonthlyAllocation(userId, new Date());
+    return NextResponse.json({ data });
+  } catch (err) {
+    console.error('[Budget v2 API] monthly', err);
+    return NextResponse.json({ error: '월 예산 조회 실패' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/budget/v2/today/route.ts
+++ b/web/src/app/api/budget/v2/today/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import { getTodayAllocation } from '@/features/budget/lib/facade';
+
+export async function GET() {
+  const userId = await requireAuth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const data = await getTodayAllocation(userId, new Date());
+    return NextResponse.json({ data });
+  } catch (err) {
+    console.error('[Budget v2 API] today', err);
+    return NextResponse.json({ error: '오늘 예산 조회 실패' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/cron/monthly-settlement/route.ts
+++ b/web/src/app/api/cron/monthly-settlement/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { runSettlementIfDue } from '@/features/budget/lib/facade';
+import { listAllUserIds } from '@/lib/users';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env['CRON_SECRET'];
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = new Date();
+  const userIds = await listAllUserIds();
+  const results: Array<{ userId: number; settled: boolean; yearMonth?: string; error?: string }> = [];
+
+  for (const userId of userIds) {
+    try {
+      const result = await runSettlementIfDue(userId, now);
+      results.push({
+        userId,
+        settled: result.settled,
+        ...(result.snapshot && { yearMonth: result.snapshot.year_month }),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[monthly-settlement] user ${userId} 실패:`, msg);
+      results.push({ userId, settled: false, error: msg });
+    }
+  }
+
+  return NextResponse.json({ ok: true, results });
+}

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -9,7 +9,10 @@ vi.mock('./repository/assets-repo', () => ({ readTotalAssetBalance: vi.fn() }));
 vi.mock('./repository/fixed-costs-repo', () => ({ readFixedCostsMonthlyTotal: vi.fn() }));
 vi.mock('./repository/installments-repo', () => ({ readActiveInstallments: vi.fn() }));
 vi.mock('./repository/planned-repo', () => ({ readPlannedExpenses: vi.fn() }));
-vi.mock('./repository/incomes-repo', () => ({ readIncomeTotal: vi.fn() }));
+vi.mock('./repository/incomes-repo', () => ({
+  readIncomeTotal: vi.fn(),
+  readDistributableIncomeTotal: vi.fn(),
+}));
 vi.mock('./repository/expenses-repo', () => ({
   readFlexibleSpent: vi.fn(),
   readExcludedSpent: vi.fn(),
@@ -23,7 +26,7 @@ import { readTotalAssetBalance } from './repository/assets-repo';
 import { readFixedCostsMonthlyTotal } from './repository/fixed-costs-repo';
 import { readActiveInstallments } from './repository/installments-repo';
 import { readPlannedExpenses } from './repository/planned-repo';
-import { readIncomeTotal } from './repository/incomes-repo';
+import { readIncomeTotal, readDistributableIncomeTotal } from './repository/incomes-repo';
 import { readFlexibleSpent, readExcludedSpent } from './repository/expenses-repo';
 import { readTargetMonth } from './repository/settings-repo';
 
@@ -40,6 +43,7 @@ function setupCommonMocks() {
   vi.mocked(readFlexibleSpent).mockResolvedValue(0);
   vi.mocked(readExcludedSpent).mockResolvedValue(0);
   vi.mocked(readIncomeTotal).mockResolvedValue(0);
+  vi.mocked(readDistributableIncomeTotal).mockResolvedValue(0);
   vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: false });
 }
 
@@ -66,7 +70,7 @@ describe('getMonthlyAllocation', () => {
       planned_total: 0, flexible_spent: 0, excluded_spent: 0, income_total: 0,
       available_at_start: 1_000_000, available_at_end: 900_000,
     });
-    vi.mocked(readIncomeTotal).mockResolvedValue(100_000);
+    vi.mocked(readDistributableIncomeTotal).mockResolvedValue(100_000);
     vi.mocked(readFlexibleSpent).mockResolvedValue(50_000);
     vi.mocked(readExcludedSpent).mockResolvedValue(0);
     // readTotalAssetBalance은 호출되지 않아야 함 (별도로 확인)

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -8,7 +8,7 @@ import { readTotalAssetBalance } from './repository/assets-repo';
 import { readFixedCostsMonthlyTotal } from './repository/fixed-costs-repo';
 import { readActiveInstallments } from './repository/installments-repo';
 import { readPlannedExpenses } from './repository/planned-repo';
-import { readIncomeTotal } from './repository/incomes-repo';
+import { readIncomeTotal, readDistributableIncomeTotal } from './repository/incomes-repo';
 import { readFlexibleSpent, readExcludedSpent, readTodayFlexSpent } from './repository/expenses-repo';
 import { readTargetMonth } from './repository/settings-repo';
 import { readLatestSnapshot, saveSnapshotIfAbsent } from './snapshot/monthly-snapshot-repo';
@@ -35,7 +35,7 @@ async function computeTotalAvailable(userId: number, today: string): Promise<num
   const snapshotEnd = getBillingRange(snapshot.year_month).to;
   const fromDate = addOneDay(snapshotEnd);
   const [income, flex, excluded] = await Promise.all([
-    readIncomeTotal(userId, fromDate, today),
+    readDistributableIncomeTotal(userId, fromDate, today),
     readFlexibleSpent(userId, fromDate, today),
     readExcludedSpent(userId, fromDate, today),
   ]);

--- a/web/src/features/budget/lib/repository/incomes-repo.ts
+++ b/web/src/features/budget/lib/repository/incomes-repo.ts
@@ -18,3 +18,24 @@ export async function readIncomeTotal(
   );
   return Number(result.rows[0]?.total ?? 0);
 }
+
+// 축 A — 자산에 흘러드는 수입만 합산 (distribute_to_budget=true + 레거시 incomes)
+export async function readDistributableIncomeTotal(
+  userId: number,
+  from: string,
+  to: string,
+): Promise<number> {
+  const result = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(amount), 0)::text AS total FROM (
+       SELECT amount FROM incomes
+        WHERE user_id = $1 AND date BETWEEN $2 AND $3
+       UNION ALL
+       SELECT amount FROM expenses
+        WHERE user_id = $1 AND type = 'income'
+          AND COALESCE(distribute_to_budget, false) = true
+          AND date BETWEEN $2 AND $3
+     ) AS combined`,
+    [userId, from, to],
+  );
+  return Number(result.rows[0]?.total ?? 0);
+}

--- a/web/src/lib/users.ts
+++ b/web/src/lib/users.ts
@@ -19,6 +19,12 @@ export interface UserRow {
 export const findUserByKakaoId = async (kakaoId: number): Promise<UserRow | null> =>
   queryOne<UserRow>('SELECT * FROM users WHERE kakao_id = $1', [kakaoId]);
 
+/** cron 멀티유저 루프용 — 등록된 모든 user id */
+export const listAllUserIds = async (): Promise<number[]> => {
+  const result = await query<{ id: number }>('SELECT id FROM users ORDER BY id');
+  return result.rows.map((row) => row.id);
+};
+
 /** 유저 수 확인 */
 export const getUserCount = async (): Promise<number> => {
   const result = await queryOne<{ count: string }>('SELECT COUNT(*) as count FROM users');

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/cron/daily-budget-log",
       "schedule": "50 14 * * *"
+    },
+    {
+      "path": "/api/cron/monthly-settlement",
+      "schedule": "30 15 * * *"
     }
   ]
 }


### PR DESCRIPTION
## 관련 이슈
Closes #289
Epic: #282 (Budget Redesign)

## 변경 내용

### 1. v2 API 라우트 2개 신설 (네임스페이스 격리)
- `GET /api/budget/v2/monthly` — facade의 `getMonthlyAllocation` 노출
- `GET /api/budget/v2/today` — facade의 `getTodayAllocation` 노출
- 기존 `/api/budget`은 Phase 5 컷오버까지 병행 운영

### 2. 월 경계 정산 cron
- `GET /api/cron/monthly-settlement` 추가 (Vercel Cron, `30 15 * * *` UTC = 00:30 KST)
- 멀티유저 루프(`listAllUserIds`) + 유저별 `try-catch` 에러 격리
- `runSettlementIfDue`가 멱등이라 매일 실행해도 안전 (16일에만 실제 스냅샷)

### 3. `distribute_to_budget` 축 A/B 의미 분리
- `readDistributableIncomeTotal` 신규 — 자산에 유입되는 수입만 합산
- `computeTotalAvailable`에서 사용 전환 → 당월만 쓸 수입이 자산으로 흘러드는 버그 제거
- 정산 스냅샷의 `income_total`은 전체 기록용으로 `readIncomeTotal` 유지

## 코드 리뷰 결과
- [x] 보안 감사 통과 (크리덴셜, SQL Injection, 인증, 입력 검증, 로그 민감도)
- [x] 타입 안전성 확인 (tsc --noEmit)
- [x] 컨벤션 점검 완료 (named export, camelCase, try-catch 경계)
- [x] 코드 품질 확인 (149/149 테스트 통과)

## 테스트
- [x] facade 단위 테스트 `readDistributableIncomeTotal` mock 전환
- [x] 전체 vitest 149개 통과
- [x] TypeScript strict 체크 통과

## 범위 외 (Phase 5 이월)
- 기존 `/api/cron/daily-budget-log` userId=1 하드코딩
- 기존 `/api/budget` 라우트 교체/제거
- 프론트엔드 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)