### PR TITLE
fix(budget): 대금기간 내 월/일 예산 고정

### DIFF
--- a/web/src/features/budget/lib/allocator/__tests__/boundary.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/boundary.test.ts
@@ -41,13 +41,13 @@ describe('D. 과거/현재/미래 경계', () => {
         monthBudget: currentMonth.free,
         flexibleSpent: 5000,
         todayFlexSpent: 1000,
-        cycleRemainingDays: 4,
+        cycleTotalDays: 31,
       });
       const dayResult2 = allocateTodayBudget({
         monthBudget: currentMonth.free, // monthBudget 동일
         flexibleSpent: 8000,            // 지출 기록만 다름
         todayFlexSpent: 2000,
-        cycleRemainingDays: 4,
+        cycleTotalDays: 31,
       });
       // 월 예산(monthBudget)은 지출에 관계없이 동일
       expect(currentMonth.free).toBe(currentMonth.free); // 변하지 않음

--- a/web/src/features/budget/lib/allocator/__tests__/day-allocator.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/day-allocator.test.ts
@@ -2,89 +2,108 @@ import { describe, it, expect } from 'vitest';
 import { allocateTodayBudget } from '../day-allocator';
 
 describe('C. 일 배분 (allocateTodayBudget)', () => {
-  describe('C-1. 정상 지출 → 남은 일수로 재분배, 월 예산 변동 없음', () => {
-    it('todayBudget = budgetBeforeToday / todayIncludedDays', () => {
+  describe('C-1. 고정 하루 예산 — monthBudget / cycleTotalDays', () => {
+    it('todayBudget = monthBudget / cycleTotalDays (대금기간 동안 불변)', () => {
+      // todayBudget = round(30000/30) = 1000
       // monthBudgetRemaining = 30000 - 12000 = 18000
-      // budgetBeforeToday = 18000 + 2000 = 20000
-      // todayIncludedDays = 7, todayBudget = round(20000/7) = 2857
+      // todayRemaining = 1000 - 2000 = -1000
       const result = allocateTodayBudget({
         monthBudget: 30000,
         flexibleSpent: 12000,
         todayFlexSpent: 2000,
-        cycleRemainingDays: 6,
+        cycleTotalDays: 30,
       });
       expect(result.monthBudgetRemaining).toBe(18000);
-      expect(result.todayBudget).toBe(2857);
-      expect(result.todayRemaining).toBe(857); // 2857 - 2000
+      expect(result.todayBudget).toBe(1000);
+      expect(result.todayRemaining).toBe(-1000);
     });
   });
 
-  describe('C-2. 월 예산 초과 → todayBudget 0 클램프, monthBudgetRemaining 음수', () => {
-    it('flexibleSpent > monthBudget 이면 todayBudget=0', () => {
+  describe('C-2. 월 예산 초과해도 todayBudget 고정 (지출 무관)', () => {
+    it('flexibleSpent > monthBudget이어도 todayBudget은 변동 없음', () => {
+      // todayBudget = round(30000/30) = 1000 (지출과 무관하게 고정)
       // monthBudgetRemaining = 30000 - 35000 = -5000
-      // budgetBeforeToday = -5000 + 2000 = -3000 → 클램프
       const result = allocateTodayBudget({
         monthBudget: 30000,
         flexibleSpent: 35000,
         todayFlexSpent: 2000,
-        cycleRemainingDays: 6,
+        cycleTotalDays: 30,
       });
       expect(result.monthBudgetRemaining).toBe(-5000);
-      expect(result.todayBudget).toBe(0);
-      expect(result.todayRemaining).toBe(-2000); // 0 - 2000
+      expect(result.todayBudget).toBe(1000);
+      expect(result.todayRemaining).toBe(-1000);
     });
   });
 
   describe('C-3. 오늘 이미 초과 → todayRemaining 음수', () => {
     it('todayFlexSpent > todayBudget 이면 todayRemaining < 0', () => {
-      // monthBudgetRemaining = 30000 - 10000 = 20000
-      // budgetBeforeToday = 20000 + 5000 = 25000
-      // todayBudget = round(25000/6) = 4167
-      // todayRemaining = 4167 - 5000 = -833
+      // todayBudget = round(30000/30) = 1000
+      // todayRemaining = 1000 - 5000 = -4000
       const result = allocateTodayBudget({
         monthBudget: 30000,
         flexibleSpent: 10000,
         todayFlexSpent: 5000,
-        cycleRemainingDays: 5,
+        cycleTotalDays: 30,
       });
-      expect(result.todayBudget).toBe(4167);
+      expect(result.todayBudget).toBe(1000);
       expect(result.todayRemaining).toBeLessThan(0);
     });
   });
 
-  describe('C-4. cycleRemainingDays=0 (주기 마지막 날) → 1일로 나눔', () => {
-    it('마지막 날 budgetBeforeToday 전액이 todayBudget', () => {
-      // monthBudgetRemaining = 10000 - 3000 = 7000
-      // budgetBeforeToday = 7000 + 3000 = 10000
-      // todayIncludedDays = max(1, 0+1) = 1
-      // todayBudget = 10000
+  describe('C-4. cycleTotalDays=0 (방어) → todayBudget 0', () => {
+    it('cycleTotalDays=0 이면 todayBudget=0', () => {
       const result = allocateTodayBudget({
         monthBudget: 10000,
         flexibleSpent: 3000,
         todayFlexSpent: 3000,
-        cycleRemainingDays: 0,
+        cycleTotalDays: 0,
       });
-      expect(result.todayBudget).toBe(10000);
-      expect(result.todayRemaining).toBe(7000); // 10000 - 3000
+      expect(result.todayBudget).toBe(0);
+      expect(result.todayRemaining).toBe(-3000);
     });
   });
 
-  describe('C-5. 오늘 지출 복원 — todayBudget은 오늘 지출에 관계없이 동일', () => {
-    it('todayFlexSpent가 달라도 todayBudget은 같음', () => {
-      // flexibleSpent에 todayFlexSpent 포함되므로 복원 후 같은 budgetBeforeToday
+  describe('C-5. flexibleSpent 변동이 todayBudget에 영향 없음 (고정 예산)', () => {
+    it('flexibleSpent/todayFlexSpent가 달라도 todayBudget은 동일', () => {
       const r1 = allocateTodayBudget({
         monthBudget: 20000,
-        flexibleSpent: 5000,   // 오늘 2000 포함
+        flexibleSpent: 5000,
         todayFlexSpent: 2000,
-        cycleRemainingDays: 9,
+        cycleTotalDays: 30,
       });
       const r2 = allocateTodayBudget({
         monthBudget: 20000,
-        flexibleSpent: 3000,   // 오늘 0 포함
+        flexibleSpent: 15000,
         todayFlexSpent: 0,
-        cycleRemainingDays: 9,
+        cycleTotalDays: 30,
       });
       expect(r1.todayBudget).toBe(r2.todayBudget);
+    });
+  });
+
+  describe('C-6. 초과/절약 다음날에도 todayBudget 불변 (재분배 없음)', () => {
+    it('어제 초과 지출 또는 절약해도 오늘 todayBudget 동일', () => {
+      // 어제까지 초과 지출: flexibleSpent=25000 (monthBudget=20000 초과)
+      const afterOverspend = allocateTodayBudget({
+        monthBudget: 20000,
+        flexibleSpent: 25000,
+        todayFlexSpent: 0,
+        cycleTotalDays: 30,
+      });
+      // 어제까지 절약: flexibleSpent=5000
+      const afterSaving = allocateTodayBudget({
+        monthBudget: 20000,
+        flexibleSpent: 5000,
+        todayFlexSpent: 0,
+        cycleTotalDays: 30,
+      });
+      // todayBudget 모두 동일 = round(20000/30) = 667
+      expect(afterOverspend.todayBudget).toBe(667);
+      expect(afterSaving.todayBudget).toBe(667);
+      expect(afterOverspend.todayBudget).toBe(afterSaving.todayBudget);
+      // monthBudgetRemaining만 다름
+      expect(afterOverspend.monthBudgetRemaining).toBe(-5000);
+      expect(afterSaving.monthBudgetRemaining).toBe(15000);
     });
   });
 });

--- a/web/src/features/budget/lib/allocator/__tests__/edge-cases.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/edge-cases.test.ts
@@ -9,19 +9,19 @@ const BASE: MonthAllocatorInput = {
   plannedExpenses: [],
   currentBillingMonth: '2026-04',
   targetMonth: '2026-06',   // 3개월: Apr, May, Jun
-  today: '2026-04-11',      // Apr 남은 5일
+  today: '2026-04-11',      // Apr 주기: 03-16~04-15 (31일)
 };
 
 describe('F. 엣지 케이스', () => {
   describe('F-1. 신규 할부 (isNew) — 현재 월 locked 제외, 미래 월만 포함', () => {
-    it('isNew=false → 현재 월도 프로레이션 포함', () => {
+    it('isNew=false → 현재 월도 전액 포함 (ratio=1)', () => {
       const result = allocateMonthlyBudgets({
         ...BASE,
         installments: [{ monthlyAmount: 10000, remainingCount: 3, isNew: false }],
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
-      // round(10000 * 5/31) = 1613
-      expect(apr.installments).toBe(1613);
+      // round(10000 * 1) = 10000
+      expect(apr.installments).toBe(10000);
     });
 
     it('isNew=true → 현재 월 installments=0, 미래 월은 포함', () => {
@@ -37,7 +37,7 @@ describe('F. 엣지 케이스', () => {
       expect(jun.installments).toBe(10000); // 미래 월 포함
     });
 
-    it('isNew=true vs isNew=false — 총 locked 차이는 현재 월 프로레이션 금액', () => {
+    it('isNew=true vs isNew=false — 총 locked 차이는 현재 월 할부 전액', () => {
       const rOld = allocateMonthlyBudgets({
         ...BASE,
         installments: [{ monthlyAmount: 10000, remainingCount: 3, isNew: false }],
@@ -46,8 +46,8 @@ describe('F. 엣지 케이스', () => {
         ...BASE,
         installments: [{ monthlyAmount: 10000, remainingCount: 3, isNew: true }],
       });
-      // isNew=false는 현재 월에 round(10000*5/31)=1613 추가
-      expect(rOld.totalLocked - rNew.totalLocked).toBe(1613);
+      // isNew=false는 현재 월에 round(10000*1)=10000 추가
+      expect(rOld.totalLocked - rNew.totalLocked).toBe(10000);
     });
   });
 

--- a/web/src/features/budget/lib/allocator/__tests__/month-allocator.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/month-allocator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { allocateMonthlyBudgets } from '../month-allocator';
 import type { MonthAllocatorInput } from '../../types-v2';
 
-// today: 2026-04-11 → 현재 주기 03-16~04-15 (31일), 남은 5일
+// today: 2026-04-11 → 현재 주기 03-16~04-15 (31일)
 const BASE: MonthAllocatorInput = {
   totalAvailable: 36000,
   fixedMonthly: 0,
@@ -24,13 +24,13 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
     });
   });
 
-  describe('B-2. 목표 = 당월 → 단일 月, 프로레이션', () => {
-    it('당월만 존재, allocatedDays = 남은 5일', () => {
+  describe('B-2. 목표 = 당월 → 단일 月', () => {
+    it('당월만 존재, allocatedDays = 전체 주기(31일)', () => {
       const result = allocateMonthlyBudgets({ ...BASE, targetMonth: '2026-04' });
       expect(result.monthlyBudgets).toHaveLength(1);
       const apr = result.monthlyBudgets[0];
       expect(apr.yearMonth).toBe('2026-04');
-      expect(apr.allocatedDays).toBe(5);
+      expect(apr.allocatedDays).toBe(31);
       expect(apr.isCurrent).toBe(true);
       expect(apr.free).toBe(36000); // totalAvailable 전부 자유 예산
     });
@@ -48,13 +48,13 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
     });
   });
 
-  describe('B-4. 자산 감소 → 현재 월도 남은 일수 기준 감소', () => {
+  describe('B-4. 자산 감소 → 전 월 자유 예산 비례 감소', () => {
     it('totalAvailable 절반 → dailyFree 절반, free 비례 감소', () => {
-      // sumDays = 5(Apr) + 30(May 주기: 04-16~05-15) = 35
-      // 35000 → dailyFree=1000, Apr=5000, May=30000
-      // 17500 → dailyFree=500, Apr=2500, May=15000
-      const r1 = allocateMonthlyBudgets({ ...BASE, totalAvailable: 35000 });
-      const r2 = allocateMonthlyBudgets({ ...BASE, totalAvailable: 17500 });
+      // sumDays = 31(Apr) + 30(May 주기: 04-16~05-15) = 61
+      // 61000 → dailyFree=1000, Apr=31000, May=30000
+      // 30500 → dailyFree=500, Apr=15500, May=15000
+      const r1 = allocateMonthlyBudgets({ ...BASE, totalAvailable: 61000 });
+      const r2 = allocateMonthlyBudgets({ ...BASE, totalAvailable: 30500 });
       expect(r2.dailyFree).toBeCloseTo(r1.dailyFree / 2, 5);
       const apr1 = r1.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
       const apr2 = r2.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
@@ -78,9 +78,9 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
     });
   });
 
-  describe('고정비 프로레이션', () => {
-    it('현재 월 fixed는 남은 일수(5/31) 기준, 미래 월은 전체', () => {
-      // fixedMonthly=31000이면 현재 월 locked = round(31000 * 5/31) = 5000
+  describe('고정비 — 현재 월도 전액 반영 (ratio=1)', () => {
+    it('현재 월/미래 월 모두 fixed 전액 반영', () => {
+      // fixedMonthly=31000이면 현재 월 locked = round(31000 * 1) = 31000
       const result = allocateMonthlyBudgets({
         ...BASE,
         fixedMonthly: 31000,
@@ -89,10 +89,10 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
       const may = result.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
-      expect(apr.fixed).toBe(5000);
+      expect(apr.fixed).toBe(31000);
       expect(may.fixed).toBe(31000);
-      // totalLocked = 5000 + 31000 = 36000
-      expect(result.totalLocked).toBe(36000);
+      // totalLocked = 31000 + 31000 = 62000
+      expect(result.totalLocked).toBe(62000);
     });
   });
 
@@ -129,15 +129,16 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
     });
 
     it('양수 bonus → 현재 월 free 에만 귀속, 미래 월 dailyFree 감소', () => {
-      // sumDays=35, totalAvailable=35000 → baseline: dailyFree=1000, apr=5000, may=30000
-      // bonus=3500 → totalFree=31500, dailyFree=900, apr=round(900*5)+3500=8000, may=round(900*30)=27000
+      // sumDays=61, totalAvailable=35000, bonus=3500
+      // totalFree=31500, dailyFree=31500/61≈516.39
+      // apr=round(516.39*31)+3500=16008+3500=19508, may=round(516.39*30)=15492
       const result = allocateMonthlyBudgets({
         ...BASE, totalAvailable: 35000, currentMonthOnlyIncome: 3500,
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
       const may = result.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
-      expect(apr.free).toBe(8000);
-      expect(may.free).toBe(27000);
+      expect(apr.free).toBe(19508);
+      expect(may.free).toBe(15492);
       expect(apr.free + may.free).toBe(35000); // 중복 없음 — 총합 = totalAvailable
     });
 
@@ -191,14 +192,14 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
       expect(apr.installments).toBe(0);
     });
 
-    it('isNew=false → 현재 월 installments 포함 + 남은 일수 비례', () => {
-      // 현재 월 ratio=5/31, installmentSum=1000 → round(1000 * 5/31) = 161
+    it('isNew=false → 현재 월 installments 전액 포함 (ratio=1)', () => {
+      // 현재 월 ratio=1, installmentSum=1000 → round(1000 * 1) = 1000
       const result = allocateMonthlyBudgets({
         ...BASE, totalAvailable: 35000,
         installments: [{ monthlyAmount: 1000, remainingCount: 3, isNew: false }],
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
-      expect(apr.installments).toBe(161);
+      expect(apr.installments).toBe(1000);
     });
 
     it('미래 월 installments 는 isNew 무관 — 항상 전액', () => {
@@ -253,6 +254,14 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
         installments: [{ monthlyAmount: 1000, remainingCount: 3, isNew: false }],
       });
       expect(rUndef).toEqual(rFalse);
+    });
+  });
+
+  describe('B-7. today가 달라도 결과 동일 (대금기간 내 고정 예산)', () => {
+    it('대금기간 내 다른 날짜여도 allocatedDays/monthlyBudgets 동일', () => {
+      const r1 = allocateMonthlyBudgets({ ...BASE, today: '2026-03-17' });
+      const r2 = allocateMonthlyBudgets({ ...BASE, today: '2026-04-14' });
+      expect(r1).toEqual(r2);
     });
   });
 });

--- a/web/src/features/budget/lib/allocator/day-allocator.ts
+++ b/web/src/features/budget/lib/allocator/day-allocator.ts
@@ -1,19 +1,13 @@
 import type { DayAllocatorInput, DayAllocatorResult } from '../types-v2';
 
-/** 월 자유 예산 + 현재 지출 → 오늘 예산/남음 */
+/** 월 자유 예산 → 고정 하루 예산 (대금기간 동안 불변) */
 export function allocateTodayBudget(input: DayAllocatorInput): DayAllocatorResult {
-  const { monthBudget, flexibleSpent, todayFlexSpent, cycleRemainingDays } = input;
+  const { monthBudget, flexibleSpent, todayFlexSpent, cycleTotalDays } = input;
 
   const monthBudgetRemaining = monthBudget - flexibleSpent;
-  // 오늘 지출을 복원해 "오늘 시작 시점" 가용 예산 산정
-  const budgetBeforeToday = monthBudgetRemaining + todayFlexSpent;
-  const todayIncludedDays = Math.max(1, cycleRemainingDays + 1);
-
-  // 이미 월 초과 상태면 오늘 예산 0으로 클램프 (누적 빚과 오늘 초과 분리)
-  const todayBudget = budgetBeforeToday > 0
-    ? Math.round(budgetBeforeToday / todayIncludedDays)
+  const todayBudget = cycleTotalDays > 0
+    ? Math.round(monthBudget / cycleTotalDays)
     : 0;
-
   const todayRemaining = todayBudget - todayFlexSpent;
 
   return { todayBudget, todayRemaining, monthBudgetRemaining };

--- a/web/src/features/budget/lib/allocator/month-allocator.ts
+++ b/web/src/features/budget/lib/allocator/month-allocator.ts
@@ -1,5 +1,4 @@
 import { addBillingMonths, getBillingRange, calcCycleDays } from '../billing/cycle';
-import { calcAllocatedDays } from './proration';
 import type {
   BillingCycle, InstallmentInput, MonthAllocatorInput, MonthAllocatorResult,
   MonthlyBudget, PlannedInput,
@@ -57,7 +56,7 @@ export function allocateMonthlyBudgets(input: MonthAllocatorInput): MonthAllocat
   const currentCycle: BillingCycle = {
     yearMonth: input.currentBillingMonth, from: cf, to: ct, totalDays: calcCycleDays(cf, ct),
   };
-  const { allocatedDays: currentAllocatedDays } = calcAllocatedDays(input.today, currentCycle);
+  const currentAllocatedDays = currentCycle.totalDays;
 
   const monthlyBudgets: MonthlyBudget[] = [];
   let totalLocked = 0;

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -96,10 +96,10 @@ describe('getMonthlyAllocation', () => {
 
   it('currentMonthOnlyIncome > 0 → 현재 월 free 에 독점 귀속, 다른 월은 오히려 감소', async () => {
     // totalAvailable = 1_000_000, bonus = 50_000, target = 2026-05
-    // Apr 10 기준 현재 월 남은 일수 = 6 (Apr 10~15), May 주기 = 30일, sumDays = 36
-    // totalFree = 1_000_000 - 50_000 = 950_000, dailyFree = 950_000/36 ≈ 26,388.88
-    // current free = round(26,388.88 * 6) + 50_000 = 158_333 + 50_000 = 208_333
-    // may free     = round(26,388.88 * 30)         = 791_667
+    // sumDays = 31(Apr) + 30(May) = 61
+    // totalFree = 950_000, dailyFree = 950_000/61 ≈ 15_573.77
+    // current free = round(15_573.77 * 31) + 50_000 = 482_787 + 50_000 = 532_787
+    // may free     = round(15_573.77 * 30) = 467_213
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(1_000_000);
     vi.mocked(readTargetMonth).mockResolvedValue('2026-05');
     vi.mocked(readCurrentMonthOnlyIncome).mockResolvedValue(50_000);
@@ -108,8 +108,8 @@ describe('getMonthlyAllocation', () => {
     const current = result.monthlyBudgets.find((m) => m.isCurrent)!;
     const future = result.monthlyBudgets.find((m) => !m.isCurrent)!;
 
-    expect(current.free).toBe(208_333);
-    expect(future.free).toBe(791_667);
+    expect(current.free).toBe(532_787);
+    expect(future.free).toBe(467_213);
     // 총 합은 totalAvailable 과 동일해야 함 (bonus 중복 없음)
     expect(current.free + future.free).toBe(1_000_000);
   });

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -96,7 +96,6 @@ export async function getTodayAllocation(
     return { todayBudget: 0, todayRemaining: 0, monthBudgetRemaining: 0, todayFlexSpent: 0, targetDate: null };
   }
   const todayStr = formatKSTDate(now);
-  const { remaining } = calcAllocatedDays(todayStr, cycle);
   const [flex, todayFlex, targetDate] = await Promise.all([
     readFlexibleSpent(userId, cycle.from, todayStr),
     readTodayFlexSpent(userId, todayStr),
@@ -107,7 +106,7 @@ export async function getTodayAllocation(
       monthBudget: currentMonth.free,
       flexibleSpent: flex,
       todayFlexSpent: todayFlex,
-      cycleRemainingDays: remaining,
+      cycleTotalDays: cycle.totalDays,
     }),
     todayFlexSpent: todayFlex,
     targetDate,

--- a/web/src/features/budget/lib/types-v2.ts
+++ b/web/src/features/budget/lib/types-v2.ts
@@ -56,7 +56,7 @@ export interface DayAllocatorInput {
   monthBudget: number;
   flexibleSpent: number;
   todayFlexSpent: number;
-  cycleRemainingDays: number;
+  cycleTotalDays: number;
 }
 
 export interface DayAllocatorResult {


### PR DESCRIPTION
## Summary
- 월 allocator 현재 월 allocatedDays를 남은 일수 → 전체 주기(totalDays)로 변경하여 대금기간 동안 월 예산 고정
- 일 allocator todayBudget = monthBudget / cycleTotalDays로 변경하여 지출 변동과 무관하게 하루 예산 고정
- 테스트 전면 업데이트 + 고정 예산 불변성 검증 테스트 추가 (133개 전체 통과)

## Test plan
- [x] day-allocator: 고정 하루 예산 공식, 초과 지출 시 불변, cycleTotalDays=0 방어, 재분배 없음 검증
- [x] month-allocator: ratio=1, today 무관 불변성, 고정비/할부/bonus 기대값 업데이트
- [x] boundary/edge-cases/facade: cycleTotalDays 전환 및 기대값 업데이트
- [x] 전체 14개 파일 133개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)