### PR TITLE
fix(budget): 결제주기 UI 보정 + billing_month 기준 지출 조회

### DIFF
--- a/web/src/app/api/expenses/route.ts
+++ b/web/src/app/api/expenses/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { queryExpenses, createExpense, createInstallmentExpenses } from '@/features/budget/lib/queries';
+import { queryExpenses, queryExpensesByBillingMonth, createExpense, createInstallmentExpenses } from '@/features/budget/lib/queries';
 import { EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/features/budget/lib/types';
 import { getTodayISO } from '@/lib/kst';
 import { validateFields } from '@/lib/validation';
@@ -15,17 +15,30 @@ export async function GET(request: Request) {
 
   try {
     const { searchParams } = new URL(request.url);
+    const category = searchParams.get('category') ?? undefined;
+
+    if (category && !VALID_CATEGORIES.has(category)) {
+      return NextResponse.json({ error: '유효하지 않은 category입니다' }, { status: 400 });
+    }
+
+    // billing_month 기준 조회 (카드별 결제주기 반영)
+    const yearMonth = searchParams.get('yearMonth');
+    if (yearMonth) {
+      if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
+        return NextResponse.json({ error: 'yearMonth 형식이 올바르지 않습니다 (YYYY-MM)' }, { status: 400 });
+      }
+      const data = await queryExpensesByBillingMonth(userId, yearMonth, category);
+      return NextResponse.json({ data });
+    }
+
+    // 날짜 범위 기준 조회 (기존 호환)
     const today = getTodayISO();
     const from = searchParams.get('from') ?? today.slice(0, 7) + '-01';
     const to = searchParams.get('to') ?? today;
-    const category = searchParams.get('category') ?? undefined;
     const plannedExpenseId = searchParams.get('planned_expense_id');
 
     if (!/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
       return NextResponse.json({ error: 'from/to 날짜 형식이 올바르지 않습니다 (YYYY-MM-DD)' }, { status: 400 });
-    }
-    if (category && !VALID_CATEGORIES.has(category)) {
-      return NextResponse.json({ error: '유효하지 않은 category입니다' }, { status: 400 });
     }
 
     const data = await queryExpenses(userId, from, to, category, plannedExpenseId ? Number(plannedExpenseId) : undefined);

--- a/web/src/features/budget/components/daily-budget-log.tsx
+++ b/web/src/features/budget/components/daily-budget-log.tsx
@@ -89,7 +89,6 @@ export function DailyBudgetLogView({ yearMonth, todayBudget }: DailyBudgetLogPro
         {runwayImpactDays !== null && runwayImpactDays > 0 && (
           <div className="mt-2 text-xs text-gray-400">
             런웨이 약 {runwayImpactDays}일 {totalSaved >= 0 ? '연장' : '단축'} 효과
-            <InfoTooltip text="일일 예산 기준 대략적인 추정치야. 고정비 변동 등에 따라 실제와 다를 수 있어" />
           </div>
         )}
       </div>

--- a/web/src/features/budget/components/month-navigator.tsx
+++ b/web/src/features/budget/components/month-navigator.tsx
@@ -6,7 +6,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@/components/ui/icons';
 function getBillingRangeLabel(yearMonth: string): string {
   const [, month] = yearMonth.split('-').map(Number);
   const prevMonth = month === 1 ? 12 : month - 1;
-  return `${prevMonth}/16~${month}/15`;
+  return `${prevMonth}/14~${month}/13`;
 }
 
 export function MonthNavigator({

--- a/web/src/features/budget/hooks/use-budget.ts
+++ b/web/src/features/budget/hooks/use-budget.ts
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import type { ExpenseRow, MonthSummary, AssetRow, FixedCostRow } from '@/features/budget/lib/types';
-import { getTodayISO } from '@/lib/kst';
+import { getCurrentBillingMonth, getBillingRange } from '@/features/budget/lib/billing/cycle';
+import { getBillingMonthForExpense } from '@/features/budget/lib/billing/card-billing';
 
 const FETCH_TIMEOUT_MS = 8000;
 
@@ -17,34 +18,8 @@ async function fetchWithTimeout(url: string, options?: RequestInit): Promise<Res
   }
 }
 
-/** 현재 결제주기의 대금 월 반환. 16일 이후면 다음달 대금. */
-function getCurrentBillingMonth(): string {
-  const today = getTodayISO();
-  const [year, month, day] = today.split('-').map(Number);
-  if (day >= 16) {
-    const nextMonth = month === 12 ? 1 : month + 1;
-    const nextYear = month === 12 ? year + 1 : year;
-    return `${nextYear}-${String(nextMonth).padStart(2, '0')}`;
-  }
-  return `${year}-${String(month).padStart(2, '0')}`;
-}
-
-/**
- * 카드 결제주기 기준 날짜 범위 계산.
- * "N월" = 전월 16일 ~ 당월 15일.
- * 예: 2026-04 → 2026-03-16 ~ 2026-04-15
- */
-function getBillingRange(yearMonth: string): { from: string; to: string } {
-  const [year, month] = yearMonth.split('-').map(Number);
-  const prevMonth = month === 1 ? 12 : month - 1;
-  const prevYear = month === 1 ? year - 1 : year;
-  const from = `${prevYear}-${String(prevMonth).padStart(2, '0')}-16`;
-  const to = `${year}-${String(month).padStart(2, '0')}-15`;
-  return { from, to };
-}
-
 export function useBudget() {
-  const [selectedMonth, setSelectedMonth] = useState(getCurrentBillingMonth);
+  const [selectedMonth, setSelectedMonth] = useState(() => getCurrentBillingMonth(new Date()));
   const [expenses, setExpenses] = useState<ExpenseRow[]>([]);
   const [summary, setSummary] = useState<MonthSummary | null>(null);
   const [assets, setAssets] = useState<AssetRow[]>([]);
@@ -107,7 +82,7 @@ export function useBudget() {
   const applyAutoBudget = useCallback((sum: MonthSummary, rd: RunwayResponse, month: string) => {
     if (rd.free_per_month == null || !rd.target_date) return;
 
-    const currentBilling = getCurrentBillingMonth();
+    const currentBilling = getCurrentBillingMonth(new Date());
     const [ty, tm] = rd.target_date.split('-').map(Number);
     const [sy, sm] = month.split('-').map(Number);
     const [cy, cm] = currentBilling.split('-').map(Number);
@@ -125,11 +100,9 @@ export function useBudget() {
       sum.today_flex_spent = rd.today_flex_spent;
       sum.today_remaining = rd.today_remaining;
     } else {
-      const [year, mon] = month.split('-').map(Number);
-      const prevMon = mon === 1 ? 12 : mon - 1;
-      const prevYear = mon === 1 ? year - 1 : year;
-      const cycFrom = new Date(`${prevYear}-${String(prevMon).padStart(2, '0')}-16T00:00:00`);
-      const cycTo = new Date(`${year}-${String(mon).padStart(2, '0')}-15T00:00:00`);
+      const { from, to } = getBillingRange(month);
+      const cycFrom = new Date(`${from}T00:00:00`);
+      const cycTo = new Date(`${to}T00:00:00`);
       const days = Math.round((cycTo.getTime() - cycFrom.getTime()) / 86400000) + 1;
       sum.auto_daily = days > 0 ? Math.round(rd.free_per_month / days) : null;
     }
@@ -157,11 +130,10 @@ export function useBudget() {
     setExpenses([]);
     setSummary(null);
     try {
-      const { from, to } = getBillingRange(month);
-
       // ── 1차: 핵심 데이터 (지출목록 + 요약 → 화면 즉시 표시) ──
+      // billing_month 컬럼 기준 조회 → 카드별 결제주기(현대 14일, 국민 13일) 자동 반영
       const [expData, sumData] = await Promise.all([
-        fetchJson<{ data: ExpenseRow[] }>(`/api/expenses?from=${from}&to=${to}`),
+        fetchJson<{ data: ExpenseRow[] }>(`/api/expenses?yearMonth=${month}`),
         fetchJson<{ data: MonthSummary }>(`/api/expenses/summary?yearMonth=${month}`),
       ]);
 
@@ -171,7 +143,7 @@ export function useBudget() {
       if (!expData && !sumData) {
         // 둘 다 실패 시 1회 재시도
         const [retryExp, retrySum] = await Promise.all([
-          fetchJson<{ data: ExpenseRow[] }>(`/api/expenses?from=${from}&to=${to}`),
+          fetchJson<{ data: ExpenseRow[] }>(`/api/expenses?yearMonth=${month}`),
           fetchJson<{ data: MonthSummary }>(`/api/expenses/summary?yearMonth=${month}`),
         ]);
         if (retryExp) setExpenses(retryExp.data);
@@ -236,8 +208,8 @@ export function useBudget() {
       }
       const { data: newExpense } = (await res.json()) as { data: ExpenseRow };
       // 현재 보고 있는 결제주기에 해당하면 목록에 추가
-      const { from, to } = getBillingRange(selectedMonth);
-      if (data.date >= from && data.date <= to) {
+      const expBillingMonth = getBillingMonthForExpense(data.date, data.payment_method ?? '현대카드');
+      if (expBillingMonth === selectedMonth) {
         setExpenses((prev) => [newExpense, ...prev]);
         void refreshBudget(selectedMonth).catch(() => {});
       }

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -48,6 +48,32 @@ export async function queryExpenses(
   return rows;
 }
 
+/** billing_month 기준 지출 목록 조회 (카드별 결제주기 반영) */
+export async function queryExpensesByBillingMonth(
+  userId: number,
+  billingMonth: string,
+  category?: string,
+): Promise<ExpenseRow[]> {
+  const conditions = ['user_id = $1', 'billing_month = $2'];
+  const params: unknown[] = [userId, billingMonth];
+  if (category) {
+    conditions.push(`category = $${params.length + 1}`);
+    params.push(category);
+  }
+  const { rows } = await query<ExpenseRow>(
+    `SELECT id, date::text, amount, category, description, payment_method,
+            is_installment, installment_num, installment_total, installment_group,
+            source, memo, COALESCE(type, 'expense') as type, planned_expense_id, created_at::text,
+            COALESCE(exclude_from_budget, false) as exclude_from_budget,
+            COALESCE(distribute_to_budget, false) as distribute_to_budget
+     FROM expenses
+     WHERE ${conditions.join(' AND ')}
+     ORDER BY date DESC, created_at DESC`,
+    params,
+  );
+  return rows;
+}
+
 /** 지출 단건 조회 */
 export async function queryExpense(userId: number, id: number): Promise<ExpenseRow | null> {
   return queryOne<ExpenseRow>(


### PR DESCRIPTION
## 변경 내용

- 대금기간 라벨 수정 (16~15 → 14~13)
- 일별 현황 중복 툴팁 제거
- `use-budget.ts` 로컬 중복 함수 제거, canonical `getBillingRange`/`getCurrentBillingMonth` import
- 지출 목록 조회를 날짜 범위 → `billing_month` 컬럼 기준으로 변경
- expenses API에 `yearMonth` 파라미터 추가
- `queryExpensesByBillingMonth` 함수 추가

카드별 결제주기(현대카드 startDay=14, 국민카드 startDay=13)가 자동 반영됨

## 테스트
- [x] TypeScript 타입 체크 통과
- [x] 전체 테스트 188건 통과
- [x] 로컬 프리뷰에서 대금기간 라벨 확인 (4/14~5/13)
- [x] API가 `yearMonth` 파라미터로 `queryExpensesByBillingMonth` 호출 확인