### PR TITLE
fix(routine): 매일 빈도 루틴도 start_date 가드 적용

### DIFF
--- a/src/cron/__tests__/life-cron.test.ts
+++ b/src/cron/__tests__/life-cron.test.ts
@@ -59,7 +59,7 @@ vi.mock('../../shared/kst.js', () => ({
 }));
 
 import { connectDB } from '../../shared/db.js';
-import { CronScheduler, type LifeCronConfig } from '../life-cron.js';
+import { CronScheduler, createTodayRecords, type LifeCronConfig } from '../life-cron.js';
 import type { UserMapping } from '../../shared/user-resolver.js';
 
 /** notification_settings 쿼리 mock 설정 */
@@ -187,5 +187,64 @@ describe('CronScheduler reload debounce', () => {
     for (const stop of initStopFns) {
       expect(stop).toHaveBeenCalled();
     }
+  });
+});
+
+// ── createTodayRecords: start_date 가드 ──
+
+describe('createTodayRecords — 매일 빈도 start_date 가드', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue({ release: vi.fn() });
+    await connectDB('postgresql://test@localhost/test');
+  });
+
+  const setupTemplateMock = (
+    template: { id: number; name: string; time_slot: string; frequency: string; start_date: string },
+  ): void => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (/FROM routine_templates/.test(sql)) {
+        return Promise.resolve({ rows: [template] });
+      }
+      if (/SELECT template_id FROM routine_records/.test(sql)) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (/INSERT INTO routine_records/.test(sql)) {
+        return Promise.resolve({ rows: [{ id: 1 }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  };
+
+  it('매일 빈도 + start_date 미래 → 기록 생성하지 않음', async () => {
+    setupTemplateMock({
+      id: 99, name: '미래 루틴', time_slot: '낮', frequency: '매일', start_date: '2026-04-21',
+    });
+
+    const created = await createTodayRecords('2026-04-20', 1);
+    expect(created).toBe(0);
+
+    const inserts = mockQuery.mock.calls.filter(
+      (call) => /INSERT INTO routine_records/.test(call[0] as string),
+    );
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('매일 빈도 + start_date = 오늘 → 기록 생성', async () => {
+    setupTemplateMock({
+      id: 99, name: '오늘 시작', time_slot: '낮', frequency: '매일', start_date: '2026-04-21',
+    });
+
+    const created = await createTodayRecords('2026-04-21', 1);
+    expect(created).toBe(1);
+  });
+
+  it('매일 빈도 + start_date 과거 → 기록 생성', async () => {
+    setupTemplateMock({
+      id: 99, name: '진행 중', time_slot: '밤', frequency: '매일', start_date: '2026-04-01',
+    });
+
+    const created = await createTodayRecords('2026-04-21', 1);
+    expect(created).toBe(1);
   });
 });

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -223,7 +223,7 @@ export const createTodayRecords = async (today: string, userId: number = DEFAULT
   for (const t of candidates) {
     const shouldCreate =
       t.frequency === '매일'
-        ? true
+        ? !t.start_date || today >= t.start_date
         : shouldCreateToday(t.frequency, await queryLastRecordDate(t.id, userId), today, t.start_date);
 
     if (shouldCreate) {


### PR DESCRIPTION
## Summary
- `createTodayRecords()`의 '매일' 분기가 `shouldCreateToday()`를 우회하면서 `start_date` 가드가 적용되지 않던 버그 수정
- 매일 분기에 `!t.start_date || today >= t.start_date` 인라인 가드를 추가해 일관된 동작 보장

## 증상
슬랙 홈 탭은 새벽 5시 전까지 전날을 effective date로 간주해 기록을 재조회한다. 이때 `createTodayRecords`가 호출되면서 매일 빈도 + 미래 start_date 템플릿이 전일 날짜로 기록 생성되어, 전일 루틴 목록에 오늘부터 시작해야 할 루틴이 끼어 보이는 현상 발생.

## Test plan
- [x] createTodayRecords 회귀 테스트 3건 추가
  - 매일 + 미래 start_date → 생성 X
  - 매일 + 당일 start_date → 생성 O
  - 매일 + 과거 start_date → 생성 O
- [x] 전체 테스트 통과 (324/324)
- [x] tsc 빌드 통과
- [ ] 머지 후 배포 및 다음 날 새벽 슬랙 홈 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)