### PR TITLE
fix(budget): 예산 계산을 billing_month 기준으로 통일

### DIFF
--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -88,10 +88,10 @@ describe('getMonthlyAllocation', () => {
     expect(result.freePerMonth).not.toBeNull();
   });
 
-  it('readCurrentMonthOnlyIncome 을 현재 결제주기 시작일 ~ 오늘 범위로 호출', async () => {
+  it('readCurrentMonthOnlyIncome 을 billing_month + 오늘 범위로 호출', async () => {
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(1_000_000);
     await getMonthlyAllocation(1, DEFAULT_NOW);
-    expect(readCurrentMonthOnlyIncome).toHaveBeenCalledWith(1, '2026-03-14', '2026-04-10');
+    expect(readCurrentMonthOnlyIncome).toHaveBeenCalledWith(1, '2026-04', '2026-04-10');
   });
 
   it('currentMonthOnlyIncome > 0 → 현재 월 free 에 독점 귀속, 다른 월은 오히려 감소', async () => {

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -70,7 +70,7 @@ export async function getMonthlyAllocation(
     readFixedCostsMonthlyTotal(userId),
     readActiveInstallments(userId, cycle.yearMonth),
     readTargetMonth(userId),
-    readCurrentMonthOnlyIncome(userId, cycle.from, todayStr),
+    readCurrentMonthOnlyIncome(userId, cycle.yearMonth, todayStr),
   ]);
   const planned = await readPlannedExpenses(
     userId, cycle.yearMonth, targetMonth ?? cycle.yearMonth,
@@ -97,7 +97,7 @@ export async function getTodayAllocation(
   }
   const todayStr = formatKSTDate(now);
   const [flex, todayFlex, targetDate] = await Promise.all([
-    readFlexibleSpent(userId, cycle.from, todayStr),
+    readFlexibleSpent(userId, cycle.yearMonth, todayStr),
     readTodayFlexSpent(userId, todayStr),
     readTargetMonth(userId),
   ]);
@@ -179,7 +179,7 @@ export async function getBudgetPreview(
     computeTotalAvailable(userId, todayStr),
     readFixedCostsMonthlyTotal(userId),
     readActiveInstallments(userId, cycle.yearMonth),
-    readCurrentMonthOnlyIncome(userId, cycle.from, todayStr),
+    readCurrentMonthOnlyIncome(userId, cycle.yearMonth, todayStr),
   ]);
   const planned = await readPlannedExpenses(userId, cycle.yearMonth, targetDate);
 
@@ -223,9 +223,9 @@ export async function runSettlementIfDue(
   const range = getBillingRange(targetMonth);
 
   const [flex, excluded, income] = await Promise.all([
-    readFlexibleSpent(userId, range.from, range.to),
-    readExcludedSpent(userId, range.from, range.to),
-    readIncomeTotal(userId, range.from, range.to),
+    readFlexibleSpent(userId, targetMonth, range.to),
+    readExcludedSpent(userId, targetMonth),
+    readIncomeTotal(userId, targetMonth),
   ]);
 
   // 정산 대상 월 기준 allocator 재실행 — T12:00:00Z = KST 21:00 (15일 이내)

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -238,15 +238,15 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
   const [totalResult, categoryResult, fixedCosts] = await Promise.all([
     query<{ total: string }>(
       `SELECT COALESCE(SUM(amount), 0) as total FROM expenses
-       WHERE user_id = $1 AND date >= $2 AND date <= $3 AND COALESCE(type, 'expense') = 'expense'`,
-      [userId, from, to],
+       WHERE user_id = $1 AND billing_month = $2 AND COALESCE(type, 'expense') = 'expense'`,
+      [userId, yearMonth],
     ),
     query<{ category: string; total: string; count: string }>(
       `SELECT category, SUM(amount) as total, COUNT(*) as count
-       FROM expenses WHERE user_id = $1 AND date >= $2 AND date <= $3
+       FROM expenses WHERE user_id = $1 AND billing_month = $2
          AND COALESCE(type, 'expense') = 'expense'
        GROUP BY category ORDER BY SUM(amount) DESC`,
-      [userId, from, to],
+      [userId, yearMonth],
     ),
     queryFixedCosts(userId),
   ]);
@@ -262,21 +262,21 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
   // 자유 지출 합계 (exclude_from_budget=false인 것만)
   const variableResult = await queryOne<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0) as total FROM expenses
-     WHERE user_id = $1 AND date >= $2 AND date <= $3
+     WHERE user_id = $1 AND billing_month = $2
        AND exclude_from_budget = false
        AND COALESCE(type, 'expense') = 'expense'`,
-    [userId, from, to],
+    [userId, yearMonth],
   );
   const variableTotal = Number(variableResult?.total ?? 0);
 
   // 할부 합계 (예산 포함인 것 중 is_installment=true)
   const installmentResult = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0) as total FROM expenses
-     WHERE user_id = $1 AND date >= $2 AND date <= $3
+     WHERE user_id = $1 AND billing_month = $2
        AND is_installment = true
        AND exclude_from_budget = false
        AND COALESCE(type, 'expense') = 'expense'`,
-    [userId, from, to],
+    [userId, yearMonth],
   );
   const installmentTotal = Number(installmentResult.rows[0]?.total ?? 0);
 
@@ -289,11 +289,11 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
        SELECT p.amount as budget, COALESCE(SUM(e.amount), 0) as used
        FROM planned_expenses p
        LEFT JOIN expenses e ON e.planned_expense_id = p.id
-         AND e.date >= $2 AND e.date <= $3
+         AND e.billing_month = $2
        WHERE p.user_id = $1
        GROUP BY p.id, p.amount
      ) sub`,
-    [userId, from, to],
+    [userId, yearMonth],
   );
   const plannedLinkedTotal = Number(plannedLinkedResult.rows[0]?.linked ?? 0);
   const flexibleSpent = variableTotal - installmentTotal - plannedLinkedTotal;
@@ -301,8 +301,8 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
   // 수입 합계 (type='income')
   const incomeResult = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0) as total FROM expenses
-     WHERE user_id = $1 AND date >= $2 AND date <= $3 AND COALESCE(type, 'expense') = 'income'`,
-    [userId, from, to],
+     WHERE user_id = $1 AND billing_month = $2 AND COALESCE(type, 'expense') = 'income'`,
+    [userId, yearMonth],
   );
   const incomeTotal = Number(incomeResult.rows[0]?.total ?? 0);
 

--- a/web/src/features/budget/lib/repository/expenses-repo.ts
+++ b/web/src/features/budget/lib/repository/expenses-repo.ts
@@ -2,8 +2,8 @@ import { query } from '@/lib/db';
 
 export async function readFlexibleSpent(
   userId: number,
-  from: string,
-  to: string,
+  billingMonth: string,
+  upToDate: string,
 ): Promise<number> {
   const result = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0)::text AS total
@@ -13,16 +13,16 @@ export async function readFlexibleSpent(
        AND exclude_from_budget = false
        AND is_installment = false
        AND planned_expense_id IS NULL
-       AND date BETWEEN $2 AND $3`,
-    [userId, from, to],
+       AND billing_month = $2
+       AND date <= $3`,
+    [userId, billingMonth, upToDate],
   );
   return Number(result.rows[0]?.total ?? 0);
 }
 
 export async function readExcludedSpent(
   userId: number,
-  from: string,
-  to: string,
+  billingMonth: string,
 ): Promise<number> {
   const result = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0)::text AS total
@@ -30,8 +30,8 @@ export async function readExcludedSpent(
      WHERE user_id = $1
        AND COALESCE(type, 'expense') = 'expense'
        AND exclude_from_budget = true
-       AND date BETWEEN $2 AND $3`,
-    [userId, from, to],
+       AND billing_month = $2`,
+    [userId, billingMonth],
   );
   return Number(result.rows[0]?.total ?? 0);
 }

--- a/web/src/features/budget/lib/repository/incomes-repo.ts
+++ b/web/src/features/budget/lib/repository/incomes-repo.ts
@@ -1,20 +1,22 @@
 import { query } from '@/lib/db';
+import { getBillingRange } from '../billing/cycle';
 
 // incomes 테이블 + expenses.type='income' 양쪽 통합 (레거시 병존 구조)
+// incomes 테이블은 billing_month 미지원 → 날짜 범위 유지, expenses는 billing_month 사용
 export async function readIncomeTotal(
   userId: number,
-  from: string,
-  to: string,
+  billingMonth: string,
 ): Promise<number> {
+  const { from, to } = getBillingRange(billingMonth);
   const result = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0)::text AS total FROM (
        SELECT amount FROM incomes
         WHERE user_id = $1 AND date BETWEEN $2 AND $3
        UNION ALL
        SELECT amount FROM expenses
-        WHERE user_id = $1 AND type = 'income' AND date BETWEEN $2 AND $3
+        WHERE user_id = $1 AND type = 'income' AND billing_month = $4
      ) AS combined`,
-    [userId, from, to],
+    [userId, from, to, billingMonth],
   );
   return Number(result.rows[0]?.total ?? 0);
 }
@@ -23,8 +25,8 @@ export async function readIncomeTotal(
 // 레거시 incomes 테이블은 항상 전체 분배로 간주하므로 제외.
 export async function readCurrentMonthOnlyIncome(
   userId: number,
-  from: string,
-  to: string,
+  billingMonth: string,
+  upToDate: string,
 ): Promise<number> {
   const result = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0)::text AS total
@@ -32,8 +34,9 @@ export async function readCurrentMonthOnlyIncome(
      WHERE user_id = $1
        AND type = 'income'
        AND COALESCE(distribute_to_budget, false) = false
-       AND date BETWEEN $2 AND $3`,
-    [userId, from, to],
+       AND billing_month = $2
+       AND date <= $3`,
+    [userId, billingMonth, upToDate],
   );
   return Number(result.rows[0]?.total ?? 0);
 }


### PR DESCRIPTION
## 관련 이슈
PR #315 후속 — 지출 목록만 billing_month로 바꿨으나 예산 계산(summary, facade)은 여전히 날짜 범위 사용 중이었음

## 변경 내용
- `queryMonthSummary`: 모든 쿼리 `date BETWEEN` → `billing_month =` 변경
- `readFlexibleSpent`: `billing_month + date <= upToDate` 조합
- `readExcludedSpent`: `billing_month` 기준
- `readIncomeTotal`: expenses는 `billing_month`, incomes 레거시 테이블은 날짜 범위 유지
- `readCurrentMonthOnlyIncome`: `billing_month + date <= upToDate` 조합
- `facade.ts`: 호출부 시그니처 일괄 수정
- `facade.test.ts`: 변경된 시그니처 반영

## 테스트
- [x] TypeScript 타입 체크 통과
- [x] 전체 테스트 188건 통과