### PR TITLE
feat(sleep): 수면 차트 데스크탑 hover 툴팁 추가

### DIFF
--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -27,9 +27,16 @@ function yToRatio(y: number): number {
 const Y_LABELS = ['20', '22', '0', '2', '4', '6', '8', '10', '12'];
 const Y_LABEL_MINUTES = [0, 120, 240, 360, 480, 600, 720, 840, 960];
 
+interface Tooltip {
+  x: number;
+  y: number;
+  record: SleepRecordWithEvents;
+}
+
 export function SleepTimeline({ records, period }: SleepTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [cw, setCw] = useState(0);
+  const [tooltip, setTooltip] = useState<Tooltip | null>(null);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -71,8 +78,14 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <style>{`
+        @media (hover: none) {
+          .desktop-hover-target { display: none; }
+          .desktop-tooltip { display: none; }
+        }
+      `}</style>
       <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 타임라인</h3>
-      <div ref={containerRef} className={allowScroll ? 'overflow-x-auto' : ''}>
+      <div ref={containerRef} className={`relative ${allowScroll ? 'overflow-x-auto' : ''}`}>
         {cw > 0 && (
           <svg
             width={chartWidth}
@@ -104,9 +117,25 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
 
               return (
                 <g key={r.id}>
+                  {/* 투명 히트 영역 — 좁은 바도 hover 쉽게 */}
+                  <rect
+                    x={x - 2} y={topPadding}
+                    width={barWidth + 4} height={chartHeight}
+                    fill="transparent"
+                    className="desktop-hover-target"
+                    onMouseEnter={() => {
+                      setTooltip({
+                        x: x + barWidth / 2,
+                        y: bedY,
+                        record: r,
+                      });
+                    }}
+                    onMouseLeave={() => setTooltip(null)}
+                  />
                   <rect
                     x={x} y={bedY} width={barWidth} height={barHeight}
                     rx={3} fill="#818cf8" opacity={0.8}
+                    className="pointer-events-none"
                   />
                   {r.events.map((e) => {
                     const ey = topPadding + yToRatio(timeToY(e.event_time)) * chartHeight;
@@ -115,6 +144,7 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
                         key={e.id}
                         cx={x + barWidth / 2} cy={ey}
                         r={2.5} fill="#ef4444"
+                        className="pointer-events-none"
                       />
                     );
                   })}
@@ -135,6 +165,31 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
             })}
           </svg>
         )}
+        {tooltip && (() => {
+        const r = tooltip.record;
+        const hours = r.duration_minutes ? Math.floor(r.duration_minutes / 60) : 0;
+        const mins = r.duration_minutes ? r.duration_minutes % 60 : 0;
+        return (
+          <div
+            className="desktop-tooltip pointer-events-none absolute z-10 -translate-x-1/2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
+            style={{ left: tooltip.x, top: tooltip.y - 8, transform: 'translate(-50%, -100%)' }}
+          >
+            <p className="mb-1 font-semibold text-gray-700">{r.date}</p>
+            <p className="text-gray-600">취침 {r.bedtime} → 기상 {r.wake_time}</p>
+            {r.duration_minutes != null && (
+              <p className="text-gray-600">수면 {hours}시간{mins > 0 ? ` ${mins}분` : ''}</p>
+            )}
+            {r.events.length > 0 && (
+              <div className="mt-1 border-t border-gray-100 pt-1">
+                <p className="text-red-500">중간기상 {r.events.length}회</p>
+                {r.events.map((e) => (
+                  <p key={e.id} className="text-gray-500">&nbsp;&nbsp;{e.event_time}{e.memo ? ` — ${e.memo}` : ''}</p>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+        })()}
       </div>
       <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
         <span className="flex items-center gap-1">

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -111,9 +111,19 @@ function DurationChart({ records, allowScroll }: { records: SleepRecordWithEvent
   );
 }
 
+interface TrendTooltip {
+  x: number;
+  y: number;
+  date: string;
+  bedtime: string;
+  wakeTime: string;
+  type: 'bed' | 'wake';
+}
+
 function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEvents[]; allowScroll: boolean }) {
   const { ref, w: cw } = useContainerWidth();
   const valid = records.filter((r) => r.bedtime && r.wake_time);
+  const [tooltip, setTooltip] = useState<TrendTooltip | null>(null);
   useScrollToEnd(ref, cw, [valid.length], allowScroll);
   if (valid.length === 0) return null;
 
@@ -152,8 +162,14 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <style>{`
+        @media (hover: none) {
+          .desktop-hover-target { display: none; }
+          .desktop-tooltip { display: none; }
+        }
+      `}</style>
       <h3 className="mb-3 text-sm font-semibold text-gray-900">취침 · 기상 시간 추이</h3>
-      <div ref={ref} className={allowScroll ? 'overflow-x-auto' : ''}>
+      <div ref={ref} className={`relative ${allowScroll ? 'overflow-x-auto' : ''}`}>
         {cw > 0 && (
           <svg width={chartWidth} height={chartHeight + 12} className="text-xs">
             {yLabels.map((label, i) => {
@@ -169,11 +185,45 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
             })}
             <path d={bedPath} fill="none" stroke="#818cf8" strokeWidth={1.5} />
             {bedPoints.map((p, i) => (
-              <circle key={`b${i}`} cx={p.x} cy={p.y} r={2.5} fill="#818cf8" />
+              <g key={`b${i}`}>
+                <circle cx={p.x} cy={p.y} r={2.5} fill="#818cf8" className="pointer-events-none" />
+                <circle
+                  cx={p.x} cy={p.y} r={8} fill="transparent"
+                  className="desktop-hover-target"
+                  onMouseEnter={() => {
+                    setTooltip({
+                      x: p.x,
+                      y: p.y,
+                      date: valid[i].date,
+                      bedtime: valid[i].bedtime!,
+                      wakeTime: valid[i].wake_time!,
+                      type: 'bed',
+                    });
+                  }}
+                  onMouseLeave={() => setTooltip(null)}
+                />
+              </g>
             ))}
             <path d={wakePath} fill="none" stroke="#f59e0b" strokeWidth={1.5} />
             {wakePoints.map((p, i) => (
-              <circle key={`w${i}`} cx={p.x} cy={p.y} r={2.5} fill="#f59e0b" />
+              <g key={`w${i}`}>
+                <circle cx={p.x} cy={p.y} r={2.5} fill="#f59e0b" className="pointer-events-none" />
+                <circle
+                  cx={p.x} cy={p.y} r={8} fill="transparent"
+                  className="desktop-hover-target"
+                  onMouseEnter={() => {
+                    setTooltip({
+                      x: p.x,
+                      y: p.y,
+                      date: valid[i].date,
+                      bedtime: valid[i].bedtime!,
+                      wakeTime: valid[i].wake_time!,
+                      type: 'wake',
+                    });
+                  }}
+                  onMouseLeave={() => setTooltip(null)}
+                />
+              </g>
             ))}
             {valid.map((r, i) => {
               const x = padding.left + (i / Math.max(1, valid.length - 1)) * innerW;
@@ -193,6 +243,20 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
               );
             })}
           </svg>
+        )}
+        {tooltip && (
+        <div
+          className="desktop-tooltip pointer-events-none absolute z-10 -translate-x-1/2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
+          style={{ left: tooltip.x, top: tooltip.y - 8, transform: 'translate(-50%, -100%)' }}
+        >
+          <p className="mb-0.5 font-semibold text-gray-700">{tooltip.date}</p>
+          <p style={{ color: tooltip.type === 'bed' ? '#818cf8' : undefined }} className={tooltip.type === 'bed' ? 'font-medium' : 'text-gray-500'}>
+            취침 {tooltip.bedtime}
+          </p>
+          <p style={{ color: tooltip.type === 'wake' ? '#f59e0b' : undefined }} className={tooltip.type === 'wake' ? 'font-medium' : 'text-gray-500'}>
+            기상 {tooltip.wakeTime}
+          </p>
+        </div>
         )}
       </div>
       <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">


### PR DESCRIPTION
## Summary
- 수면 타임라인 차트: 바에 hover 시 취침/기상 시간, 수면 시간, 중간기상 횟수 및 시각 표시
- 취침·기상 시간 추이 차트: 데이터 포인트에 hover 시 정확한 HH:MM 표시 (hover한 항목 색상 강조)
- 모바일(터치 기기)에서는 `@media (hover: none)`으로 툴팁 비활성화

## Test plan
- [ ] 데스크탑 브라우저에서 수면 타임라인 바에 hover 시 툴팁 정상 표시 확인
- [ ] 취침·기상 추이 차트 점에 hover 시 시간 정보 정상 표시 확인
- [ ] 1주/2주/1개월 기간 전환 시 툴팁 정상 동작 확인
- [ ] 모바일 뷰포트에서 hover 요소가 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)