### PR TITLE
feat(sleep): 수면 대시보드 시각화 개선 - 아침잠/낮잠 분리, 모바일 터치 인터랙션

### DIFF
--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -1269,3 +1269,4 @@ insight 채널의 핵심 목표: 일기 데이터와 일운 분석을 비교하�
 | 2026-04-15 | **예산 재설계 Phase 2** — DB 마이그레이션: `monthly_budget_snapshots` 테이블 신설 (과거 월 불변 스냅샷 구조). Phase 3(Repository/Facade) 준비 완료 (Issue #285, PR #286) |
 | 2026-04-15 | **예산 재설계 Phase 5 (최종)** — v2 아키텍처 전환 완료. 런웨이 프로젝션/월별 시뮬레이션/동적 일일 예산/cron 드리프트 보정 신규 구현. v1 API 라우트·queries.ts v1 함수·budget-calc.ts 전면 제거. budgets 테이블 DROP 마이그레이션 적용. 멀티유저 cron 지원. 3계층 구조(allocator/repository/facade) 완성 (Issue #291) |
 | 2026-04-15 | **설정/분석 계산 정합성 통합** — target\_date 있을 때 allocator 결과를 projection이 재사용하도록 리팩토링. current month prorated vs full-month drift(±1개월) 제거. `projectFromAllocator` 신규 추가 + `getRunwayProjection` 분기 적용 (Issue #294) |
+| 2026-04-19 | **수면 대시보드 시각화 개선** — `DailySleep` 단일 렌더 단위 도입. 아침잠(정오 전 nap)은 밤잠 연장으로 통합해 수면 타임라인·수면시간 추이·기상시간 추이에 반영. 낮잠(정오 이후 nap)은 별도 NapTimeline으로 분리(Y축 12\~24시). 낮잠 통계 요약 카드, 규칙성 점수 툴팁 추가. 모바일 터치 tap 툴팁 지원(useChartTooltip 공통 훅). (Issue #317) |

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -1,5 +1,66 @@
 # Work Log
 
+## 2026-04-18 (토)
+
+### 작업 요약
+- 카드 결제주기 `billing_month` 시스템 전면 도입 — DB 컬럼 추가부터 facade/query/UI까지 수직 완성 (PR #312, #313)
+- 대금기간 경계일 14\~13일로 변경 + 프로레이션 제거 + 가용자금 계산 단순화 (PR #310, #311)
+- `billing_month` 기준 지출 조회·예산 요약 계산 정합성 확보 (PR #314, #308, #309)
+
+### 변경 규모
+- 12개 커밋, 3개 PR 머지, 47개 파일, +509 / -353 lines
+
+### 주요 변경
+- `db/migrations/043_billing_month.sql` — billing_month 컬럼 + 카드별 대금기간 모듈 신규
+- `web/src/features/budget/lib/billing/cycle.ts` — 대금기간 경계일 14\~13일로 변경
+- `web/src/features/budget/lib/queries.ts` — billing_month 기준 지출 조회 로직 전면 수정
+- `web/src/features/budget/lib/facade.ts`, `repository/expenses-repo.ts`, `incomes-repo.ts` — billing_month 기준 예산 계산 통일
+- `web/src/app/api/expenses/route.ts` — 결제주기 UI 보정 + billing_month 기준 API 정합성 보정
+
+### 다음 할 일
+- billing_month 기반 월간 통계 뷰 + 카드사별 정산 리포트 검토
+
+## 2026-04-17 (금)
+
+### 작업 요약
+- 수면 차트 데스크탑 hover 툴팁 신규 추가 (PR #305) → 중간기상 중복·우측 끝 잘림 버그 즉각 수정 (PR #306) → sleep_events JOIN 쿼리 롤백 + JS 중복 제거로 전환 (PR #307)
+- 예정지출 연결 지출 일일 예산 이중 차감 버그 수정 + 수정 모달 연결 폼 추가 (PR #303)
+- 예정지출 수정 모달 신규 구현 + 연결 지출 내역 표시 (PR #304)
+- 아침/밤 크론 톤 + 달성률 개선 (PR #302)
+
+### 변경 규모
+- 6개 커밋, 5개 PR 머지, 18개 파일, +704 / -147 lines
+
+### 주요 변경
+- `web/src/features/sleep/components/sleep-timeline.tsx`, `sleep-trend-chart.tsx` — 툴팁 신규 (+123줄) + 버그 수정 (+20/-11)
+- `web/src/features/sleep/lib/queries.ts` — JOIN 쿼리 롤백, JS 레벨 중복 제거로 전환
+- `web/src/features/budget/components/planned-expense-edit-modal.tsx` — 수정 모달 신규 (201줄)
+- `web/src/features/budget/components/planned-expense-list.tsx` — 수정 모달 연결 + 이중 차감 방어
+- `web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts` — 이중 차감 회귀 테스트 추가 (75줄)
+- `src/cron/life-cron.ts` — 밤 크론 현황 톤 + 아침 크론 어제 달성률 추가
+
+### 다음 할 일
+- 예정지출 삭제/연결 해제 UX 검토
+
+## 2026-04-16 (목)
+
+### 작업 요약
+- 루틴 시작일 이전 체크리스트 생성 방어 + 이전 기록 자동 정리 기능 추가 (PR #300, #301)
+- 예산 도메인 강화 — projectFromAllocator 계산 정합성 통합 + 수입 옵션 추가 + 감사 테스트 확대 (PR #295, #299)
+- Gemini provider 완전 제거 — LLM 스택을 Claude 단일화 (PR #297/#298)
+
+### 변경 규모
+- 6개 커밋, 38개 파일, +986 / -1237 lines
+
+### 주요 변경
+- `src/shared/life-queries.ts`, `web/src/app/api/routines/[id]/` — 루틴 시작일 경계 검사 + 이전 기록 정리 API
+- `web/src/features/budget/lib/allocator/runway-projection.ts` — projectFromAllocator 도입, 설정/분석 계산 일치 보장
+- `docs/domains/budget-spec.md` — 기능 명세 193줄 신규 + 테스트 파일 3개 (\~360줄) 추가
+- `src/shared/llm.ts`, `src/shared/__tests__/llm.test.ts` — Gemini 관련 코드 전면 제거 (-1134줄)
+
+### 다음 할 일
+- 루틴 시작일 변경 + 월 전환 엣지케이스 동작 검증
+
 ## 2026-04-15 (수)
 
 ### 작업 요약

--- a/web/src/app/api/sleep/dashboard/route.ts
+++ b/web/src/app/api/sleep/dashboard/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
 import {
   querySleepRecordsWithEvents,
+  buildDailySleeps,
   calculateSleepSummary,
   calculateDayOfWeekPattern,
 } from '@/features/sleep/lib/queries';
@@ -22,11 +23,12 @@ export async function GET(request: Request) {
     }
 
     const records = await querySleepRecordsWithEvents(userId, from, to);
-    const summary = calculateSleepSummary(records);
-    const dayOfWeekPattern = calculateDayOfWeekPattern(records);
+    const dailySleeps = buildDailySleeps(records, from, to);
+    const summary = calculateSleepSummary(dailySleeps);
+    const dayOfWeekPattern = calculateDayOfWeekPattern(dailySleeps);
 
     return NextResponse.json(
-      { data: { records, summary, dayOfWeekPattern } },
+      { data: { records, dailySleeps, summary, dayOfWeekPattern } },
       { headers: { 'Cache-Control': 'no-store, max-age=0' } },
     );
   } catch {

--- a/web/src/app/life/sleep/page.tsx
+++ b/web/src/app/life/sleep/page.tsx
@@ -7,6 +7,7 @@ import { PeriodSelector } from '@/features/sleep/components/period-selector';
 import { SleepSummaryCards } from '@/features/sleep/components/sleep-summary-cards';
 import { SleepTimeline } from '@/features/sleep/components/sleep-timeline';
 import { SleepTrendChart } from '@/features/sleep/components/sleep-trend-chart';
+import { NapTimeline } from '@/features/sleep/components/nap-timeline';
 import { SleepDayPattern } from '@/features/sleep/components/sleep-day-pattern';
 import { CardSkeleton } from '@/components/ui/skeleton';
 import type { SleepPeriod } from '@/features/sleep/lib/types';
@@ -74,8 +75,9 @@ function SleepContent() {
       <div className="mx-auto max-w-5xl space-y-4 px-4 py-4 md:py-6">
         <PeriodSelector period={period} onChange={onPeriodChange} />
         <SleepSummaryCards summary={data.summary} />
-        <SleepTimeline records={data.records} period={period} />
-        <SleepTrendChart records={data.records} period={period} />
+        <SleepTimeline dailies={data.dailySleeps} period={period} />
+        <SleepTrendChart dailies={data.dailySleeps} period={period} />
+        <NapTimeline dailies={data.dailySleeps} period={period} />
         <SleepDayPattern pattern={data.dayOfWeekPattern} />
       </div>
     </div>

--- a/web/src/features/sleep/components/nap-timeline.tsx
+++ b/web/src/features/sleep/components/nap-timeline.tsx
@@ -126,11 +126,11 @@ export function NapTimeline({ dailies, period }: NapTimelineProps) {
                       width={barWidth + 4} height={chartHeight}
                       fill="transparent"
                       style={{ cursor: 'pointer' }}
-                      onMouseEnter={(e) => {
+                      onPointerEnter={(e) => {
                         if (e.pointerType === 'touch') return;
                         setTooltip({ x: x + barWidth / 2, y: topPadding, date: d.date, naps: d.afternoonNaps });
                       }}
-                      onMouseLeave={(e) => {
+                      onPointerLeave={(e) => {
                         if (e.pointerType === 'touch') return;
                         setTooltip(null);
                       }}

--- a/web/src/features/sleep/components/nap-timeline.tsx
+++ b/web/src/features/sleep/components/nap-timeline.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useRef, useState, useEffect } from 'react';
+import type { DailySleep, SleepRecord, SleepPeriod } from '../lib/types';
+import { formatDateLabel, getDayOfWeek } from '../lib/chart-utils';
+
+interface NapTimelineProps {
+  dailies: DailySleep[];
+  period: SleepPeriod;
+}
+
+// 12:00(=0) ~ 24:00(=720) 범위를 Y축으로 매핑
+const Y_START_MINUTES = 12 * 60;
+const Y_RANGE_MINUTES = 12 * 60;
+
+const Y_LABELS = ['12', '14', '16', '18', '20', '22', '24'];
+const Y_LABEL_MINUTES = [0, 120, 240, 360, 480, 600, 720];
+
+function timeToNapY(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  const totalMins = (h ?? 0) * 60 + (m ?? 0);
+  return Math.max(0, totalMins - Y_START_MINUTES);
+}
+
+function yToRatio(y: number): number {
+  return Math.max(0, Math.min(1, y / Y_RANGE_MINUTES));
+}
+
+interface Tooltip {
+  x: number;
+  y: number;
+  date: string;
+  naps: SleepRecord[];
+}
+
+export function NapTimeline({ dailies, period }: NapTimelineProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [cw, setCw] = useState(0);
+  const [tooltip, setTooltip] = useState<Tooltip | null>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setCw(el.clientWidth);
+  }, []);
+
+  const allowScroll = period === '1m';
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el && cw > 0 && allowScroll) {
+      el.scrollLeft = el.scrollWidth;
+    }
+  }, [cw, dailies, allowScroll]);
+
+  // 외부 탭 시 툴팁 닫기 (모바일)
+  useEffect(() => {
+    if (!tooltip) return;
+    const handler = (e: PointerEvent) => {
+      if (e.pointerType !== 'touch') return;
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setTooltip(null);
+      }
+    };
+    document.addEventListener('pointerdown', handler);
+    return () => document.removeEventListener('pointerdown', handler);
+  }, [tooltip]);
+
+  const hasAnyNap = dailies.some((d) => d.afternoonNaps.length > 0);
+
+  if (!hasAnyNap) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-5">
+        <h3 className="mb-2 text-sm font-semibold text-gray-900">낮잠 타임라인</h3>
+        <p className="py-8 text-center text-sm text-gray-400">이 기간에 낮잠 기록이 없어</p>
+      </div>
+    );
+  }
+
+  const chartHeight = 200;
+  const labelWidth = 28;
+  const barGap = 2;
+  const topPadding = 12;
+  const minBarWidth = allowScroll ? 16 : 8;
+  const minContentWidth = labelWidth + 8 + dailies.length * (minBarWidth + barGap);
+  const chartWidth = allowScroll ? Math.max(cw, minContentWidth) : Math.max(cw, 300);
+  const availableWidth = chartWidth - labelWidth - 8;
+  const barWidth = Math.max(minBarWidth, availableWidth / dailies.length - barGap);
+  const dateAreaHeight = 32;
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <h3 className="mb-3 text-sm font-semibold text-gray-900">낮잠 타임라인</h3>
+      <div ref={containerRef} className={`relative ${allowScroll ? 'overflow-x-auto' : ''}`}>
+        {cw > 0 && (
+          <svg
+            width={chartWidth}
+            height={topPadding + chartHeight + dateAreaHeight}
+            className="text-xs"
+          >
+            {Y_LABELS.map((label, i) => {
+              const y = topPadding + ((Y_LABEL_MINUTES[i] ?? 0) / Y_RANGE_MINUTES) * chartHeight;
+              return (
+                <g key={label}>
+                  <text x={labelWidth - 4} y={y + 4} textAnchor="end" className="fill-gray-400 text-[10px]">
+                    {label}
+                  </text>
+                  <line
+                    x1={labelWidth} y1={y} x2={chartWidth} y2={y}
+                    stroke="#f3f4f6" strokeWidth={1}
+                  />
+                </g>
+              );
+            })}
+
+            {dailies.map((d, i) => {
+              const x = labelWidth + i * (barWidth + barGap);
+              const dateLabel = formatDateLabel(d.date);
+              const dayLabel = getDayOfWeek(d.date);
+
+              return (
+                <g key={d.date}>
+                  {d.afternoonNaps.length > 0 && (
+                    <rect
+                      x={x - 2} y={topPadding}
+                      width={barWidth + 4} height={chartHeight}
+                      fill="transparent"
+                      style={{ cursor: 'pointer' }}
+                      onMouseEnter={(e) => {
+                        if (e.pointerType === 'touch') return;
+                        setTooltip({ x: x + barWidth / 2, y: topPadding, date: d.date, naps: d.afternoonNaps });
+                      }}
+                      onMouseLeave={(e) => {
+                        if (e.pointerType === 'touch') return;
+                        setTooltip(null);
+                      }}
+                      onClick={() => {
+                        setTooltip((prev) =>
+                          prev?.date === d.date ? null : { x: x + barWidth / 2, y: topPadding, date: d.date, naps: d.afternoonNaps },
+                        );
+                      }}
+                    />
+                  )}
+                  {d.afternoonNaps.map((nap, ni) => {
+                    if (!nap.bedtime || !nap.wake_time) return null;
+                    const bedY = topPadding + yToRatio(timeToNapY(nap.bedtime)) * chartHeight;
+                    const wakeY = topPadding + yToRatio(timeToNapY(nap.wake_time)) * chartHeight;
+                    return (
+                      <rect
+                        key={ni}
+                        x={x} y={bedY}
+                        width={barWidth} height={Math.max(4, wakeY - bedY)}
+                        rx={3} fill="#a78bfa" opacity={0.8}
+                        className="pointer-events-none"
+                      />
+                    );
+                  })}
+                  <text
+                    x={x + barWidth / 2} y={topPadding + chartHeight + 12}
+                    textAnchor="middle" className="fill-gray-500 text-[9px]"
+                  >
+                    {dateLabel}
+                  </text>
+                  <text
+                    x={x + barWidth / 2} y={topPadding + chartHeight + 24}
+                    textAnchor="middle" className="fill-gray-400 text-[8px]"
+                  >
+                    {dayLabel}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        )}
+        {tooltip && (() => {
+          const alignRight = tooltip.x > chartWidth - 120;
+          const alignLeft = tooltip.x < 120;
+          const translateX = alignRight ? '-100%' : alignLeft ? '0%' : '-50%';
+          return (
+            <div
+              className="pointer-events-none absolute z-10 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
+              style={{ left: tooltip.x, top: 0, transform: `translateX(${translateX})` }}
+            >
+              <p className="mb-1 font-semibold text-gray-700">{tooltip.date}</p>
+              {tooltip.naps.map((nap, i) => {
+                const h = nap.duration_minutes ? Math.floor(nap.duration_minutes / 60) : 0;
+                const m = nap.duration_minutes ? nap.duration_minutes % 60 : 0;
+                return (
+                  <div key={i}>
+                    <p className="text-violet-500">
+                      {nap.bedtime} → {nap.wake_time ?? '?'}
+                    </p>
+                    {nap.duration_minutes != null && (
+                      <p className="text-gray-500">{h}시간{m > 0 ? ` ${m}분` : ''}</p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })()}
+      </div>
+      <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-violet-400" /> 낮잠
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/sleep/components/sleep-dashboard.tsx
+++ b/web/src/features/sleep/components/sleep-dashboard.tsx
@@ -5,6 +5,7 @@ import { PeriodSelector } from './period-selector';
 import { SleepSummaryCards } from './sleep-summary-cards';
 import { SleepTimeline } from './sleep-timeline';
 import { SleepTrendChart } from './sleep-trend-chart';
+import { NapTimeline } from './nap-timeline';
 import { SleepDayPattern } from './sleep-day-pattern';
 import { CardSkeleton } from '@/components/ui/skeleton';
 
@@ -35,8 +36,9 @@ export function SleepDashboard() {
       <div className="mx-auto max-w-5xl space-y-4 px-4 py-4 md:py-6">
         <PeriodSelector period={period} onChange={handlePeriodChange} />
         <SleepSummaryCards summary={data.summary} />
-        <SleepTimeline records={data.records} period={period} />
-        <SleepTrendChart records={data.records} period={period} />
+        <SleepTimeline dailies={data.dailySleeps} period={period} />
+        <SleepTrendChart dailies={data.dailySleeps} period={period} />
+        <NapTimeline dailies={data.dailySleeps} period={period} />
         <SleepDayPattern pattern={data.dayOfWeekPattern} />
       </div>
     </div>

--- a/web/src/features/sleep/components/sleep-day-pattern.tsx
+++ b/web/src/features/sleep/components/sleep-day-pattern.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { DayOfWeekPattern } from '../lib/types';
+import { useChartTooltip } from '../hooks/use-chart-tooltip';
 
 interface SleepDayPatternProps {
   pattern: DayOfWeekPattern[];
@@ -12,20 +13,52 @@ function barColor(minutes: number): string {
   return '#f87171';
 }
 
+function minsToTimeStr(mins: number): string {
+  let m = mins;
+  if (m < 0) m += 1440;
+  const hh = String(Math.floor(m / 60) % 24).padStart(2, '0');
+  const mm = String(m % 60).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+interface PatternTooltip {
+  day: number;
+  x: number;
+}
+
+const DAY_FULL: Record<string, string> = {
+  '일': '일요일', '월': '월요일', '화': '화요일',
+  '수': '수요일', '목': '목요일', '금': '금요일', '토': '토요일',
+};
+
 export function SleepDayPattern({ pattern }: SleepDayPatternProps) {
   const ordered = [1, 2, 3, 4, 5, 6, 0].map((d) => pattern.find((p) => p.day === d)!);
   const maxDur = Math.max(...ordered.map((p) => p.avgDuration), 1);
+  const { tooltip, setTooltip, ref } = useChartTooltip<PatternTooltip>();
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
       <h3 className="mb-4 text-sm font-semibold text-gray-900">요일별 수면 패턴</h3>
-      <div className="flex items-end justify-between gap-2">
+      <div ref={ref} className="relative flex items-end justify-between gap-2">
         {ordered.map((p) => {
           const h = Math.floor(p.avgDuration / 60);
           const m = p.avgDuration % 60;
           const heightPx = Math.max(4, (p.avgDuration / (maxDur + 60)) * 100);
           return (
-            <div key={p.day} className="flex flex-1 flex-col items-center gap-1">
+            <div
+              key={p.day}
+              className="flex flex-1 flex-col items-center gap-1"
+              style={{ cursor: p.count > 0 ? 'pointer' : 'default' }}
+              onMouseEnter={() => {
+                if (p.count === 0) return;
+                setTooltip((prev) => prev?.day === p.day ? prev : { day: p.day, x: 0 });
+              }}
+              onMouseLeave={() => setTooltip(null)}
+              onClick={() => {
+                if (p.count === 0) return;
+                setTooltip((prev) => prev?.day === p.day ? null : { day: p.day, x: 0 });
+              }}
+            >
               <span className="text-xs text-gray-500">
                 {p.count > 0 ? `${h}h${m > 0 ? m : ''}` : '—'}
               </span>
@@ -44,6 +77,24 @@ export function SleepDayPattern({ pattern }: SleepDayPatternProps) {
             </div>
           );
         })}
+        {tooltip && (() => {
+          const p = ordered.find((o) => o.day === tooltip.day);
+          if (!p || p.count === 0) return null;
+          const h = Math.floor(p.avgDuration / 60);
+          const m = p.avgDuration % 60;
+          return (
+            <div className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg">
+              <p className="mb-1 font-semibold text-gray-700">{DAY_FULL[p.dayName] ?? p.dayName}</p>
+              <p className="text-gray-600">평균 {h}시간{m > 0 ? ` ${m}분` : ''}</p>
+              {p.avgBedtime !== 0 && (
+                <p className="text-gray-500">
+                  취침 {minsToTimeStr(p.avgBedtime)} · 기상 {minsToTimeStr(p.avgWakeTime)}
+                </p>
+              )}
+              <p className="text-gray-400">기록 {p.count}일</p>
+            </div>
+          );
+        })()}
       </div>
     </div>
   );

--- a/web/src/features/sleep/components/sleep-summary-cards.tsx
+++ b/web/src/features/sleep/components/sleep-summary-cards.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect, useRef } from 'react';
 import type { SleepSummary } from '../lib/types';
 
 interface SleepSummaryCardsProps {
@@ -18,9 +19,58 @@ function scoreColor(score: number): string {
   return 'text-red-500';
 }
 
+function InfoButton({ content }: { content: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: PointerEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', handler);
+    return () => document.removeEventListener('pointerdown', handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <button
+        type="button"
+        className="flex h-4 w-4 items-center justify-center rounded-full border border-gray-300 text-[10px] text-gray-400 hover:border-gray-400 hover:text-gray-600"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onClick={() => setOpen((v) => !v)}
+        aria-label="규칙성 점수 설명"
+      >
+        i
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-20 mt-1 w-56 rounded-lg border border-gray-200 bg-white p-3 shadow-lg">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const regularityContent = (
+  <div className="text-xs leading-relaxed">
+    <p className="mb-1 font-semibold text-gray-700">규칙성 점수란?</p>
+    <p className="mb-2 text-gray-600">취침 시각이 얼마나 일정한지를 100점 만점으로 나타내.</p>
+    <ul className="space-y-0.5 text-gray-500">
+      <li><span className="font-medium text-green-600">80점↑</span> 거의 같은 시간에 잠</li>
+      <li><span className="font-medium text-green-600">70\~79</span> 꽤 규칙적</li>
+      <li><span className="font-medium text-yellow-600">40\~69</span> 변동 큼</li>
+      <li><span className="font-medium text-red-500">40점↓</span> 매우 불규칙</li>
+    </ul>
+  </div>
+);
+
 export function SleepSummaryCards({ summary }: SleepSummaryCardsProps) {
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5">
       {/* 평균 수면 */}
       <div className="rounded-xl border border-gray-200 bg-white p-4">
         <div className="text-xs text-gray-400">평균 수면</div>
@@ -51,12 +101,30 @@ export function SleepSummaryCards({ summary }: SleepSummaryCardsProps) {
       </div>
 
       {/* 규칙성 */}
-      <div className="rounded-xl border border-gray-200 bg-white p-4">
-        <div className="text-xs text-gray-400">규칙성</div>
+      <div className="relative rounded-xl border border-gray-200 bg-white p-4">
+        <div className="flex items-center gap-1 text-xs text-gray-400">
+          규칙성
+          <InfoButton content={regularityContent} />
+        </div>
         <div className={`mt-1 text-lg font-bold ${scoreColor(summary.regularityScore)}`}>
           {summary.regularityScore}점
         </div>
         <div className="mt-0.5 text-xs text-gray-400">취침 시간 기준</div>
+      </div>
+
+      {/* 낮잠 */}
+      <div className="rounded-xl border border-gray-200 bg-white p-4">
+        <div className="text-xs text-gray-400">낮잠</div>
+        <div className="mt-1 text-lg font-bold text-gray-900">
+          {summary.napDaysCount > 0
+            ? formatDuration(summary.avgNapMinutes)
+            : '없음'}
+        </div>
+        <div className="mt-0.5 text-xs text-gray-400">
+          {summary.napDaysCount > 0
+            ? `${summary.napDaysCount}일 기록 · 평균`
+            : '기간 내 없음'}
+        </div>
       </div>
     </div>
   );

--- a/web/src/features/sleep/components/sleep-summary-cards.tsx
+++ b/web/src/features/sleep/components/sleep-summary-cards.tsx
@@ -61,8 +61,8 @@ const regularityContent = (
     <p className="mb-2 text-gray-600">취침 시각이 얼마나 일정한지를 100점 만점으로 나타내.</p>
     <ul className="space-y-0.5 text-gray-500">
       <li><span className="font-medium text-green-600">80점↑</span> 거의 같은 시간에 잠</li>
-      <li><span className="font-medium text-green-600">70\~79</span> 꽤 규칙적</li>
-      <li><span className="font-medium text-yellow-600">40\~69</span> 변동 큼</li>
+      <li><span className="font-medium text-green-600">70~79</span> 꽤 규칙적</li>
+      <li><span className="font-medium text-yellow-600">40~69</span> 변동 큼</li>
       <li><span className="font-medium text-red-500">40점↓</span> 매우 불규칙</li>
     </ul>
   </div>

--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useRef, useState, useEffect } from 'react';
-import type { SleepRecordWithEvents, SleepPeriod } from '../lib/types';
+import type { DailySleep, SleepPeriod } from '../lib/types';
 import { formatDateLabel, getDayOfWeek } from '../lib/chart-utils';
 
 interface SleepTimelineProps {
-  records: SleepRecordWithEvents[];
+  dailies: DailySleep[];
   period: SleepPeriod;
 }
 
@@ -15,7 +15,7 @@ const Y_RANGE_MINUTES = 16 * 60;
 
 function timeToY(time: string): number {
   const [h, m] = time.split(':').map(Number);
-  let minutesFromStart = (h * 60 + (m ?? 0)) - (Y_START_HOUR * 60);
+  let minutesFromStart = ((h ?? 0) * 60 + (m ?? 0)) - (Y_START_HOUR * 60);
   if (minutesFromStart < 0) minutesFromStart += 1440;
   return minutesFromStart;
 }
@@ -27,13 +27,43 @@ function yToRatio(y: number): number {
 const Y_LABELS = ['20', '22', '0', '2', '4', '6', '8', '10', '12'];
 const Y_LABEL_MINUTES = [0, 120, 240, 360, 480, 600, 720, 840, 960];
 
+interface Session {
+  bedY: number;
+  wakeY: number;
+  kind: 'night' | 'morning';
+}
+
 interface Tooltip {
   x: number;
   y: number;
-  record: SleepRecordWithEvents;
+  daily: DailySleep;
 }
 
-export function SleepTimeline({ records, period }: SleepTimelineProps) {
+function buildSessions(
+  d: DailySleep,
+  topPadding: number,
+  chartHeight: number,
+): Session[] {
+  const sessions: Session[] = [];
+  if (d.nightSleep?.bedtime && d.nightSleep?.wake_time) {
+    sessions.push({
+      bedY: topPadding + yToRatio(timeToY(d.nightSleep.bedtime)) * chartHeight,
+      wakeY: topPadding + yToRatio(timeToY(d.nightSleep.wake_time)) * chartHeight,
+      kind: 'night',
+    });
+  }
+  for (const m of d.morningSleeps) {
+    if (!m.bedtime || !m.wake_time) continue;
+    sessions.push({
+      bedY: topPadding + yToRatio(timeToY(m.bedtime)) * chartHeight,
+      wakeY: topPadding + yToRatio(timeToY(m.wake_time)) * chartHeight,
+      kind: 'morning',
+    });
+  }
+  return sessions;
+}
+
+export function SleepTimeline({ dailies, period }: SleepTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [cw, setCw] = useState(0);
   const [tooltip, setTooltip] = useState<Tooltip | null>(null);
@@ -46,17 +76,31 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
 
   const allowScroll = period === '1m';
 
-  // 1개월일 때만 스크롤을 오른쪽(최신)으로 이동
   useEffect(() => {
     const el = containerRef.current;
     if (el && cw > 0 && allowScroll) {
       el.scrollLeft = el.scrollWidth;
     }
-  }, [cw, records, allowScroll]);
+  }, [cw, dailies, allowScroll]);
 
-  const validRecords = records.filter((r) => r.bedtime && r.wake_time);
+  // 외부 탭 시 툴팁 닫기 (모바일)
+  useEffect(() => {
+    if (!tooltip) return;
+    const handler = (e: PointerEvent) => {
+      if (e.pointerType !== 'touch') return;
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setTooltip(null);
+      }
+    };
+    document.addEventListener('pointerdown', handler);
+    return () => document.removeEventListener('pointerdown', handler);
+  }, [tooltip]);
 
-  if (validRecords.length === 0) {
+  const validDailies = dailies.filter(
+    (d) => d.nightSleep?.bedtime || d.morningSleeps.length > 0,
+  );
+
+  if (validDailies.length === 0) {
     return (
       <div className="rounded-xl border border-gray-200 bg-white p-5">
         <h3 className="mb-2 text-sm font-semibold text-gray-900">수면 타임라인</h3>
@@ -70,20 +114,14 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
   const barGap = 2;
   const topPadding = 12;
   const minBarWidth = allowScroll ? 16 : 8;
-  const minContentWidth = labelWidth + 8 + validRecords.length * (minBarWidth + barGap);
+  const minContentWidth = labelWidth + 8 + dailies.length * (minBarWidth + barGap);
   const chartWidth = allowScroll ? Math.max(cw, minContentWidth) : Math.max(cw, 300);
   const availableWidth = chartWidth - labelWidth - 8;
-  const barWidth = Math.max(minBarWidth, availableWidth / validRecords.length - barGap);
+  const barWidth = Math.max(minBarWidth, availableWidth / dailies.length - barGap);
   const dateAreaHeight = 32;
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
-      <style>{`
-        @media (hover: none) {
-          .desktop-hover-target { display: none; }
-          .desktop-tooltip { display: none; }
-        }
-      `}</style>
       <h3 className="mb-3 text-sm font-semibold text-gray-900">수면 타임라인</h3>
       <div ref={containerRef} className={`relative ${allowScroll ? 'overflow-x-auto' : ''}`}>
         {cw > 0 && (
@@ -107,37 +145,46 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
               );
             })}
 
-            {validRecords.map((r, i) => {
+            {dailies.map((d, i) => {
               const x = labelWidth + i * (barWidth + barGap);
-              const bedY = topPadding + yToRatio(timeToY(r.bedtime!)) * chartHeight;
-              const wakeY = topPadding + yToRatio(timeToY(r.wake_time!)) * chartHeight;
-              const barHeight = Math.max(4, wakeY - bedY);
-              const dateLabel = formatDateLabel(r.date);
-              const dayLabel = getDayOfWeek(r.date);
+              const sessions = buildSessions(d, topPadding, chartHeight);
+              const dateLabel = formatDateLabel(d.date);
+              const dayLabel = getDayOfWeek(d.date);
 
               return (
-                <g key={r.id}>
-                  {/* 투명 히트 영역 — 좁은 바도 hover 쉽게 */}
+                <g key={d.date}>
+                  {/* 히트 영역 — 좁은 바도 hover/tap 쉽게 */}
                   <rect
                     x={x - 2} y={topPadding}
                     width={barWidth + 4} height={chartHeight}
                     fill="transparent"
-                    className="desktop-hover-target"
-                    onMouseEnter={() => {
-                      setTooltip({
-                        x: x + barWidth / 2,
-                        y: bedY,
-                        record: r,
-                      });
+                    style={{ cursor: 'pointer' }}
+                    onMouseEnter={(e) => {
+                      if (e.pointerType === 'touch') return;
+                      setTooltip({ x: x + barWidth / 2, y: topPadding, daily: d });
                     }}
-                    onMouseLeave={() => setTooltip(null)}
+                    onMouseLeave={(e) => {
+                      if (e.pointerType === 'touch') return;
+                      setTooltip(null);
+                    }}
+                    onClick={() => {
+                      setTooltip((prev) =>
+                        prev?.daily.date === d.date ? null : { x: x + barWidth / 2, y: topPadding, daily: d },
+                      );
+                    }}
                   />
-                  <rect
-                    x={x} y={bedY} width={barWidth} height={barHeight}
-                    rx={3} fill="#818cf8" opacity={0.8}
-                    className="pointer-events-none"
-                  />
-                  {r.events.map((e) => {
+                  {/* 세션 블록들 (밤잠·아침잠 모두 인디고) */}
+                  {sessions.map((s, si) => (
+                    <rect
+                      key={si}
+                      x={x} y={s.bedY}
+                      width={barWidth} height={Math.max(4, s.wakeY - s.bedY)}
+                      rx={3} fill="#818cf8" opacity={0.8}
+                      className="pointer-events-none"
+                    />
+                  ))}
+                  {/* 밤잠 중간 기상 이벤트 */}
+                  {d.nightSleep?.events.map((e) => {
                     const ey = topPadding + yToRatio(timeToY(e.event_time)) * chartHeight;
                     return (
                       <circle
@@ -166,32 +213,45 @@ export function SleepTimeline({ records, period }: SleepTimelineProps) {
           </svg>
         )}
         {tooltip && (() => {
-        const r = tooltip.record;
-        const hours = r.duration_minutes ? Math.floor(r.duration_minutes / 60) : 0;
-        const mins = r.duration_minutes ? r.duration_minutes % 60 : 0;
-        const alignRight = tooltip.x > chartWidth - 100;
-        const alignLeft = tooltip.x < 100;
-        const translateX = alignRight ? '-100%' : alignLeft ? '0%' : '-50%';
-        return (
-          <div
-            className="desktop-tooltip pointer-events-none absolute z-10 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
-            style={{ left: tooltip.x, top: tooltip.y - 8, transform: `translate(${translateX}, -100%)` }}
-          >
-            <p className="mb-1 font-semibold text-gray-700">{r.date}</p>
-            <p className="text-gray-600">취침 {r.bedtime} → 기상 {r.wake_time}</p>
-            {r.duration_minutes != null && (
-              <p className="text-gray-600">수면 {hours}시간{mins > 0 ? ` ${mins}분` : ''}</p>
-            )}
-            {r.events.length > 0 && (
-              <div className="mt-1 border-t border-gray-100 pt-1">
-                <p className="text-red-500">중간기상 {r.events.length}회</p>
-                {r.events.map((e) => (
-                  <p key={e.id} className="text-gray-500">&nbsp;&nbsp;{e.event_time}{e.memo ? ` — ${e.memo}` : ''}</p>
-                ))}
-              </div>
-            )}
-          </div>
-        );
+          const d = tooltip.daily;
+          const totalH = Math.floor(d.totalNightDurationMinutes / 60);
+          const totalM = d.totalNightDurationMinutes % 60;
+          const hasMorning = d.morningSleeps.length > 0;
+          const alignRight = tooltip.x > chartWidth - 120;
+          const alignLeft = tooltip.x < 120;
+          const translateX = alignRight ? '-100%' : alignLeft ? '0%' : '-50%';
+          return (
+            <div
+              className="pointer-events-none absolute z-10 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
+              style={{ left: tooltip.x, top: 0, transform: `translateX(${translateX})` }}
+            >
+              <p className="mb-1 font-semibold text-gray-700">{d.date}</p>
+              {d.nightSleep?.bedtime && (
+                <p className="text-gray-600">
+                  밤잠 {d.nightSleep.bedtime} → {d.nightSleep.wake_time ?? '?'}
+                </p>
+              )}
+              {d.morningSleeps.map((m, i) => (
+                <p key={i} className="text-indigo-500">
+                  아침잠 {m.bedtime} → {m.wake_time ?? '?'}
+                </p>
+              ))}
+              {d.totalNightDurationMinutes > 0 && (
+                <p className="text-gray-600">
+                  총 {totalH}시간{totalM > 0 ? ` ${totalM}분` : ''}
+                  {hasMorning ? ' (합산)' : ''}
+                </p>
+              )}
+              {(d.nightSleep?.events.length ?? 0) > 0 && (
+                <div className="mt-1 border-t border-gray-100 pt-1">
+                  <p className="text-red-500">중간기상 {d.nightSleep!.events.length}회</p>
+                  {d.nightSleep!.events.map((e) => (
+                    <p key={e.id} className="text-gray-500">&nbsp;&nbsp;{e.event_time}{e.memo ? ` — ${e.memo}` : ''}</p>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
         })()}
       </div>
       <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">

--- a/web/src/features/sleep/components/sleep-timeline.tsx
+++ b/web/src/features/sleep/components/sleep-timeline.tsx
@@ -159,11 +159,11 @@ export function SleepTimeline({ dailies, period }: SleepTimelineProps) {
                     width={barWidth + 4} height={chartHeight}
                     fill="transparent"
                     style={{ cursor: 'pointer' }}
-                    onMouseEnter={(e) => {
+                    onPointerEnter={(e) => {
                       if (e.pointerType === 'touch') return;
                       setTooltip({ x: x + barWidth / 2, y: topPadding, daily: d });
                     }}
-                    onMouseLeave={(e) => {
+                    onPointerLeave={(e) => {
                       if (e.pointerType === 'touch') return;
                       setTooltip(null);
                     }}

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -210,11 +210,11 @@ function TimesTrendChart({ dailies, allowScroll }: { dailies: DailySleep[]; allo
                 <circle
                   cx={p.x} cy={p.y} r={12} fill="transparent"
                   style={{ cursor: 'pointer' }}
-                  onMouseEnter={(e) => {
+                  onPointerEnter={(e) => {
                     if (e.pointerType === 'touch') return;
                     setTooltip({ x: p.x, y: p.y, daily: valid[i], type: 'bed' });
                   }}
-                  onMouseLeave={(e) => {
+                  onPointerLeave={(e) => {
                     if (e.pointerType === 'touch') return;
                     setTooltip(null);
                   }}
@@ -237,11 +237,11 @@ function TimesTrendChart({ dailies, allowScroll }: { dailies: DailySleep[]; allo
                   <circle
                     cx={p.x} cy={p.y} r={12} fill="transparent"
                     style={{ cursor: 'pointer' }}
-                    onMouseEnter={(e) => {
+                    onPointerEnter={(e) => {
                       if (e.pointerType === 'touch') return;
                       setTooltip({ x: p.x, y: p.y!, daily: valid[i], type: 'wake' });
                     }}
-                    onMouseLeave={(e) => {
+                    onPointerLeave={(e) => {
                       if (e.pointerType === 'touch') return;
                       setTooltip(null);
                     }}

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -113,7 +113,7 @@ function DurationChart({ dailies, allowScroll }: { dailies: DailySleep[]; allowS
       </div>
       <div className="mt-2 flex items-center gap-3 text-xs text-gray-400">
         <span className="flex items-center gap-1">
-          <span className="inline-block h-2 w-4 rounded-sm bg-green-100" /> 적정 (7\~8h)
+          <span className="inline-block h-2 w-4 rounded-sm bg-green-100" /> 적정 (7~8h)
         </span>
       </div>
     </div>

--- a/web/src/features/sleep/components/sleep-trend-chart.tsx
+++ b/web/src/features/sleep/components/sleep-trend-chart.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useRef, useState, useEffect } from 'react';
-import type { SleepRecordWithEvents, SleepPeriod } from '../lib/types';
+import type { DailySleep, SleepPeriod } from '../lib/types';
 import { formatDateLabel, getDayOfWeek } from '../lib/chart-utils';
 
 interface SleepTrendChartProps {
-  records: SleepRecordWithEvents[];
+  dailies: DailySleep[];
   period: SleepPeriod;
 }
 
@@ -33,19 +33,19 @@ function useScrollToEnd(
   }, [w, enabled, ...deps]);
 }
 
-function DurationChart({ records, allowScroll }: { records: SleepRecordWithEvents[]; allowScroll: boolean }) {
+function DurationChart({ dailies, allowScroll }: { dailies: DailySleep[]; allowScroll: boolean }) {
   const { ref, w: cw } = useContainerWidth();
-  const valid = records.filter((r) => r.duration_minutes != null);
+  const valid = dailies.filter((d) => d.totalNightDurationMinutes > 0);
   useScrollToEnd(ref, cw, [valid.length], allowScroll);
   if (valid.length === 0) return null;
 
-  const maxDur = Math.max(...valid.map((r) => r.duration_minutes!));
+  const maxDur = Math.max(...valid.map((d) => d.totalNightDurationMinutes));
   const chartHeight = 120;
   const barGap = 3;
   const minBarWidth = allowScroll ? 16 : 6;
-  const minContentWidth = 8 + valid.length * (minBarWidth + barGap);
+  const minContentWidth = 8 + dailies.length * (minBarWidth + barGap);
   const chartWidth = allowScroll ? Math.max(cw, minContentWidth) : Math.max(cw, 200);
-  const barWidth = Math.max(minBarWidth, (chartWidth - 8) / valid.length - barGap);
+  const barWidth = Math.max(minBarWidth, (chartWidth - 8) / dailies.length - barGap);
   const dateAreaHeight = 32;
 
   const idealMin = 420;
@@ -67,33 +67,42 @@ function DurationChart({ records, allowScroll }: { records: SleepRecordWithEvent
               fill="#d1fae5" opacity={0.3}
             />
 
-            {valid.map((r, i) => {
+            {dailies.map((d, i) => {
               const x = i * (barWidth + 3) + 2;
-              const h = (r.duration_minutes! / (maxDur + 60)) * chartHeight;
+              if (d.totalNightDurationMinutes === 0) {
+                const dateLabel = formatDateLabel(d.date);
+                const dayLabel = getDayOfWeek(d.date);
+                return (
+                  <g key={d.date}>
+                    <text x={x + barWidth / 2} y={chartHeight + 12} textAnchor="middle" className="fill-gray-300 text-[9px]">
+                      {dateLabel}
+                    </text>
+                    <text x={x + barWidth / 2} y={chartHeight + 24} textAnchor="middle" className="fill-gray-200 text-[8px]">
+                      {dayLabel}
+                    </text>
+                  </g>
+                );
+              }
+              const dur = d.totalNightDurationMinutes;
+              const h = (dur / (maxDur + 60)) * chartHeight;
               const y = chartHeight - h;
-              const hours = Math.floor(r.duration_minutes! / 60);
-              const mins = r.duration_minutes! % 60;
-              const isLow = r.duration_minutes! < idealMin;
+              const hours = Math.floor(dur / 60);
+              const mins = dur % 60;
+              const isLow = dur < idealMin;
               const color = isLow ? '#f87171' : '#818cf8';
-              const dateLabel = formatDateLabel(r.date);
-              const dayLabel = getDayOfWeek(r.date);
+              const dateLabel = formatDateLabel(d.date);
+              const dayLabel = getDayOfWeek(d.date);
 
               return (
-                <g key={r.id}>
+                <g key={d.date}>
                   <rect x={x} y={y} width={barWidth} height={h} rx={2} fill={color} opacity={0.8} />
                   <text x={x + barWidth / 2} y={y - 3} textAnchor="middle" className="fill-gray-500 text-[8px]">
                     {hours}h{mins > 0 ? mins : ''}
                   </text>
-                  <text
-                    x={x + barWidth / 2} y={chartHeight + 12}
-                    textAnchor="middle" className="fill-gray-500 text-[9px]"
-                  >
+                  <text x={x + barWidth / 2} y={chartHeight + 12} textAnchor="middle" className="fill-gray-500 text-[9px]">
                     {dateLabel}
                   </text>
-                  <text
-                    x={x + barWidth / 2} y={chartHeight + 24}
-                    textAnchor="middle" className="fill-gray-400 text-[8px]"
-                  >
+                  <text x={x + barWidth / 2} y={chartHeight + 24} textAnchor="middle" className="fill-gray-400 text-[8px]">
                     {dayLabel}
                   </text>
                 </g>
@@ -104,7 +113,7 @@ function DurationChart({ records, allowScroll }: { records: SleepRecordWithEvent
       </div>
       <div className="mt-2 flex items-center gap-3 text-xs text-gray-400">
         <span className="flex items-center gap-1">
-          <span className="inline-block h-2 w-4 rounded-sm bg-green-100" /> 적정 (7~8h)
+          <span className="inline-block h-2 w-4 rounded-sm bg-green-100" /> 적정 (7\~8h)
         </span>
       </div>
     </div>
@@ -114,17 +123,29 @@ function DurationChart({ records, allowScroll }: { records: SleepRecordWithEvent
 interface TrendTooltip {
   x: number;
   y: number;
-  date: string;
-  bedtime: string;
-  wakeTime: string;
+  daily: DailySleep;
   type: 'bed' | 'wake';
 }
 
-function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEvents[]; allowScroll: boolean }) {
+function TimesTrendChart({ dailies, allowScroll }: { dailies: DailySleep[]; allowScroll: boolean }) {
   const { ref, w: cw } = useContainerWidth();
-  const valid = records.filter((r) => r.bedtime && r.wake_time);
+  const valid = dailies.filter((d) => d.nightSleep?.bedtime);
   const [tooltip, setTooltip] = useState<TrendTooltip | null>(null);
   useScrollToEnd(ref, cw, [valid.length], allowScroll);
+
+  // 외부 탭 시 툴팁 닫기 (모바일)
+  useEffect(() => {
+    if (!tooltip) return;
+    const handler = (e: PointerEvent) => {
+      if (e.pointerType !== 'touch') return;
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setTooltip(null);
+      }
+    };
+    document.addEventListener('pointerdown', handler);
+    return () => document.removeEventListener('pointerdown', handler);
+  }, [tooltip, ref]);
+
   if (valid.length === 0) return null;
 
   const chartHeight = 140;
@@ -140,34 +161,33 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
 
   function timeToNorm(time: string): number {
     const [h, m] = time.split(':').map(Number);
-    let mins = h * 60 + (m ?? 0) - yStart;
+    let mins = (h ?? 0) * 60 + (m ?? 0) - yStart;
     if (mins < 0) mins += 1440;
     return mins / yRange;
   }
 
-  const bedPoints = valid.map((r, i) => ({
+  const bedPoints = valid.map((d, i) => ({
     x: padding.left + (i / Math.max(1, valid.length - 1)) * innerW,
-    y: padding.top + timeToNorm(r.bedtime!) * innerH,
+    y: padding.top + timeToNorm(d.nightSleep!.bedtime!) * innerH,
   }));
-  const wakePoints = valid.map((r, i) => ({
+  const wakePoints = valid.map((d, i) => ({
     x: padding.left + (i / Math.max(1, valid.length - 1)) * innerW,
-    y: padding.top + timeToNorm(r.wake_time!) * innerH,
+    y: d.effectiveWakeTime
+      ? padding.top + timeToNorm(d.effectiveWakeTime) * innerH
+      : null,
   }));
 
   const bedPath = bedPoints.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
-  const wakePath = wakePoints.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
+  const wakePath = wakePoints
+    .filter((p): p is { x: number; y: number } => p.y !== null)
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`)
+    .join(' ');
 
   const yLabels = ['20', '0', '4', '8', '12'];
   const yLabelNorms = [0, 240 / 960, 480 / 960, 720 / 960, 1];
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5">
-      <style>{`
-        @media (hover: none) {
-          .desktop-hover-target { display: none; }
-          .desktop-tooltip { display: none; }
-        }
-      `}</style>
       <h3 className="mb-3 text-sm font-semibold text-gray-900">취침 · 기상 시간 추이</h3>
       <div ref={ref} className={`relative ${allowScroll ? 'overflow-x-auto' : ''}`}>
         {cw > 0 && (
@@ -188,51 +208,62 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
               <g key={`b${i}`}>
                 <circle cx={p.x} cy={p.y} r={2.5} fill="#818cf8" className="pointer-events-none" />
                 <circle
-                  cx={p.x} cy={p.y} r={8} fill="transparent"
-                  className="desktop-hover-target"
-                  onMouseEnter={() => {
-                    setTooltip({
-                      x: p.x,
-                      y: p.y,
-                      date: valid[i].date,
-                      bedtime: valid[i].bedtime!,
-                      wakeTime: valid[i].wake_time!,
-                      type: 'bed',
-                    });
+                  cx={p.x} cy={p.y} r={12} fill="transparent"
+                  style={{ cursor: 'pointer' }}
+                  onMouseEnter={(e) => {
+                    if (e.pointerType === 'touch') return;
+                    setTooltip({ x: p.x, y: p.y, daily: valid[i], type: 'bed' });
                   }}
-                  onMouseLeave={() => setTooltip(null)}
+                  onMouseLeave={(e) => {
+                    if (e.pointerType === 'touch') return;
+                    setTooltip(null);
+                  }}
+                  onClick={() => {
+                    setTooltip((prev) =>
+                      prev?.daily.date === valid[i].date && prev.type === 'bed'
+                        ? null
+                        : { x: p.x, y: p.y, daily: valid[i], type: 'bed' },
+                    );
+                  }}
                 />
               </g>
             ))}
             <path d={wakePath} fill="none" stroke="#f59e0b" strokeWidth={1.5} />
-            {wakePoints.map((p, i) => (
-              <g key={`w${i}`}>
-                <circle cx={p.x} cy={p.y} r={2.5} fill="#f59e0b" className="pointer-events-none" />
-                <circle
-                  cx={p.x} cy={p.y} r={8} fill="transparent"
-                  className="desktop-hover-target"
-                  onMouseEnter={() => {
-                    setTooltip({
-                      x: p.x,
-                      y: p.y,
-                      date: valid[i].date,
-                      bedtime: valid[i].bedtime!,
-                      wakeTime: valid[i].wake_time!,
-                      type: 'wake',
-                    });
-                  }}
-                  onMouseLeave={() => setTooltip(null)}
-                />
-              </g>
-            ))}
-            {valid.map((r, i) => {
+            {wakePoints.map((p, i) => {
+              if (p.y === null) return null;
+              return (
+                <g key={`w${i}`}>
+                  <circle cx={p.x} cy={p.y} r={2.5} fill="#f59e0b" className="pointer-events-none" />
+                  <circle
+                    cx={p.x} cy={p.y} r={12} fill="transparent"
+                    style={{ cursor: 'pointer' }}
+                    onMouseEnter={(e) => {
+                      if (e.pointerType === 'touch') return;
+                      setTooltip({ x: p.x, y: p.y!, daily: valid[i], type: 'wake' });
+                    }}
+                    onMouseLeave={(e) => {
+                      if (e.pointerType === 'touch') return;
+                      setTooltip(null);
+                    }}
+                    onClick={() => {
+                      setTooltip((prev) =>
+                        prev?.daily.date === valid[i].date && prev.type === 'wake'
+                          ? null
+                          : { x: p.x, y: p.y!, daily: valid[i], type: 'wake' },
+                      );
+                    }}
+                  />
+                </g>
+              );
+            })}
+            {valid.map((d, i) => {
               const x = padding.left + (i / Math.max(1, valid.length - 1)) * innerW;
               const step = Math.max(1, Math.floor(valid.length / 7));
               if (i % step !== 0 && i !== valid.length - 1) return null;
-              const dateLabel = formatDateLabel(r.date);
-              const dayLabel = getDayOfWeek(r.date);
+              const dateLabel = formatDateLabel(d.date);
+              const dayLabel = getDayOfWeek(d.date);
               return (
-                <g key={r.id}>
+                <g key={d.date}>
                   <text x={x} y={chartHeight - padding.bottom + 14} textAnchor="middle" className="fill-gray-500 text-[9px]">
                     {dateLabel}
                   </text>
@@ -245,23 +276,28 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
           </svg>
         )}
         {tooltip && (() => {
-        const alignRight = tooltip.x > chartWidth - 80;
-        const alignLeft = tooltip.x < 80;
-        const translateX = alignRight ? '-100%' : alignLeft ? '0%' : '-50%';
-        return (
-        <div
-          className="desktop-tooltip pointer-events-none absolute z-10 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
-          style={{ left: tooltip.x, top: tooltip.y - 8, transform: `translate(${translateX}, -100%)` }}
-        >
-          <p className="mb-0.5 font-semibold text-gray-700">{tooltip.date}</p>
-          <p style={{ color: tooltip.type === 'bed' ? '#818cf8' : undefined }} className={tooltip.type === 'bed' ? 'font-medium' : 'text-gray-500'}>
-            취침 {tooltip.bedtime}
-          </p>
-          <p style={{ color: tooltip.type === 'wake' ? '#f59e0b' : undefined }} className={tooltip.type === 'wake' ? 'font-medium' : 'text-gray-500'}>
-            기상 {tooltip.wakeTime}
-          </p>
-        </div>
-        );
+          const d = tooltip.daily;
+          const hasMorning = d.morningSleeps.length > 0;
+          const alignRight = tooltip.x > chartWidth - 100;
+          const alignLeft = tooltip.x < 100;
+          const translateX = alignRight ? '-100%' : alignLeft ? '0%' : '-50%';
+          return (
+            <div
+              className="pointer-events-none absolute z-10 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs shadow-lg"
+              style={{ left: tooltip.x, top: tooltip.y - 8, transform: `translate(${translateX}, -100%)` }}
+            >
+              <p className="mb-0.5 font-semibold text-gray-700">{d.date}</p>
+              <p style={{ color: tooltip.type === 'bed' ? '#818cf8' : undefined }} className={tooltip.type === 'bed' ? 'font-medium' : 'text-gray-500'}>
+                취침 {d.nightSleep?.bedtime ?? '--:--'}
+              </p>
+              <p style={{ color: tooltip.type === 'wake' ? '#f59e0b' : undefined }} className={tooltip.type === 'wake' ? 'font-medium' : 'text-gray-500'}>
+                기상 {d.effectiveWakeTime ?? '--:--'}
+                {hasMorning && tooltip.type === 'wake' && (
+                  <span className="ml-1 text-gray-400 font-normal">※아침잠 포함</span>
+                )}
+              </p>
+            </div>
+          );
         })()}
       </div>
       <div className="mt-2 flex items-center gap-4 text-xs text-gray-400">
@@ -276,12 +312,12 @@ function TimesTrendChart({ records, allowScroll }: { records: SleepRecordWithEve
   );
 }
 
-export function SleepTrendChart({ records, period }: SleepTrendChartProps) {
+export function SleepTrendChart({ dailies, period }: SleepTrendChartProps) {
   const allowScroll = period === '1m';
   return (
     <div className="space-y-4">
-      <DurationChart records={records} allowScroll={allowScroll} />
-      <TimesTrendChart records={records} allowScroll={allowScroll} />
+      <DurationChart dailies={dailies} allowScroll={allowScroll} />
+      <TimesTrendChart dailies={dailies} allowScroll={allowScroll} />
     </div>
   );
 }

--- a/web/src/features/sleep/hooks/use-chart-tooltip.ts
+++ b/web/src/features/sleep/hooks/use-chart-tooltip.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+/**
+ * 데스크톱 hover / 모바일 tap 공통 툴팁 훅.
+ * - 모바일: 차트 영역 외부 tap 시 닫힘
+ * - 데스크톱: mouseleave로 닫힘
+ */
+export function useChartTooltip<T>() {
+  const [tooltip, setTooltip] = useState<T | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!tooltip) return;
+    const handler = (e: PointerEvent) => {
+      if (e.pointerType !== 'touch') return;
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setTooltip(null);
+      }
+    };
+    document.addEventListener('pointerdown', handler);
+    return () => document.removeEventListener('pointerdown', handler);
+  }, [tooltip]);
+
+  return { tooltip, setTooltip, ref };
+}

--- a/web/src/features/sleep/lib/queries.ts
+++ b/web/src/features/sleep/lib/queries.ts
@@ -1,9 +1,9 @@
 import { query } from '@/lib/db';
-import type { SleepRecord, SleepEvent, SleepRecordWithEvents, SleepSummary, DayOfWeekPattern } from './types';
+import type { SleepRecord, SleepEvent, SleepRecordWithEvents, SleepSummary, DayOfWeekPattern, DailySleep } from './types';
 
 const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
 
-/** 기간별 수면 기록 + 이벤트 조회 */
+/** 기간별 수면 기록 + 이벤트 조회 (모든 sleep_type 포함) */
 export async function querySleepRecordsWithEvents(
   userId: number,
   from: string,
@@ -13,8 +13,8 @@ export async function querySleepRecordsWithEvents(
     query<SleepRecord>(
       `SELECT id, date::text, bedtime, wake_time, duration_minutes, sleep_type, memo
        FROM sleep_records
-       WHERE user_id = $1 AND date BETWEEN $2 AND $3 AND sleep_type = 'night'
-       ORDER BY date`,
+       WHERE user_id = $1 AND date BETWEEN $2 AND $3
+       ORDER BY date, sleep_type, bedtime`,
       [userId, from, to],
     ),
     query<SleepEvent>(
@@ -38,14 +38,33 @@ export async function querySleepRecordsWithEvents(
 
   return recordsResult.rows.map((r) => ({
     ...r,
-    events: eventsByDate.get(r.date) ?? [],
+    events: r.sleep_type === 'night' ? (eventsByDate.get(r.date) ?? []) : [],
   }));
+}
+
+/** YYYY-MM-DD 문자열 사이의 모든 날짜 배열 생성 */
+function eachDate(from: string, to: string): string[] {
+  const dates: string[] = [];
+  const current = new Date(from + 'T12:00:00Z');
+  const end = new Date(to + 'T12:00:00Z');
+  while (current <= end) {
+    dates.push(current.toISOString().slice(0, 10));
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return dates;
+}
+
+/** 아침잠 판별: bedtime이 정오 이전 (00:00~11:59) */
+function isMorningNap(bedtime: string | null): boolean {
+  if (!bedtime) return false;
+  const [h] = bedtime.split(':').map(Number);
+  return (h ?? 24) < 12;
 }
 
 /** 시간 문자열(HH:MM)을 자정 기준 분으로 변환. 20:00 이후는 음수 */
 function timeToMinutesFromMidnight(time: string): number {
   const [h, m] = time.split(':').map(Number);
-  const total = h * 60 + (m ?? 0);
+  const total = (h ?? 0) * 60 + (m ?? 0);
   return total >= 1200 ? total - 1440 : total;
 }
 
@@ -58,51 +77,136 @@ function minutesToTimeStr(minutes: number): string {
   return `${hh}:${mm}`;
 }
 
-/** 수면 요약 통계 계산 */
-export function calculateSleepSummary(
+/** 하루 기록 → DailySleep 묶기 */
+export function buildDailySleeps(
   records: SleepRecordWithEvents[],
-): SleepSummary {
-  const validRecords = records.filter((r) => r.bedtime && r.wake_time && r.duration_minutes);
+  from: string,
+  to: string,
+): DailySleep[] {
+  const byDate = new Map<string, {
+    night: SleepRecordWithEvents | null;
+    morning: SleepRecord[];
+    afternoon: SleepRecord[];
+  }>();
 
-  if (validRecords.length === 0) {
+  for (const d of eachDate(from, to)) {
+    byDate.set(d, { night: null, morning: [], afternoon: [] });
+  }
+
+  for (const r of records) {
+    const bucket = byDate.get(r.date);
+    if (!bucket) continue;
+    if (r.sleep_type === 'night') {
+      bucket.night = r;
+    } else if (isMorningNap(r.bedtime)) {
+      bucket.morning.push(r);
+    } else {
+      bucket.afternoon.push(r);
+    }
+  }
+
+  const result: DailySleep[] = [];
+  for (const [date, b] of byDate) {
+    const nightDur = b.night?.duration_minutes ?? 0;
+    const morningDur = b.morning.reduce((s, r) => s + (r.duration_minutes ?? 0), 0);
+    const morningWakes = b.morning
+      .map((r) => r.wake_time)
+      .filter((t): t is string => !!t)
+      .sort();
+    const effectiveWakeTime =
+      morningWakes.length > 0
+        ? morningWakes[morningWakes.length - 1]
+        : (b.night?.wake_time ?? null);
+
+    result.push({
+      date,
+      nightSleep: b.night,
+      morningSleeps: b.morning,
+      afternoonNaps: b.afternoon,
+      totalNightDurationMinutes: nightDur + morningDur,
+      effectiveWakeTime,
+    });
+  }
+  return result.sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/** 수면 요약 통계 계산 (DailySleep[] 기반) */
+export function calculateSleepSummary(dailies: DailySleep[]): SleepSummary {
+  const withNight = dailies.filter((d) => d.nightSleep?.bedtime && d.nightSleep?.wake_time);
+  const withAnySleep = dailies.filter((d) => d.totalNightDurationMinutes > 0);
+  const withWake = dailies.filter((d) => d.effectiveWakeTime != null);
+
+  const totalNights = withAnySleep.length;
+
+  if (totalNights === 0) {
+    const napDaysCount = dailies.filter((d) => d.afternoonNaps.length > 0).length;
+    const totalNapMinutes = dailies.reduce(
+      (s, d) => s + d.afternoonNaps.reduce((x, n) => x + (n.duration_minutes ?? 0), 0),
+      0,
+    );
     return {
-      avgDuration: 0, avgBedtime: '--:--', avgWakeTime: '--:--',
-      totalMidWakes: 0, avgMidWakesPerNight: 0, regularityScore: 0, totalNights: 0,
+      avgDuration: 0,
+      avgBedtime: '--:--',
+      avgWakeTime: '--:--',
+      totalMidWakes: 0,
+      avgMidWakesPerNight: 0,
+      regularityScore: 0,
+      totalNights: 0,
+      napDaysCount,
+      avgNapMinutes: napDaysCount > 0 ? Math.round(totalNapMinutes / napDaysCount) : 0,
+      totalNapMinutes,
     };
   }
 
-  const totalDuration = validRecords.reduce((s, r) => s + (r.duration_minutes ?? 0), 0);
-  const avgDuration = totalDuration / validRecords.length;
+  const totalDuration = withAnySleep.reduce((s, d) => s + d.totalNightDurationMinutes, 0);
+  const avgDuration = Math.round(totalDuration / withAnySleep.length);
 
-  const bedtimeMins = validRecords.map((r) => timeToMinutesFromMidnight(r.bedtime!));
-  const waketimeMins = validRecords.map((r) => timeToMinutesFromMidnight(r.wake_time!));
-  const avgBedtimeMin = bedtimeMins.reduce((a, b) => a + b, 0) / bedtimeMins.length;
-  const avgWakeTimeMin = waketimeMins.reduce((a, b) => a + b, 0) / waketimeMins.length;
+  const bedtimeMins = withNight.map((d) => timeToMinutesFromMidnight(d.nightSleep!.bedtime!));
+  const avgBedtimeMin = bedtimeMins.length > 0
+    ? bedtimeMins.reduce((a, b) => a + b, 0) / bedtimeMins.length
+    : 0;
 
-  const totalMidWakes = records.reduce((s, r) => s + r.events.length, 0);
+  const waketimeMins = withWake.map((d) => timeToMinutesFromMidnight(d.effectiveWakeTime!));
+  const avgWakeTimeMin = waketimeMins.length > 0
+    ? waketimeMins.reduce((a, b) => a + b, 0) / waketimeMins.length
+    : 0;
 
-  const bedtimeStdDev = Math.sqrt(
-    bedtimeMins.reduce((s, m) => s + (m - avgBedtimeMin) ** 2, 0) / bedtimeMins.length,
+  const totalMidWakes = dailies.reduce(
+    (s, d) => s + (d.nightSleep?.events.length ?? 0),
+    0,
   );
+
+  const bedtimeStdDev = bedtimeMins.length > 0
+    ? Math.sqrt(
+        bedtimeMins.reduce((s, m) => s + (m - avgBedtimeMin) ** 2, 0) / bedtimeMins.length,
+      )
+    : 0;
   const regularityScore = Math.max(0, Math.min(100, Math.round(100 - (bedtimeStdDev / 120) * 100)));
 
+  const napDaysCount = dailies.filter((d) => d.afternoonNaps.length > 0).length;
+  const totalNapMinutes = dailies.reduce(
+    (s, d) => s + d.afternoonNaps.reduce((x, n) => x + (n.duration_minutes ?? 0), 0),
+    0,
+  );
+
   return {
-    avgDuration: Math.round(avgDuration),
-    avgBedtime: minutesToTimeStr(avgBedtimeMin),
-    avgWakeTime: minutesToTimeStr(avgWakeTimeMin),
+    avgDuration,
+    avgBedtime: bedtimeMins.length > 0 ? minutesToTimeStr(avgBedtimeMin) : '--:--',
+    avgWakeTime: waketimeMins.length > 0 ? minutesToTimeStr(avgWakeTimeMin) : '--:--',
     totalMidWakes,
-    avgMidWakesPerNight: validRecords.length > 0
-      ? Math.round((totalMidWakes / validRecords.length) * 10) / 10
+    avgMidWakesPerNight: withAnySleep.length > 0
+      ? Math.round((totalMidWakes / withAnySleep.length) * 10) / 10
       : 0,
     regularityScore,
-    totalNights: validRecords.length,
+    totalNights,
+    napDaysCount,
+    avgNapMinutes: napDaysCount > 0 ? Math.round(totalNapMinutes / napDaysCount) : 0,
+    totalNapMinutes,
   };
 }
 
-/** 요일별 패턴 계산 */
-export function calculateDayOfWeekPattern(
-  records: SleepRecordWithEvents[],
-): DayOfWeekPattern[] {
+/** 요일별 패턴 계산 (DailySleep[] 기반) */
+export function calculateDayOfWeekPattern(dailies: DailySleep[]): DayOfWeekPattern[] {
   const buckets = Array.from({ length: 7 }, (_, i) => ({
     day: i,
     dayName: DAY_NAMES[i] ?? '',
@@ -111,14 +215,18 @@ export function calculateDayOfWeekPattern(
     waketimes: [] as number[],
   }));
 
-  for (const r of records) {
-    if (!r.bedtime || !r.wake_time || !r.duration_minutes) continue;
-    const dow = new Date(r.date + 'T12:00:00+09:00').getUTCDay();
+  for (const d of dailies) {
+    if (d.totalNightDurationMinutes === 0) continue;
+    const dow = new Date(d.date + 'T12:00:00+09:00').getUTCDay();
     const bucket = buckets[dow];
     if (!bucket) continue;
-    bucket.durations.push(r.duration_minutes);
-    bucket.bedtimes.push(timeToMinutesFromMidnight(r.bedtime));
-    bucket.waketimes.push(timeToMinutesFromMidnight(r.wake_time));
+    bucket.durations.push(d.totalNightDurationMinutes);
+    if (d.nightSleep?.bedtime) {
+      bucket.bedtimes.push(timeToMinutesFromMidnight(d.nightSleep.bedtime));
+    }
+    if (d.effectiveWakeTime) {
+      bucket.waketimes.push(timeToMinutesFromMidnight(d.effectiveWakeTime));
+    }
   }
 
   return buckets.map((b) => ({

--- a/web/src/features/sleep/lib/types.ts
+++ b/web/src/features/sleep/lib/types.ts
@@ -32,6 +32,21 @@ export interface DayOfWeekPattern {
   count: number;
 }
 
+/** 날짜별 통합 수면 데이터 (대시보드 차트용 렌더 단위) */
+export interface DailySleep {
+  date: string;
+  /** 밤잠 (sleep_type='night') */
+  nightSleep: SleepRecordWithEvents | null;
+  /** 아침잠 (nap, bedtime < 12:00) */
+  morningSleeps: SleepRecord[];
+  /** 낮잠 (nap, bedtime >= 12:00) */
+  afternoonNaps: SleepRecord[];
+  /** 밤잠 + 아침잠 합산 duration (분) */
+  totalNightDurationMinutes: number;
+  /** 기상 시각 — 아침잠 있으면 아침잠 중 가장 늦은 wake_time, 없으면 밤잠 wake_time */
+  effectiveWakeTime: string | null;
+}
+
 /** 대시보드 요약 통계 */
 export interface SleepSummary {
   avgDuration: number; // 분
@@ -41,11 +56,15 @@ export interface SleepSummary {
   avgMidWakesPerNight: number;
   regularityScore: number; // 0~100
   totalNights: number;
+  napDaysCount: number;      // 낮잠을 잔 날 수
+  avgNapMinutes: number;     // 낮잠 일수 중 평균 낮잠 시간(분)
+  totalNapMinutes: number;   // 기간 내 낮잠 총합(분)
 }
 
 /** 대시보드 API 응답 */
 export interface SleepDashboardData {
   records: SleepRecordWithEvents[];
+  dailySleeps: DailySleep[];
   summary: SleepSummary;
   dayOfWeekPattern: DayOfWeekPattern[];
 }


### PR DESCRIPTION
## 관련 이슈
Closes #317

## 변경 내용

### 핵심 구조 변경
- `DailySleep` 타입 도입 — 날짜별 통합 렌더 단위. 모든 차트가 이 단일 타입을 기반으로 동작
- DB 쿼리에서 `sleep_type='night'` 필터 제거 → 아침잠/낮잠 포함 전체 조회
- `buildDailySleeps()` — 아침잠(정오 전 nap)·낮잠(정오 이후 nap) 분류 + `effectiveWakeTime` 계산

### 수면 타임라인
- 하루 한 슬롯에 밤잠·아침잠을 같은 Y축(20:00~12:00)에 별도 블록으로 표시

### 수면시간·취침기상 추이
- DurationChart: 밤잠+아침잠 합산 시간 기준
- TimesTrendChart: 기상 시각을 `effectiveWakeTime`(아침잠 있으면 아침잠 기상 기준)으로 교체

### 낮잠 타임라인 신규
- Y축 12:00~24:00 전용 타임라인 (`NapTimeline` 컴포넌트)
- 낮잠 기록 없는 기간은 빈 상태 메시지 표시

### 요약 카드 개선
- 낮잠 통계 카드 추가 (평균 낮잠 시간, 기록 일수)
- 그리드 `md:grid-cols-3 lg:grid-cols-5`로 확장
- 규칙성 점수 옆 `InfoButton` — hover/tap으로 점수 구간 가이드 표시

### 모바일 인터랙션
- `useChartTooltip` 공통 훅 신규 — 모바일 tap/데스크톱 hover 통합 상태 관리
- 수면 타임라인·낮잠 타임라인·취침기상 추이: tap 툴팁 토글, 외부 tap 시 닫힘
- 요일별 수면 패턴: tap 시 요일별 평균 수면·취침·기상·기록일수 팝업

## 코드 리뷰 결과
- [x] 보안 감사 통과 (파라미터화 쿼리, 크리덴셜 없음, requireAuth 유지)
- [x] 타입 안전성 확인 (tsc --noEmit 통과)
- [x] 컨벤션 점검 완료 (named export, kebab-case, any 금지)
- [x] 코드 품질 확인 (nullable 안전 처리, 빈 상태 핸들링)

## 테스트
- [x] tsc --noEmit 통과
- [ ] 브라우저에서 밤잠+아침잠 합산 렌더 확인
- [ ] 낮잠 타임라인 표시 확인
- [ ] 모바일 tap 툴팁 동작 확인
- [ ] 1주/2주/1개월 기간 전환 시 차트 정상 렌더