### PR TITLE
docs(adr): 핵심 아키텍처 판단 4건 ADR 백필 + 기존 0001 → 0005 rename

### DIFF
--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -3,7 +3,7 @@ name: Uptime Check
 # 봇·웹 헬스체크 엔드포인트를 5분 간격으로 폴링.
 # - 2회 재시도로 일시적 네트워크 튐 흡수 (cry wolf 방지)
 # - 직전 run 조회로 DOWN / RECOVERY 상태 전이 알림
-# - 설계 판단: docs/adr/0001-uptime-monitoring-github-actions.md
+# - 설계 판단: docs/adr/0005-uptime-monitoring-github-actions.md
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ AI를 "코딩 보조"가 아니라 **협업 개발자**로 취급하고, 작업 
 - **`workflow_run` API**로 직전 실행 상태 조회 → **DOWN / RECOVERY** 양방향 Slack 알림
 - **Variables vs Secrets** 분리: URL은 Variables, Webhook은 Secrets
 
-설계 판단 배경: [docs/adr/0001-uptime-monitoring-github-actions.md](docs/adr/0001-uptime-monitoring-github-actions.md)
+설계 판단 배경: [docs/adr/0005-uptime-monitoring-github-actions.md](docs/adr/0005-uptime-monitoring-github-actions.md)
 
 ---
 

--- a/docs/adr/0001-sql-tool-llm-agent.md
+++ b/docs/adr/0001-sql-tool-llm-agent.md
@@ -1,0 +1,77 @@
+# 0001. SQL 도구 기반 LLM 에이전트 설계
+
+- Status: Accepted
+- Date: 2026-03-08
+- Related: #34, PR #41
+- Tags: architecture, llm, data
+
+## Context
+
+- v1은 Notion 기반 + MCP로 DB별 도구 6개를 노출하는 구조였다. DB 간 JOIN·크로스 도메인 분석이 불가능했고, 새 도메인을 추가할 때마다 도구 개수가 늘었다.
+- v2로 통합 PostgreSQL에 모든 도메인을 모으면서, LLM에 어떤 도구를 노출할지 다시 결정해야 했다.
+- 도메인별 고수준 API(`createSchedule`, `addRoutine`, `logExpense`, `recordSleep` 등)를 전부 도구로 노출하면 **tool schema 토큰이 도메인 수에 비례해 증가**한다.
+- 프로젝트 목표는 일정·루틴·일기·수면·명리·예산 등의 도메인을 **계속 추가해도 복잡도가 선형 증가하지 않는 구조**였다.
+
+## Decision
+
+**범용 SQL 도구 3개만 LLM에 노출하고, 도메인 지식은 스키마 + 프롬프트/문서로 이동한다.**
+
+| 도구 | 용도 |
+|------|------|
+| `query_db` | SELECT (조회·분석) |
+| `modify_db` | INSERT / UPDATE / DELETE (변경) |
+| `get_schema` | 현재 DB 스키마 확인 (LLM이 테이블 구조를 런타임에 파악) |
+
+- LLM이 스키마를 조회하고 직접 SQL을 작성한다.
+- 도메인별 규칙·컨벤션은 시스템 프롬프트 + `docs/domains/*.md`에서 관리한다 (schedule / routine / insight / budget 각각 분리 문서).
+- 새 도메인 추가 = DB 스키마 + 도메인 문서만 추가. 코드 도구는 그대로 유지.
+
+## Alternatives considered
+
+### A. 도메인별 고수준 도구 다수 정의 (`createSchedule`, `updateExpense`, `logSleep` …)
+
+- 장점: 각 도구의 책임이 명확하고, 개별 검증/타입 안전성을 강하게 가져갈 수 있음
+- 단점: 도구 수가 도메인 수에 비례해 증가 → LLM 호출마다 수십 개 도구 설명 토큰
+- 단점: 새 도메인마다 코드 변경이 필요
+- 기각 이유: 확장성과 토큰 비용 양쪽에서 불리
+
+### B. MCP 서버 유지 (v1 방식)
+
+- 장점: 이미 익숙한 구조
+- 단점: DB 간 JOIN·크로스 도메인 분석 불가, MCP 계층 오버헤드
+- 기각 이유: v1의 근본 한계를 그대로 이어감
+
+### C. SQL 도구 + 스키마 기반 LLM 자율 (선택)
+
+- Decision 섹션 참조.
+
+## Consequences
+
+### 장점
+
+- 도메인 추가 비용이 **DB 스키마 + 도메인 문서 작성**으로 축소. 현재 schedule/routine/insight/budget 4개 도메인이 이 방식으로 확장됨.
+- LLM이 JOIN/GROUP BY/윈도우 함수로 크로스 도메인 분석을 자유롭게 수행.
+- 도구 수 최소화 → 컨텍스트·토큰 절약, 도구 선택 오류 확률 감소.
+- 프롬프트/문서에서 도메인 규칙을 관리 → **코드 수정 없이 LLM 행동을 조정** 가능.
+
+### 단점 / 제약
+
+- LLM이 잘못된 SQL을 생성할 가능성 → 애플리케이션 계층 방어선 필수.
+  - 완화: DB Proxy의 SQL 화이트리스트(ADR 0004), 봇 내부 `assertSafeSQL` 검증.
+- 스키마 변경 시 LLM이 학습·캐시한 구조와 실제가 다를 수 있음.
+  - 완화: `get_schema` 도구로 런타임 재조회, 스키마 변경 후 프롬프트 갱신.
+- 멀티유저 지원 시 `user_id` 스코프 강제가 프롬프트/쿼리 생성에 의존 → 런타임 방어 추가 필요.
+  - 완화: `user-resolver` + Slack 진입점 파라미터화 (PR #237).
+- 도메인 간 복잡한 트랜잭션/무결성 규칙은 SQL 한 번으로 풀리지 않을 수 있음 — 필요 시 범용 도구 위에 얇은 헬퍼 추가.
+
+### 후속 작업
+
+- [x] 도메인별 문서 구조 정착 (완료: `docs/domains/schedule.md`, `routine.md`, `insight.md`, `budget.md`)
+- [x] fast path 패턴 도입 (정규식 매칭 → SQL 직결 → LLM 바이패스)로 자주 쓰는 조회의 지연·비용 개선
+
+---
+
+**참고**
+
+- [docs/project-history.md](../project-history.md) — v2 전환 시점의 맥락
+- [CLAUDE.md](../../CLAUDE.md) — "핵심 설계 원칙" 섹션

--- a/docs/adr/0002-v3-architecture-split.md
+++ b/docs/adr/0002-v3-architecture-split.md
@@ -1,0 +1,74 @@
+# 0002. v3 아키텍처 — Vercel 웹 + VM 봇 + managed DB
+
+- Status: Accepted
+- Date: 2026-03-12
+- Related: #94, PR #96
+- Tags: infra, architecture
+
+## Context
+
+- v2는 Oracle Cloud ARM VM 한 대에서 Docker 4 서비스(app/db/web/caddy)를 운영했다.
+- **웹 대시보드 빌드 4분+, 전체 배포 8\~9분** — ARM 스펙 + 동시 빌드 한계.
+- **배포 자동화가 없어** 매번 SSH로 VM에 접속해 `git pull && docker compose up -d --build`를 수동 실행해야 했다.
+- Caddy로 직접 TLS를 종료하는 구조 → 인증서 갱신·도메인 관리를 운영자가 감당.
+- 웹·봇·DB가 같은 VM에서 CPU·메모리를 경합 → 봇 응답성에 간헐적 영향.
+
+이 ADR의 **핵심 동기는 웹 배포 경험의 개선**이다. DB 이동은 Vercel serverless 환경과 pooled connection 호환을 맞추기 위한 **부산물**이지, 이동 자체가 동기가 아니다.
+
+## Decision
+
+**역할별 3-tier로 인프라를 분리한다.**
+
+- **웹 대시보드**: Oracle VM Docker → Vercel 자동 배포 (GitHub push 트리거, Root Directory: `web/`)
+- **데이터베이스**: VM Docker → Neon managed PostgreSQL
+  - Vercel 웹: Neon pooled endpoint (serverless 함수와의 pooled connection 호환)
+  - VM 봇: Neon direct endpoint (장기 실행 프로세스)
+- **Slack 봇**: Oracle VM Docker 유지 (Socket Mode 장기 실행 + 크론 스케줄러 특성)
+- **TLS/도메인**: Vercel이 웹 HTTPS를 담당 → VM의 Caddy 및 80/443 포트 제거
+
+결과적으로 VM에는 Docker 서비스 1개(app)만 남는다.
+
+## Alternatives considered
+
+### A. VM 유지 + 빌드 파이프라인 최적화 (BuildKit 캐시, 멀티스테이지 개선, 별도 CI 도입)
+
+- 장점: 인프라 구조 유지, 학습 비용 없음
+- 단점: ARM 스펙 한계와 3서비스 동시 빌드의 근본 병목은 해소되지 않음. 자동 배포도 별도 구축 필요.
+- 기각 이유: 재투자 대비 개선 폭이 작음
+
+### B. 전 구성요소를 Vercel/Serverless로 이전
+
+- 장점: 관리 포인트 최소화
+- 단점: 봇은 Slack Socket Mode 기반의 장기 실행 프로세스 + 크론 스케줄러 → serverless 모델과 부적합.
+- 기각 이유: 봇 런타임 특성과 정면 충돌
+
+### C. Vercel 웹 + VM 봇 + Neon DB (선택)
+
+- Decision 섹션 참조.
+
+## Consequences
+
+### 장점
+
+- 웹 빌드/배포 \~1\~2분으로 단축, 전체 파이프라인 시간 감소
+- **GitHub push → 자동 배포** — 수동 SSH 배포 제거
+- VM 자원 경합 해소 → 봇 응답 안정성 개선
+- VM의 80/443 포트를 닫을 수 있어 공격 표면 축소
+- 웹 인증서·도메인 관리가 Vercel로 위임 → Caddy 제거
+
+### 단점 / 제약
+
+- 인프라가 2개 플랫폼으로 나뉘어 환경변수·배포 이력 관리 대상이 늘어남
+- **Neon 무료 티어라는 외부 의존이 추가**됨 → 후일 이것이 단일 실패점으로 작동 → ADR 0003의 계기
+
+### 후속 작업
+
+- [x] Vercel/VM 양쪽 환경변수 동기화 규칙 정립
+- [x] VM 내 Docker 서비스 정리 (app 외 제거)
+
+---
+
+**참고**
+
+- [docs/project-history.md](../project-history.md) — v3 전환 항목
+- PR [#96](https://github.com/hyewon3938/slack-ai-agents/pull/96)

--- a/docs/adr/0003-self-hosted-postgres.md
+++ b/docs/adr/0003-self-hosted-postgres.md
@@ -1,0 +1,77 @@
+# 0003. DB 자가 호스팅 전환 (Neon → VM PostgreSQL)
+
+- Status: Accepted
+- Date: 2026-04-06
+- Related: 운영 작업으로 직접 진행 (연결된 PR 없음). 직접 후속: PR #329 (DB 자동 백업 파이프라인)
+- Tags: infra, data
+
+## Context
+
+- v3 전환(ADR 0002) 이후 Neon 무료 티어를 DB로 사용 중이었다.
+- 무료 티어의 구조적 특성: **compute 한도를 초과하는 순간 쿼리·조회 자체가 자동 차단되며, 결제 전까지 복구되지 않는다.**
+- 개발·운영 중 크론 알림 로직이 DB를 과도하게 참조해 compute 한도를 트리거 → **서비스 전체 중단**.
+- 차단된 상태에서는 **데이터 조회도 불가능해져 덤프를 떠서 다른 DB로 옮기는 긴급 마이그레이션 경로 자체가 막힘**.
+- 즉 **managed DB 무료 티어의 hard limit 정책 자체가 구조적 단일 실패점** — 어떤 운영 실수든 곧바로 전체 중단으로 번진다.
+
+제약:
+- 월 고정비 0원 유지
+- 이미 확보된 Oracle Cloud Free Tier VM에 봇 외 여유 CPU/메모리/디스크가 있음
+
+## Decision
+
+**DB를 Neon → Oracle VM 내부 PostgreSQL Docker 컨테이너로 이관한다.**
+
+- 봇: 같은 VM 내부에서 localhost 경로로 연결 (`DATABASE_URL`)
+- Vercel: 일시적으로 VM의 DB 포트에 직접 연결 (이후 ADR 0004에서 프록시 경유로 전환)
+- 데이터 이관: Neon compute를 임시로 살려 `pg_dump` 덤프 → VM PostgreSQL에 `psql` 임포트
+
+## Alternatives considered
+
+### A. Neon 유료 플랜으로 전환
+
+- 장점: 인프라 변경 없이 차단 해소
+- 단점: 월 고정비 발생 — 비용 상한 제약과 충돌
+- 단점: **유료 플랜에서도 플랜 한도를 초과하면 동일한 hard limit이 작동한다.** 구조적 리스크는 그대로이고, 트리거 시점만 늦춰질 뿐.
+- 기각 이유: 돈만 들고 근본 리스크가 남음
+
+### B. 다른 무료 managed DB로 재이전 (Supabase, Cloudflare D1 등)
+
+- 장점: 자가 호스팅보다 운영 부담이 적음
+- 단점: **당시 Neon compute가 차단된 상태라 원본 덤프 자체를 뜰 수 없었다.** 정기 백업이 있었다면 열렸을 옵션이지만 **실질적으로 닫혀있던 대안**.
+- 단점: 옮기더라도 대부분의 무료 티어는 유사한 hard limit 정책을 가져 같은 리스크가 반복됨.
+- 기각 이유: 현실적 접근 불가 + 구조적 리스크 미해결
+
+### C. VM 자가 호스팅 (선택)
+
+- Decision 섹션 참조.
+
+## Consequences
+
+### 장점
+
+- managed DB 무료 티어 hard limit 의존 제거 → 쿼리 폭증이 곧바로 전체 중단이 아니게 됨
+- 월 고정비 0원 유지
+- 봇-DB 간 레이턴시 감소 (동일 VM 내부 통신)
+- DB 통제권 완전 확보 (설정·확장·백업 모두 본인 재량)
+
+### 단점 / 제약
+
+- DB 운영 책임(백업·업그레이드·장애 복구)이 본인에게 이전
+- VM의 디스크·메모리 용량이 DB 규모 상한이 됨
+- Vercel이 VM의 DB 포트를 직접 노출해야 하는 임시 구조 발생 → **공격 표면 확대** → ADR 0004 필요성
+
+### 교훈
+
+**정기 백업의 부재가 이번 사건의 선택지를 좁혔다.** 원본이 차단된 상태에서 B(다른 무료 DB 재이전) 옵션이 실질적으로 닫혔던 이유가 여기에 있다. 이 ADR의 직접적 후속으로 2026-04-21 **DB 자동 백업 파이프라인(PR #329, pg_dump + Cloudflare R2 + rclone)** 이 도입됐다.
+
+### 후속 작업
+
+- [x] DB 자동 백업 파이프라인 구축 (완료: 2026-04-21, `docs/operations/db-backup.md`)
+- [x] Vercel → DB 경로의 보안 재설계 (완료: ADR 0004)
+
+---
+
+**참고**
+
+- [docs/project-history.md](../project-history.md) — Neon → VM 이관 항목
+- PR [#329](https://github.com/hyewon3938/slack-ai-agents/pull/329) — 백업 파이프라인 (직접 후속)

--- a/docs/adr/0004-db-proxy-api.md
+++ b/docs/adr/0004-db-proxy-api.md
@@ -1,0 +1,73 @@
+# 0004. DB Proxy API 패턴 — Vercel → VM DB 직결 제거
+
+- Status: Accepted
+- Date: 2026-04-09
+- Related: PR #217 (도입), PR #218 (아키텍처 문서 갱신), PR #234 (프록시 루프백 바인딩 강화)
+- Tags: infra, security
+
+## Context
+
+- ADR 0003 이후 Vercel이 VM의 PostgreSQL 포트에 **직접 연결**하는 임시 구조였다.
+- **DB 포트를 공개 인터넷에 노출**하는 형태 → 공격 표면 확대.
+- 자가 호스팅 DB는 managed DB가 기본 제공하는 방어선(WAF, 레이트 제한, 인증 강화 등)을 갖추지 않는다.
+- 본 프로젝트는 ORM 없이 LLM이 생성한 SQL을 직접 실행하는 구조라 **애플리케이션 경계에서 SQL 수준 방어선**을 추가할 여지가 있었다.
+
+## Decision
+
+**봇 서버 프로세스 안에 HTTP 기반 DB Proxy API를 추가하고, Vercel은 그 API만 호출한다.** 별도 프록시 서버 프로세스는 띄우지 않는다.
+
+- 경로: `Vercel 웹 → HTTPS (Bearer API Key) → 봇 서버 내부 DB Proxy 엔드포인트 → VM 내부 DB`
+- 환경변수: `DB_PROXY_URL`, `DB_PROXY_API_KEY`
+- `POST /api/db/query`만 허용 (서버 간 호출이라 CORS 불필요)
+- SQL 화이트리스트:
+  - 허용 키워드: `SELECT` / `WITH` / `INSERT` / `UPDATE` / `DELETE`
+  - 차단: DDL (`DROP`/`ALTER`/`CREATE`/`TRUNCATE`/`GRANT`/`REVOKE`), 파일 I/O (`COPY`/`pg_read_file`/`lo_import` 등), 프로시저 (`DO`/`CALL`), `dblink`, `pg_sleep`
+- 복수 문(`;`) 금지, SQL 길이·파라미터 수·바디 크기 상한
+- API Key 32자+ 강제, `timingSafeEqual` 상수 시간 비교
+- 프록시 포트 `127.0.0.1:3100` 바인딩 (호스트 Caddy TLS 종료 경유 강제, PR #234)
+
+## Alternatives considered
+
+### A. Vercel 아웃바운드 IP를 DB 방화벽 허용 리스트에 고정
+
+- 장점: 구현 공수 최소 (방화벽 규칙만 추가)
+- 단점: **Vercel serverless 함수의 아웃바운드 IP는 동적**이며, 프리티어에서 고정 IP를 제공하지 않음 → 방화벽 허용 리스트 고정 불가
+- 기각 이유: 플랫폼 제약으로 근본 동작 불가
+
+### B. VM에 VPN 설치 후 Vercel이 VPN 클라이언트로 경유
+
+- 장점: 네트워크 계층에서 터널로 DB 보호
+- 단점: 1인 프로젝트 규모에 VPN 서버 운영은 오버엔지니어링
+- 단점: **VPN 크리덴셜을 Vercel 환경변수에 보관해야 함** — 환경변수 유출 시 블래스트 반경이 네트워크 계층까지 확장됨
+- 기각 이유: 운영 부담 + 크리덴셜 블래스트 반경 모두 불리
+
+### C. 봇 서버 프로세스 안에 HTTP API 레이어 추가 (= DB Proxy) (선택)
+
+- Decision 섹션 참조. 별도 프록시 인프라 없이 기존 봇 Node.js 프로세스에 엔드포인트만 추가.
+
+## Consequences
+
+### 장점
+
+- DB 포트를 외부에 노출하지 않아 공격 표면 축소
+- 애플리케이션 계층에 SQL 화이트리스트 방어선 추가 (ORM 부재 보완)
+- **크리덴셜 유출 블래스트 반경 제한** — Vercel은 DB 직접 크리덴셜을 모르고 Proxy API Key만 보유. 환경변수 유출 시 피해 범위가 **화이트리스트된 쿼리 실행**으로 한정됨 (비교: SSH 터널·VPN 방식이었다면 크리덴셜 유출 시 VM 쉘 접근이나 네트워크 계층 침투까지 가능)
+- 감사 로그를 프록시에 중앙화 가능 (쿼리 단위 기록)
+
+### 단점 / 제약
+
+- Vercel → VM 왕복이 한 번 추가되어 레이턴시 증가
+- 프록시 서버 프로세스 장애 시 웹 대시보드의 DB 접근 불가 (봇 프로세스와 SPOF 공유)
+- 화이트리스트가 비즈니스 쿼리 유연성과 트레이드오프 — 새 쿼리 패턴 도입 시 프록시 검증 로직 점검 필요
+
+### 후속 작업
+
+- [x] 프록시 헬스체크 & 외부 업타임 모니터링 (완료: ADR 0005)
+- [ ] 프록시 실패 시 Vercel 측 폴백/캐시 전략 검토
+
+---
+
+**참고**
+
+- PR [#217](https://github.com/hyewon3938/slack-ai-agents/pull/217), [#218](https://github.com/hyewon3938/slack-ai-agents/pull/218), [#234](https://github.com/hyewon3938/slack-ai-agents/pull/234)
+- `src/db-proxy.ts` — 구현체

--- a/docs/adr/0005-uptime-monitoring-github-actions.md
+++ b/docs/adr/0005-uptime-monitoring-github-actions.md
@@ -1,11 +1,9 @@
-# 0001. GitHub Actions 기반 자체 업타임 모니터링
+# 0005. GitHub Actions 기반 자체 업타임 모니터링
 
 - Status: Accepted
 - Date: 2026-04-22
 - Related: #334
 - Tags: infra, observability
-
-> **메타 주석**: 이 프로젝트의 ADR 운영은 이 문서부터 시작한다. 이전 주요 설계 판단(v3 아키텍처 전환, Neon→VM 마이그레이션, DB Proxy 패턴, SQL 도구 기반 에이전트)은 [docs/project-history.md](../project-history.md)에 서술형으로 남아있으며, 후속 PR에서 ADR 0001\~0004로 백필 후 본 문서는 0005로 rename 예정.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,7 +79,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 ```
 
 - `NNNN` — 4자리 zero-padded 번호 (0001, 0002, ...)
-- 제목은 간결하게. ADR 자체의 짧은 제목 (예: `0001-uptime-monitoring-github-actions.md`)
+- 제목은 간결하게. ADR 자체의 짧은 제목 (예: `0005-uptime-monitoring-github-actions.md`)
 
 ### 번호 부여
 
@@ -107,9 +107,13 @@ docs/adr/NNNN-<kebab-case-제목>.md
 
 | 번호 | 제목 | Status | Date | Tags |
 |------|------|--------|------|------|
-| [0001](0001-uptime-monitoring-github-actions.md) | GitHub Actions 기반 자체 업타임 모니터링 | Accepted | 2026-04-22 | infra, observability |
+| [0001](0001-sql-tool-llm-agent.md) | SQL 도구 기반 LLM 에이전트 설계 | Accepted | 2026-03-08 | architecture, llm, data |
+| [0002](0002-v3-architecture-split.md) | v3 아키텍처 — Vercel 웹 + VM 봇 + managed DB | Accepted | 2026-03-12 | infra, architecture |
+| [0003](0003-self-hosted-postgres.md) | DB 자가 호스팅 전환 (Neon → VM PostgreSQL) | Accepted | 2026-04-06 | infra, data |
+| [0004](0004-db-proxy-api.md) | DB Proxy API 패턴 — Vercel→VM DB 직결 제거 | Accepted | 2026-04-09 | infra, security |
+| [0005](0005-uptime-monitoring-github-actions.md) | GitHub Actions 기반 자체 업타임 모니터링 | Accepted | 2026-04-22 | infra, observability |
 
-> **주**: 이 프로젝트의 ADR 운영은 2026-04-22부터 시작했다. 그 이전 주요 설계 판단(v3 아키텍처 전환, Neon→VM PostgreSQL 마이그레이션, DB Proxy 패턴, SQL 도구 기반 에이전트 설계 등)은 [docs/project-history.md](../project-history.md)에 서술형으로 남아있으며, 후속 PR에서 ADR 0001\~0004로 백필할 예정이다 (백필 시 본 ADR은 0005로 rename).
+> **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 
 ---
 

--- a/docs/ops/health-monitoring.md
+++ b/docs/ops/health-monitoring.md
@@ -6,7 +6,7 @@
 
 - 모니터링 주체: **GitHub Actions** (자체 구현)
 - 체크 간격: 5분 (GitHub cron 특성상 실제 5\~10분)
-- 설계 판단 근거: [docs/adr/0001-uptime-monitoring-github-actions.md](../adr/0001-uptime-monitoring-github-actions.md)
+- 설계 판단 근거: [docs/adr/0005-uptime-monitoring-github-actions.md](../adr/0005-uptime-monitoring-github-actions.md)
 
 ## 엔드포인트
 
@@ -132,7 +132,7 @@ gh workflow run uptime-check.yml
 1주일 이상 일시적 실패 알림이 반복되면:
 1. Actions 로그에서 해당 run의 curl 결과 확인
 2. 재시도 간격(현재 10초) · 재시도 횟수(현재 2회) 튜닝 검토
-3. 튜닝 시 본 문서와 `0001-uptime-monitoring-github-actions.md` 후속 ADR 동시 업데이트
+3. 튜닝 시 본 문서와 `0005-uptime-monitoring-github-actions.md` 후속 ADR 동시 업데이트
 
 ## 알려진 한계
 

--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -17,8 +17,8 @@
 
 **ADR 체계 도입**: 되돌리기 어려운 설계 판단을 Michael Nygard 포맷으로 별도 기록하는 구조 신설. `docs/adr/README.md`에 기록 기준·운영 규칙 명시. `/design`·`/build` 스킬에 ADR 작성 판단 단계 내장.
 
-- 첫 ADR: [0001 — GitHub Actions 기반 자체 업타임 모니터링](adr/0001-uptime-monitoring-github-actions.md)
-- 후속 PR에서 v3 전환·Neon→VM 마이그레이션·DB Proxy 패턴·SQL 도구 기반 설계를 ADR 0001\~0004로 백필 예정 (백필 시 본 ADR은 0005로 rename)
+- 첫 ADR: [GitHub Actions 기반 자체 업타임 모니터링](adr/0005-uptime-monitoring-github-actions.md) — 당시 0001로 기록됐고, 이후 #339에서 핵심 아키텍처 판단 4건 백필과 함께 0005로 rename됨
+- 후속 백필: #339에서 SQL 도구 기반 에이전트·v3 전환·Neon→VM·DB Proxy 판단 4건을 ADR 0001\~0004로 소급 기록
 
 ---
 


### PR DESCRIPTION
## 관련 이슈
Closes #339

## 변경 내용

2026-04-22 도입한 ADR 체계의 첫 ADR이 말단 운영 판단(업타임 모니터링)이라 프로젝트 핵심 설계 판단이 ADR에 빠져있었음. 시간순으로 재배치하면서 핵심 판단 4건을 ADR 0001\~0004로 소급 기록.

| 번호 | 제목 | Date |
|------|------|------|
| 0001 | SQL 도구 기반 LLM 에이전트 설계 | 2026-03-08 |
| 0002 | v3 아키텍처 — Vercel 웹 + VM 봇 + managed DB | 2026-03-12 |
| 0003 | DB 자가 호스팅 전환 (Neon → VM PostgreSQL) | 2026-04-06 |
| 0004 | DB Proxy API 패턴 | 2026-04-09 |
| 0005 | GitHub Actions 기반 자체 업타임 모니터링 (기존 0001 rename) | 2026-04-22 |

### 원칙

- **ADR 불변성 준수**: 기존 0001 본문(Context 이하) 완전 불변. 헤딩 `# 0001.` → `# 0005.` 및 상단 메타 주석 블록쿼트 제거만 (rename 유사도 94%)
- **Date는 실제 판단 시점**: 백필 작성일이 아니라 PR 머지일·운영 작업 시점 사용
- **Alternatives는 실제 고민했던 대안만**: 사후 창작 없이 당시 실제 후보만 기재
- **Consequences는 현시점 관점**: 실제로 나타난 트레이드오프 반영 (예: 0002 → 0003 계기, 0003 → 0004 필요성, 0003 → #329 백업 파이프라인)

### 부가 변경

- 기존 `0001-uptime-monitoring-github-actions.md`를 링크로 참조하던 5개 파일 갱신
  - `.github/workflows/uptime-check.yml`, `docs/ops/health-monitoring.md`, `README.md`, `docs/project-history.md`, `docs/adr/README.md` 내 파일명 예시
- `docs/adr/README.md` 인덱스 테이블 5행으로 재작성 + 하단 백필 안내 주석 갱신
- `docs/project-history.md` 4-22 엔트리에 "이후 #339에서 0005로 rename + 0001\~0004 백필" 사실 반영

## 코드 리뷰 결과
- [x] 보안 감사 통과 (크리덴셜·IP·재정 정보 노출 없음, 공격 벡터 추상화)
- [x] ADR 템플릿 포맷 준수 (4섹션 구조, 한글 톤 일관)
- [x] 파일명 kebab-case, 틸드 이스케이프 `\~` 규칙 준수
- [x] `git mv`로 rename 이력 보존 (유사도 94%)
- [x] 상호 참조 번호 정합성 확인 (0001→0004, 0002→0003, 0003→0004, 0004→0005)

## 테스트
- [x] 5개 ADR 파일 모두 템플릿 구조 확인
- [x] `docs/adr/README.md` 인덱스 링크 5개 모두 실제 파일 존재
- [x] 구 `0001-uptime-monitoring-github-actions` 참조 전수 갱신 (grep으로 0건 확인)
- [x] 기존 0005 본문(Context 이하)이 rename diff에서 변화 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)