### PR TITLE
fix(budget): 스냅샷 이후 자산 갱신 시 가용자금 미반영 수정

### DIFF
--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -82,14 +82,13 @@ describe('getMonthlyAllocation', () => {
     vi.mocked(readIncomeTotal).mockResolvedValue(100_000);
     vi.mocked(readFlexibleSpent).mockResolvedValue(50_000);
     vi.mocked(readExcludedSpent).mockResolvedValue(0);
-    // readDistributableAssetBalance은 호출되지 않아야 함 (별도로 확인)
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(999_999);
 
     const result = await getMonthlyAllocation(1, DEFAULT_NOW);
 
-    // totalAvailable = 900_000 + 100_000 - 50_000 - 0 = 950_000 → assets(999_999)와 다른 값
+    // snapshotBased = 900_000 + 100_000 - 50_000 = 950_000
+    // Math.max(950_000, 999_999) = 999_999 (자산 갱신분 반영)
     expect(result.monthlyBudgets.length).toBeGreaterThan(0);
-    // freePerMonth은 totalAvailable 950_000 기준 계산 (≠ 999_999 기준)
     expect(result.freePerMonth).not.toBeNull();
   });
 

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -61,9 +61,12 @@ function addOneDay(dateStr: string): string {
 
 /** 최신 스냅샷 기준 가용자금 계산 (없으면 전체 자산 합계 fallback) */
 async function computeTotalAvailable(userId: number, today: string): Promise<number> {
-  const snapshot = await readLatestSnapshot(userId);
+  const [snapshot, currentAssets] = await Promise.all([
+    readLatestSnapshot(userId),
+    readDistributableAssetBalance(userId),
+  ]);
   if (!snapshot) {
-    return readDistributableAssetBalance(userId);
+    return currentAssets;
   }
   const snapshotEnd = getBillingRange(snapshot.year_month).to;
   const fromDate = addOneDay(snapshotEnd);
@@ -72,7 +75,9 @@ async function computeTotalAvailable(userId: number, today: string): Promise<num
     readFlexibleSpent(userId, fromDate, today),
     readExcludedSpent(userId, fromDate, today),
   ]);
-  return snapshot.available_at_end + income - flex - excluded;
+  const snapshotBased = snapshot.available_at_end + income - flex - excluded;
+  // 스냅샷 이후 자산 갱신(입금, 잔액 수정 등)이 반영되도록 큰 값 사용
+  return Math.max(snapshotBased, currentAssets);
 }
 
 /** 월 예산 배분 */


### PR DESCRIPTION
## Summary
- `computeTotalAvailable`에서 스냅샷 기반 계산값만 사용하던 로직을 `Math.max(snapshotBased, currentAssets)`로 변경
- 스냅샷 봉인 이후 자산 잔액이 변경(입금, 수동 갱신 등)된 경우 즉시 예산에 반영

## 원인
- 월 정산 스냅샷(`available_at_end`)이 봉인된 이후 자산 잔액이 갱신되면, 기존 로직은 스냅샷 값만 참조해 실제 자산보다 낮은 가용자금으로 예산을 계산
- 이로 인해 하루 예산이 비정상적으로 낮게 산출되는 현상 발생

## Test plan
- [x] facade.test.ts 18개 테스트 전체 통과
- [ ] 배포 후 `/api/budget/today` 응답의 `todayBudget` 값이 정상 범위로 복원되는지 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)