### PR TITLE
fix(budget): 가용자금 계산을 현재 자산 잔액 기준으로 단순화

### DIFF
--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -72,22 +72,18 @@ describe('getMonthlyAllocation', () => {
     expect(result.monthlyBudgets.length).toBeGreaterThan(0);
   });
 
-  it('스냅샷 있을 때 → available_at_end + 이후 변동으로 totalAvailable 계산', async () => {
+  it('스냅샷 있어도 → 현재 자산 잔액을 totalAvailable로 사용', async () => {
     vi.mocked(readLatestSnapshot).mockResolvedValue({
       id: 1, user_id: 1, year_month: '2026-03', sealed_at: '2026-03-16T00:00:00Z',
       allocated_budget: 500_000, fixed_total: 0, installment_total: 0,
       planned_total: 0, flexible_spent: 0, excluded_spent: 0, income_total: 0,
       available_at_start: 1_000_000, available_at_end: 900_000,
     });
-    vi.mocked(readIncomeTotal).mockResolvedValue(100_000);
-    vi.mocked(readFlexibleSpent).mockResolvedValue(50_000);
-    vi.mocked(readExcludedSpent).mockResolvedValue(0);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(999_999);
 
     const result = await getMonthlyAllocation(1, DEFAULT_NOW);
 
-    // snapshotBased = 900_000 + 100_000 - 50_000 = 950_000
-    // Math.max(950_000, 999_999) = 999_999 (자산 갱신분 반영)
+    // totalAvailable = currentAssets = 999_999 (스냅샷 무관, 자산 잔액 직접 사용)
     expect(result.monthlyBudgets.length).toBeGreaterThan(0);
     expect(result.freePerMonth).not.toBeNull();
   });

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -53,31 +53,9 @@ function formatKSTDate(d: Date): string {
   return kst.toISOString().slice(0, 10);
 }
 
-function addOneDay(dateStr: string): string {
-  const d = new Date(`${dateStr}T00:00:00Z`);
-  d.setUTCDate(d.getUTCDate() + 1);
-  return d.toISOString().slice(0, 10);
-}
-
-/** 최신 스냅샷 기준 가용자금 계산 (없으면 전체 자산 합계 fallback) */
-async function computeTotalAvailable(userId: number, today: string): Promise<number> {
-  const [snapshot, currentAssets] = await Promise.all([
-    readLatestSnapshot(userId),
-    readDistributableAssetBalance(userId),
-  ]);
-  if (!snapshot) {
-    return currentAssets;
-  }
-  const snapshotEnd = getBillingRange(snapshot.year_month).to;
-  const fromDate = addOneDay(snapshotEnd);
-  const [income, flex, excluded] = await Promise.all([
-    readIncomeTotal(userId, fromDate, today),
-    readFlexibleSpent(userId, fromDate, today),
-    readExcludedSpent(userId, fromDate, today),
-  ]);
-  const snapshotBased = snapshot.available_at_end + income - flex - excluded;
-  // 스냅샷 이후 자산 갱신(입금, 잔액 수정 등)이 반영되도록 큰 값 사용
-  return Math.max(snapshotBased, currentAssets);
+/** 가용자금 = 현재 자산 잔액 (사용자가 갱신하는 실제 재정 상태) */
+async function computeTotalAvailable(userId: number, _today: string): Promise<number> {
+  return readDistributableAssetBalance(userId);
 }
 
 /** 월 예산 배분 */


### PR DESCRIPTION
## Summary
- `computeTotalAvailable`을 현재 자산 잔액(`readDistributableAssetBalance`) 직접 사용으로 단순화
- 이전 `Math.max(snapshotBased, currentAssets)` 방식은 자산을 줄인 경우를 무시하는 문제가 있었음
- 스냅샷은 월 정산 기록용으로만 유지, 현재 예산 계산에는 자산 잔액을 기준으로 사용

## Test plan
- [x] facade.test.ts 18개 테스트 전체 통과
- [ ] 배포 후 하루 예산이 정상 범위로 복원되는지 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)