### PR TITLE
feat(safety): modify_db 대량 변경 확인 플로우 (#342)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ POSTGRES_PASSWORD=...              # docker-compose PostgreSQL 비밀번호
 # Budget
 # ESTIMATED_MONTHLY_INCOME=0       # 월 예상 수입 (원 단위)
 
+# modify_db 확인 플로우 트리거 기준
+# 영향 row 수가 이 값 이상이면 Slack 확인 카드로 사용자 승인을 받은 뒤 실행
+# MODIFY_CONFIRM_THRESHOLD=3
+
 # Kakao OAuth (Vercel 환경변수로 설정)
 # KAKAO_CLIENT_ID=...             # Kakao REST API 키
 # NEXT_PUBLIC_KAKAO_CLIENT_ID=... # 클라이언트용 (KAKAO_CLIENT_ID와 동일 값)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Vercel(웹)은 DB에 직접 연결하지 않고, **HTTPS API 프록시**를 경�
 ### 2. LLM × SQL 자율 에이전트 + 비용·안전 제어
 
 - **2-tier 비용 구조** — Claude Sonnet(대화/크론/주간 리포트) + Pure SQL(프로액티브 인사이트/넛지). 패턴 감지가 명확한 영역은 LLM 호출 없이 SQL로 처리.
+- **프롬프트 캐싱** — Anthropic `cache_control: ephemeral`을 시스템 프롬프트·도구 정의에 적용. 연속 대화 시 반복 전송되는 컨텍스트의 토큰 비용 최대 90% 절감. [llm.ts:108](src/shared/llm.ts:108)
 - **프롬프트 엔지니어링** — LLM 반복 실수를 관찰·분류해 규칙으로 차단. 의도 분류 시스템은 3단계 진화 후 **삭제**("분류 단계가 필요하다"는 가정 자체가 틀렸다는 결론).
 - **아키텍처 3회 전환** — Notion→PostgreSQL, 단일 Docker→멀티 서비스→Vercel 분리. 임시방편 대신 코어 교체로 대응. [의사결정 과정](docs/project-history.md).
 

--- a/db/migrations/044_pending_modify.sql
+++ b/db/migrations/044_pending_modify.sql
@@ -1,0 +1,21 @@
+-- modify_db 확인 플로우용 대기 테이블.
+-- LLM이 생성한 DELETE/UPDATE의 dry-run 영향 row가 임계치 이상이면
+-- 이 테이블에 token과 함께 저장하고, Slack 확인 버튼 클릭 시 실제 실행한다.
+CREATE TABLE IF NOT EXISTS pending_modify (
+  id SERIAL PRIMARY KEY,
+  token VARCHAR(16) UNIQUE NOT NULL,
+  user_id INTEGER NOT NULL,
+  sql_text TEXT NOT NULL,
+  dry_run_row_count INTEGER NOT NULL,
+  slack_channel VARCHAR(64),
+  slack_thread_ts VARCHAR(32),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  executed_at TIMESTAMPTZ,
+  canceled_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_modify_token ON pending_modify(token);
+CREATE INDEX IF NOT EXISTS idx_pending_modify_pending
+  ON pending_modify(expires_at)
+  WHERE executed_at IS NULL AND canceled_at IS NULL;

--- a/docs/adr/0006-modify-db-confirm-flow.md
+++ b/docs/adr/0006-modify-db-confirm-flow.md
@@ -1,0 +1,125 @@
+# 0006. modify_db 대량 변경 확인 플로우
+
+- Status: Accepted
+- Date: 2026-04-22
+- Related: #342
+- Tags: security, llm, ux
+
+## Context
+
+- LLM이 `modify_db` 도구로 생성한 DELETE/UPDATE는 기존 방어층으로 명백한 위험을 차단해 왔다.
+  - DDL 키워드(DROP/TRUNCATE/ALTER/CREATE/GRANT/REVOKE) 전면 차단
+  - DELETE/UPDATE에 WHERE 절 필수
+  - 모든 쿼리에 `user_id = {caller}` 필터 강제 (교차 사용자 차단)
+  - 트랜잭션 + 최대 50행 제한 — 50행 초과 시 자동 ROLLBACK
+- 그러나 위 방어는 **형식적 조건만 검증**한다. 형식은 통과하면서 **의도치 않게 광범위한 범위를 건드리는 쿼리**(예: `DELETE FROM schedules WHERE user_id = 1 AND category = 'old'` — 운영 중 'old' 레코드가 30개 있는 상황)는 막지 못한다.
+- 도메인 특성상 일정·수면·지출 레코드는 복구 난이도가 높다. 백업은 있지만 복구 과정 자체가 비용이다.
+- LLM의 지시 해석 오류·할루시네이션이 상존하므로, **자동 실행 이전의 휴먼 체크 레이어**가 필요했다.
+- Threshold 선택은 **False Positive vs False Negative** 트레이드오프이다.
+  - **False Positive (FP)**: 안전한 작업인데 확인 카드가 뜸 → UX 피로, 탭 한 번 더
+  - **False Negative (FN)**: 실제 위험한 작업이 threshold 미만이라 그냥 실행됨 → 사고로 이어질 수 있음
+  - Threshold를 낮게 잡을수록 FN↓ / FP↑, 높게 잡을수록 FN↑ / FP↓.
+  - 정답이 하나인 값이 아니므로, 초기값은 경험적 타협점으로 잡고 운영 데이터로 재조정 가능해야 한다.
+
+## Decision
+
+**DELETE/UPDATE 쿼리에 한해 실행 전 dry-run으로 영향 row 수를 계산하고, 임계치 이상이면 Slack 확인 카드로 사용자 승인을 받은 뒤에만 실제 실행한다.**
+
+### 구체 구조
+
+1. **Dry-run**: `BEGIN → 실행 → ROLLBACK` 트랜잭션으로 영향 row 수만 얻는다 (DB 상태 무변경).
+2. **임계치 분기**:
+   - `rowCount < MODIFY_CONFIRM_THRESHOLD` (기본 3): 기존 즉시 실행 경로
+   - `rowCount >= MODIFY_CONFIRM_THRESHOLD`: `pending_modify` 테이블에 token·SQL·TTL(5분) 저장 후 Slack Block Kit 확인 카드 전송
+3. **사용자 액션**:
+   - "실행" 버튼 → `pending_modify` 조회 → `queryWithRowLimit`로 실제 실행 → 결과 메시지로 카드 교체
+   - "취소" 버튼 → `canceled_at` 마킹 → 취소 메시지로 카드 교체
+4. **LLM agent-loop는 pending 응답 받은 시점에 종료.** 사용자 클릭 후 실행 결과 보고는 액션 핸들러가 **고정 템플릿**으로 처리한다 (LLM 재호출 없음).
+5. **Threshold는 `MODIFY_CONFIRM_THRESHOLD` 환경변수로 외부화.** 재배포 없이 조정 가능하다.
+
+### 보안 설계
+
+- `pending_modify.token`은 crypto.randomBytes(8) → 16 hex chars. URL-safe, 식별용.
+- 조회는 항상 `token + user_id` 쌍으로 — 다른 유저의 token 접근을 DB 레벨에서 차단.
+- TTL 5분 — 만료되거나 executed/canceled 된 pending은 재사용 불가.
+- 액션 핸들러는 `resolveBodyUserId`로 클릭한 Slack 유저 → DB user_id 해석 후 대조.
+
+## Alternatives considered
+
+### A. 모든 DELETE/UPDATE에 확인 요구
+
+- 장점: FN = 0. 절대 실수 없음.
+- 단점: 단일 row 수정까지 매번 탭 한 번. UX 피로가 심하고, 특히 대시보드가 아닌 대화형 에이전트 맥락에서 흐름을 끊는다.
+- 기각: FP 비용이 너무 큼.
+
+### B. 특정 테이블만 보호 (화이트리스트)
+
+- 장점: 중요 테이블만 선별 보호.
+- 단점: 테이블이 늘어날 때마다 수기 유지보수. 신규 테이블이 기본값으로 무방비.
+- 기각: 운영 부담 + 누락 위험.
+
+### C. 영향 row 기반 threshold (선택)
+
+- 장점: FN/FP 균형점. 테이블 무관하게 일괄 적용.
+- 단점: threshold 초기값이 경험적. 재조정 필요.
+- 완화: 환경변수로 외부화 + 운영 데이터로 조정.
+
+### D. LLM agent-loop를 pending 상태로 일시정지하고 사용자 클릭 후 재개
+
+- 장점: 실행 결과를 LLM이 받아 자연스럽게 후속 대화 (예: "취소했다면 다른 조건으로 다시 시도할까?"). 에이전트로서의 자율성이 유지됨.
+- 단점:
+  - Durable state 관리 필요 (LLM 대화 컨텍스트·message history를 DB 또는 Redis에 직렬화 저장)
+  - 클릭 시점에 Claude API를 1회 더 호출 → 비용 증가
+  - 실패 경로(만료, 재시작 중 크래시 등) 처리 복잡
+- 기각: 현시점에서 과잉 설계. 수정 후 후속 LLM 판단이 거의 필요 없고, 확인 플로우는 "실행 or 취소" 두 결과로 수렴.
+
+## Consequences
+
+### 장점
+
+- 기존 방어층(DDL 차단, WHERE 필수, user_id 스코프, 50행 제한)을 그대로 유지하며 **"범위는 괜찮지만 넓은 쿼리"**에 대한 마지막 안전망 추가
+- 실수 복구 비용이 높은 도메인(일정·수면·지출)에 휴먼 체크 플로우 도입
+- Claude API 호출 수는 **기존 대비 감소 가능** — 기존에는 도구 결과를 받아 LLM이 응답 문장을 생성했지만, 이제는 고정 템플릿이 대체
+- Threshold 외부화로 운영 중 재배포 없이 튜닝 가능
+
+### 단점 / 제약
+
+- DELETE/UPDATE마다 트랜잭션 1회 (dry-run) 추가 — DB 부하 측면에서 사실상 영향 미미하나, 이론상 2배 IO
+- `pending_modify` 테이블의 만료 레코드 정리 책임이 생김 (현재는 조회 시 `expires_at > NOW()` 필터로 배제. 주기적 cleanup은 선택적)
+- 초기 threshold 3은 경험적 — 데이터·UX에 따라 재조정 필요
+- LLM이 후속 판단을 하지 않으므로, 사용자가 실행 후 "다른 방식으로 다시" 같은 멀티스텝 인터랙션은 새 메시지로 재시작해야 함
+
+### 현재 선택의 맥락
+
+이 프로젝트의 장기 방향성은 LLM이 대화를 이어가며 자율적으로 후속 판단을 수행하는 **풀 에이전트**다.
+현시점에서는 LLM 호출 비용 제약으로 대시보드 중심 UX를 채택 중이며, Slack 에이전트 상호작용은 fast path 바이패스와 최소 호출 전략으로 운영된다.
+
+이 맥락에서 본 ADR은 **D안(LLM agent-loop 재개)이 장기 방향성에 더 부합함을 인정**하면서도, 현재 단계의 비용·단순성 요구에 따라 **C안 + 고정 템플릿 종료**를 선택한다.
+D안의 durable state 관리·추가 LLM 호출 비용은 현재 트래픽에서 과잉이며, 우선 가드레일 자체의 정확성과 구현 단순성을 확보한다.
+
+### D안 전환 시나리오
+
+향후 LLM 호출 예산이 확보되거나 다단계 인터랙션 기능이 필요해지는 시점에 다음 변경으로 전환:
+
+1. `pending_modify` 스키마에 `llm_context` JSONB 컬럼 추가 (직전 메시지 N개 저장)
+2. 액션 핸들러(execute)가 실행 후 agent-loop를 `llm_context` 복원해서 재진입
+3. tool 결과 반환 형식 변경 (`pending: true` flag → LLM이 읽을 수 있는 후속 프롬프트 구조)
+4. 고정 템플릿 응답 경로는 fallback으로 유지
+
+**전환 트리거 조건**:
+- 월간 Claude API 비용이 안정적으로 예산 이하로 내려올 때
+- 사용자 요청 중 "확인 후 후속 대화" 니즈가 반복 관찰될 때
+- 다른 LLM 도구에서도 유사한 multi-step 인터랙션 요구가 생길 때
+
+### 후속 작업
+
+- [ ] Threshold 값 운영 후 재평가 (env로 외부화 완료, 사용 데이터 축적 후 조정)
+- [ ] `pending_modify` 만료 레코드 주기적 정리 (경량 크론 or 조회 시 무시)
+- [ ] 향후 다른 LLM 도구(예: 파일 쓰기, 외부 API 호출) 추가 시 동일 패턴 재사용 검토
+
+---
+
+**참고**
+
+- [CLAUDE.md](../../CLAUDE.md) — "핵심 설계 원칙"
+- [ADR 0001](0001-sql-tool-llm-agent.md) — SQL 도구 기반 LLM 에이전트 설계 (이 ADR의 기반)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -112,6 +112,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0003](0003-self-hosted-postgres.md) | DB 자가 호스팅 전환 (Neon → VM PostgreSQL) | Accepted | 2026-04-06 | infra, data |
 | [0004](0004-db-proxy-api.md) | DB Proxy API 패턴 — Vercel→VM DB 직결 제거 | Accepted | 2026-04-09 | infra, security |
 | [0005](0005-uptime-monitoring-github-actions.md) | GitHub Actions 기반 자체 업타임 모니터링 | Accepted | 2026-04-22 | infra, observability |
+| [0006](0006-modify-db-confirm-flow.md) | modify_db 대량 변경 확인 플로우 | Accepted | 2026-04-22 | security, llm, ux |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -6,6 +6,23 @@
 
 ---
 
+## 2026-04-22: modify_db 대량 변경 확인 플로우 (#342, PR #343)
+
+LLM이 `modify_db` 도구로 생성한 DELETE/UPDATE의 영향 row가 임계치(기본 3) 이상이면 즉시 실행 대신 Slack 확인 카드로 전환해 사용자 승인을 받는 구조 추가.
+
+**구조**:
+- `dryRunRowCount`(BEGIN → 실행 → ROLLBACK)로 DB 상태 변경 없이 영향 row 수만 계산
+- `pending_modify` 테이블(token/user_id/TTL 5분)에 대기 쿼리 저장
+- `buildConfirmModifyCard`로 SQL 미리보기 + 실행/취소 버튼 카드 생성
+- 사용자 클릭 시 `queryWithRowLimit`(50행 한도 유지)로 실제 실행, 결과 메시지로 카드 교체
+- `MODIFY_CONFIRM_THRESHOLD` 환경변수로 재배포 없이 임계치 조정
+
+기존 가드레일(DDL 차단, WHERE 필수, user_id 스코프, 50행 제한) 전부 유지. "범위는 괜찮지만 넓은 쿼리"에 대한 추가 안전망.
+
+판단 근거: [ADR 0006](adr/0006-modify-db-confirm-flow.md) — C안(threshold) + 고정 템플릿 종료 채택 근거와 D안(LLM agent-loop 재개) 전환 시나리오 기록.
+
+---
+
 ## 2026-04-22: 관측성 레이어 & ADR 체계 도입 (#334)
 
 **업타임 모니터링 자체 구현**: 봇·웹 헬스체크를 GitHub Actions cron으로 5분 간격 폴링하는 자체 모니터 구축. 외부 SaaS(UptimeRobot 등) 무료 티어 제약을 피해 완전 자체 통제 구조로 전환.

--- a/src/agents/life/__tests__/blocks.test.ts
+++ b/src/agents/life/__tests__/blocks.test.ts
@@ -6,10 +6,13 @@ import {
   buildFilteredRoutineBlocks,
   buildMorningGreetingBlocks,
   buildScheduleBlocks,
+  buildConfirmModifyCard,
   parseButtonValue,
   parseOverflowValue,
   ROUTINE_ACTION_ID,
   SCHEDULE_ACTION_ID,
+  CONFIRM_MODIFY_EXECUTE_ACTION_ID,
+  CONFIRM_MODIFY_CANCEL_ACTION_ID,
 } from '../blocks.js';
 
 // ─── 테스트 데이터 ─────────────────────────────────────
@@ -333,5 +336,61 @@ describe('buildScheduleBlocks', () => {
     const 업무Index = sectionTexts.findIndex((t) => t.includes('[업무]'));
     const 미분류Index = sectionTexts.findIndex((t) => t.includes('[미분류]'));
     expect(업무Index).toBeLessThan(미분류Index);
+  });
+});
+
+describe('buildConfirmModifyCard', () => {
+  it('실행/취소 버튼에 token이 value로 들어간다', () => {
+    const { blocks } = buildConfirmModifyCard({
+      token: 'abc1234567890def',
+      sql: 'DELETE FROM schedules WHERE user_id = 1 AND category = \'old\'',
+      rowCount: 5,
+    });
+
+    const actionsBlock = blocks.find((b) => b.type === 'actions');
+    expect(actionsBlock).toBeDefined();
+    if (!actionsBlock || actionsBlock.type !== 'actions') {
+      throw new Error('actions block missing');
+    }
+
+    const buttons = actionsBlock.elements.filter(
+      (e): e is Extract<typeof e, { type: 'button' }> => e.type === 'button',
+    );
+    expect(buttons).toHaveLength(2);
+
+    const execute = buttons.find((b) => b.action_id === CONFIRM_MODIFY_EXECUTE_ACTION_ID);
+    const cancel = buttons.find((b) => b.action_id === CONFIRM_MODIFY_CANCEL_ACTION_ID);
+    expect(execute?.value).toBe('abc1234567890def');
+    expect(cancel?.value).toBe('abc1234567890def');
+    expect(execute?.style).toBe('primary');
+    expect(cancel?.style).toBe('danger');
+  });
+
+  it('rowCount가 fallback text와 헤더에 노출된다', () => {
+    const { text, blocks } = buildConfirmModifyCard({
+      token: 't0',
+      sql: 'DELETE FROM schedules WHERE user_id = 1',
+      rowCount: 17,
+    });
+
+    expect(text).toContain('17개');
+    const header = blocks[0];
+    if (header?.type === 'section' && 'text' in header && header.text && 'text' in header.text) {
+      expect(header.text.text).toContain('17개');
+    } else {
+      throw new Error('header block shape unexpected');
+    }
+  });
+
+  it('긴 SQL은 500자로 잘린다', () => {
+    const longSql = 'DELETE FROM schedules WHERE user_id = 1 AND ' + 'a'.repeat(1000);
+    const { blocks } = buildConfirmModifyCard({ token: 't', sql: longSql, rowCount: 3 });
+    const codeBlock = blocks[1];
+    if (codeBlock?.type === 'section' && 'text' in codeBlock && codeBlock.text && 'text' in codeBlock.text) {
+      expect(codeBlock.text.text).toContain('...');
+      expect(codeBlock.text.text.length).toBeLessThan(longSql.length);
+    } else {
+      throw new Error('code block shape unexpected');
+    }
   });
 });

--- a/src/agents/life/actions.ts
+++ b/src/agents/life/actions.ts
@@ -16,6 +16,12 @@ import {
   moveScheduleToDate,
 } from '../../shared/life-queries.js';
 import { updateMessage } from '../../shared/slack.js';
+import { queryWithRowLimit } from '../../shared/db.js';
+import {
+  findActivePending,
+  markExecuted,
+  markCanceled,
+} from '../../shared/pending-modify.js';
 import { getTodayISO, addDays } from '../../shared/kst.js';
 import { resolveUserId, DEFAULT_USER_ID } from '../../shared/user-resolver.js';
 import {
@@ -25,6 +31,8 @@ import {
   DELETE_ACTION,
   TOGGLE_IMPORTANT_ACTION,
   MOVE_TO_TODAY_ACTION,
+  CONFIRM_MODIFY_EXECUTE_ACTION_ID,
+  CONFIRM_MODIFY_CANCEL_ACTION_ID,
   parseButtonValue,
   parseOverflowValue,
   buildRoutineBlocks,
@@ -32,6 +40,9 @@ import {
   buildScheduleBlocks,
 } from './blocks.js';
 import { publishHomeView } from './home.js';
+
+const CONFIRM_EXECUTE_TIMEOUT_MS = 10_000;
+const CONFIRM_EXECUTE_MAX_ROWS = 50;
 
 /** Slack body에서 userId 해석 (미등록이면 DEFAULT_USER_ID 폴백) */
 const resolveBodyUserId = async (body: { user?: string | { id: string } }): Promise<number> => {
@@ -146,6 +157,90 @@ export const registerLifeActions = (app: App): void => {
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       console.error(`[Life Action] 일정 상태 변경 오류: ${msg}`);
+    }
+  });
+
+  // ── modify_db 확인 플로우: 실행 ──
+  app.action(CONFIRM_MODIFY_EXECUTE_ACTION_ID, async ({ ack, body, client }) => {
+    await ack();
+
+    const action = 'actions' in body ? body.actions[0] : undefined;
+    if (!action || !('value' in action)) return;
+    const token = action.value;
+    if (!token) return;
+
+    const userId = await resolveBodyUserId(body);
+    const pending = await findActivePending(token, userId);
+
+    const channelId =
+      'channel' in body && body.channel ? body.channel.id : undefined;
+    const messageTs =
+      'message' in body && body.message ? body.message.ts : undefined;
+
+    if (!pending) {
+      if (channelId && messageTs) {
+        await updateMessage(
+          client,
+          channelId,
+          messageTs,
+          '이 요청은 만료됐거나 이미 처리됐어. 다시 요청해줘.',
+          [],
+        );
+      }
+      return;
+    }
+
+    try {
+      const result = await queryWithRowLimit(
+        pending.sql_text,
+        CONFIRM_EXECUTE_TIMEOUT_MS,
+        CONFIRM_EXECUTE_MAX_ROWS,
+      );
+      await markExecuted(pending.id);
+      if (channelId && messageTs) {
+        await updateMessage(
+          client,
+          channelId,
+          messageTs,
+          `실행 완료. ${result.rowCount ?? 0}개 행 변경됐어.`,
+          [],
+        );
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[Life Action] modify_db 실행 오류: ${msg}`);
+      if (channelId && messageTs) {
+        await updateMessage(client, channelId, messageTs, `실행 실패: ${msg}`, []);
+      }
+    }
+  });
+
+  // ── modify_db 확인 플로우: 취소 ──
+  app.action(CONFIRM_MODIFY_CANCEL_ACTION_ID, async ({ ack, body, client }) => {
+    await ack();
+
+    const action = 'actions' in body ? body.actions[0] : undefined;
+    if (!action || !('value' in action)) return;
+    const token = action.value;
+    if (!token) return;
+
+    const userId = await resolveBodyUserId(body);
+    const pending = await findActivePending(token, userId);
+    if (pending) await markCanceled(pending.id);
+
+    const channelId =
+      'channel' in body && body.channel ? body.channel.id : undefined;
+    const messageTs =
+      'message' in body && body.message ? body.message.ts : undefined;
+
+    if (channelId && messageTs) {
+      await updateMessage(
+        client,
+        channelId,
+        messageTs,
+        '취소했어. 아무것도 바뀌지 않았어.',
+        [],
+      );
     }
   });
 };

--- a/src/agents/life/blocks.ts
+++ b/src/agents/life/blocks.ts
@@ -21,6 +21,10 @@ export const POSTPONE_ACTION = 'postpone';
 export const DELETE_ACTION = 'delete';
 export const TOGGLE_IMPORTANT_ACTION = 'toggle_important';
 export const MOVE_TO_TODAY_ACTION = 'move_today';
+export const CONFIRM_MODIFY_EXECUTE_ACTION_ID = 'life_confirm_modify_execute';
+export const CONFIRM_MODIFY_CANCEL_ACTION_ID = 'life_confirm_modify_cancel';
+
+const CONFIRM_CARD_SQL_MAX_LEN = 500;
 
 const TIME_SLOT_ORDER = ['낮', '밤'] as const;
 
@@ -167,6 +171,59 @@ export const buildMorningGreetingBlocks = (greetingText: string): KnownBlock[] =
   { type: 'section', text: { type: 'mrkdwn', text: greetingText } },
 ];
 
+
+// ─── 대량 변경 확인 카드 ────────────────────────────────
+
+/**
+ * modify_db 확인 카드. value에 pending token 인코딩.
+ * ⚠️ 경고 이모지는 Block Kit UI 요소로, 에이전트 대화체 이모지 금지 규칙과는 별개.
+ */
+export const buildConfirmModifyCard = (params: {
+  token: string;
+  sql: string;
+  rowCount: number;
+}): { text: string; blocks: KnownBlock[] } => {
+  const sqlPreview =
+    params.sql.length > CONFIRM_CARD_SQL_MAX_LEN
+      ? params.sql.slice(0, CONFIRM_CARD_SQL_MAX_LEN) + '...'
+      : params.sql;
+
+  return {
+    text: `${params.rowCount}개 행이 변경될 예정이야. 확인해줘.`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*⚠️ 확인 필요* — 이 쿼리로 *${params.rowCount}개* 행이 변경돼. 진짜 실행할까?`,
+        },
+      },
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: '```' + sqlPreview + '```' },
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: '실행', emoji: true },
+            action_id: CONFIRM_MODIFY_EXECUTE_ACTION_ID,
+            value: params.token,
+            style: 'primary',
+          },
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: '취소', emoji: true },
+            action_id: CONFIRM_MODIFY_CANCEL_ACTION_ID,
+            value: params.token,
+            style: 'danger',
+          },
+        ],
+      },
+    ],
+  };
+};
 
 // ─── 인사이트 넛지 ──────────────────────────────────────
 

--- a/src/agents/life/index.ts
+++ b/src/agents/life/index.ts
@@ -100,6 +100,12 @@ export const createLifeAgent = (llmClient: LLMClient): AgentHandler => {
     }
 
     // ── LLM 에이전트 루프 ──
+    const threadTs = 'thread_ts' in message ? message.thread_ts : undefined;
+    const sqlContext = {
+      slackUserId,
+      slackChannel: channelId,
+      ...(threadTs ? { slackThreadTs: threadTs } : {}),
+    };
     try {
       const result = await runAgentLoop(
         llmClient,
@@ -108,7 +114,7 @@ export const createLifeAgent = (llmClient: LLMClient): AgentHandler => {
           label: 'Life Agent',
           buildSystemPrompt: () => buildLifeSystemPrompt(channelId, userId),
           getTools: async () => SQL_TOOLS,
-          executeToolCall: (name, args) => executeSQLTool(name, args, userId),
+          executeToolCall: (name, args) => executeSQLTool(name, args, userId, sqlContext),
           historyMessages: history.toMessages(channelId),
         },
       );

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,9 @@ import { registerLifeActions } from './agents/life/actions.js';
 import { registerHomeTab } from './agents/life/home.js';
 import { createInsightAgent } from './agents/insight/index.js';
 import { CronScheduler } from './cron/life-cron.js';
-import { setPostModifyHook } from './shared/sql-tools.js';
+import { setPostModifyHook, setConfirmCardSender } from './shared/sql-tools.js';
+import { buildConfirmModifyCard } from './agents/life/blocks.js';
+import { postBlockMessage } from './shared/slack.js';
 import { startDBProxy } from './db-proxy.js';
 
 const app = new App({
@@ -53,6 +55,24 @@ const startApp = async (): Promise<void> => {
     if (/\bnotification_settings\b/i.test(sql)) {
       cronScheduler.reload();
     }
+  });
+
+  // 대량 변경 확인 카드 전송자 주입
+  setConfirmCardSender(async ({ token, sql, rowCount, context }) => {
+    if (!context.slackChannel) {
+      console.warn(
+        `[Confirm] slackChannel 없음 — 카드 전송 스킵. token: ${token}`,
+      );
+      return;
+    }
+    const { text, blocks } = buildConfirmModifyCard({ token, sql, rowCount });
+    await postBlockMessage(
+      app.client,
+      context.slackChannel,
+      text,
+      blocks,
+      context.slackThreadTs,
+    );
   });
 
   // DB 프록시 서버 (웹 대시보드용 — Vercel → HTTPS → VM → DB)

--- a/src/shared/__tests__/pending-modify.test.ts
+++ b/src/shared/__tests__/pending-modify.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockEnd = vi.fn();
+const mockClientQuery = vi.fn();
+const mockRelease = vi.fn();
+
+vi.mock('pg', () => {
+  const MockPool = vi.fn(function (this: Record<string, unknown>) {
+    this.query = mockQuery;
+    this.connect = mockConnect;
+    this.end = mockEnd;
+  });
+  return { default: { Pool: MockPool, types: { setTypeParser: vi.fn() } } };
+});
+
+describe('pending-modify', () => {
+  let createPendingModify: typeof import('../pending-modify.js').createPendingModify;
+  let findActivePending: typeof import('../pending-modify.js').findActivePending;
+  let markExecuted: typeof import('../pending-modify.js').markExecuted;
+  let markCanceled: typeof import('../pending-modify.js').markCanceled;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue({ query: mockClientQuery, release: mockRelease });
+    mockEnd.mockResolvedValue(undefined);
+
+    const db = await import('../db.js');
+    await db.disconnectDB();
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue({ query: mockClientQuery, release: mockRelease });
+    mockEnd.mockResolvedValue(undefined);
+    await db.connectDB('postgresql://test@localhost/test');
+    vi.clearAllMocks();
+
+    const pm = await import('../pending-modify.js');
+    createPendingModify = pm.createPendingModify;
+    findActivePending = pm.findActivePending;
+    markExecuted = pm.markExecuted;
+    markCanceled = pm.markCanceled;
+  });
+
+  it('createPendingModify: 16자 hex token 반환 + INSERT 수행', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+
+    const token = await createPendingModify({
+      userId: 1,
+      sqlText: 'DELETE FROM schedules WHERE user_id = 1',
+      rowCount: 5,
+      slackChannel: 'C123',
+    });
+
+    expect(token).toMatch(/^[a-f0-9]{16}$/);
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('INSERT INTO pending_modify');
+    expect(params[0]).toBe(token);
+    expect(params[1]).toBe(1);
+    expect(params[2]).toBe('DELETE FROM schedules WHERE user_id = 1');
+    expect(params[3]).toBe(5);
+    expect(params[4]).toBe('C123');
+    expect(params[5]).toBeNull();
+  });
+
+  it('findActivePending: token + userId로 SELECT 수행', async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ id: 7, token: 'abc', user_id: 1, sql_text: 'DELETE ...' }],
+      rowCount: 1,
+    });
+
+    const row = await findActivePending('abc', 1);
+    expect(row?.id).toBe(7);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('token = $1');
+    expect(sql).toContain('user_id = $2');
+    expect(sql).toContain('executed_at IS NULL');
+    expect(sql).toContain('canceled_at IS NULL');
+    expect(sql).toContain('expires_at > NOW()');
+    expect(params).toEqual(['abc', 1]);
+  });
+
+  it('findActivePending: 결과 없으면 null', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    expect(await findActivePending('missing', 1)).toBeNull();
+  });
+
+  it('markExecuted: executed_at = NOW() UPDATE', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    await markExecuted(42);
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('UPDATE pending_modify');
+    expect(sql).toContain('executed_at = NOW()');
+    expect(params).toEqual([42]);
+  });
+
+  it('markCanceled: canceled_at = NOW() UPDATE', async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+    await markCanceled(99);
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('UPDATE pending_modify');
+    expect(sql).toContain('canceled_at = NOW()');
+    expect(params).toEqual([99]);
+  });
+});

--- a/src/shared/__tests__/sql-tools.test.ts
+++ b/src/shared/__tests__/sql-tools.test.ts
@@ -388,3 +388,155 @@ describe('executeSQLTool', () => {
     expect(parsed.error).toContain('알 수 없는');
   });
 });
+
+describe('executeSQLTool — modify_db 확인 플로우', () => {
+  let executeSQLTool: typeof import('../sql-tools.js').executeSQLTool;
+  let setConfirmCardSender: typeof import('../sql-tools.js').setConfirmCardSender;
+  let clearConfirmCardSender: typeof import('../sql-tools.js').clearConfirmCardSender;
+  let connectDB: (url: string) => Promise<void>;
+  let disconnectDB: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockClientQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    mockConnect.mockResolvedValue({ query: mockClientQuery, release: mockRelease });
+    mockEnd.mockResolvedValue(undefined);
+
+    const db = await import('../db.js');
+    connectDB = db.connectDB;
+    disconnectDB = db.disconnectDB;
+
+    await disconnectDB();
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue({ query: mockClientQuery, release: mockRelease });
+    mockEnd.mockResolvedValue(undefined);
+    await connectDB('postgresql://test@localhost/test');
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue({ query: mockClientQuery, release: mockRelease });
+
+    const sqlTools = await import('../sql-tools.js');
+    executeSQLTool = sqlTools.executeSQLTool;
+    setConfirmCardSender = sqlTools.setConfirmCardSender;
+    clearConfirmCardSender = sqlTools.clearConfirmCardSender;
+  });
+
+  it('DELETE with row < threshold → 즉시 실행 (confirm 스킵)', async () => {
+    // dry-run (BEGIN/쿼리/ROLLBACK) → 2 rows
+    // 이어서 실제 실행 (SET/BEGIN/쿼리/COMMIT) → 2 rows
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // dry SET timeout
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // dry BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 2 }) // dry DELETE (영향 2행)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // dry ROLLBACK
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // dry SET timeout 0
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // 실제 SET timeout
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // 실제 BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 2 }) // 실제 DELETE
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // 실제 COMMIT
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // 실제 SET timeout 0
+
+    const sender = vi.fn().mockResolvedValue(undefined);
+    setConfirmCardSender(sender);
+
+    const result = await executeSQLTool(
+      'modify_db',
+      { sql: 'DELETE FROM schedules WHERE user_id = 1 AND id = 5' },
+      1,
+      { slackChannel: 'C123' },
+    );
+    const parsed = JSON.parse(result) as { rowCount?: number; pending?: boolean };
+
+    expect(parsed.pending).toBeUndefined();
+    expect(parsed.rowCount).toBe(2);
+    expect(sender).not.toHaveBeenCalled();
+
+    clearConfirmCardSender();
+  });
+
+  it('DELETE with row ≥ threshold → pending + sender 호출', async () => {
+    // dry-run → 5 rows (threshold 3 이상)
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // dry SET timeout
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // dry BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 5 }) // dry DELETE
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // dry ROLLBACK
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // dry SET timeout 0
+    // pending INSERT는 pool.query(mockQuery) 경유
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const sender = vi.fn().mockResolvedValue(undefined);
+    setConfirmCardSender(sender);
+
+    const result = await executeSQLTool(
+      'modify_db',
+      { sql: 'DELETE FROM schedules WHERE user_id = 1 AND category = \'old\'' },
+      1,
+      { slackChannel: 'C123', slackThreadTs: '1700000000.000100' },
+    );
+    const parsed = JSON.parse(result) as {
+      pending?: boolean;
+      rowCount?: number;
+      message?: string;
+    };
+
+    expect(parsed.pending).toBe(true);
+    expect(parsed.rowCount).toBe(5);
+    expect(sender).toHaveBeenCalledTimes(1);
+    const callArg = sender.mock.calls[0]?.[0] as {
+      token: string;
+      rowCount: number;
+      context: { slackChannel?: string; slackThreadTs?: string };
+    };
+    expect(callArg.rowCount).toBe(5);
+    expect(callArg.token).toMatch(/^[a-f0-9]{16}$/);
+    expect(callArg.context.slackChannel).toBe('C123');
+
+    clearConfirmCardSender();
+  });
+
+  it('INSERT는 threshold 체크 없이 즉시 실행', async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET timeout
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: 9 }], rowCount: 1 }) // INSERT
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // COMMIT
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // SET timeout 0
+
+    const sender = vi.fn().mockResolvedValue(undefined);
+    setConfirmCardSender(sender);
+
+    const result = await executeSQLTool(
+      'modify_db',
+      { sql: "INSERT INTO schedules (title, user_id) VALUES ('test', 1) RETURNING id" },
+      1,
+      { slackChannel: 'C123' },
+    );
+    const parsed = JSON.parse(result) as { rowCount?: number; pending?: boolean };
+
+    expect(parsed.pending).toBeUndefined();
+    expect(parsed.rowCount).toBe(1);
+    expect(sender).not.toHaveBeenCalled();
+
+    clearConfirmCardSender();
+  });
+
+  it('sender 미설정 시 DELETE도 즉시 실행 (하위 호환)', async () => {
+    clearConfirmCardSender();
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 10 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await executeSQLTool(
+      'modify_db',
+      { sql: 'DELETE FROM schedules WHERE user_id = 1 AND category = \'x\'' },
+      1,
+    );
+    const parsed = JSON.parse(result) as { rowCount?: number; pending?: boolean };
+
+    expect(parsed.pending).toBeUndefined();
+    expect(parsed.rowCount).toBe(10);
+  });
+});

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -45,4 +45,5 @@ export const CONFIG = {
   dbProxy: {
     apiKey: process.env['DB_PROXY_API_KEY'] ?? '',
   },
+  modifyConfirmThreshold: Number(process.env['MODIFY_CONFIRM_THRESHOLD'] ?? 3),
 } as const;

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -103,6 +103,31 @@ export const queryWithRowLimit = async <T extends pg.QueryResultRow = pg.QueryRe
   }
 };
 
+/**
+ * 쿼리를 BEGIN → 실행 → ROLLBACK으로 실행해 영향 row 수만 얻는다.
+ * DB 상태는 변경되지 않는다. DELETE/UPDATE 실행 전 영향 범위 사전 점검용.
+ */
+export const dryRunRowCount = async (
+  text: string,
+  timeoutMs: number,
+): Promise<number> => {
+  const p = getPool();
+  const client = await p.connect();
+  try {
+    await client.query(`SET statement_timeout = ${Number(timeoutMs)}`);
+    await client.query('BEGIN');
+    const result = await client.query(text);
+    await client.query('ROLLBACK');
+    return result.rowCount ?? 0;
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {/* 무시 */});
+    throw err;
+  } finally {
+    await client.query('SET statement_timeout = 0').catch(() => {/* 무시 */});
+    client.release();
+  }
+};
+
 /** 연결 풀 종료 */
 export const disconnectDB = async (): Promise<void> => {
   if (!pool) return;

--- a/src/shared/pending-modify.ts
+++ b/src/shared/pending-modify.ts
@@ -1,0 +1,72 @@
+import { randomBytes } from 'crypto';
+import { query, queryOne } from './db.js';
+
+const TOKEN_BYTES = 8; // 16 hex chars
+const TTL_MINUTES = 5;
+
+export interface PendingModifyRow {
+  id: number;
+  token: string;
+  user_id: number;
+  sql_text: string;
+  dry_run_row_count: number;
+  slack_channel: string | null;
+  slack_thread_ts: string | null;
+  created_at: string;
+  expires_at: string;
+  executed_at: string | null;
+  canceled_at: string | null;
+}
+
+const generateToken = (): string => randomBytes(TOKEN_BYTES).toString('hex');
+
+/** 새 pending_modify 생성 후 token 반환 */
+export const createPendingModify = async (params: {
+  userId: number;
+  sqlText: string;
+  rowCount: number;
+  slackChannel?: string;
+  slackThreadTs?: string;
+}): Promise<string> => {
+  const token = generateToken();
+  await query(
+    `INSERT INTO pending_modify
+       (token, user_id, sql_text, dry_run_row_count,
+        slack_channel, slack_thread_ts, expires_at)
+     VALUES ($1, $2, $3, $4, $5, $6, NOW() + INTERVAL '${TTL_MINUTES} minutes')`,
+    [
+      token,
+      params.userId,
+      params.sqlText,
+      params.rowCount,
+      params.slackChannel ?? null,
+      params.slackThreadTs ?? null,
+    ],
+  );
+  return token;
+};
+
+/** token + user_id로 활성 pending 조회. 다른 유저의 token 접근 차단. */
+export const findActivePending = async (
+  token: string,
+  userId: number,
+): Promise<PendingModifyRow | null> =>
+  queryOne<PendingModifyRow>(
+    `SELECT * FROM pending_modify
+     WHERE token = $1
+       AND user_id = $2
+       AND executed_at IS NULL
+       AND canceled_at IS NULL
+       AND expires_at > NOW()`,
+    [token, userId],
+  );
+
+/** 실행 완료 마킹 */
+export const markExecuted = async (id: number): Promise<void> => {
+  await query(`UPDATE pending_modify SET executed_at = NOW() WHERE id = $1`, [id]);
+};
+
+/** 취소 마킹 */
+export const markCanceled = async (id: number): Promise<void> => {
+  await query(`UPDATE pending_modify SET canceled_at = NOW() WHERE id = $1`, [id]);
+};

--- a/src/shared/slack.ts
+++ b/src/shared/slack.ts
@@ -10,14 +10,20 @@ export const postToChannel = async (
   await client.chat.postMessage({ channel, text });
 };
 
-/** Block Kit 메시지 전송 (인터랙티브 메시지용) */
+/** Block Kit 메시지 전송 (인터랙티브 메시지용). threadTs 지정 시 스레드 답글 */
 export const postBlockMessage = async (
   client: WebClient,
   channel: string,
   text: string,
   blocks: KnownBlock[],
+  threadTs?: string,
 ): Promise<{ ts: string; channel: string }> => {
-  const result = await client.chat.postMessage({ channel, text, blocks });
+  const result = await client.chat.postMessage({
+    channel,
+    text,
+    blocks,
+    ...(threadTs ? { thread_ts: threadTs } : {}),
+  });
   return { ts: result.ts as string, channel: result.channel as string };
 };
 

--- a/src/shared/sql-tools.ts
+++ b/src/shared/sql-tools.ts
@@ -1,5 +1,6 @@
 import type { LLMToolDefinition } from './llm.js';
-import { query, queryWithClient, queryWithRowLimit } from './db.js';
+import { query, queryWithClient, queryWithRowLimit, dryRunRowCount } from './db.js';
+import { createPendingModify } from './pending-modify.js';
 
 // ---- 상수 ----
 
@@ -297,6 +298,33 @@ export const setPostModifyHook = (hook: PostModifyHook): void => {
   postModifyHook = hook;
 };
 
+// ---- Confirm card sender ----
+
+export interface SQLToolContext {
+  slackUserId?: string;
+  slackChannel?: string;
+  slackThreadTs?: string;
+}
+
+export type ConfirmCardSender = (params: {
+  token: string;
+  sql: string;
+  rowCount: number;
+  context: SQLToolContext & { userId: number };
+}) => Promise<void>;
+
+let confirmCardSender: ConfirmCardSender | null = null;
+
+/** 확인 카드 전송 함수 주입. app.ts에서 Slack client 바인딩하여 호출 */
+export const setConfirmCardSender = (sender: ConfirmCardSender): void => {
+  confirmCardSender = sender;
+};
+
+/** 테스트용: sender 해제 */
+export const clearConfirmCardSender = (): void => {
+  confirmCardSender = null;
+};
+
 // ---- 감사 로그 ----
 
 /** SQL 실행 로그 (도구명, SQL 앞부분, 결과 요약) */
@@ -315,11 +343,13 @@ const logSQLExecution = (tool: string, sql: string, result: { rowCount?: number 
  * SQL 도구 실행기.
  * agent-loop의 executeToolCall 시그니처: (name, args) => Promise<string>
  * userId: 현재 사용자의 DB user_id (기본값 1)
+ * context: Slack 채널/스레드 정보 (modify_db 확인 카드 전송용)
  */
 export const executeSQLTool = async (
   name: string,
   args: Record<string, unknown>,
   userId: number = 1,
+  context?: SQLToolContext,
 ): Promise<string> => {
   switch (name) {
     case 'query_db': {
@@ -343,7 +373,49 @@ export const executeSQLTool = async (
         return JSON.stringify({ error });
       }
 
-      // INSERT/UPDATE/DELETE 모두 트랜잭션 + row 수 제한 적용 (대량 변경 방지)
+      // DELETE/UPDATE: 영향 row 수가 임계치 이상이면 확인 카드로 전환
+      const keyword = extractFirstKeyword(sql);
+      if ((keyword === 'DELETE' || keyword === 'UPDATE') && confirmCardSender) {
+        const threshold = (await import('./config.js')).CONFIG.modifyConfirmThreshold;
+        let dryRunCount: number;
+        try {
+          dryRunCount = await dryRunRowCount(sql, SQL_TIMEOUT_MS);
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logSQLExecution('modify_db', sql, { error: `dry-run 실패: ${msg}` });
+          return JSON.stringify({ error: `쿼리 검증 실패: ${msg}` });
+        }
+
+        if (dryRunCount >= threshold) {
+          const token = await createPendingModify({
+            userId,
+            sqlText: sql,
+            rowCount: dryRunCount,
+            slackChannel: context?.slackChannel,
+            slackThreadTs: context?.slackThreadTs,
+          });
+
+          try {
+            await confirmCardSender({
+              token,
+              sql,
+              rowCount: dryRunCount,
+              context: { userId, ...context },
+            });
+          } catch (err: unknown) {
+            console.error('[SQL Tools] confirm card 전송 실패:', err);
+          }
+
+          logSQLExecution('modify_db', sql, { error: `confirm pending (${dryRunCount} rows)` });
+          return JSON.stringify({
+            pending: true,
+            rowCount: dryRunCount,
+            message: `${dryRunCount}개 행이 변경될 예정이야. Slack 확인 카드에서 실행/취소해줘.`,
+          });
+        }
+      }
+
+      // 즉시 실행 경로 (INSERT 전체, 또는 DELETE/UPDATE 중 영향 row < threshold)
       const result = await queryWithRowLimit(sql, SQL_TIMEOUT_MS, MAX_MODIFY_ROWS);
       logSQLExecution('modify_db', sql, { rowCount: result.rowCount });
 

--- a/src/shared/sql-tools.ts
+++ b/src/shared/sql-tools.ts
@@ -376,7 +376,7 @@ export const executeSQLTool = async (
       // DELETE/UPDATE: 영향 row 수가 임계치 이상이면 확인 카드로 전환
       const keyword = extractFirstKeyword(sql);
       if ((keyword === 'DELETE' || keyword === 'UPDATE') && confirmCardSender) {
-        const threshold = (await import('./config.js')).CONFIG.modifyConfirmThreshold;
+        const threshold = Number(process.env['MODIFY_CONFIRM_THRESHOLD'] ?? 3);
         let dryRunCount: number;
         try {
           dryRunCount = await dryRunRowCount(sql, SQL_TIMEOUT_MS);


### PR DESCRIPTION
## 관련 이슈
Closes #342

## 변경 내용
LLM이 `modify_db` 도구로 생성한 DELETE/UPDATE의 dry-run 영향 row가 임계치(기본 3) 이상이면, 즉시 실행 대신 Slack 확인 카드로 전환해 사용자 승인을 받은 뒤 실행한다.

- **DB 레이어**: `pending_modify` 테이블 추가 (token/user_id/sql_text/TTL 5분), `dryRunRowCount` 헬퍼(BEGIN → 실행 → ROLLBACK)
- **CRUD 모듈**: `pending-modify.ts` — 16 hex 토큰 생성, token+user_id 쌍 조회(교차 사용자 차단), executed/canceled 마킹
- **sql-tools**: DELETE/UPDATE 분기에 dry-run + threshold 분기. 임계치 이상 시 pending 저장 + confirmCardSender 호출, LLM에는 `pending:true` 반환 (agent-loop 종료)
- **Slack UI**: `buildConfirmModifyCard` — SQL 미리보기(500자) + 실행(primary) / 취소(danger) 버튼
- **액션 핸들러**: execute → `queryWithRowLimit`(50행 한도 유지)로 실제 실행, 결과 메시지로 카드 교체. cancel → 취소 마킹 + 취소 메시지
- **주입 구조**: `app.ts`에서 Slack client 바인딩된 sender 주입. `postBlockMessage` threadTs 옵션 추가
- **외부화**: `MODIFY_CONFIRM_THRESHOLD` 환경변수 (기본 3)

기존 가드레일(DDL 차단, WHERE 필수, user_id 스코프, 50행 제한) 전부 유지. 확인 플로우는 **범위는 괜찮지만 넓은 쿼리**에 대한 추가 안전망.

## 설계 판단 근거 (ADR)
[0006-modify-db-confirm-flow.md](docs/adr/0006-modify-db-confirm-flow.md)에 Context/Decision/Alternatives(A 전수 확인 / B 테이블 화이트리스트 / C threshold / D agent-loop 재개) 기록. 장기 방향성은 D안(풀 에이전트)이지만, 현재 단계의 비용·단순성 요구에 따라 C안 + 고정 템플릿 종료를 채택. D안 전환 시나리오도 함께 문서화.

## 코드 리뷰 결과
- [x] 보안 감사 통과 (parameterized query, token+user_id 이중 조회, 기존 가드 유지)
- [x] 타입 안전성 확인 (`tsc --noEmit` 통과, `unknown` + 타입 가드)
- [x] 컨벤션 점검 완료 (네이밍, ESM `.js` 확장자, 에이전트 톤)
- [x] 코드 품질 확인

## 테스트
- [x] pending-modify CRUD 5건
- [x] modify_db 확인 플로우 4건 (threshold 미만/이상, INSERT 스킵, sender 미설정 하위 호환)
- [x] buildConfirmModifyCard 3건 (token value, rowCount 노출, 500자 절단)
- [x] 전체 스위트 339건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)