### PR TITLE
fix(sleep): 수면 차트 툴팁 버그 수정

### DIFF
--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -169,10 +169,13 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
         const r = tooltip.record;
         const hours = r.duration_minutes ? Math.floor(r.duration_minutes / 60) : 0;
         const mins = r.duration_minutes ? r.duration_minutes % 60 : 0;
+        const alignRight = tooltip.x > chartWidth - 100;
+        const alignLeft = tooltip.x < 100;
+        const translateX = alignRight ? '-100%' : alignLeft ? '0%' : '-50%';
         return (
           <div
-            className="desktop-tooltip pointer-events-none absolute z-10 -translate-x-1/2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
-            style={{ left: tooltip.x, top: tooltip.y - 8, transform: 'translate(-50%, -100%)' }}
+            className="desktop-tooltip pointer-events-none absolute z-10 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
+            style={{ left: tooltip.x, top: tooltip.y - 8, transform: `translate(${translateX}, -100%)` }}
           >
             <p className="mb-1 font-semibold text-gray-700">{r.date}</p>
             <p className="text-gray-600">취침 {r.bedtime} → 기상 {r.wake_time}</p>

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -244,10 +244,14 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
             })}
           </svg>
         )}
-        {tooltip && (
+        {tooltip && (() => {
+        const alignRight = tooltip.x > chartWidth - 80;
+        const alignLeft = tooltip.x < 80;
+        const translateX = alignRight ? '-100%' : alignLeft ? '0%' : '-50%';
+        return (
         <div
-          className="desktop-tooltip pointer-events-none absolute z-10 -translate-x-1/2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
-          style={{ left: tooltip.x, top: tooltip.y - 8, transform: 'translate(-50%, -100%)' }}
+          className="desktop-tooltip pointer-events-none absolute z-10 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
+          style={{ left: tooltip.x, top: tooltip.y - 8, transform: `translate(${translateX}, -100%)` }}
         >
           <p className="mb-0.5 font-semibold text-gray-700">{tooltip.date}</p>
           <p style={{ color: tooltip.type === 'bed' ? '#818cf8' : undefined }} className={tooltip.type === 'bed' ? 'font-medium' : 'text-gray-500'}>
@@ -257,7 +261,8 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
             기상 {tooltip.wakeTime}
           </p>
         </div>
-        )}
+        );
+        })()}
       </div>
       <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
         <span className="flex items-center gap-1">

--- a/web/src/features/sleep/lib/queries.ts
+++ b/web/src/features/sleep/lib/queries.ts
@@ -18,11 +18,12 @@ export async function querySleepRecordsWithEvents(
       [userId, from, to],
     ),
     query<SleepEvent>(
-      `SELECT id, date::text, event_time, memo
-       FROM sleep_events
-       WHERE date BETWEEN $1 AND $2
-       ORDER BY date, event_time`,
-      [from, to],
+      `SELECT DISTINCT e.id, e.date::text, e.event_time, e.memo
+       FROM sleep_events e
+       JOIN sleep_records r ON r.date = e.date AND r.user_id = $1
+       WHERE e.date BETWEEN $2 AND $3
+       ORDER BY e.date, e.event_time`,
+      [userId, from, to],
     ),
   ]);
 


### PR DESCRIPTION
## Summary
- 수면 타임라인 중간기상 데이터 중복 표시 수정 (sleep_events 쿼리에 user JOIN 추가)
- 차트 우측 끝 데이터의 툴팁이 좁게 잘리는 문제 수정 (정렬 보정 + whitespace-nowrap)

## Test plan
- [ ] 수면 타임라인에서 중간기상이 있는 날짜의 툴팁에 이벤트가 중복 없이 표시되는지 확인
- [ ] 가장 우측(최신) 데이터에 hover 시 툴팁이 정상 너비로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)