### PR TITLE
fix(budget): 예정지출 연결 기능 수정 + 수정 모달 폼 추가

### DIFF
--- a/web/src/app/budget/manage/page.tsx
+++ b/web/src/app/budget/manage/page.tsx
@@ -28,6 +28,7 @@ export default function ManagePage() {
     selectedMonth, setSelectedMonth,
     expenses, summary,
     loading, error,
+    expenseVersion,
     addExpense, deleteExpense, updateExpense,
   } = useBudget();
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
@@ -59,7 +60,7 @@ export default function ManagePage() {
 
       {/* 예정 지출 */}
       <div className="mb-4">
-        <PlannedExpenseList yearMonth={selectedMonth} />
+        <PlannedExpenseList yearMonth={selectedMonth} refreshTrigger={expenseVersion} />
       </div>
 
       {/* 지출 추가 폼 */}
@@ -109,6 +110,7 @@ export default function ManagePage() {
       {editingExpense && editingExpense.type !== 'income' && (
         <ExpenseEditModal
           expense={editingExpense}
+          yearMonth={selectedMonth}
           onSave={updateExpense}
           onDelete={deleteExpense}
           onClose={() => setEditingExpense(null)}

--- a/web/src/features/budget/components/expense-edit-modal.tsx
+++ b/web/src/features/budget/components/expense-edit-modal.tsx
@@ -1,28 +1,50 @@
 'use client';
 
-import { useState } from 'react';
-import type { ExpenseRow } from '@/features/budget/lib/types';
+import { useState, useEffect } from 'react';
+import type { ExpenseRow, PlannedExpenseRow } from '@/features/budget/lib/types';
 import { EXPENSE_CATEGORIES, BUDGET_EXCLUDED_CATEGORIES } from '@/features/budget/lib/types';
+import { formatAmount } from '@/lib/types';
 import { XMarkIcon } from '@/components/ui/icons';
 import { Button } from '@/components/ui/button';
 import { Input, Select } from '@/components/ui/input';
 
 interface ExpenseEditModalProps {
   expense: ExpenseRow;
-  onSave: (id: number, updates: { date: string; amount: number; category: string; description: string | null; exclude_from_budget: boolean }) => Promise<void>;
+  /** 현재 보고 있는 결제주기 월 (예정 지출 목록용) */
+  yearMonth?: string;
+  onSave: (id: number, updates: {
+    date: string;
+    amount: number;
+    category: string;
+    description: string | null;
+    exclude_from_budget: boolean;
+    planned_expense_id: number | null;
+  }) => Promise<void>;
   onDelete: (id: number) => Promise<void>;
   onClose: () => void;
 }
 
-export function ExpenseEditModal({ expense, onSave, onDelete, onClose }: ExpenseEditModalProps) {
+export function ExpenseEditModal({ expense, yearMonth, onSave, onDelete, onClose }: ExpenseEditModalProps) {
   const [deleting, setDeleting] = useState(false);
   const [date, setDate] = useState(expense.date);
   const [amountStr, setAmountStr] = useState(expense.amount.toLocaleString('ko-KR'));
   const [category, setCategory] = useState(expense.category);
   const [description, setDescription] = useState(expense.description ?? '');
   const [excludeFromBudget, setExcludeFromBudget] = useState(expense.exclude_from_budget);
+  const [selectedPlanned, setSelectedPlanned] = useState<number | null>(expense.planned_expense_id);
+  const [plannedExpenses, setPlannedExpenses] = useState<PlannedExpenseRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const showPlannedSelect = yearMonth && !expense.is_installment && expense.type !== 'income';
+
+  useEffect(() => {
+    if (!showPlannedSelect) return;
+    void fetch(`/api/budget/planned-expenses?yearMonth=${yearMonth}`)
+      .then((r) => r.json())
+      .then((d: { data?: PlannedExpenseRow[] }) => setPlannedExpenses(d.data ?? []))
+      .catch(() => setPlannedExpenses([]));
+  }, [yearMonth, showPlannedSelect]);
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value.replace(/[^0-9]/g, '');
@@ -51,6 +73,7 @@ export function ExpenseEditModal({ expense, onSave, onDelete, onClose }: Expense
         category,
         description: description || null,
         exclude_from_budget: excludeFromBudget,
+        planned_expense_id: selectedPlanned,
       });
       onClose();
     } catch (err) {
@@ -156,6 +179,28 @@ export function ExpenseEditModal({ expense, onSave, onDelete, onClose }: Expense
               </button>
             </div>
           </div>
+
+          {/* 예정 지출 연결 (일시불 지출만, 할부/수입 제외) */}
+          {showPlannedSelect && plannedExpenses.length > 0 && (
+            <div>
+              <Select
+                label="예정 지출 연결"
+                value={selectedPlanned ?? ''}
+                onChange={(e) => setSelectedPlanned(e.target.value ? Number(e.target.value) : null)}
+              >
+                <option value="">일반 지출 (일일 예산 차감)</option>
+                {plannedExpenses.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.memo ?? '예정 지출'} — {formatAmount(p.amount)}
+                    {(p.used_amount ?? 0) > 0 && ` (사용 ${formatAmount(p.used_amount ?? 0)})`}
+                  </option>
+                ))}
+              </Select>
+              {selectedPlanned && (
+                <p className="mt-1 text-[10px] text-blue-500">이 지출은 일일 예산에 영향을 주지 않습니다</p>
+              )}
+            </div>
+          )}
 
           {/* Error */}
           {error && (

--- a/web/src/features/budget/components/planned-expense-list.tsx
+++ b/web/src/features/budget/components/planned-expense-list.tsx
@@ -7,9 +7,11 @@ import { XMarkIcon } from '@/components/ui/icons';
 
 interface PlannedExpenseListProps {
   yearMonth: string;
+  /** 지출 변경 시 리프레시 트리거 (카운터) */
+  refreshTrigger?: number;
 }
 
-export function PlannedExpenseList({ yearMonth }: PlannedExpenseListProps) {
+export function PlannedExpenseList({ yearMonth, refreshTrigger }: PlannedExpenseListProps) {
   const [items, setItems] = useState<PlannedExpenseRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -30,7 +32,9 @@ export function PlannedExpenseList({ yearMonth }: PlannedExpenseListProps) {
     }
   }, [yearMonth]);
 
-  useEffect(() => { void fetchItems(); }, [fetchItems]);
+  // yearMonth 변경 또는 지출 변경(refreshTrigger) 시 예정지출 목록 리프레시
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { void fetchItems(); }, [fetchItems, refreshTrigger]);
 
   const handleAdd = async () => {
     const amount = parseInt(amountInput.replace(/,/g, ''), 10);

--- a/web/src/features/budget/hooks/use-budget.ts
+++ b/web/src/features/budget/hooks/use-budget.ts
@@ -51,6 +51,7 @@ export function useBudget() {
   const [fixedCosts, setFixedCosts] = useState<FixedCostRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [expenseVersion, setExpenseVersion] = useState(0);
 
   const fetchJson = useCallback(async <T,>(url: string): Promise<T | null> => {
     try {
@@ -240,6 +241,7 @@ export function useBudget() {
         setExpenses((prev) => [newExpense, ...prev]);
         void refreshBudget(selectedMonth).catch(() => {});
       }
+      setExpenseVersion((v) => v + 1);
       return newExpense;
     },
     [selectedMonth, refreshBudget],
@@ -252,11 +254,12 @@ export function useBudget() {
       throw new Error(err.error ?? '지출 삭제 실패');
     }
     setExpenses((prev) => prev.filter((e) => e.id !== id));
+    setExpenseVersion((v) => v + 1);
     void refreshBudget(selectedMonth).catch(() => {});
   }, [selectedMonth, refreshBudget]);
 
   const updateExpense = useCallback(
-    async (id: number, updates: { date: string; amount: number; category: string; description: string | null; exclude_from_budget?: boolean }): Promise<void> => {
+    async (id: number, updates: { date: string; amount: number; category: string; description: string | null; exclude_from_budget?: boolean; planned_expense_id?: number | null }): Promise<void> => {
       const res = await fetch(`/api/expenses/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -268,6 +271,7 @@ export function useBudget() {
       }
       const { data } = (await res.json()) as { data: ExpenseRow };
       setExpenses((prev) => prev.map((e) => (e.id === id ? data : e)));
+      setExpenseVersion((v) => v + 1);
       void refreshBudget(selectedMonth).catch(() => {});
     },
     [selectedMonth, refreshBudget],
@@ -296,6 +300,7 @@ export function useBudget() {
     fixedCosts,
     loading,
     error,
+    expenseVersion,
     addExpense,
     deleteExpense,
     updateExpense,

--- a/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '@/lib/db';
+import { readFlexibleSpent, readTodayFlexSpent } from '../expenses-repo';
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
+type Any = any;
+
+describe('readFlexibleSpent', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('planned_expense_id IS NULL 조건이 SQL에 포함되어야 함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '50000' }] } as Any);
+
+    await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
+  });
+
+  it('예정지출 연결 건이 자유지출 합계에 포함되지 않아야 함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '30000' }] } as Any);
+
+    const result = await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
+
+    expect(result).toBe(30000);
+    // SQL이 planned_expense_id IS NULL을 포함하므로, 연결된 건은 이미 제외됨
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
+  });
+
+  it('기본 필터 조건: expense 타입, exclude_from_budget=false, is_installment=false', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+
+    await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
+
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/exclude_from_budget\s*=\s*false/i);
+    expect(sql).toMatch(/is_installment\s*=\s*false/i);
+    expect(sql).toMatch(/type.*expense/i);
+  });
+});
+
+describe('readTodayFlexSpent', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('planned_expense_id IS NULL 조건이 SQL에 포함되어야 함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '15000' }] } as Any);
+
+    await readTodayFlexSpent(1, '2026-04-10');
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
+  });
+
+  it('예정지출 연결 건이 오늘 자유지출에 포함되지 않아야 함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '10000' }] } as Any);
+
+    const result = await readTodayFlexSpent(1, '2026-04-10');
+
+    expect(result).toBe(10000);
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
+  });
+});

--- a/web/src/features/budget/lib/repository/expenses-repo.ts
+++ b/web/src/features/budget/lib/repository/expenses-repo.ts
@@ -12,6 +12,7 @@ export async function readFlexibleSpent(
        AND COALESCE(type, 'expense') = 'expense'
        AND exclude_from_budget = false
        AND is_installment = false
+       AND planned_expense_id IS NULL
        AND date BETWEEN $2 AND $3`,
     [userId, from, to],
   );
@@ -46,6 +47,7 @@ export async function readTodayFlexSpent(
        AND COALESCE(type, 'expense') = 'expense'
        AND exclude_from_budget = false
        AND is_installment = false
+       AND planned_expense_id IS NULL
        AND date = $2::date`,
     [userId, today],
   );


### PR DESCRIPTION
## Summary
- 예정지출 연결 지출이 자유지출(일일 예산)에서 이중 차감되는 버그 수정
- 지출 수정 모달에 예정지출 연결/해제 드롭다운 추가
- 지출 변경 시 예정지출 카드 실시간 리프레시

## Changes
- `readFlexibleSpent`/`readTodayFlexSpent`에 `planned_expense_id IS NULL` 필터 추가
- `expense-edit-modal.tsx`에 예정지출 선택 UI 추가 (할부/수입 제외)
- `use-budget.ts`에 `expenseVersion` 카운터 → `PlannedExpenseList` 리프레시 트리거
- `expenses-repo.test.ts` 테스트 5건 추가

## Test plan
- [x] 기존 테스트 172건 통과
- [x] 신규 테스트 5건 통과 (expenses-repo planned_expense_id 필터 검증)
- [x] 빌드 성공
- [ ] 예정지출 연결하여 지출 기록 → 일일 예산 변동 없음 확인
- [ ] 수정 모달에서 예정지출 연결/해제 → 예정지출 카드 실시간 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)