### PR TITLE
fix(routine): 시작일 이전엔 체크리스트 생성하지 않도록 수정

### DIFF
--- a/src/shared/__tests__/life-queries.test.ts
+++ b/src/shared/__tests__/life-queries.test.ts
@@ -75,6 +75,17 @@ describe('shouldCreateToday', () => {
   it('알 수 없는 빈도는 true', () => {
     expect(shouldCreateToday('unknown', '2026-03-07', '2026-03-08')).toBe(true);
   });
+
+  it('시작일이 미래면 빈도와 무관하게 false', () => {
+    expect(shouldCreateToday('매일', null, '2026-03-08', '2026-03-09')).toBe(false);
+    expect(shouldCreateToday('격일', null, '2026-03-08', '2026-03-09')).toBe(false);
+    expect(shouldCreateToday('주1회', null, '2026-03-08', '2026-03-09')).toBe(false);
+    expect(shouldCreateToday('3일마다', null, '2026-03-08', '2026-03-09')).toBe(false);
+  });
+
+  it('시작일이 오늘이면 매일은 true', () => {
+    expect(shouldCreateToday('매일', null, '2026-03-08', '2026-03-08')).toBe(true);
+  });
 });
 
 // ─── frequencyBadge ────────────────────────────────────

--- a/src/shared/life-queries.ts
+++ b/src/shared/life-queries.ts
@@ -75,6 +75,9 @@ export const shouldCreateToday = (
   today: string,
   startDate?: string,
 ): boolean => {
+  // 시작일이 미래면 생성하지 않음 (YYYY-MM-DD는 사전순 비교 = 시간순 비교)
+  if (startDate && today < startDate) return false;
+
   if (frequency === '매일') return true;
 
   // 간격 빈도(격일, N일마다): start_date 기준 모듈러 연산

--- a/web/src/features/routine/lib/queries.ts
+++ b/web/src/features/routine/lib/queries.ts
@@ -142,6 +142,9 @@ function parseIntervalDays(frequency: string): number | null {
 }
 
 function shouldCreateToday(frequency: string | null, lastDate: string | null, today: string, startDate?: string): boolean {
+  // 시작일이 미래면 생성하지 않음 (YYYY-MM-DD는 사전순 비교 = 시간순 비교)
+  if (startDate && today < startDate) return false;
+
   if (!frequency || frequency === '매일') return true;
 
   // 간격 빈도(격일, N일마다, 주1회): start_date 기준 모듈러 연산


### PR DESCRIPTION
## Summary
- 매일 빈도 루틴 추가 시 `start_date`를 미래로 설정해도 오늘 체크리스트에 즉시 노출되던 문제 수정
- `shouldCreateToday()` 진입부에 `today < startDate` 가드 추가 — 빈도 종류와 무관하게 시작일 이전에는 record 미생성
- 봇/크론 (`src/shared/life-queries.ts`) + 웹 (`web/src/features/routine/lib/queries.ts`) 동일 수정 적용

## Test plan
- [x] `shouldCreateToday` 단위 테스트 통과 (미래 시작일 케이스 4건 + 시작일 == 오늘 케이스 1건 추가)
- [ ] 배포 후 매일 빈도 루틴을 내일 시작일로 추가 → 오늘 체크리스트에 안 뜨는지 확인
- [ ] 내일 09:05 크론 알림에서 정상적으로 노출되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)