### PR TITLE
feat(budget): 카드별 대금기간 + billing_month 컬럼 추가

### DIFF
--- a/db/migrations/043_billing_month.sql
+++ b/db/migrations/043_billing_month.sql
@@ -1,0 +1,12 @@
+-- expenses에 billing_month 컬럼 추가
+ALTER TABLE expenses ADD COLUMN IF NOT EXISTS billing_month VARCHAR(7);
+
+-- backfill: 기존 데이터는 시스템 대금기간(14~13) 기준으로 계산
+-- day >= 14면 다음 달, day < 14면 현재 달
+UPDATE expenses
+SET billing_month = CASE
+  WHEN EXTRACT(DAY FROM date) >= 14
+  THEN TO_CHAR(date + INTERVAL '1 month', 'YYYY-MM')
+  ELSE TO_CHAR(date, 'YYYY-MM')
+END
+WHERE billing_month IS NULL;

--- a/web/src/features/budget/components/expense-form.tsx
+++ b/web/src/features/budget/components/expense-form.tsx
@@ -7,6 +7,7 @@ import { PlusIcon, XMarkIcon } from '@/components/ui/icons';
 import { formatAmount } from '@/lib/types';
 import { Input, Select } from '@/components/ui/input';
 import { getTodayISO } from '@/lib/kst';
+import { getBillingMonthForExpense } from '@/features/budget/lib/billing/card-billing';
 
 interface ExpenseFormProps {
   onAdd: (data: {
@@ -26,6 +27,8 @@ interface ExpenseFormProps {
 }
 
 const INSTALLMENT_OPTIONS = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+const PAYMENT_OPTIONS = ['현대카드', '국민카드', '현금'] as const;
+type PaymentOption = (typeof PAYMENT_OPTIONS)[number];
 
 export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
   const today = getTodayISO();
@@ -36,7 +39,7 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
   const [description, setDescription] = useState('');
   const [selectedPlanned, setSelectedPlanned] = useState<number | null>(null);
   const [plannedExpenses, setPlannedExpenses] = useState<PlannedExpenseRow[]>([]);
-  const [paymentMethod, setPaymentMethod] = useState<'카드' | '현금'>('카드');
+  const [paymentMethod, setPaymentMethod] = useState<PaymentOption>('현대카드');
   const [installmentMonths, setInstallmentMonths] = useState<number>(1);
   const [excludeFromBudget, setExcludeFromBudget] = useState(false);
   const [distributeToBudget, setDistributeToBudget] = useState(false);
@@ -67,7 +70,7 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
     }
   };
 
-  const handlePaymentMethodChange = (method: '카드' | '현금') => {
+  const handlePaymentMethodChange = (method: PaymentOption) => {
     setPaymentMethod(method);
     // 현금으로 바꾸면 할부 초기화
     if (method === '현금') setInstallmentMonths(1);
@@ -91,7 +94,7 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
         type: entryType,
         planned_expense_id: selectedPlanned,
         payment_method: entryType === 'expense' ? paymentMethod : '기타',
-        installment_months: entryType === 'expense' && paymentMethod === '카드' ? installmentMonths : undefined,
+        installment_months: entryType === 'expense' && paymentMethod !== '현금' ? installmentMonths : undefined,
         exclude_from_budget: entryType === 'expense' ? excludeFromBudget : false,
         distribute_to_budget: entryType === 'income' ? distributeToBudget : false,
       });
@@ -123,6 +126,9 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
     ? Math.round(rawAmount / installmentMonths)
     : null;
 
+  // 귀속 월 계산 (지출 모드에서 실시간 표시)
+  const billingMonthNum = parseInt(getBillingMonthForExpense(date, paymentMethod).slice(5), 10);
+
   return (
     <form onSubmit={(e) => void handleSubmit(e)} className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
       {/* 지출 / 수입 토글 */}
@@ -150,6 +156,11 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
         <h2 className="flex items-center gap-1 text-sm font-semibold text-gray-700">
           <PlusIcon size={14} />
           {entryType === 'expense' ? '지출 추가' : '수입 추가'}
+          {entryType === 'expense' && (
+            <span className="ml-1 text-xs font-normal text-gray-400">
+              {billingMonthNum}월 대금
+            </span>
+          )}
         </h2>
       </div>
 
@@ -200,29 +211,23 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
           <div>
             <label className="mb-1 block text-xs text-gray-500">결제수단</label>
             <div className="flex rounded-lg border border-gray-200 p-0.5">
-              <button
-                type="button"
-                onClick={() => handlePaymentMethodChange('카드')}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                  paymentMethod === '카드' ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                카드
-              </button>
-              <button
-                type="button"
-                onClick={() => handlePaymentMethodChange('현금')}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                  paymentMethod === '현금' ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                현금
-              </button>
+              {PAYMENT_OPTIONS.map((method) => (
+                <button
+                  key={method}
+                  type="button"
+                  onClick={() => handlePaymentMethodChange(method)}
+                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
+                    paymentMethod === method ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  {method}
+                </button>
+              ))}
             </div>
           </div>
 
           {/* 할부 (카드 선택 시만) */}
-          {paymentMethod === '카드' && (
+          {paymentMethod !== '현금' && (
             <div>
               <Select
                 label="할부"

--- a/web/src/features/budget/components/expense-list.tsx
+++ b/web/src/features/budget/components/expense-list.tsx
@@ -36,6 +36,16 @@ function getCategoryColor(category: string): string {
   return CATEGORY_COLORS[category] ?? '#9ca3af';
 }
 
+const PAYMENT_LABELS: Record<string, string> = {
+  '현대카드': '현대',
+  '국민카드': '국민',
+  '현금': '현금',
+};
+
+function getPaymentLabel(method: string): string | null {
+  return PAYMENT_LABELS[method] ?? null;
+}
+
 interface ExpenseListProps {
   expenses: ExpenseRow[];
   onEdit: (expense: ExpenseRow) => void;
@@ -156,6 +166,11 @@ export function ExpenseList({ expenses, onEdit, selectedCategory, onCategoryChan
                           {expense.is_installment && expense.installment_num !== null && expense.installment_total !== null && (
                             <span className="rounded bg-sky-50 px-1.5 py-0.5 text-xs text-sky-500">
                               {expense.installment_num}/{expense.installment_total}
+                            </span>
+                          )}
+                          {expense.type === 'expense' && getPaymentLabel(expense.payment_method) && (
+                            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-400">
+                              {getPaymentLabel(expense.payment_method)}
                             </span>
                           )}
                         </div>

--- a/web/src/features/budget/components/month-summary.tsx
+++ b/web/src/features/budget/components/month-summary.tsx
@@ -4,6 +4,7 @@ import type { MonthSummary } from '@/features/budget/lib/types';
 import { calcRunwayShorten } from '@/features/budget/lib/allocator/runway-warn';
 import { formatAmount } from '@/lib/types';
 import { getTodayISO } from '@/lib/kst';
+import { getBillingRange, calcCycleDays } from '@/features/budget/lib/billing/cycle';
 import { BanknotesIcon, ClockIcon, CheckCircleIcon } from '@/components/ui/icons';
 
 interface MonthSummaryCardProps {
@@ -30,15 +31,13 @@ export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
   const todayFlexSpent = summary.today_flex_spent ?? 0;
   const todayRemaining = summary.today_remaining;
 
-  // 결제주기: 전월 16일 ~ 당월 15일
+  // 결제주기: 전월 14일 ~ 당월 13일
   const todayISO = getTodayISO();
   const today = new Date(`${todayISO}T00:00:00`);
-  const [year, month] = summary.year_month.split('-').map(Number);
-  const prevMonth = month === 1 ? 12 : month - 1;
-  const prevYear = month === 1 ? year - 1 : year;
-  const cycleStart = new Date(`${prevYear}-${String(prevMonth).padStart(2, '0')}-16T00:00:00`);
-  const cycleEnd = new Date(`${year}-${String(month).padStart(2, '0')}-15T00:00:00`);
-  const totalDays = Math.round((cycleEnd.getTime() - cycleStart.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  const { from, to } = getBillingRange(summary.year_month);
+  const cycleStart = new Date(`${from}T00:00:00`);
+  const cycleEnd = new Date(`${to}T00:00:00`);
+  const totalDays = calcCycleDays(from, to);
   const isFutureCycle = today < cycleStart;
   const isCurrentCycle = today >= cycleStart && today <= cycleEnd;
   const daysPassed = isFutureCycle

--- a/web/src/features/budget/components/planned-expense-edit-modal.tsx
+++ b/web/src/features/budget/components/planned-expense-edit-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import type { PlannedExpenseRow, ExpenseRow } from '@/features/budget/lib/types';
+import { getBillingRange } from '@/features/budget/lib/billing/cycle';
 import { formatAmount } from '@/lib/types';
 import { XMarkIcon } from '@/components/ui/icons';
 import { Button } from '@/components/ui/button';
@@ -26,11 +27,7 @@ export function PlannedExpenseEditModal({ item, yearMonth, onSave, onDelete, onC
 
   // 연결된 지출 내역 로드
   useEffect(() => {
-    const [year, month] = yearMonth.split('-').map(Number);
-    const prevMonth = month === 1 ? 12 : month - 1;
-    const prevYear = month === 1 ? year - 1 : year;
-    const from = `${prevYear}-${String(prevMonth).padStart(2, '0')}-16`;
-    const to = `${year}-${String(month).padStart(2, '0')}-15`;
+    const { from, to } = getBillingRange(yearMonth);
 
     void fetch(`/api/expenses?from=${from}&to=${to}&planned_expense_id=${item.id}`)
       .then((r) => r.json())

--- a/web/src/features/budget/lib/allocator/__tests__/edge-cases.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/edge-cases.test.ts
@@ -9,7 +9,7 @@ const BASE: MonthAllocatorInput = {
   plannedExpenses: [],
   currentBillingMonth: '2026-04',
   targetMonth: '2026-06',   // 3개월: Apr, May, Jun
-  today: '2026-04-11',      // Apr 주기: 03-16~04-15 (31일)
+  today: '2026-04-11',      // Apr 주기: 03-14~04-13 (31일)
 };
 
 describe('F. 엣지 케이스', () => {

--- a/web/src/features/budget/lib/allocator/__tests__/month-allocator.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/month-allocator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { allocateMonthlyBudgets } from '../month-allocator';
 import type { MonthAllocatorInput } from '../../types-v2';
 
-// today: 2026-04-11 → 현재 주기 03-16~04-15 (31일)
+// today: 2026-04-11 → 현재 주기 03-14~04-13 (31일)
 const BASE: MonthAllocatorInput = {
   totalAvailable: 36000,
   fixedMonthly: 0,
@@ -50,7 +50,7 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
 
   describe('B-4. 자산 감소 → 전 월 자유 예산 비례 감소', () => {
     it('totalAvailable 절반 → dailyFree 절반, free 비례 감소', () => {
-      // sumDays = 31(Apr) + 30(May 주기: 04-16~05-15) = 61
+      // sumDays = 31(Apr) + 30(May 주기: 04-14~05-13) = 61
       // 61000 → dailyFree=1000, Apr=31000, May=30000
       // 30500 → dailyFree=500, Apr=15500, May=15000
       const r1 = allocateMonthlyBudgets({ ...BASE, totalAvailable: 61000 });
@@ -260,7 +260,7 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
   describe('B-7. today가 달라도 결과 동일 (대금기간 내 고정 예산)', () => {
     it('대금기간 내 다른 날짜여도 allocatedDays/monthlyBudgets 동일', () => {
       const r1 = allocateMonthlyBudgets({ ...BASE, today: '2026-03-17' });
-      const r2 = allocateMonthlyBudgets({ ...BASE, today: '2026-04-14' });
+      const r2 = allocateMonthlyBudgets({ ...BASE, today: '2026-04-10' });
       expect(r1).toEqual(r2);
     });
   });

--- a/web/src/features/budget/lib/allocator/__tests__/proration.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/proration.test.ts
@@ -4,37 +4,37 @@ import type { BillingCycle } from '../../types-v2';
 
 const CYCLE_APR: BillingCycle = {
   yearMonth: '2026-04',
-  from: '2026-03-16',
-  to: '2026-04-15',
+  from: '2026-03-14',
+  to: '2026-04-13',
   totalDays: 31,
 };
 
 describe('프로레이션 — calcAllocatedDays', () => {
   it('주기 중간: elapsed + remaining = totalDays', () => {
-    // today: 2026-04-11 → 4/11~4/15 = 5일 남음
+    // today: 2026-04-11 → 4/11~4/13 = 3일 남음
     const result = calcAllocatedDays('2026-04-11', CYCLE_APR);
-    expect(result.elapsed).toBe(26);   // 3/16~4/10
-    expect(result.remaining).toBe(5);  // 4/11~4/15
-    expect(result.allocatedDays).toBe(5);
+    expect(result.elapsed).toBe(28);   // 3/14~4/10
+    expect(result.remaining).toBe(3);  // 4/11~4/13
+    expect(result.allocatedDays).toBe(3);
     expect(result.elapsed + result.remaining).toBe(CYCLE_APR.totalDays);
   });
 
   it('주기 첫날: elapsed=0, allocatedDays=totalDays', () => {
-    const result = calcAllocatedDays('2026-03-16', CYCLE_APR);
+    const result = calcAllocatedDays('2026-03-14', CYCLE_APR);
     expect(result.elapsed).toBe(0);
     expect(result.remaining).toBe(31);
     expect(result.allocatedDays).toBe(31);
   });
 
   it('주기 마지막 날: allocatedDays=1', () => {
-    const result = calcAllocatedDays('2026-04-15', CYCLE_APR);
+    const result = calcAllocatedDays('2026-04-13', CYCLE_APR);
     expect(result.elapsed).toBe(30);
     expect(result.remaining).toBe(1);
     expect(result.allocatedDays).toBe(1);
   });
 
   it('주기 하루 전날: allocatedDays=2', () => {
-    const result = calcAllocatedDays('2026-04-14', CYCLE_APR);
+    const result = calcAllocatedDays('2026-04-12', CYCLE_APR);
     expect(result.allocatedDays).toBe(2);
   });
 });

--- a/web/src/features/budget/lib/billing/__tests__/card-billing.test.ts
+++ b/web/src/features/budget/lib/billing/__tests__/card-billing.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { getBillingMonthForExpense } from '../card-billing';
+
+describe('getBillingMonthForExpense — 카드별 귀속 월 판별', () => {
+  describe('현대카드 (startDay=14)', () => {
+    it('13일 → 현재 달 귀속 (13 < 14)', () => {
+      expect(getBillingMonthForExpense('2026-04-13', '현대카드')).toBe('2026-04');
+    });
+
+    it('14일 → 다음 달 귀속 (14 >= 14)', () => {
+      expect(getBillingMonthForExpense('2026-04-14', '현대카드')).toBe('2026-05');
+    });
+
+    it('1일 → 현재 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-04-01', '현대카드')).toBe('2026-04');
+    });
+
+    it('31일 → 다음 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-03-31', '현대카드')).toBe('2026-04');
+    });
+  });
+
+  describe('국민카드 (startDay=13)', () => {
+    it('12일 → 현재 달 귀속 (12 < 13)', () => {
+      expect(getBillingMonthForExpense('2026-04-12', '국민카드')).toBe('2026-04');
+    });
+
+    it('13일 → 다음 달 귀속 (13 >= 13)', () => {
+      expect(getBillingMonthForExpense('2026-04-13', '국민카드')).toBe('2026-05');
+    });
+  });
+
+  describe('현금 (시스템 기본 startDay=14 적용)', () => {
+    it('13일 → 현재 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-04-13', '현금')).toBe('2026-04');
+    });
+
+    it('14일 → 다음 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-04-14', '현금')).toBe('2026-05');
+    });
+  });
+
+  describe('미등록 결제수단 → 시스템 기본 적용', () => {
+    it('13일 → 현재 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-04-13', '알수없는카드')).toBe('2026-04');
+    });
+
+    it('14일 → 다음 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-04-14', '알수없는카드')).toBe('2026-05');
+    });
+  });
+
+  describe('12월 → 연도 넘김 처리', () => {
+    it('현대카드 12월 14일 → 2027-01', () => {
+      expect(getBillingMonthForExpense('2026-12-14', '현대카드')).toBe('2027-01');
+    });
+
+    it('국민카드 12월 13일 → 2027-01', () => {
+      expect(getBillingMonthForExpense('2026-12-13', '국민카드')).toBe('2027-01');
+    });
+
+    it('현대카드 12월 13일 → 2026-12 (현재 달)', () => {
+      expect(getBillingMonthForExpense('2026-12-13', '현대카드')).toBe('2026-12');
+    });
+  });
+});

--- a/web/src/features/budget/lib/billing/__tests__/cycle.test.ts
+++ b/web/src/features/budget/lib/billing/__tests__/cycle.test.ts
@@ -9,54 +9,54 @@ import {
 } from '../cycle';
 
 describe('A. 빌링 주기', () => {
-  describe('A-1. getCurrentBillingMonth — 15일/16일 경계', () => {
-    it('15일 23:59 KST는 당월', () => {
-      // 2026-04-15 23:59 KST = 2026-04-15 14:59 UTC
-      const now = new Date('2026-04-15T14:59:00Z');
+  describe('A-1. getCurrentBillingMonth — 13일/14일 경계', () => {
+    it('13일 23:59 KST는 당월', () => {
+      // 2026-04-13 23:59 KST = 2026-04-13 14:59 UTC
+      const now = new Date('2026-04-13T14:59:00Z');
       expect(getCurrentBillingMonth(now)).toBe('2026-04');
     });
 
-    it('16일 00:00 KST는 다음 월', () => {
-      // 2026-04-16 00:00 KST = 2026-04-15 15:00 UTC
-      const now = new Date('2026-04-15T15:00:00Z');
+    it('14일 00:00 KST는 다음 월', () => {
+      // 2026-04-14 00:00 KST = 2026-04-13 15:00 UTC
+      const now = new Date('2026-04-13T15:00:00Z');
       expect(getCurrentBillingMonth(now)).toBe('2026-05');
     });
 
     it('월말(31일) → 다음 월로 올바르게 넘어감', () => {
-      // 2026-03-16 → 2026-04
-      const now = new Date('2026-03-16T00:00:00+09:00');
+      // 2026-03-14 → 2026-04
+      const now = new Date('2026-03-14T00:00:00+09:00');
       expect(getCurrentBillingMonth(now)).toBe('2026-04');
     });
 
-    it('12월 16일 → 다음 해 1월', () => {
-      const now = new Date('2025-12-16T00:00:00+09:00');
+    it('12월 14일 → 다음 해 1월', () => {
+      const now = new Date('2025-12-14T00:00:00+09:00');
       expect(getCurrentBillingMonth(now)).toBe('2026-01');
     });
   });
 
   describe('A-2. getBillingRange', () => {
-    it("'2026-04' → { from: '2026-03-16', to: '2026-04-15' }", () => {
+    it("'2026-04' → { from: '2026-03-14', to: '2026-04-13' }", () => {
       expect(getBillingRange('2026-04')).toEqual({
-        from: '2026-03-16',
-        to: '2026-04-15',
+        from: '2026-03-14',
+        to: '2026-04-13',
       });
     });
 
-    it('1월인 경우 전년 12월 16일', () => {
+    it('1월인 경우 전년 12월 14일', () => {
       expect(getBillingRange('2026-01')).toEqual({
-        from: '2025-12-16',
-        to: '2026-01-15',
+        from: '2025-12-14',
+        to: '2026-01-13',
       });
     });
   });
 
   describe('A-3. calcCycleDays', () => {
-    it("'2026-03-16' ~ '2026-04-15' = 31일", () => {
-      expect(calcCycleDays('2026-03-16', '2026-04-15')).toBe(31);
+    it("'2026-03-14' ~ '2026-04-13' = 31일", () => {
+      expect(calcCycleDays('2026-03-14', '2026-04-13')).toBe(31);
     });
 
-    it('2월 포함 주기 (2025-01-16 ~ 2025-02-15) = 31일', () => {
-      expect(calcCycleDays('2025-01-16', '2025-02-15')).toBe(31);
+    it('2월 포함 주기 (2025-01-14 ~ 2025-02-13) = 31일', () => {
+      expect(calcCycleDays('2025-01-14', '2025-02-13')).toBe(31);
     });
 
     it('같은 날 = 1일', () => {
@@ -83,23 +83,23 @@ describe('A. 빌링 주기', () => {
       const now = new Date('2026-04-10T10:00:00+09:00');
       const cycle = getBillingCycle(now);
       expect(cycle.yearMonth).toBe('2026-04');
-      expect(cycle.from).toBe('2026-03-16');
-      expect(cycle.to).toBe('2026-04-15');
+      expect(cycle.from).toBe('2026-03-14');
+      expect(cycle.to).toBe('2026-04-13');
       expect(cycle.totalDays).toBe(31);
     });
   });
 
   describe('isLastDayOfCycle', () => {
-    it('15일 = true', () => {
-      expect(isLastDayOfCycle('2026-04-15')).toBe(true);
+    it('13일 = true', () => {
+      expect(isLastDayOfCycle('2026-04-13')).toBe(true);
     });
 
-    it('14일 = false', () => {
-      expect(isLastDayOfCycle('2026-04-14')).toBe(false);
+    it('12일 = false', () => {
+      expect(isLastDayOfCycle('2026-04-12')).toBe(false);
     });
 
-    it('1월 15일 = true', () => {
-      expect(isLastDayOfCycle('2026-01-15')).toBe(true);
+    it('1월 13일 = true', () => {
+      expect(isLastDayOfCycle('2026-01-13')).toBe(true);
     });
   });
 });

--- a/web/src/features/budget/lib/billing/__tests__/fixed-cost-date.test.ts
+++ b/web/src/features/budget/lib/billing/__tests__/fixed-cost-date.test.ts
@@ -7,12 +7,12 @@ describe('resolveFixedCostExpenseDate', () => {
       expect(resolveFixedCostExpenseDate('2026-04', 1)).toBe('2026-04-01');
     });
 
-    it('결제일 15일 (결제주기 말일) → 당월', () => {
-      expect(resolveFixedCostExpenseDate('2026-04', 15)).toBe('2026-04-15');
+    it('결제일 13일 (결제주기 말일) → 당월', () => {
+      expect(resolveFixedCostExpenseDate('2026-04', 13)).toBe('2026-04-13');
     });
 
-    it('결제일 16일 (결제주기 시작일) → 전월', () => {
-      expect(resolveFixedCostExpenseDate('2026-04', 16)).toBe('2026-03-16');
+    it('결제일 14일 (결제주기 시작일) → 전월', () => {
+      expect(resolveFixedCostExpenseDate('2026-04', 14)).toBe('2026-03-14');
     });
 
     it('결제일 31일 → 전월 말일', () => {
@@ -20,10 +20,10 @@ describe('resolveFixedCostExpenseDate', () => {
     });
   });
 
-  describe('월 경계 — 15일/16일 boundary', () => {
-    it('15일 ↔ 16일 경계에서 월이 바뀐다', () => {
-      expect(resolveFixedCostExpenseDate('2026-04', 15)).toBe('2026-04-15');
-      expect(resolveFixedCostExpenseDate('2026-04', 16)).toBe('2026-03-16');
+  describe('월 경계 — 13일/14일 boundary', () => {
+    it('13일 ↔ 14일 경계에서 월이 바뀐다', () => {
+      expect(resolveFixedCostExpenseDate('2026-04', 13)).toBe('2026-04-13');
+      expect(resolveFixedCostExpenseDate('2026-04', 14)).toBe('2026-03-14');
     });
   });
 
@@ -32,8 +32,8 @@ describe('resolveFixedCostExpenseDate', () => {
       expect(resolveFixedCostExpenseDate('2026-01', 16)).toBe('2025-12-16');
     });
 
-    it('1월 + 결제일 15일 → 당월 1월', () => {
-      expect(resolveFixedCostExpenseDate('2026-01', 15)).toBe('2026-01-15');
+    it('1월 + 결제일 13일 → 당월 1월', () => {
+      expect(resolveFixedCostExpenseDate('2026-01', 13)).toBe('2026-01-13');
     });
 
     it('12월 + 결제일 16일 → 당년 11월', () => {

--- a/web/src/features/budget/lib/billing/card-billing.ts
+++ b/web/src/features/budget/lib/billing/card-billing.ts
@@ -1,0 +1,31 @@
+/** 카드별 대금기간 상수 (startDay: 해당 일 이상이면 다음 달 대금) */
+export const CARD_BILLING_CYCLES: Record<string, { startDay: number }> = {
+  '현대카드': { startDay: 14 },
+  '국민카드': { startDay: 13 },
+};
+
+/** 시스템 기본 대금기간 시작일 (현대카드 기준) */
+const DEFAULT_START_DAY = 14;
+
+/**
+ * 결제수단 + 결제일 → 귀속 billing month 반환
+ *
+ * - 현대카드: 14일 이상 → 다음 달 대금
+ * - 국민카드: 13일 이상 → 다음 달 대금
+ * - 현금 / 미등록 결제수단: 시스템 기본(14일 기준) 적용
+ *
+ * @param date 'YYYY-MM-DD'
+ * @param paymentMethod 결제수단 문자열
+ * @returns 'YYYY-MM'
+ */
+export function getBillingMonthForExpense(date: string, paymentMethod: string): string {
+  const d = new Date(`${date}T00:00:00`);
+  const day = d.getDate();
+  const startDay = CARD_BILLING_CYCLES[paymentMethod]?.startDay ?? DEFAULT_START_DAY;
+
+  if (day >= startDay) {
+    const next = new Date(d.getFullYear(), d.getMonth() + 1, 1);
+    return `${next.getFullYear()}-${String(next.getMonth() + 1).padStart(2, '0')}`;
+  }
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}

--- a/web/src/features/budget/lib/billing/cycle.ts
+++ b/web/src/features/budget/lib/billing/cycle.ts
@@ -11,10 +11,10 @@ function pad2(n: number): string {
   return String(n).padStart(2, '0');
 }
 
-/** 현재 결제 주기의 billing month (16일 이후면 다음 달) */
+/** 현재 결제 주기의 billing month (14일 이후면 다음 달) */
 export function getCurrentBillingMonth(now: Date): string {
   const { year, month, day } = toKST(now);
-  if (day >= 16) {
+  if (day >= 14) {
     const nextMonth = month === 12 ? 1 : month + 1;
     const nextYear = month === 12 ? year + 1 : year;
     return `${nextYear}-${pad2(nextMonth)}`;
@@ -22,14 +22,14 @@ export function getCurrentBillingMonth(now: Date): string {
   return `${year}-${pad2(month)}`;
 }
 
-/** 결제 주기 날짜 범위 (전월 16일 ~ 당월 15일) */
+/** 결제 주기 날짜 범위 (전월 14일 ~ 당월 13일) */
 export function getBillingRange(yearMonth: string): { from: string; to: string } {
   const [y, m] = yearMonth.split('-').map(Number);
   const prevMonth = m === 1 ? 12 : m - 1;
   const prevYear = m === 1 ? y - 1 : y;
   return {
-    from: `${prevYear}-${pad2(prevMonth)}-16`,
-    to: `${y}-${pad2(m)}-15`,
+    from: `${prevYear}-${pad2(prevMonth)}-14`,
+    to: `${y}-${pad2(m)}-13`,
   };
 }
 
@@ -53,7 +53,7 @@ export function getBillingCycle(now: Date): BillingCycle {
   return { yearMonth, from, to, totalDays: calcCycleDays(from, to) };
 }
 
-/** 날짜(YYYY-MM-DD)가 결제 주기 마지막 날(15일)인지 */
+/** 날짜(YYYY-MM-DD)가 결제 주기 마지막 날(13일)인지 */
 export function isLastDayOfCycle(date: string): boolean {
-  return date.endsWith('-15');
+  return date.endsWith('-13');
 }

--- a/web/src/features/budget/lib/billing/fixed-cost-date.ts
+++ b/web/src/features/budget/lib/billing/fixed-cost-date.ts
@@ -1,6 +1,6 @@
 /**
  * 결제주기 기반 고정비 기록 날짜 결정 (순수 함수).
- * 결제주기는 전월 16일 ~ 당월 15일이므로, day_of_month >= 16 이면 전월에 기록된다.
+ * 결제주기는 전월 14일 ~ 당월 13일이므로, day_of_month >= 14 이면 전월에 기록된다.
  * 해당 월에 day_of_month 가 없는 경우(예: 2월 31일)는 그 달의 말일로 보정한다.
  *
  * @param yearMonth 'YYYY-MM' — 결제주기 기준 월
@@ -22,8 +22,8 @@ export function resolveFixedCostExpenseDate(
   const prevMonth = month === 1 ? 12 : month - 1;
   const prevYear = month === 1 ? year - 1 : year;
 
-  const expenseYear = dayOfMonth >= 16 ? prevYear : year;
-  const expenseMonth = dayOfMonth >= 16 ? prevMonth : month;
+  const expenseYear = dayOfMonth >= 14 ? prevYear : year;
+  const expenseMonth = dayOfMonth >= 14 ? prevMonth : month;
 
   const lastDay = new Date(expenseYear, expenseMonth, 0).getDate();
   const actualDay = Math.min(dayOfMonth, lastDay);

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -37,7 +37,7 @@ import { readIncomeTotal, readCurrentMonthOnlyIncome } from './repository/income
 import { readFlexibleSpent, readExcludedSpent, readTodayFlexSpent, readAvgVariableMonthly } from './repository/expenses-repo';
 import { readTargetMonth } from './repository/settings-repo';
 
-// April 10 21:00 KST — billing cycle: 2026-04 (Mar 16 ~ Apr 15)
+// April 10 21:00 KST — billing cycle: 2026-04 (Mar 14 ~ Apr 13)
 const DEFAULT_NOW = new Date('2026-04-10T12:00:00Z');
 
 function setupCommonMocks() {
@@ -91,7 +91,7 @@ describe('getMonthlyAllocation', () => {
   it('readCurrentMonthOnlyIncome 을 현재 결제주기 시작일 ~ 오늘 범위로 호출', async () => {
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(1_000_000);
     await getMonthlyAllocation(1, DEFAULT_NOW);
-    expect(readCurrentMonthOnlyIncome).toHaveBeenCalledWith(1, '2026-03-16', '2026-04-10');
+    expect(readCurrentMonthOnlyIncome).toHaveBeenCalledWith(1, '2026-03-14', '2026-04-10');
   });
 
   it('currentMonthOnlyIncome > 0 → 현재 월 free 에 독점 귀속, 다른 월은 오히려 감소', async () => {
@@ -121,18 +121,18 @@ describe('runSettlementIfDue', () => {
     setupCommonMocks();
   });
 
-  it('정산일(16일)이 아니면 settled=false', async () => {
+  it('정산일(14일)이 아니면 settled=false', async () => {
     const result = await runSettlementIfDue(1, DEFAULT_NOW); // April 10
 
     expect(result.settled).toBe(false);
     expect(saveSnapshotIfAbsent).not.toHaveBeenCalled();
   });
 
-  it('정산일(16일)이고 스냅샷 신규 → settled=true + 스냅샷 반환', async () => {
-    // April 16 12:00 UTC = April 16 21:00 KST → yesterday=April 15 → shouldSettle=true, targetMonth='2026-04'...
-    // wait: targetMonth = '2026-04-15'.slice(0,7) = '2026-04', range.to = '2026-04-15'
-    // targetEnd = new Date('2026-04-15T12:00:00Z') = Apr 15 21:00 KST → billing cycle '2026-04' ✓
-    const settlementNow = new Date('2026-04-16T12:00:00Z');
+  it('정산일(14일)이고 스냅샷 신규 → settled=true + 스냅샷 반환', async () => {
+    // April 14 12:00 UTC = April 14 21:00 KST → yesterday=April 13 → shouldSettle=true, targetMonth='2026-04'
+    // targetMonth = '2026-04-13'.slice(0,7) = '2026-04', range.to = '2026-04-13'
+    // targetEnd = new Date('2026-04-13T12:00:00Z') = Apr 13 21:00 KST → billing cycle '2026-04' ✓
+    const settlementNow = new Date('2026-04-14T12:00:00Z');
 
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
@@ -149,7 +149,7 @@ describe('runSettlementIfDue', () => {
   });
 
   it('available_at_end = availableAtStart + income - flex - excluded (자산 미참조)', async () => {
-    const settlementNow = new Date('2026-04-16T12:00:00Z');
+    const settlementNow = new Date('2026-04-14T12:00:00Z');
 
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -68,7 +68,7 @@ export async function getMonthlyAllocation(
   const [totalAvailable, fixedMonthly, installments, targetMonth, currentMonthOnlyIncome] = await Promise.all([
     computeTotalAvailable(userId, todayStr),
     readFixedCostsMonthlyTotal(userId),
-    readActiveInstallments(userId, cycle.from),
+    readActiveInstallments(userId, cycle.yearMonth),
     readTargetMonth(userId),
     readCurrentMonthOnlyIncome(userId, cycle.from, todayStr),
   ]);
@@ -125,7 +125,7 @@ export async function getRunwayProjection(
     getMonthlyAllocation(userId, now),
     readAvgVariableMonthly(userId, 3),
     readFixedCostsMonthlyTotal(userId),
-    readActiveInstallments(userId, cycle.from),
+    readActiveInstallments(userId, cycle.yearMonth),
     readTargetMonth(userId),
   ]);
 
@@ -178,7 +178,7 @@ export async function getBudgetPreview(
   const [totalAvailable, fixedMonthly, installments, currentMonthOnlyIncome] = await Promise.all([
     computeTotalAvailable(userId, todayStr),
     readFixedCostsMonthlyTotal(userId),
-    readActiveInstallments(userId, cycle.from),
+    readActiveInstallments(userId, cycle.yearMonth),
     readCurrentMonthOnlyIncome(userId, cycle.from, todayStr),
   ]);
   const planned = await readPlannedExpenses(userId, cycle.yearMonth, targetDate);

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -1,7 +1,7 @@
 import { query, queryOne } from '@/lib/db';
 import { getTodayISO } from '@/lib/kst';
 import { getTodayAllocation } from './facade';
-import { getCurrentBillingMonth } from './billing/cycle';
+import { getCurrentBillingMonth, getBillingRange, calcCycleDays } from './billing/cycle';
 import { resolveFixedCostExpenseDate } from './billing/fixed-cost-date';
 import type {
   ExpenseRow,
@@ -199,14 +199,10 @@ export async function deleteExpense(userId: number, id: number): Promise<boolean
 
 /**
  * 월간 요약: 총 지출, 카테고리별, 예산 대비.
- * 카드 결제주기 기준: 전월 16일 ~ 당월 15일.
+ * 카드 결제주기 기준: 전월 14일 ~ 당월 13일.
  */
 export async function queryMonthSummary(userId: number, yearMonth: string): Promise<MonthSummary> {
-  const [year, month] = yearMonth.split('-').map(Number);
-  const prevMonth = month === 1 ? 12 : month - 1;
-  const prevYear = month === 1 ? year - 1 : year;
-  const from = `${prevYear}-${String(prevMonth).padStart(2, '0')}-16`;
-  const to = `${year}-${String(month).padStart(2, '0')}-15`;
+  const { from, to } = getBillingRange(yearMonth);
 
   const [totalResult, categoryResult, fixedCosts] = await Promise.all([
     query<{ total: string }>(
@@ -283,10 +279,8 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
   const plannedRows = await queryPlannedExpenses(userId, yearMonth);
   const plannedTotal = plannedRows.reduce((s, p) => s + p.amount, 0);
 
-  // 결제주기 일수 계산 (전월 16일 ~ 당월 15일)
-  const fromDate = new Date(`${from}T00:00:00`);
-  const toDate = new Date(`${to}T00:00:00`);
-  const daysInCycle = Math.round((toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  // 결제주기 일수 계산 (전월 14일 ~ 당월 13일)
+  const daysInCycle = calcCycleDays(from, to);
   const dailyAvg = variableTotal > 0 ? Math.round(variableTotal / daysInCycle) : 0;
 
   // 자동 예산은 런웨이 API에서 따로 로드 (순환 참조 방지)

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -3,6 +3,7 @@ import { getTodayISO } from '@/lib/kst';
 import { getTodayAllocation } from './facade';
 import { getCurrentBillingMonth, getBillingRange, calcCycleDays } from './billing/cycle';
 import { resolveFixedCostExpenseDate } from './billing/fixed-cost-date';
+import { getBillingMonthForExpense } from './billing/card-billing';
 import type {
   ExpenseRow,
   FixedCostRow,
@@ -76,9 +77,10 @@ export async function createExpense(
     distribute_to_budget?: boolean;
   },
 ): Promise<ExpenseRow> {
+  const billingMonth = getBillingMonthForExpense(data.date, data.payment_method ?? '현대카드');
   const row = await queryOne<ExpenseRow>(
-    `INSERT INTO expenses (user_id, date, amount, category, description, payment_method, memo, source, type, planned_expense_id, exclude_from_budget, distribute_to_budget)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, 'manual', $8, $9, $10, $11)
+    `INSERT INTO expenses (user_id, date, amount, category, description, payment_method, memo, source, type, planned_expense_id, exclude_from_budget, distribute_to_budget, billing_month)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'manual', $8, $9, $10, $11, $12)
      RETURNING id, date::text, amount, category, description, payment_method,
                is_installment, installment_num, installment_total, installment_group,
                source, memo, COALESCE(type, 'expense') as type, planned_expense_id, created_at::text,
@@ -90,12 +92,13 @@ export async function createExpense(
       data.amount,
       data.category,
       data.description ?? null,
-      data.payment_method ?? '카드',
+      data.payment_method ?? '현대카드',
       data.memo ?? null,
       data.type ?? 'expense',
       data.planned_expense_id ?? null,
       data.exclude_from_budget ?? false,
       data.distribute_to_budget ?? false,
+      billingMonth,
     ],
   );
   if (!row) throw new Error('createExpense: INSERT returned no rows');
@@ -132,12 +135,13 @@ export async function createInstallmentExpenses(
     const baseDate = new Date(`${data.date}T00:00:00`);
     baseDate.setMonth(baseDate.getMonth() + i);
     const expDate = `${baseDate.getFullYear()}-${String(baseDate.getMonth() + 1).padStart(2, '0')}-${String(baseDate.getDate()).padStart(2, '0')}`;
+    const billingMonth = getBillingMonthForExpense(expDate, data.payment_method ?? '현대카드');
 
     const row = await queryOne<ExpenseRow>(
       `INSERT INTO expenses (user_id, date, amount, category, description, payment_method,
                              is_installment, installment_num, installment_total, installment_group,
-                             memo, source, type, exclude_from_budget)
-       VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8, $9, $10, 'manual', $11, $12)
+                             memo, source, type, exclude_from_budget, billing_month)
+       VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8, $9, $10, 'manual', $11, $12, $13)
        RETURNING id, date::text, amount, category, description, payment_method,
                  is_installment, installment_num, installment_total, installment_group,
                  source, memo, COALESCE(type, 'expense') as type, planned_expense_id, created_at::text,
@@ -148,13 +152,14 @@ export async function createInstallmentExpenses(
         amount,
         data.category,
         data.description ?? null,
-        data.payment_method ?? '카드',
+        data.payment_method ?? '현대카드',
         i + 1,
         data.months,
         groupId,
         data.memo ?? null,
         data.type ?? 'expense',
         excludeFromBudget,
+        billingMonth,
       ],
     );
     if (i === 0) firstRow = row ?? null;
@@ -390,11 +395,12 @@ export async function ensureFixedCostExpenses(userId: number, yearMonth: string)
 
     if (existing) continue;
 
+    const fixedBillingMonth = getBillingMonthForExpense(expenseDate, '현대카드');
     await queryOne(
-      `INSERT INTO expenses (user_id, date, amount, category, description, payment_method, source, memo, type, exclude_from_budget)
-       VALUES ($1, $2, $3, $4, $5, '카드', 'fixed', $6, 'expense', true)
+      `INSERT INTO expenses (user_id, date, amount, category, description, payment_method, source, memo, type, exclude_from_budget, billing_month)
+       VALUES ($1, $2, $3, $4, $5, '현대카드', 'fixed', $6, 'expense', true, $7)
        RETURNING id`,
-      [userId, expenseDate, fc.amount, fc.category ?? '기타', fc.name, `고정비 자동 기록 (fixed_cost_id: ${fc.id})`],
+      [userId, expenseDate, fc.amount, fc.category ?? '기타', fc.name, `고정비 자동 기록 (fixed_cost_id: ${fc.id})`, fixedBillingMonth],
     );
     created++;
   }

--- a/web/src/features/budget/lib/repository/installments-repo.ts
+++ b/web/src/features/budget/lib/repository/installments-repo.ts
@@ -3,7 +3,7 @@ import type { InstallmentInput } from '../types-v2';
 
 export async function readActiveInstallments(
   userId: number,
-  currentBillingFrom: string,
+  currentBillingMonth: string,
 ): Promise<InstallmentInput[]> {
   const result = await query<{
     group: string;
@@ -14,15 +14,15 @@ export async function readActiveInstallments(
     `SELECT
        installment_group AS group,
        MAX(amount)::int AS monthly_amount,
-       COUNT(*) FILTER (WHERE date >= $2::date)::int AS remaining_count,
-       (MIN(date) FILTER (WHERE installment_num = 1) >= $2::date) AS is_new
+       COUNT(*) FILTER (WHERE billing_month >= $2)::int AS remaining_count,
+       (MIN(billing_month) FILTER (WHERE installment_num = 1) >= $2) AS is_new
      FROM expenses
      WHERE user_id = $1
        AND is_installment = true
        AND installment_group IS NOT NULL
      GROUP BY installment_group
-     HAVING COUNT(*) FILTER (WHERE date >= $2::date) > 0`,
-    [userId, currentBillingFrom],
+     HAVING COUNT(*) FILTER (WHERE billing_month >= $2) > 0`,
+    [userId, currentBillingMonth],
   );
 
   return result.rows.map((r) => ({

--- a/web/src/features/budget/lib/settlement/__tests__/settle.test.ts
+++ b/web/src/features/budget/lib/settlement/__tests__/settle.test.ts
@@ -4,25 +4,25 @@ import type { MonthlyBudget, SettlementInput } from '../../types-v2';
 
 describe('E. 월 경계 정산', () => {
   describe('E-1. detectSettlementTrigger', () => {
-    it('KST 00:30 on 16일 → 어제(15일) = 주기 끝 → shouldSettle:true', () => {
-      // 2026-04-16 00:30 KST = 2026-04-15 15:30 UTC
-      const today = new Date('2026-04-15T15:30:00Z');
+    it('KST 00:30 on 14일 → 어제(13일) = 주기 끝 → shouldSettle:true', () => {
+      // 2026-04-14 00:30 KST = 2026-04-13 15:30 UTC
+      const today = new Date('2026-04-13T15:30:00Z');
       const result = detectSettlementTrigger(today);
       expect(result.shouldSettle).toBe(true);
       expect(result.targetMonth).toBe('2026-04');
     });
 
-    it('KST 00:30 on 17일 → 어제(16일) = 주기 시작일 → shouldSettle:false', () => {
-      // 2026-04-17 00:30 KST = 2026-04-16 15:30 UTC
-      const today = new Date('2026-04-16T15:30:00Z');
+    it('KST 00:30 on 15일 → 어제(14일) = 주기 시작일 → shouldSettle:false', () => {
+      // 2026-04-15 00:30 KST = 2026-04-14 15:30 UTC
+      const today = new Date('2026-04-14T15:30:00Z');
       const result = detectSettlementTrigger(today);
       expect(result.shouldSettle).toBe(false);
       expect(result.targetMonth).toBeNull();
     });
 
-    it('1월 16일 KST → 어제(1월 15일) = 주기 끝 → targetMonth=\'2026-01\'', () => {
-      // 2026-01-16 00:30 KST = 2026-01-15 15:30 UTC
-      const today = new Date('2026-01-15T15:30:00Z');
+    it('1월 14일 KST → 어제(1월 13일) = 주기 끝 → targetMonth=\'2026-01\'', () => {
+      // 2026-01-14 00:30 KST = 2026-01-13 15:30 UTC
+      const today = new Date('2026-01-13T15:30:00Z');
       const result = detectSettlementTrigger(today);
       expect(result.shouldSettle).toBe(true);
       expect(result.targetMonth).toBe('2026-01');

--- a/web/src/features/budget/lib/settlement/settle.ts
+++ b/web/src/features/budget/lib/settlement/settle.ts
@@ -18,7 +18,7 @@ function subtractOneDay(dateStr: string): string {
   return `${y}-${m}-${day}`;
 }
 
-/** 어제 날짜가 주기 마지막 날(15일)인지 확인 */
+/** 어제 날짜가 주기 마지막 날(13일)인지 확인 */
 export function detectSettlementTrigger(
   today: Date,
 ): { shouldSettle: boolean; targetMonth: string | null } {
@@ -26,7 +26,7 @@ export function detectSettlementTrigger(
   const yesterday = subtractOneDay(todayKST);
   const day = parseInt(yesterday.slice(8, 10), 10);
 
-  if (day !== 15) return { shouldSettle: false, targetMonth: null };
+  if (day !== 13) return { shouldSettle: false, targetMonth: null };
 
   const targetMonth = yesterday.slice(0, 7); // YYYY-MM
   return { shouldSettle: true, targetMonth };


### PR DESCRIPTION
## 관련 이슈
Closes #312

## 변경 내용
- 현대카드(14일), 국민카드(13일) 기준 카드별 대금 귀속 월 산출 모듈 추가
- 결제주기 경계일 14\~13일로 변경 (cycle.ts, fixed-cost-date.ts, settle.ts)
- expenses 테이블 \`billing_month\` 컬럼 추가 + 지출 생성 시 자동 계산
- 할부 잔여 건수 조회를 \`billing_month\` 기준으로 변경
- 지출 폼 결제수단 3종 토글 + 귀속 대금월 실시간 표시

## 코드 리뷰 결과
- [x] 보안 감사 통과
- [x] 타입 안전성 확인
- [x] 컨벤션 점검 완료
- [x] 코드 품질 확인

## 테스트
- [x] card-billing 단위 테스트 (13개)
- [x] cycle/fixed-cost-date/settle 경계 테스트 업데이트
- [x] facade 통합 테스트 (18개)
- [x] 전체 188개 테스트 통과