### PR TITLE
fix(ops): 헬스체크 엔드포인트를 공개 경로에 포함

### DIFF
--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { unsealData } from 'iron-session';
 
-const PUBLIC_PATHS = ['/login', '/api/auth', '/api/cron'];
+const PUBLIC_PATHS = ['/login', '/api/auth', '/api/cron', '/api/health'];
 const SESSION_COOKIE = 'life-dashboard-session';
 
 /** Next.js 16 — proxy는 기본 Node.js 런타임에서 동작 */


### PR DESCRIPTION
## 관련 이슈
Follow-up of #327 / PR #332

## 배경
웹 `/api/health`가 Next.js Routing Middleware(proxy)의 세션 쿠키 검증에 걸려 `/login`으로 307 리다이렉트되고 있었음. 외부 업타임 모니터가 폴링 시 keyword 체크 실패.

## 변경 내용
- `web/src/proxy.ts`의 `PUBLIC_PATHS`에 `/api/health` 추가
- 기존 `/api/auth`, `/api/cron`과 동일한 공개 경로 취급

## 코드 리뷰 결과
- [x] 민감 정보 미노출 — 응답은 `{ ok: true }`만 반환
- [x] 다른 인증 경로에 영향 없음

## 테스트
- [x] 배포 후 `curl https://life.leecommit.kr/api/health` → `{"ok":true}` 확인 예정