### PR TITLE
fix(ops): DB 백업 cron 시간을 UTC 19:00(KST 04:00)으로 정정

### DIFF
--- a/docs/operations/db-backup.md
+++ b/docs/operations/db-backup.md
@@ -86,6 +86,8 @@ rclone lsf r2:slack-ai-agents-backup/daily/
 
 ## 3. crontab 등록
 
+> **주의**: VM 타임존은 `Etc/UTC`이므로 cron 시간도 UTC로 기입한다. KST 04:00은 UTC 19:00 (전날 기준).
+
 ```bash
 crontab -e
 ```
@@ -93,7 +95,7 @@ crontab -e
 아래 줄 추가:
 
 ```
-0 4 * * * /home/ubuntu/slack-ai-agents/scripts/backup-db.sh
+0 19 * * * /home/ubuntu/slack-ai-agents/scripts/backup-db.sh  # UTC 19:00 = KST 04:00
 ```
 
 등록 확인:

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # DB 일일 백업 → Cloudflare R2 업로드.
-# crontab: 0 4 * * * /home/ubuntu/slack-ai-agents/scripts/backup-db.sh
+# crontab: 0 19 * * * /home/ubuntu/slack-ai-agents/scripts/backup-db.sh  # UTC 기준 (= KST 04:00)
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- VM 타임존이 `Etc/UTC`인데 cron 표기가 `0 4 * * *`라 실제 백업이 KST 13:00에 실행되고 있었음
- cron 주석과 문서 예시를 `0 19 * * *` (UTC = KST 04:00)로 정정
- 문서에 타임존 주의 문구 추가

## 비고
VM crontab은 이미 `0 19 * * *`로 수정 적용 완료. 레거시 백업 스크립트(`/home/ubuntu/db-backup.sh`)도 동일 작업에서 제거하고 저장소의 R2 백업 스크립트로 일원화했다. 기존 로컬 백업 파일은 유지.

## Test plan
- [ ] 다음 예약 실행 (UTC 19:00 / KST 04:00) 이후 R2 daily 버킷에 신규 dump가 생성되는지 확인
- [ ] 다음 일요일 KST 04:00 이후 weekly 버킷에 파일이 생기는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)