### PR TITLE
fix(ops): backup-db.sh의 .env LOG_DIR 무시 버그 수정

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -5,13 +5,15 @@
 set -euo pipefail
 
 REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
-LOG_DIR="${LOG_DIR:-/var/log/slack-ai-agents}"
-LOG_FILE="$LOG_DIR/backup.log"
 
-# .env 로드 (POSTGRES_USER, POSTGRES_DB, R2_REMOTE, SLACK_BOT_TOKEN, PROJECT_CHANNEL_ID)
+# .env 로드 (POSTGRES_USER, POSTGRES_DB, R2_REMOTE, SLACK_BOT_TOKEN, PROJECT_CHANNEL_ID, LOG_DIR)
+# LOG_DIR/LOG_FILE 평가는 .env 로드 이후에 수행 (.env의 LOG_DIR이 적용되도록)
 if [ -f "$REPO_DIR/.env" ]; then
   set -a; . "$REPO_DIR/.env"; set +a
 fi
+
+LOG_DIR="${LOG_DIR:-/var/log/slack-ai-agents}"
+LOG_FILE="$LOG_DIR/backup.log"
 
 : "${POSTGRES_USER:?POSTGRES_USER 필요}"
 : "${POSTGRES_DB:?POSTGRES_DB 필요}"


### PR DESCRIPTION
## 관련 이슈
관련: #326 (PR #329에서 도입된 스크립트 버그 fix)

## 문제
`backup-db.sh`에서 \`LOG_DIR\`/\`LOG_FILE\` 평가가 \`.env\` 로드 **이전**에 수행되어, \`.env\`에서 \`LOG_DIR\`을 설정해도 항상 기본값(\`/var/log/slack-ai-agents\`)이 사용되던 버그.

VM에서 \`/var/log\` 쓰기 권한이 없는 환경(passwordless sudo 미설정 등)에서 백업 로그 작성 실패로 스크립트 전체가 실패.

## 변경
- \`.env\` 로드 후로 \`LOG_DIR\`/\`LOG_FILE\` 평가 시점 이동
- 워크어라운드 (\`LOG_DIR=... ./scripts/backup-db.sh\`) 없이 \`.env\` 단독으로 동작 가능

## 검증
- \`bash -n\` 통과
- VM 실측: 워크어라운드로 첫 백업 성공 확인 (\`2026-04-21.dump\` 269KB R2 업로드 완료)
- 본 fix 머지 후 crontab은 환경변수 prefix 없이 등록 가능

## 테스트
- [x] 문법 검증
- [ ] VM 머지 후 .env LOG_DIR만으로 백업 정상 동작 확인 (수동)