### PR TITLE
chore(ci): uptime-check 워크플로우 Node.js 24 전환

### DIFF
--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -10,6 +10,12 @@ on:
     - cron: '*/5 * * * *'
   workflow_dispatch:
 
+# actions/github-script@v7 Node.js 20 deprecation 선제 대응.
+# 2026-06-02 이후 기본값 변경, 2026-09-16에 Node 20 제거 예정.
+# ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   actions: read
   contents: read


### PR DESCRIPTION
## 관련 이슈
Closes #336

## 변경 내용

\`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'\` 환경변수를 워크플로우 레벨에 추가하여 \`actions/github-script@v7\`가 Node.js 24로 실행되도록 했다.

## 배경

- GitHub이 2026-06-02부터 Node.js 24를 JS 기반 액션 기본 런타임으로 강제 전환
- 2026-09-16에 Node.js 20은 러너에서 완전 제거
- 선제적으로 전환하여 6월 이후 호환성 이슈 차단

## 테스트

- [ ] 머지 후 \`gh workflow run uptime-check.yml\` 수동 실행 → deprecation 경고 사라졌는지 확인
- [ ] 봇/웹 헬스체크 정상 동작 확인

## 참고
[GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)