### PR TITLE
feat(budget): 예정지출 수정 모달 + 연결 지출 내역 표시

### DIFF
--- a/web/src/app/api/budget/planned-expenses/route.ts
+++ b/web/src/app/api/budget/planned-expenses/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { queryPlannedExpenses, createPlannedExpense, deletePlannedExpense } from '@/features/budget/lib/queries';
+import { queryPlannedExpenses, createPlannedExpense, updatePlannedExpense, deletePlannedExpense } from '@/features/budget/lib/queries';
 
 export const dynamic = 'force-dynamic';
 
@@ -39,6 +39,30 @@ export async function POST(request: Request) {
   } catch (err) {
     console.error('[Budget API]', request.url, err);
     return NextResponse.json({ error: '예정 지출 추가 실패' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request) {
+  const userId = await requireAuth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const body = (await request.json()) as { id?: number; amount?: number; memo?: string | null };
+    const { id, amount, memo } = body;
+
+    if (!id || typeof id !== 'number') {
+      return NextResponse.json({ error: 'id 필수' }, { status: 400 });
+    }
+    if (amount !== undefined && (typeof amount !== 'number' || amount <= 0)) {
+      return NextResponse.json({ error: 'amount는 양수여야 합니다' }, { status: 400 });
+    }
+
+    const data = await updatePlannedExpense(userId, id, { amount, memo });
+    if (!data) return NextResponse.json({ error: '항목을 찾을 수 없습니다' }, { status: 404 });
+    return NextResponse.json({ data });
+  } catch (err) {
+    console.error('[Budget API]', request.url, err);
+    return NextResponse.json({ error: '예정 지출 수정 실패' }, { status: 500 });
   }
 }
 

--- a/web/src/app/api/expenses/route.ts
+++ b/web/src/app/api/expenses/route.ts
@@ -19,6 +19,7 @@ export async function GET(request: Request) {
     const from = searchParams.get('from') ?? today.slice(0, 7) + '-01';
     const to = searchParams.get('to') ?? today;
     const category = searchParams.get('category') ?? undefined;
+    const plannedExpenseId = searchParams.get('planned_expense_id');
 
     if (!/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
       return NextResponse.json({ error: 'from/to 날짜 형식이 올바르지 않습니다 (YYYY-MM-DD)' }, { status: 400 });
@@ -27,7 +28,7 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: '유효하지 않은 category입니다' }, { status: 400 });
     }
 
-    const data = await queryExpenses(userId, from, to, category);
+    const data = await queryExpenses(userId, from, to, category, plannedExpenseId ? Number(plannedExpenseId) : undefined);
     return NextResponse.json({ data });
   } catch (err) {
     console.error('[Expense API]', request.url, err);

--- a/web/src/features/budget/components/planned-expense-edit-modal.tsx
+++ b/web/src/features/budget/components/planned-expense-edit-modal.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import type { PlannedExpenseRow, ExpenseRow } from '@/features/budget/lib/types';
+import { formatAmount } from '@/lib/types';
+import { XMarkIcon } from '@/components/ui/icons';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface PlannedExpenseEditModalProps {
+  item: PlannedExpenseRow;
+  yearMonth: string;
+  onSave: (id: number, updates: { amount: number; memo: string | null }) => Promise<void>;
+  onDelete: (id: number) => Promise<void>;
+  onClose: () => void;
+}
+
+export function PlannedExpenseEditModal({ item, yearMonth, onSave, onDelete, onClose }: PlannedExpenseEditModalProps) {
+  const [amountStr, setAmountStr] = useState(item.amount.toLocaleString('ko-KR'));
+  const [memo, setMemo] = useState(item.memo ?? '');
+  const [linkedExpenses, setLinkedExpenses] = useState<ExpenseRow[]>([]);
+  const [loadingExpenses, setLoadingExpenses] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 연결된 지출 내역 로드
+  useEffect(() => {
+    const [year, month] = yearMonth.split('-').map(Number);
+    const prevMonth = month === 1 ? 12 : month - 1;
+    const prevYear = month === 1 ? year - 1 : year;
+    const from = `${prevYear}-${String(prevMonth).padStart(2, '0')}-16`;
+    const to = `${year}-${String(month).padStart(2, '0')}-15`;
+
+    void fetch(`/api/expenses?from=${from}&to=${to}&planned_expense_id=${item.id}`)
+      .then((r) => r.json())
+      .then((d: { data?: ExpenseRow[] }) => setLinkedExpenses(d.data ?? []))
+      .catch(() => setLinkedExpenses([]))
+      .finally(() => setLoadingExpenses(false));
+  }, [item.id, yearMonth]);
+
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.replace(/[^0-9]/g, '');
+    const num = parseInt(raw, 10);
+    setAmountStr(raw ? num.toLocaleString('ko-KR') : '');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const amount = parseInt(amountStr.replace(/,/g, ''), 10);
+    if (isNaN(amount) || amount <= 0) {
+      setError('금액을 올바르게 입력해주세요');
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSave(item.id, { amount, memo: memo.trim() || null });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '수정 실패');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (linkedExpenses.length > 0) {
+      if (!confirm(`연결된 지출 ${linkedExpenses.length}건이 일반 지출로 전환됩니다. 삭제할까요?`)) return;
+    } else {
+      if (!confirm('이 예정 지출을 삭제할까요?')) return;
+    }
+    setDeleting(true);
+    try {
+      await onDelete(item.id);
+      onClose();
+    } catch {
+      setDeleting(false);
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const used = item.used_amount ?? 0;
+  const remaining = item.amount - used;
+  const isOver = used > item.amount;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={handleBackdropClick}
+    >
+      <div className="w-full max-w-md rounded-xl bg-white p-5 shadow-lg">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-700">예정 지출 수정</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 transition hover:text-gray-600"
+          >
+            <XMarkIcon size={18} />
+          </button>
+        </div>
+
+        {/* 사용 현황 */}
+        <div className="mb-4 rounded-lg bg-gray-50 px-3 py-2.5">
+          <div className="flex items-center justify-between text-xs text-gray-500">
+            <span>사용 {formatAmount(used)} / {formatAmount(item.amount)}</span>
+            <span className={isOver ? 'font-medium text-red-500' : ''}>
+              {isOver ? `${formatAmount(Math.abs(remaining))} 초과` : `${formatAmount(remaining)} 남음`}
+            </span>
+          </div>
+          {item.amount > 0 && (
+            <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-gray-200">
+              <div
+                className={`h-full rounded-full transition-all ${isOver ? 'bg-red-400' : 'bg-blue-400'}`}
+                style={{ width: `${Math.min((used / item.amount) * 100, 100)}%` }}
+              />
+            </div>
+          )}
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3">
+          <Input
+            label="예산 금액 (원)"
+            type="text"
+            inputMode="numeric"
+            value={amountStr}
+            onChange={handleAmountChange}
+            placeholder="0"
+            required
+          />
+
+          <Input
+            label="메모"
+            type="text"
+            value={memo}
+            onChange={(e) => setMemo(e.target.value)}
+            placeholder="예: 여행, 선물"
+          />
+
+          {/* 연결된 지출 내역 */}
+          <div>
+            <label className="mb-1 block text-xs text-gray-500">
+              연결된 지출 내역 ({linkedExpenses.length}건)
+            </label>
+            <div className="max-h-40 overflow-y-auto rounded-lg border border-gray-200">
+              {loadingExpenses ? (
+                <div className="px-3 py-2 text-xs text-gray-400">불러오는 중...</div>
+              ) : linkedExpenses.length === 0 ? (
+                <div className="px-3 py-2 text-xs text-gray-400">연결된 지출 없음</div>
+              ) : (
+                <div className="divide-y divide-gray-100">
+                  {linkedExpenses.map((exp) => (
+                    <div key={exp.id} className="flex items-center justify-between px-3 py-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-gray-400">{exp.date}</span>
+                        <span className="text-xs text-gray-700">{exp.description ?? exp.category}</span>
+                      </div>
+                      <span className="text-xs font-medium text-gray-700">{formatAmount(exp.amount)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-1 text-xs text-red-500">
+              <XMarkIcon size={13} />
+              {error}
+            </div>
+          )}
+
+          {/* Buttons */}
+          <div className="flex items-center justify-between pt-1">
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deleting}
+              onClick={() => void handleDelete()}
+            >
+              {deleting ? '삭제 중...' : '삭제'}
+            </Button>
+            <div className="flex items-center gap-2">
+              <Button type="button" variant="ghost" onClick={onClose}>
+                취소
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? '저장 중...' : '저장'}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/budget/components/planned-expense-list.tsx
+++ b/web/src/features/budget/components/planned-expense-list.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { PlannedExpenseRow } from '@/features/budget/lib/types';
 import { formatAmount } from '@/lib/types';
-import { XMarkIcon } from '@/components/ui/icons';
+import { PlannedExpenseEditModal } from './planned-expense-edit-modal';
 
 interface PlannedExpenseListProps {
   yearMonth: string;
@@ -18,6 +18,7 @@ export function PlannedExpenseList({ yearMonth, refreshTrigger }: PlannedExpense
   const [amountInput, setAmountInput] = useState('');
   const [memoInput, setMemoInput] = useState('');
   const [saving, setSaving] = useState(false);
+  const [editingItem, setEditingItem] = useState<PlannedExpenseRow | null>(null);
 
   const fetchItems = useCallback(async () => {
     setLoading(true);
@@ -58,15 +59,24 @@ export function PlannedExpenseList({ yearMonth, refreshTrigger }: PlannedExpense
     }
   };
 
-  const handleDelete = async (id: number) => {
-    try {
-      const res = await fetch(`/api/budget/planned-expenses?id=${id}`, { method: 'DELETE' });
-      if (res.ok) {
-        setItems((prev) => prev.filter((i) => i.id !== id));
-      }
-    } catch {
-      // 삭제 실패 시 무시
+  const handleSave = async (id: number, updates: { amount: number; memo: string | null }) => {
+    const res = await fetch('/api/budget/planned-expenses', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, ...updates }),
+    });
+    if (!res.ok) {
+      const err = (await res.json()) as { error?: string };
+      throw new Error(err.error ?? '수정 실패');
     }
+    const { data } = (await res.json()) as { data: PlannedExpenseRow };
+    setItems((prev) => prev.map((i) => (i.id === id ? { ...i, ...data } : i)));
+  };
+
+  const handleDelete = async (id: number) => {
+    const res = await fetch(`/api/budget/planned-expenses?id=${id}`, { method: 'DELETE' });
+    if (!res.ok) throw new Error('삭제 실패');
+    setItems((prev) => prev.filter((i) => i.id !== id));
   };
 
   const totalPlanned = items.reduce((s, i) => s + i.amount, 0);
@@ -90,112 +100,125 @@ export function PlannedExpenseList({ yearMonth, refreshTrigger }: PlannedExpense
   }
 
   return (
-    <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
-      <div className="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-t-xl">
-        <div className="flex items-center gap-2">
-          <h2 className="text-sm font-semibold text-gray-700">예정 지출</h2>
-          {totalPlanned > 0 && (
-            <span className="text-xs text-gray-400">
-              {formatAmount(totalUsed)} / {formatAmount(totalPlanned)}
-            </span>
-          )}
-        </div>
-        <button
-          onClick={() => setShowForm(!showForm)}
-          className="rounded-md px-2 py-1 text-xs text-blue-500 hover:bg-blue-50 transition"
-        >
-          {showForm ? '취소' : '+ 추가'}
-        </button>
-      </div>
-
-      {/* 추가 폼 */}
-      {showForm && (
-        <div className="border-b border-gray-100 px-4 py-3">
+    <>
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-t-xl">
           <div className="flex items-center gap-2">
-            <input
-              type="text"
-              inputMode="numeric"
-              placeholder="금액"
-              value={amountInput}
-              onChange={(e) => {
-                const raw = e.target.value.replace(/[^0-9]/g, '');
-                const num = parseInt(raw, 10);
-                setAmountInput(raw ? num.toLocaleString('ko-KR') : '');
-              }}
-              className="w-28 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
-            />
-            <input
-              type="text"
-              placeholder="메모 (예: 영화제, 여행)"
-              value={memoInput}
-              onChange={(e) => setMemoInput(e.target.value)}
-              className="flex-1 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
-            />
-            <button
-              onClick={() => void handleAdd()}
-              disabled={saving || !amountInput}
-              className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white disabled:opacity-40 hover:bg-blue-700 transition"
-            >
-              {saving ? '...' : '추가'}
-            </button>
+            <h2 className="text-sm font-semibold text-gray-700">예정 지출</h2>
+            {totalPlanned > 0 && (
+              <span className="text-xs text-gray-400">
+                {formatAmount(totalUsed)} / {formatAmount(totalPlanned)}
+              </span>
+            )}
           </div>
+          <button
+            onClick={() => setShowForm(!showForm)}
+            className="rounded-md px-2 py-1 text-xs text-blue-500 hover:bg-blue-50 transition"
+          >
+            {showForm ? '취소' : '+ 추가'}
+          </button>
         </div>
-      )}
 
-      {/* 목록 */}
-      <div className="divide-y divide-gray-100">
-        {items.map((item) => {
-          const used = item.used_amount ?? 0;
-          const remaining = item.amount - used;
-          const pct = item.amount > 0 ? Math.min((used / item.amount) * 100, 100) : 0;
-          const isOver = used > item.amount;
-
-          return (
-            <div key={item.id} className="px-4 py-2.5">
-              <div className="flex items-center justify-between mb-1">
-                <div className="flex items-center gap-2">
-                  {item.memo && (
-                    <span className="text-sm font-medium text-gray-700">{item.memo}</span>
-                  )}
-                  <span className="text-sm text-gray-500">{formatAmount(item.amount)}</span>
-                </div>
-                <button
-                  onClick={() => void handleDelete(item.id)}
-                  className="rounded-md p-1 text-gray-300 hover:bg-gray-100 hover:text-gray-500 transition"
-                >
-                  <XMarkIcon size={14} />
-                </button>
-              </div>
-              {/* 사용 현황 바 */}
-              {used > 0 && (
-                <>
-                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
-                    <div
-                      className={`h-full rounded-full transition-all ${isOver ? 'bg-red-400' : 'bg-blue-400'}`}
-                      style={{ width: `${pct}%` }}
-                    />
-                  </div>
-                  <div className="mt-1 flex justify-between text-[10px] text-gray-400">
-                    <span>사용 {formatAmount(used)}</span>
-                    <span className={isOver ? 'text-red-500' : ''}>
-                      {isOver ? `${formatAmount(Math.abs(remaining))} 초과` : `${formatAmount(remaining)} 남음`}
-                    </span>
-                  </div>
-                </>
-              )}
-              {used === 0 && (
-                <div className="text-[10px] text-gray-400">아직 사용 내역 없음</div>
-              )}
+        {/* 추가 폼 */}
+        {showForm && (
+          <div className="border-b border-gray-100 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                inputMode="numeric"
+                placeholder="금액"
+                value={amountInput}
+                onChange={(e) => {
+                  const raw = e.target.value.replace(/[^0-9]/g, '');
+                  const num = parseInt(raw, 10);
+                  setAmountInput(raw ? num.toLocaleString('ko-KR') : '');
+                }}
+                className="w-28 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+              />
+              <input
+                type="text"
+                placeholder="메모 (예: 영화제, 여행)"
+                value={memoInput}
+                onChange={(e) => setMemoInput(e.target.value)}
+                className="flex-1 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+              />
+              <button
+                onClick={() => void handleAdd()}
+                disabled={saving || !amountInput}
+                className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white disabled:opacity-40 hover:bg-blue-700 transition"
+              >
+                {saving ? '...' : '추가'}
+              </button>
             </div>
-          );
-        })}
+          </div>
+        )}
+
+        {/* 목록 */}
+        <div className="divide-y divide-gray-100">
+          {items.map((item) => {
+            const used = item.used_amount ?? 0;
+            const remaining = item.amount - used;
+            const pct = item.amount > 0 ? Math.min((used / item.amount) * 100, 100) : 0;
+            const isOver = used > item.amount;
+
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setEditingItem(item)}
+                className="w-full px-4 py-2.5 text-left transition hover:bg-gray-50"
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-2">
+                    {item.memo && (
+                      <span className="text-sm font-medium text-gray-700">{item.memo}</span>
+                    )}
+                    <span className="text-sm text-gray-500">{formatAmount(item.amount)}</span>
+                  </div>
+                  <span className="text-[10px] text-gray-400">수정</span>
+                </div>
+                {/* 사용 현황 바 */}
+                {used > 0 && (
+                  <>
+                    <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+                      <div
+                        className={`h-full rounded-full transition-all ${isOver ? 'bg-red-400' : 'bg-blue-400'}`}
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                    <div className="mt-1 flex justify-between text-[10px] text-gray-400">
+                      <span>사용 {formatAmount(used)}</span>
+                      <span className={isOver ? 'text-red-500' : ''}>
+                        {isOver ? `${formatAmount(Math.abs(remaining))} 초과` : `${formatAmount(remaining)} 남음`}
+                      </span>
+                    </div>
+                  </>
+                )}
+                {used === 0 && (
+                  <div className="text-[10px] text-gray-400">아직 사용 내역 없음</div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="border-t border-gray-100 px-4 py-2">
+          <p className="text-[10px] text-gray-400">
+            지출 기록 시 예정 지출을 선택하면 일일 예산에 영향 없이 별도 관리됩니다.
+          </p>
+        </div>
       </div>
 
-      <div className="border-t border-gray-100 px-4 py-2">
-        <p className="text-[10px] text-gray-400">
-          지출 기록 시 예정 지출을 선택하면 일일 예산에 영향 없이 별도 관리됩니다.
-        </p>
-      </div>
-    </div>
+      {/* 수정 모달 */}
+      {editingItem && (
+        <PlannedExpenseEditModal
+          item={editingItem}
+          yearMonth={yearMonth}
+          onSave={handleSave}
+          onDelete={handleDelete}
+          onClose={() => setEditingItem(null)}
+        />
+      )}
+    </>
   );
 }

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -21,12 +21,17 @@ export async function queryExpenses(
   from: string,
   to: string,
   category?: string,
+  plannedExpenseId?: number,
 ): Promise<ExpenseRow[]> {
   const conditions = ['user_id = $1', 'date >= $2', 'date <= $3'];
   const params: unknown[] = [userId, from, to];
   if (category) {
     conditions.push(`category = $${params.length + 1}`);
     params.push(category);
+  }
+  if (plannedExpenseId) {
+    conditions.push(`planned_expense_id = $${params.length + 1}`);
+    params.push(plannedExpenseId);
   }
   const { rows } = await query<ExpenseRow>(
     `SELECT id, date::text, amount, category, description, payment_method,
@@ -465,6 +470,31 @@ export async function createPlannedExpense(
   );
   if (!row) throw new Error('createPlannedExpense: INSERT returned no rows');
   return row;
+}
+
+/** 예정 지출 수정 */
+export async function updatePlannedExpense(
+  userId: number,
+  id: number,
+  data: { amount?: number; memo?: string | null },
+): Promise<PlannedExpenseRow | null> {
+  const sets: string[] = [];
+  const values: unknown[] = [id, userId];
+  if (data.amount !== undefined) {
+    sets.push(`amount = $${values.length + 1}`);
+    values.push(data.amount);
+  }
+  if (data.memo !== undefined) {
+    sets.push(`memo = $${values.length + 1}`);
+    values.push(data.memo);
+  }
+  if (sets.length === 0) return null;
+  return queryOne<PlannedExpenseRow>(
+    `UPDATE planned_expenses SET ${sets.join(', ')}
+     WHERE id = $1 AND user_id = $2
+     RETURNING id, year_month, amount, memo, created_at::text`,
+    values,
+  );
 }
 
 /** 예정 지출 삭제 */


### PR DESCRIPTION
## Summary
- 예정지출 항목 클릭 시 수정 모달 (X 즉시삭제 제거)
- 모달에서 연결된 지출 내역 목록 표시 + 금액/메모 수정 + 삭제
- 예정지출 PATCH API 추가

## Changes
- `planned-expense-edit-modal.tsx` 신규 생성 (수정/삭제/연결 내역)
- `planned-expense-list.tsx` X 버튼 제거 → 항목 클릭으로 모달 열기
- `queries.ts` `updatePlannedExpense` 함수 + `queryExpenses` planned_expense_id 필터 추가
- `planned-expenses/route.ts` PATCH 핸들러 추가
- `expenses/route.ts` GET에 planned_expense_id 쿼리 파라미터 지원

## Test plan
- [x] 기존 테스트 172건 통과
- [x] 빌드 성공
- [ ] 예정지출 항목 클릭 → 수정 모달 열림 확인
- [ ] 모달에서 금액/메모 수정 후 저장 → 목록 반영 확인
- [ ] 모달에서 삭제 → 확인 다이얼로그 후 삭제 확인
- [ ] 연결된 지출 내역이 모달에 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)