### PR TITLE
fix(budget): 월 정산 스냅샷 available_at_end 계산 오류 수정

### DIFF
--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -152,6 +152,24 @@ describe('runSettlementIfDue', () => {
     expect(result.snapshot).toBeDefined();
     expect(result.snapshot?.year_month).toBe('2026-04');
   });
+
+  it('available_at_end = availableAtStart + income - flex - excluded (자산 미참조)', async () => {
+    const settlementNow = new Date('2026-04-16T12:00:00Z');
+
+    vi.mocked(readLatestSnapshot).mockResolvedValue(null);
+    vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
+    vi.mocked(readFlexibleSpent).mockResolvedValue(300_000);
+    vi.mocked(readExcludedSpent).mockResolvedValue(50_000);
+    vi.mocked(readIncomeTotal).mockResolvedValue(200_000);
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
+
+    const result = await runSettlementIfDue(1, settlementNow);
+
+    // availableAtStart = 5_000_000 (자산 fallback)
+    // availableAtEnd = 5_000_000 + 200_000 - 300_000 - 50_000 = 4_850_000
+    expect(result.snapshot?.available_at_end).toBe(4_850_000);
+    expect(result.snapshot?.available_at_start).toBe(5_000_000);
+  });
 });
 
 describe('getTodayAllocation', () => {

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -256,7 +256,7 @@ export async function runSettlementIfDue(
 
   const prevSnapshot = await readLatestSnapshot(userId);
   const availableAtStart = prevSnapshot?.available_at_end ?? await readDistributableAssetBalance(userId);
-  const availableAtEnd = await computeTotalAvailable(userId, formatKSTDate(now));
+  const availableAtEnd = availableAtStart + income - flex - excluded;
 
   const snapshot = buildSettlementSnapshot({
     yearMonth: targetMonth, monthlyBudget,


### PR DESCRIPTION
## Summary
- 월 경계 정산(`runSettlementIfDue`)에서 `available_at_end` 계산 시 DB 자산 잔액을 직접 읽던 로직을 수입/지출 기반 산술 계산으로 변경
- 자산을 수동 갱신하지 않아도 정산 스냅샷에 정확한 가용자금이 기록되도록 개선
- 검증 테스트 추가

## Test plan
- [x] 기존 18개 테스트 전부 통과
- [x] `available_at_end` 산출 검증 테스트 추가 (availableAtStart + income - flex - excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)