### PR TITLE
fix(schedule): 기간 일정 진행 중이면 '못 끝낸 일정'에서 제외

### DIFF
--- a/src/agents/life/blocks.ts
+++ b/src/agents/life/blocks.ts
@@ -518,16 +518,50 @@ export const buildScheduleText = (
   return lines.join('\n').trimEnd();
 };
 
-/** 밤 미완료 일정 텍스트 (없으면 null) — event 타입 제외 */
-export const buildNightScheduleText = (items: ScheduleRow[], targetDate: string): string | null => {
-  const incomplete = items.filter(
-    (s) => !isEventType(s) && s.status !== 'done' && s.status !== 'cancelled',
+/**
+ * 미완료 일정 필터.
+ * - event 타입 제외
+ * - done/cancelled 제외
+ * - 기간 일정(end_date 존재)이 오늘(today) 이후까지 이어지면(end_date >= today) 아직 진행 중이므로 제외.
+ *   일정 최종 완료 검증은 end_date가 지난 다음 날 아침에 이뤄짐.
+ *   예) 월~목 일정: 목요일 밤까진 진행 중 → 제외, 금요일 아침에 미완료로 검증.
+ */
+const filterIncompleteTasks = (items: ScheduleRow[], today: string): ScheduleRow[] =>
+  items.filter(
+    (s) =>
+      !isEventType(s) &&
+      s.status !== 'done' &&
+      s.status !== 'cancelled' &&
+      !(s.end_date != null && s.end_date >= today),
   );
+
+/** 밤 미완료 일정 텍스트 (없으면 null) — event 타입 + 진행 중 기간 일정 제외 */
+export const buildNightScheduleText = (items: ScheduleRow[], today: string): string | null => {
+  const incomplete = filterIncompleteTasks(items, today);
   if (incomplete.length === 0) return null;
   return buildScheduleText(
     incomplete,
-    targetDate,
+    today,
     '오늘 아직 못 끝낸 일정이야. 내일로 넘길 건 정리해둬!',
+  );
+};
+
+/**
+ * 아침용 어제 미완료 일정 텍스트 (없으면 null).
+ * - yesterday: 헤더/그룹핑용 표시 날짜
+ * - today: 진행 중 판단 기준 (end_date >= today이면 제외)
+ */
+export const buildYesterdayIncompleteText = (
+  items: ScheduleRow[],
+  yesterday: string,
+  today: string,
+): string | null => {
+  const incomplete = filterIncompleteTasks(items, today);
+  if (incomplete.length === 0) return null;
+  return buildScheduleText(
+    incomplete,
+    yesterday,
+    '어제 못 끝낸 일정이야. 오늘로 넘길 건 정리해둬!',
   );
 };
 

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -36,6 +36,7 @@ import {
   buildRoutineBlocks,
   buildScheduleText,
   buildNightScheduleText,
+  buildYesterdayIncompleteText,
 } from '../agents/life/blocks.js';
 // insights.ts 넛지는 제거 — Sonnet이 생활 맥락에서 직접 인사이트 도출
 // 복원 시: import { pickMorningNudge, pickNightNudge } from '../shared/insights.js';
@@ -259,6 +260,17 @@ const morningTask = async (app: App, config: LifeCronConfig): Promise<void> => {
           ? `어제 루틴 전부 완료! ${stats.rate}% (${stats.completed}/${stats.total}) — ${slotText}`
           : `어제 루틴 최종 ${stats.rate}% (${stats.completed}/${stats.total}) — ${slotText}`;
       await postToChannel(app.client, channelId, line);
+    }
+
+    // 1-2. 어제 못 끝낸 일정 요약 (end_date가 오늘 이후인 진행 중 기간 일정은 제외)
+    const yesterdaySchedules = await queryTodaySchedules(yesterday, userId);
+    const yesterdayIncompleteText = buildYesterdayIncompleteText(
+      yesterdaySchedules,
+      yesterday,
+      today,
+    );
+    if (yesterdayIncompleteText) {
+      await postToChannel(app.client, channelId, yesterdayIncompleteText);
     }
 
     // 2. 오늘 루틴 기록 생성


### PR DESCRIPTION
## Summary
- 밤/아침 크론의 '못 끝낸 일정' 요약에서 `end_date >= today`인 진행 중 기간 일정 제외
- 아침 크론에 '어제 못 끝낸 일정' 요약 블록 추가
- 일정 최종 완료 검증은 end_date가 지난 다음 날 아침에 수행하도록 기준 통일

## 동작 예시 (월\~목 기간 일정)
| 시점 | today | end_date(Thu) >= today | 표시 |
|------|-------|------------------------|------|
| 화요일 밤 | Tue | true | 제외 |
| 목요일 밤 | Thu | true | 제외 |
| 금요일 아침 | Fri | false | '어제 못 끝낸 일정' |

## Test plan
- [x] `yarn tsc --noEmit` 통과
- [x] `yarn vitest run blocks.test.ts life-cron.test.ts` 통과 (26 tests)
- [ ] 배포 후 다음 아침/밤 크론에서 실제 기간 일정 처리 확인