### PR TITLE
refactor(deploy): 배포 경로를 GitHub Actions 단일 경로로 통합

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: deploy-production

--- a/README.md
+++ b/README.md
@@ -172,7 +172,11 @@ yarn install
 cp .env.example .env        # Slack, Anthropic, DB 등 API 키 설정
 yarn dev                    # 개발 모드
 yarn build && yarn start    # 빌드 & 실행
-yarn deploy                 # 운영 VM 배포 (SSH → deploy.sh)
+
+# 운영 배포는 GitHub Actions가 담당:
+#   - main 브랜치 push → 자동 배포
+#   - 수동 재배포: GitHub Actions에서 Deploy 워크플로우 "Run workflow"
+#     또는 CLI: `gh workflow run deploy.yml`
 
 # 웹 대시보드
 cd web && yarn install

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "dev:web": "yarn --cwd web dev",
-    "deploy": "ssh life-server 'bash ~/deploy.sh'",
     "prepare": "husky"
   },
   "lint-staged": {


### PR DESCRIPTION
## Summary
- 로컬 `yarn deploy`와 GitHub Actions 자동 배포가 공존하던 이중 경로를 단일 경로(GitHub Actions)로 통합
- 머지 직후 수동 배포 시 발생하던 레이스 컨디션(이전 이미지 pull) 원천 제거
- 수동 재배포 필요 시 `workflow_dispatch`로 동일 파이프라인 경유

## 변경 내역
- `.github/workflows/deploy.yml`: `workflow_dispatch` 트리거 추가
- `package.json`: `deploy` 스크립트 제거
- `README.md`: 배포 가이드 갱신 (`gh workflow run deploy.yml` 안내)
- VM `~/deploy.sh`: `docker compose up -d --force-recreate app`로 변경 (이미지 digest 동일 시에도 컨테이너 강제 재생성)

## Test plan
- [x] 로컬 빌드/테스트 통과 (324/324)
- [x] VM `~/deploy.sh` 백업(`~/deploy.sh.bak`) 후 교체
- [ ] 머지 후 자동 배포(main push) 정상 동작 확인
- [ ] `gh workflow run deploy.yml` 수동 트리거 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)