### PR TITLE
refactor(routine): 루틴 API 캐시 제거 및 force-dynamic 전환

### DIFF
--- a/web/src/app/api/routines/[id]/inactive-periods/[periodId]/route.ts
+++ b/web/src/app/api/routines/[id]/inactive-periods/[periodId]/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
 import { updateInactivePeriod, deleteInactivePeriod } from '@/features/routine/lib/queries';
 
@@ -23,7 +22,6 @@ export async function PATCH(
       body.end_date ?? null,
     );
     if (!data) return NextResponse.json({ error: '비활성 기간을 찾을 수 없어' }, { status: 404 });
-    revalidateTag('routine-stats', 'seconds');
     return NextResponse.json({ data });
   } catch {
     return NextResponse.json({ error: '비활성 기간 수정 실패' }, { status: 500 });
@@ -41,7 +39,6 @@ export async function DELETE(
     const { periodId } = await params;
     const deleted = await deleteInactivePeriod(userId, Number(periodId));
     if (!deleted) return NextResponse.json({ error: '비활성 기간을 찾을 수 없어' }, { status: 404 });
-    revalidateTag('routine-stats', 'seconds');
     return NextResponse.json({ data: { id: Number(periodId) } });
   } catch {
     return NextResponse.json({ error: '비활성 기간 삭제 실패' }, { status: 500 });

--- a/web/src/app/api/routines/[id]/inactive-periods/route.ts
+++ b/web/src/app/api/routines/[id]/inactive-periods/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
 import { queryInactivePeriods, createInactivePeriod } from '@/features/routine/lib/queries';
 
@@ -40,7 +39,6 @@ export async function POST(
       body.start_date,
       body.end_date ?? null,
     );
-    revalidateTag('routine-stats', 'seconds');
     return NextResponse.json({ data }, { status: 201 });
   } catch {
     return NextResponse.json({ error: '비활성 기간 생성 실패' }, { status: 500 });

--- a/web/src/app/api/routines/[id]/records/route.ts
+++ b/web/src/app/api/routines/[id]/records/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
 import { deleteRecordsBefore } from '@/features/routine/lib/queries';
 
@@ -20,8 +19,6 @@ export async function DELETE(
 
     const deleted = await deleteRecordsBefore(userId, Number(id), before, true);
 
-    revalidateTag('routine-records', 'seconds');
-    revalidateTag('routine-stats', 'seconds');
     return NextResponse.json({ data: { deleted } });
   } catch {
     return NextResponse.json({ error: '기록 삭제 실패' }, { status: 500 });

--- a/web/src/app/api/routines/[id]/route.ts
+++ b/web/src/app/api/routines/[id]/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
 import { getTodayISO, addDays } from '@/lib/kst';
 import { validateFields } from '@/lib/validation';
@@ -63,9 +62,6 @@ export async function PATCH(
       staleCompletedCount = await countCompletedRecordsBefore(userId, numId, data.start_date);
     }
 
-    revalidateTag('routines', 'seconds');
-    revalidateTag('routine-records', 'seconds');
-    revalidateTag('routine-stats', 'seconds');
     return NextResponse.json({ data, staleCompletedCount });
   } catch {
     return NextResponse.json({ error: '루틴 수정 실패' }, { status: 500 });
@@ -84,7 +80,6 @@ export async function DELETE(
     const deleted = await deleteRoutineTemplate(userId, Number(id));
     if (!deleted) return NextResponse.json({ error: '루틴을 찾을 수 없어' }, { status: 404 });
 
-    revalidateTag('routines', 'seconds');
     return NextResponse.json({ data: { id: Number(id) } });
   } catch {
     return NextResponse.json({ error: '루틴 삭제 실패' }, { status: 500 });

--- a/web/src/app/api/routines/records/[id]/route.ts
+++ b/web/src/app/api/routines/records/[id]/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
 import { toggleRoutineRecord, updateRoutineRecordMemo } from '@/features/routine/lib/queries';
 
@@ -24,8 +23,6 @@ export async function PATCH(
       await updateRoutineRecordMemo(userId, Number(id), body.memo);
     }
 
-    revalidateTag('routine-records', 'seconds');
-    revalidateTag('routine-stats', 'seconds');
     return NextResponse.json({ data: { id: Number(id) } });
   } catch {
     return NextResponse.json({ error: '루틴 기록 수정 실패' }, { status: 500 });

--- a/web/src/app/api/routines/records/route.ts
+++ b/web/src/app/api/routines/records/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
-import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
-import { getCachedRoutineRecords } from '@/lib/cache';
-import { ensureTodayRecords } from '@/features/routine/lib/queries';
+import { ensureTodayRecords, queryRoutineRecords } from '@/features/routine/lib/queries';
 import { getTodayISO } from '@/lib/kst';
+
+export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
   const userId = await requireAuth();
@@ -15,12 +15,14 @@ export async function GET(request: Request) {
     if (!date) return NextResponse.json({ error: 'date 파라미터 필요' }, { status: 400 });
 
     if (date === getTodayISO()) {
-      const created = await ensureTodayRecords(userId, date);
-      if (created > 0) revalidateTag('routine-records', 'seconds');
+      await ensureTodayRecords(userId, date);
     }
 
-    const data = await getCachedRoutineRecords(userId, date);
-    return NextResponse.json({ data });
+    const data = await queryRoutineRecords(userId, date);
+    return NextResponse.json(
+      { data },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
   } catch {
     return NextResponse.json({ error: '루틴 기록 조회 실패' }, { status: 500 });
   }

--- a/web/src/app/api/routines/route.ts
+++ b/web/src/app/api/routines/route.ts
@@ -1,18 +1,25 @@
 import { NextResponse } from 'next/server';
-import { revalidateTag } from 'next/cache';
 import { requireAuth } from '@/lib/auth';
-import { getCachedRoutineTemplates } from '@/lib/cache';
-import { createRoutineTemplate, backfillRecords } from '@/features/routine/lib/queries';
+import {
+  createRoutineTemplate,
+  backfillRecords,
+  queryRoutineTemplates,
+} from '@/features/routine/lib/queries';
 import { getTodayISO } from '@/lib/kst';
 import { validateFields } from '@/lib/validation';
+
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
   const userId = await requireAuth();
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   try {
-    const data = await getCachedRoutineTemplates(userId);
-    return NextResponse.json({ data });
+    const data = await queryRoutineTemplates(userId);
+    return NextResponse.json(
+      { data },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
   } catch {
     return NextResponse.json({ error: '루틴 조회 실패' }, { status: 500 });
   }
@@ -58,7 +65,6 @@ export async function POST(request: Request) {
       await backfillRecords(userId, data.id, body.start_date, body.frequency ?? null, today);
     }
 
-    revalidateTag('routines', 'seconds');
     return NextResponse.json({ data }, { status: 201 });
   } catch {
     return NextResponse.json({ error: '루틴 생성 실패' }, { status: 500 });

--- a/web/src/app/api/routines/stats/route.ts
+++ b/web/src/app/api/routines/stats/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { getCachedRoutineStats } from '@/lib/cache';
-import { queryRoutinePerStats } from '@/features/routine/lib/queries';
+import { queryRoutinePerStats, queryRoutineStats } from '@/features/routine/lib/queries';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,8 +29,11 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'from/to 파라미터 필요' }, { status: 400 });
     }
 
-    const data = await getCachedRoutineStats(userId, from, to);
-    return NextResponse.json({ data });
+    const data = await queryRoutineStats(userId, from, to);
+    return NextResponse.json(
+      { data },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+    );
   } catch {
     return NextResponse.json({ error: '루틴 통계 조회 실패' }, { status: 500 });
   }

--- a/web/src/lib/cache.ts
+++ b/web/src/lib/cache.ts
@@ -4,11 +4,6 @@ import {
   queryBacklogSchedules,
   queryCategories,
 } from '@/features/schedule/lib/queries';
-import {
-  queryRoutineTemplates,
-  queryRoutineRecords,
-  queryRoutineStats,
-} from '@/features/routine/lib/queries';
 
 const REVALIDATE_SECONDS = 30;
 
@@ -32,27 +27,3 @@ export const getCachedCategories = (userId: number) =>
     ['categories', String(userId)],
     { revalidate: REVALIDATE_SECONDS, tags: ['categories'] },
   )();
-
-// ─── 루틴 ────────────────────────────────────────────
-
-export const getCachedRoutineTemplates = (userId: number) =>
-  unstable_cache(
-    async () => queryRoutineTemplates(userId),
-    ['routines', String(userId)],
-    { revalidate: REVALIDATE_SECONDS, tags: ['routines'] },
-  )();
-
-export const getCachedRoutineRecords = (userId: number, date: string) =>
-  unstable_cache(
-    async () => queryRoutineRecords(userId, date),
-    ['routine-records', String(userId), date],
-    { revalidate: REVALIDATE_SECONDS, tags: ['routine-records'] },
-  )();
-
-export const getCachedRoutineStats = (userId: number, from: string, to: string) =>
-  unstable_cache(
-    async () => queryRoutineStats(userId, from, to),
-    ['routine-stats', String(userId), from, to],
-    { revalidate: REVALIDATE_SECONDS, tags: ['routine-stats'] },
-  )();
-


### PR DESCRIPTION
## Summary
- 루틴 기록은 체크/해제 빈도가 높아 캐시 무효화 타이밍이 불안정해서 `unstable_cache` + `revalidateTag` 구조 제거
- 매 요청마다 직접 쿼리 + `Cache-Control: no-store` 헤더로 전환

## Changes
- `web/src/lib/cache.ts`: 루틴 관련 캐시 헬퍼(Templates/Records/Stats) 제거
- 모든 루틴 API 라우트에서 `revalidateTag`, `getCachedRoutineX` 호출 제거
- GET 라우트에 `export const dynamic = 'force-dynamic'`

## Test plan
- [x] \`yarn tsc --noEmit\` 통과
- [ ] 배포 후 루틴 체크/해제 즉시 반영 확인