### PR TITLE
refactor(budget): 설정/분석 계산 정합성 통합 — projectFromAllocator 도입

### DIFF
--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -1268,3 +1268,4 @@ insight 채널의 핵심 목표: 일기 데이터와 일운 분석을 비교하�
 | 2026-04-11 | **Insight 일주 할루시네이션 방지** — 프롬프트 경량화(PR #223) 이후 약화된 일주 가드레일 복원. 상단 일주 앵커 고정, 사주 연결 규칙에 역산 금지 명시, saju\_patterns 주의 문구 추가, fortune context 이중 앵커 구조. getDayPillar 중복 계산 제거 + 단위 테스트 3개 추가 (Issue #249, PR #250) |
 | 2026-04-15 | **예산 재설계 Phase 2** — DB 마이그레이션: `monthly_budget_snapshots` 테이블 신설 (과거 월 불변 스냅샷 구조). Phase 3(Repository/Facade) 준비 완료 (Issue #285, PR #286) |
 | 2026-04-15 | **예산 재설계 Phase 5 (최종)** — v2 아키텍처 전환 완료. 런웨이 프로젝션/월별 시뮬레이션/동적 일일 예산/cron 드리프트 보정 신규 구현. v1 API 라우트·queries.ts v1 함수·budget-calc.ts 전면 제거. budgets 테이블 DROP 마이그레이션 적용. 멀티유저 cron 지원. 3계층 구조(allocator/repository/facade) 완성 (Issue #291) |
+| 2026-04-15 | **설정/분석 계산 정합성 통합** — target\_date 있을 때 allocator 결과를 projection이 재사용하도록 리팩토링. current month prorated vs full-month drift(±1개월) 제거. `projectFromAllocator` 신규 추가 + `getRunwayProjection` 분기 적용 (Issue #294) |

--- a/web/src/features/budget/lib/allocator/__tests__/runway-projection.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/runway-projection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { projectRunway } from '../runway-projection';
+import { projectRunway, projectFromAllocator } from '../runway-projection';
+import type { MonthlyBudget } from '../../types-v2';
 
 const BASE = {
   billingMonth: '2026-04',
@@ -66,5 +67,38 @@ describe('projectRunway', () => {
       ...BASE, totalAvailable: 999_999_999, maxMonths: 5,
     });
     expect(projections.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('projectFromAllocator', () => {
+  it('allocator 결과 기반 projection — remaining이 target 끝에 0으로 수렴', () => {
+    // sum(free) = 1_000_000 (라운딩 오차 포함)
+    const monthlyBudgets: MonthlyBudget[] = [
+      { yearMonth: '2026-04', allocatedDays: 6,  fixed: 0, installments: 0, planned: 0, free: 46_875,  isCurrent: true  },
+      { yearMonth: '2026-05', allocatedDays: 30, fixed: 0, installments: 0, planned: 0, free: 234_375, isCurrent: false },
+      { yearMonth: '2026-06', allocatedDays: 31, fixed: 0, installments: 0, planned: 0, free: 242_188, isCurrent: false },
+      { yearMonth: '2026-07', allocatedDays: 30, fixed: 0, installments: 0, planned: 0, free: 234_375, isCurrent: false },
+      { yearMonth: '2026-08', allocatedDays: 31, fixed: 0, installments: 0, planned: 0, free: 242_187, isCurrent: false },
+    ];
+
+    const { projections, actualRunwayDate } = projectFromAllocator(1_000_000, monthlyBudgets, '2026-04');
+
+    expect(projections).toHaveLength(5);
+    expect(actualRunwayDate).toBe('2026-08');
+    expect(projections.at(-1)!.remaining).toBeLessThanOrEqual(1); // 라운딩 오차만
+  });
+
+  it('잠긴돈이 자산 초과 — target 전에 소진', () => {
+    const monthlyBudgets: MonthlyBudget[] = [
+      { yearMonth: '2026-04', allocatedDays: 6,  fixed: 500_000, installments: 0, planned: 0, free: 0, isCurrent: true  },
+      { yearMonth: '2026-05', allocatedDays: 30, fixed: 500_000, installments: 0, planned: 0, free: 0, isCurrent: false },
+      { yearMonth: '2026-06', allocatedDays: 31, fixed: 500_000, installments: 0, planned: 0, free: 0, isCurrent: false },
+      { yearMonth: '2026-07', allocatedDays: 30, fixed: 500_000, installments: 0, planned: 0, free: 0, isCurrent: false },
+    ];
+
+    const { projections } = projectFromAllocator(1_000_000, monthlyBudgets, '2026-04');
+
+    expect(projections.length).toBeLessThan(4); // target 전 소진
+    expect(projections.at(-1)!.remaining).toBe(0);
   });
 });

--- a/web/src/features/budget/lib/allocator/runway-projection.ts
+++ b/web/src/features/budget/lib/allocator/runway-projection.ts
@@ -1,4 +1,5 @@
 import { addBillingMonths } from '../billing/cycle';
+import type { MonthlyBudget } from '../types-v2';
 
 export interface ProjectionInstallmentInput {
   monthlyAmount: number;
@@ -38,7 +39,56 @@ export interface RunwayProjectionResult {
   actualRunwayDate: string;
 }
 
-/** 월별 자산 소진 시뮬레이션 (순수 함수) */
+interface MonthBurnBreakdown {
+  month: string;
+  fixed: number;
+  installments: number;
+  planned: number;
+  free: number;
+}
+
+/** 월별 burn 시퀀스 → projection 결과 (누적 remaining + actualRunway 계산) */
+function computeProjection(
+  totalAvailable: number,
+  burns: MonthBurnBreakdown[],
+  billingMonth: string,
+): RunwayProjectionResult {
+  const projections: MonthProjection[] = [];
+  let remaining = totalAvailable;
+
+  for (const b of burns) {
+    if (remaining <= 0) break;
+
+    const locked = b.fixed + b.installments + b.planned;
+    const netBurn = locked + b.free;
+    remaining -= netBurn;
+
+    projections.push({
+      month: b.month, fixed: b.fixed, installments: b.installments,
+      locked, free_budget: b.free, income: 0,
+      net_burn: netBurn, remaining: Math.max(remaining, 0),
+    });
+  }
+
+  let actualRunwayMonths = 0;
+  let actualRunwayDate = billingMonth;
+
+  if (projections.length > 0) {
+    const last = projections.at(-1)!;
+    if (remaining <= 0) {
+      const startOfLastMonth = remaining + last.net_burn;
+      const fraction = last.net_burn > 0 ? startOfLastMonth / last.net_burn : 0;
+      actualRunwayMonths = Math.round((projections.length - 1 + fraction) * 10) / 10;
+    } else {
+      actualRunwayMonths = projections.length;
+    }
+    actualRunwayDate = last.month;
+  }
+
+  return { projections, actualRunwayMonths, actualRunwayDate };
+}
+
+/** 동적 burn — freePerMonthEstimate 기반 시뮬레이션 (target 없을 때) */
 export function projectRunway(input: RunwayProjectionInput): RunwayProjectionResult {
   const {
     billingMonth,
@@ -50,10 +100,8 @@ export function projectRunway(input: RunwayProjectionInput): RunwayProjectionRes
     maxMonths = 120,
   } = input;
 
-  const projections: MonthProjection[] = [];
-  let remaining = totalAvailable;
-
-  for (let i = 0; i < maxMonths && remaining > 0; i++) {
+  const burns: MonthBurnBreakdown[] = [];
+  for (let i = 0; i < maxMonths; i++) {
     const month = addBillingMonths(billingMonth, i);
     const installmentSum = installments
       .filter((inst) => inst.remainingCount > i)
@@ -62,39 +110,24 @@ export function projectRunway(input: RunwayProjectionInput): RunwayProjectionRes
       .filter((p) => p.yearMonth === month)
       .reduce((s, p) => s + p.amount, 0);
 
-    const locked = fixedMonthly + installmentSum + plannedSum;
-    const netBurn = locked + freePerMonthEstimate;
-    remaining -= netBurn;
-
-    projections.push({
-      month,
-      fixed: fixedMonthly,
-      installments: installmentSum,
-      locked,
-      free_budget: freePerMonthEstimate,
-      income: 0,
-      net_burn: netBurn,
-      remaining: Math.max(remaining, 0),
+    burns.push({
+      month, fixed: fixedMonthly, installments: installmentSum,
+      planned: plannedSum, free: freePerMonthEstimate,
     });
-
-    if (remaining <= 0) break;
   }
 
-  let actualRunwayMonths = 0;
-  let actualRunwayDate = billingMonth;
+  return computeProjection(totalAvailable, burns, billingMonth);
+}
 
-  if (projections.length > 0) {
-    const last = projections.at(-1)!;
-    if (remaining <= 0) {
-      // remaining은 클램핑 전 음수값. 마지막 달 시작 잔고 = remaining + last.net_burn
-      const startOfLastMonth = remaining + last.net_burn;
-      const fraction = last.net_burn > 0 ? startOfLastMonth / last.net_burn : 0;
-      actualRunwayMonths = Math.round((projections.length - 1 + fraction) * 10) / 10;
-    } else {
-      actualRunwayMonths = projections.length;
-    }
-    actualRunwayDate = last.month;
-  }
-
-  return { projections, actualRunwayMonths, actualRunwayDate };
+/** allocator 결과 기반 projection — target 있을 때 정합성 보장 */
+export function projectFromAllocator(
+  totalAvailable: number,
+  monthlyBudgets: MonthlyBudget[],
+  billingMonth: string,
+): RunwayProjectionResult {
+  const burns: MonthBurnBreakdown[] = monthlyBudgets.map((mb) => ({
+    month: mb.yearMonth, fixed: mb.fixed, installments: mb.installments,
+    planned: mb.planned, free: mb.free,
+  }));
+  return computeProjection(totalAvailable, burns, billingMonth);
 }

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -205,9 +205,7 @@ describe('getRunwayProjection', () => {
     expect(result.projections[0]!.free_budget).toBe(200_000);
   });
 
-  it('free_per_month은 전체월 기준 — prorated(현재월 남은일수) 금지 + 런웨이 target 근사', async () => {
-    // April 10 (current cycle 31일, 남은일수 6일)
-    // 고정/할부/예정 0, 자산 1M, target 8월(5개월): 부풀림/prorated 없으면 런웨이가 target 근처에서 소진
+  it('target 설정 시 actual_runway_date === target_date (정합성 불변식)', async () => {
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(1_000_000);
     vi.mocked(readFixedCostsMonthlyTotal).mockResolvedValue(0);
     vi.mocked(readAvgVariableMonthly).mockResolvedValue(999_999); // 사용 안 됨 확인
@@ -215,13 +213,24 @@ describe('getRunwayProjection', () => {
 
     const result = await getRunwayProjection(1, DEFAULT_NOW);
 
-    // prorated(dailyFree × 6 ≈ 47k) 였으면 100k 아래 — 전체월(≈ 242k) 이어야 함
-    expect(result.free_per_month).not.toBeNull();
-    expect(result.free_per_month!).toBeGreaterThan(100_000);
+    expect(result.target_date).toBe('2026-08');
+    expect(result.actual_runway_date).toBe('2026-08'); // 정확히 일치
+    expect(result.projections).toHaveLength(5); // 4월 ~ 8월
+    expect(result.projections.at(-1)!.remaining).toBeLessThanOrEqual(10);
+  });
 
-    // 런웨이가 target(8월) 근처에서 끝나야 함. prorated 라면 수십 개월로 연장됨
-    expect(result.projections.length).toBeLessThanOrEqual(6);
-    expect(result.actual_runway_date.startsWith('2026-0')).toBe(true);
+  it('고정비/할부 있어도 target 정확히 일치', async () => {
+    vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
+    vi.mocked(readFixedCostsMonthlyTotal).mockResolvedValue(500_000);
+    vi.mocked(readActiveInstallments).mockResolvedValue([
+      { monthlyAmount: 100_000, remainingCount: 3, isNew: false },
+    ]);
+    vi.mocked(readTargetMonth).mockResolvedValue('2026-08');
+
+    const result = await getRunwayProjection(1, DEFAULT_NOW);
+
+    expect(result.actual_runway_date).toBe('2026-08');
+    expect(result.projections[0]!.installments).toBeGreaterThan(0);
   });
 });
 

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -2,7 +2,7 @@ import { getBillingCycle, getBillingRange } from './billing/cycle';
 import { calcAllocatedDays } from './allocator/proration';
 import { allocateMonthlyBudgets } from './allocator/month-allocator';
 import { allocateTodayBudget } from './allocator/day-allocator';
-import { projectRunway } from './allocator/runway-projection';
+import { projectRunway, projectFromAllocator } from './allocator/runway-projection';
 import { detectSettlementTrigger, buildSettlementSnapshot } from './settlement/settle';
 
 import { readDistributableAssetBalance } from './repository/assets-repo';
@@ -145,33 +145,38 @@ export async function getRunwayProjection(
     readTargetMonth(userId),
   ]);
 
-  const planned = await readPlannedExpenses(userId, cycle.yearMonth, targetDate ?? cycle.yearMonth);
   const totalAvailable = await computeTotalAvailable(userId, todayStr);
-
   const freePerMonth = monthly.freePerMonth;
-  const freePerMonthEstimate = freePerMonth ?? avgVariableMonthly;
 
-  const { projections, actualRunwayMonths, actualRunwayDate } = projectRunway({
-    billingMonth: cycle.yearMonth,
-    totalAvailable,
-    fixedMonthly,
-    installments: installments.map((inst) => ({
-      monthlyAmount: inst.monthlyAmount,
-      remainingCount: inst.remainingCount,
-    })),
-    plannedExpenses: planned,
-    freePerMonthEstimate,
-  });
+  let projResult;
+  if (targetDate && monthly.monthlyBudgets.length > 0) {
+    // target 있음 → allocator 결과 재사용 (정합성 보장)
+    projResult = projectFromAllocator(totalAvailable, monthly.monthlyBudgets, cycle.yearMonth);
+  } else {
+    // target 없음 → 평균 지출 기반 시뮬레이션
+    const planned = await readPlannedExpenses(userId, cycle.yearMonth, cycle.yearMonth);
+    projResult = projectRunway({
+      billingMonth: cycle.yearMonth,
+      totalAvailable,
+      fixedMonthly,
+      installments: installments.map((inst) => ({
+        monthlyAmount: inst.monthlyAmount,
+        remainingCount: inst.remainingCount,
+      })),
+      plannedExpenses: planned,
+      freePerMonthEstimate: avgVariableMonthly,
+    });
+  }
 
   return {
-    actual_runway_months: actualRunwayMonths,
-    actual_runway_date: actualRunwayDate,
+    actual_runway_months: projResult.actualRunwayMonths,
+    actual_runway_date: projResult.actualRunwayDate,
     free_per_month: freePerMonth,
     effective_available: totalAvailable,
     fixed_monthly: fixedMonthly,
     avg_variable_monthly: avgVariableMonthly,
     target_date: targetDate,
-    projections,
+    projections: projResult.projections,
   };
 }
 


### PR DESCRIPTION
## 관련 이슈
Closes #294

## 변경 내용
- `projectFromAllocator` 신규 추가 — allocator의 `monthlyBudgets`를 그대로 projection burn 시퀀스로 변환
- `computeProjection` 헬퍼 추출 — `projectRunway`와 `projectFromAllocator`가 누적 remaining 계산 로직 공유
- `getRunwayProjection` 분기 추가 — `target_date` 있을 때 allocator 결과 재사용, 없을 때 기존 `avgVariableMonthly` 기반 시뮬레이션 유지

## 코드 리뷰 결과
- [x] 보안 감사 통과
- [x] 타입 안전성 확인
- [x] 컨벤션 점검 완료
- [x] 코드 품질 확인 (파일 134줄, 함수 30줄 이하)

## 테스트
- [x] `projectFromAllocator` — allocator 합산이 totalAvailable과 정확히 수렴 (라운딩 오차 ≤ 1)
- [x] `projectFromAllocator` — 잠긴돈 초과 시 target 전 소진
- [x] `projectRunway` 기존 7개 테스트 회귀 없음
- [x] `getRunwayProjection` — `actual_runway_date === target_date` 정합성 불변식
- [x] `getRunwayProjection` — 고정비/할부 있어도 target 정확히 일치
- [x] 전체 vitest 스위트 128개 통과