### PR TITLE
feat(routine): 시작일 변경 시 이전 기록 자동 정리

### DIFF
--- a/web/src/app/api/routines/[id]/records/route.ts
+++ b/web/src/app/api/routines/[id]/records/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
+import { requireAuth } from '@/lib/auth';
+import { deleteRecordsBefore } from '@/features/routine/lib/queries';
+
+/** 특정 날짜 이전의 완료된 기록 일괄 삭제 (시작일 변경 후 정리용) */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const userId = await requireAuth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const { id } = await params;
+    const before = new URL(request.url).searchParams.get('before');
+    if (!before || !/^\d{4}-\d{2}-\d{2}$/.test(before)) {
+      return NextResponse.json({ error: 'before 파라미터(YYYY-MM-DD)가 필요해' }, { status: 400 });
+    }
+
+    const deleted = await deleteRecordsBefore(userId, Number(id), before, true);
+
+    revalidateTag('routine-records', 'seconds');
+    revalidateTag('routine-stats', 'seconds');
+    return NextResponse.json({ data: { deleted } });
+  } catch {
+    return NextResponse.json({ error: '기록 삭제 실패' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/routines/[id]/route.ts
+++ b/web/src/app/api/routines/[id]/route.ts
@@ -8,6 +8,9 @@ import {
   deleteRoutineTemplate,
   createInactivePeriod,
   closeOpenInactivePeriod,
+  queryRoutineTemplate,
+  deleteRecordsBefore,
+  countCompletedRecordsBefore,
 } from '@/features/routine/lib/queries';
 
 export async function PATCH(
@@ -37,6 +40,10 @@ export async function PATCH(
       return NextResponse.json({ error: lengthError }, { status: 400 });
     }
 
+    // 시작일 변경 감지를 위해 이전 값 미리 조회
+    const oldTemplate = await queryRoutineTemplate(userId, numId);
+    if (!oldTemplate) return NextResponse.json({ error: '루틴을 찾을 수 없어' }, { status: 404 });
+
     const data = await updateRoutineTemplate(userId, numId, body);
     if (!data) return NextResponse.json({ error: '루틴을 찾을 수 없어' }, { status: 404 });
 
@@ -49,10 +56,17 @@ export async function PATCH(
       await closeOpenInactivePeriod(userId, numId, addDays(getTodayISO(), -1));
     }
 
+    // 시작일이 미래로 이동된 경우 이전 기록 정리 (미완료만 자동, 완료는 카운트만 반환)
+    let staleCompletedCount = 0;
+    if (data.start_date && oldTemplate.start_date && data.start_date > oldTemplate.start_date) {
+      await deleteRecordsBefore(userId, numId, data.start_date, false);
+      staleCompletedCount = await countCompletedRecordsBefore(userId, numId, data.start_date);
+    }
+
     revalidateTag('routines', 'seconds');
     revalidateTag('routine-records', 'seconds');
     revalidateTag('routine-stats', 'seconds');
-    return NextResponse.json({ data });
+    return NextResponse.json({ data, staleCompletedCount });
   } catch {
     return NextResponse.json({ error: '루틴 수정 실패' }, { status: 500 });
   }

--- a/web/src/features/routine/hooks/use-routines.ts
+++ b/web/src/features/routine/hooks/use-routines.ts
@@ -110,10 +110,22 @@ export function useRoutines() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
-      if (res.ok) {
-        setEditingTemplate(null);
-        await fetchData();
+      if (!res.ok) return;
+      const { data: template, staleCompletedCount } = (await res.json()) as {
+        data: RoutineTemplateRow;
+        staleCompletedCount: number;
+      };
+      // 시작일 이전 완료 기록이 남아있으면 확인 후 추가 정리
+      if (staleCompletedCount > 0 && template?.start_date) {
+        const ok = confirm(`시작일 이전에 완료한 기록 ${staleCompletedCount}개도 같이 지울까?`);
+        if (ok) {
+          await fetch(`/api/routines/${id}/records?before=${template.start_date}`, {
+            method: 'DELETE',
+          });
+        }
       }
+      setEditingTemplate(null);
+      await fetchData();
     },
     [fetchData],
   );

--- a/web/src/features/routine/lib/queries.ts
+++ b/web/src/features/routine/lib/queries.ts
@@ -68,6 +68,50 @@ export async function updateRoutineTemplate(
   );
 }
 
+/** 템플릿 단건 조회 (삭제되지 않은 것) */
+export async function queryRoutineTemplate(
+  userId: number,
+  id: number,
+): Promise<RoutineTemplateRow | null> {
+  return queryOne<RoutineTemplateRow>(
+    `SELECT id, name, time_slot, frequency, active, start_date::text, created_at::text
+     FROM routine_templates
+     WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+    [id, userId],
+  );
+}
+
+/** 특정 날짜 이전 기록 삭제 (includeCompleted=false면 미완료만) */
+export async function deleteRecordsBefore(
+  userId: number,
+  templateId: number,
+  before: string,
+  includeCompleted: boolean,
+): Promise<number> {
+  const completedFilter = includeCompleted ? '' : 'AND completed = false';
+  const result = await query(
+    `DELETE FROM routine_records
+     WHERE template_id = $1 AND user_id = $2 AND date < $3
+     ${completedFilter}`,
+    [templateId, userId, before],
+  );
+  return result.rowCount ?? 0;
+}
+
+/** 특정 날짜 이전 완료된 기록 개수 */
+export async function countCompletedRecordsBefore(
+  userId: number,
+  templateId: number,
+  before: string,
+): Promise<number> {
+  const row = await queryOne<{ count: number }>(
+    `SELECT COUNT(*)::int AS count FROM routine_records
+     WHERE template_id = $1 AND user_id = $2 AND date < $3 AND completed = true`,
+    [templateId, userId, before],
+  );
+  return row?.count ?? 0;
+}
+
 /** 템플릿 삭제 (soft delete — UI에서 완전히 숨김, DB에는 보존) */
 export async function deleteRoutineTemplate(userId: number, id: number): Promise<boolean> {
   const result = await query(


### PR DESCRIPTION
## Summary
- 시작일이 미래로 이동된 PATCH 시 미완료 기록은 자동 DELETE — UI에서 더 이상 노출되지 않도록 즉시 반영
- 완료된 기록은 자동 삭제하지 않고 `staleCompletedCount`로 응답에 포함 → 프론트가 confirm 다이얼로그로 사용자에게 추가 정리 의사 확인
- 신규 엔드포인트 `DELETE /api/routines/[id]/records?before=YYYY-MM-DD` — 사용자 확인 후 완료된 기록까지 일괄 삭제 (정규식 검증 + 본인 user_id 필터)

## Test plan
- [x] 타입 체크 통과 (`yarn tsc --noEmit` web/bot 양쪽)
- [ ] 시작일을 과거 → 미래로 변경 시 이전 미완료 record가 체크리스트에서 사라지는지
- [ ] 변경 시점 이전에 완료된 record가 있으면 confirm 다이얼로그가 뜨는지
- [ ] 다이얼로그 확인 시 완료 record까지 정리되는지
- [ ] 시작일을 그대로 두거나 과거로 이동 시 기존 동작 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)