### PR TITLE
fix(budget): month-summary 누락 변수 복구

### DIFF
--- a/web/src/features/budget/components/month-summary.tsx
+++ b/web/src/features/budget/components/month-summary.tsx
@@ -31,6 +31,8 @@ export function MonthSummaryCard({ summary }: MonthSummaryCardProps) {
   const todayFlexSpent = summary.today_flex_spent ?? 0;
   const todayRemaining = summary.today_remaining;
 
+  const month = parseInt(summary.year_month.slice(5), 10);
+
   // 결제주기: 전월 14일 ~ 당월 13일
   const todayISO = getTodayISO();
   const today = new Date(`${todayISO}T00:00:00`);


### PR DESCRIPTION
## 변경 내용
- `MonthSummaryCard`에서 `{month}` 렌더링에 필요한 변수 정의 누락 복구
- #313 리팩토링 시 `getBillingRange` 전환 과정에서 실수로 삭제됨

## 테스트
- [x] 빌드 오류 해결 확인