### PR TITLE
fix(sleep): sleep_events 쿼리 롤백 + JS 중복 제거

### DIFF
--- a/web/src/features/sleep/lib/queries.ts
+++ b/web/src/features/sleep/lib/queries.ts
@@ -18,17 +18,19 @@ export async function querySleepRecordsWithEvents(
       [userId, from, to],
     ),
     query<SleepEvent>(
-      `SELECT DISTINCT e.id, e.date::text, e.event_time, e.memo
+      `SELECT e.id, e.date::text, e.event_time, e.memo
        FROM sleep_events e
-       JOIN sleep_records r ON r.date = e.date AND r.user_id = $1
-       WHERE e.date BETWEEN $2 AND $3
+       WHERE e.date BETWEEN $1 AND $2
        ORDER BY e.date, e.event_time`,
-      [userId, from, to],
+      [from, to],
     ),
   ]);
 
   const eventsByDate = new Map<string, SleepEvent[]>();
+  const seenEventIds = new Set<number>();
   for (const e of eventsResult.rows) {
+    if (seenEventIds.has(e.id)) continue;
+    seenEventIds.add(e.id);
     const list = eventsByDate.get(e.date) ?? [];
     list.push(e);
     eventsByDate.set(e.date, list);


### PR DESCRIPTION
## Summary
- #306에서 추가한 JOIN 쿼리가 DB 프록시에서 500 에러 유발하여 원본 쿼리로 롤백
- 이벤트 중복은 클라이언트 측 id 기준 중복 제거로 해결

## Test plan
- [ ] 수면 대시보드 500 에러 해소 확인
- [ ] 중간기상 데이터 중복 없이 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)