### PR TITLE
feat(safety): modify_db 확인 카드 UX 개선 (#344)

### DIFF
--- a/src/agents/life/__tests__/blocks.test.ts
+++ b/src/agents/life/__tests__/blocks.test.ts
@@ -343,8 +343,10 @@ describe('buildConfirmModifyCard', () => {
   it('실행/취소 버튼에 token이 value로 들어간다', () => {
     const { blocks } = buildConfirmModifyCard({
       token: 'abc1234567890def',
-      sql: 'DELETE FROM schedules WHERE user_id = 1 AND category = \'old\'',
-      rowCount: 5,
+      operation: 'DELETE',
+      tableName: 'schedules',
+      rowCount: 0,
+      rows: [],
     });
 
     const actionsBlock = blocks.find((b) => b.type === 'actions');
@@ -369,8 +371,10 @@ describe('buildConfirmModifyCard', () => {
   it('rowCount가 fallback text와 헤더에 노출된다', () => {
     const { text, blocks } = buildConfirmModifyCard({
       token: 't0',
-      sql: 'DELETE FROM schedules WHERE user_id = 1',
+      operation: 'DELETE',
+      tableName: 'schedules',
       rowCount: 17,
+      rows: [],
     });
 
     expect(text).toContain('17개');
@@ -382,15 +386,130 @@ describe('buildConfirmModifyCard', () => {
     }
   });
 
-  it('긴 SQL은 500자로 잘린다', () => {
-    const longSql = 'DELETE FROM schedules WHERE user_id = 1 AND ' + 'a'.repeat(1000);
-    const { blocks } = buildConfirmModifyCard({ token: 't', sql: longSql, rowCount: 3 });
-    const codeBlock = blocks[1];
-    if (codeBlock?.type === 'section' && 'text' in codeBlock && codeBlock.text && 'text' in codeBlock.text) {
-      expect(codeBlock.text.text).toContain('...');
-      expect(codeBlock.text.text.length).toBeLessThan(longSql.length);
-    } else {
-      throw new Error('code block shape unexpected');
+  it('UPDATE 라벨은 "변경", DELETE 라벨은 "삭제"로 노출된다', () => {
+    const del = buildConfirmModifyCard({
+      token: 't', operation: 'DELETE', tableName: 'schedules', rowCount: 2,
+      rows: [{ date: '2026-04-23', title: 'A' }, { date: '2026-04-23', title: 'B' }],
+    });
+    expect(del.text).toContain('삭제');
+
+    const upd = buildConfirmModifyCard({
+      token: 't', operation: 'UPDATE', tableName: 'schedules', rowCount: 1,
+      rows: [{ date: '2026-04-23', title: 'A' }],
+    });
+    expect(upd.text).toContain('변경');
+  });
+
+  it('schedules rows는 date + title로 포맷된다', () => {
+    const { blocks } = buildConfirmModifyCard({
+      token: 't',
+      operation: 'DELETE',
+      tableName: 'schedules',
+      rowCount: 2,
+      rows: [
+        { id: 1, title: '아침 운동', date: '2026-04-23', end_date: null },
+        { id: 2, title: '저녁 회의', date: '2026-04-24', end_date: null },
+      ],
+    });
+
+    const texts = blocks
+      .filter((b) => b.type === 'section')
+      .map((b) => ('text' in b && b.text && 'text' in b.text ? b.text.text : ''))
+      .join('\n');
+    expect(texts).toContain('2026-04-23');
+    expect(texts).toContain('아침 운동');
+    expect(texts).toContain('2026-04-24');
+    expect(texts).toContain('저녁 회의');
+  });
+
+  it('기간 일정은 date~end_date 범위로 표시된다', () => {
+    const { blocks } = buildConfirmModifyCard({
+      token: 't',
+      operation: 'DELETE',
+      tableName: 'schedules',
+      rowCount: 1,
+      rows: [{ id: 1, title: '출장', date: '2026-04-23', end_date: '2026-04-25' }],
+    });
+    const texts = blocks
+      .filter((b) => b.type === 'section')
+      .map((b) => ('text' in b && b.text && 'text' in b.text ? b.text.text : ''))
+      .join('\n');
+    expect(texts).toContain('2026-04-23~2026-04-25');
+  });
+
+  it('date가 null이면 "백로그"로 표시된다', () => {
+    const { blocks } = buildConfirmModifyCard({
+      token: 't',
+      operation: 'DELETE',
+      tableName: 'schedules',
+      rowCount: 1,
+      rows: [{ id: 1, title: '나중에 할 일', date: null, end_date: null }],
+    });
+    const texts = blocks
+      .filter((b) => b.type === 'section')
+      .map((b) => ('text' in b && b.text && 'text' in b.text ? b.text.text : ''))
+      .join('\n');
+    expect(texts).toContain('백로그');
+    expect(texts).toContain('나중에 할 일');
+  });
+
+  it('tableName이 null이면 fallback 포맷(id + 첫 string 필드)을 사용한다', () => {
+    const { blocks } = buildConfirmModifyCard({
+      token: 't',
+      operation: 'DELETE',
+      tableName: null,
+      rowCount: 1,
+      rows: [{ id: 42, label: 'something' }],
+    });
+    const texts = blocks
+      .filter((b) => b.type === 'section')
+      .map((b) => ('text' in b && b.text && 'text' in b.text ? b.text.text : ''))
+      .join('\n');
+    expect(texts).toContain('id=42');
+    expect(texts).toContain('something');
+  });
+
+  it('rows가 비어있으면 항목 섹션이 없다', () => {
+    const { blocks } = buildConfirmModifyCard({
+      token: 't',
+      operation: 'DELETE',
+      tableName: 'schedules',
+      rowCount: 0,
+      rows: [],
+    });
+    const texts = blocks
+      .filter((b) => b.type === 'section')
+      .map((b) => ('text' in b && b.text && 'text' in b.text ? b.text.text : ''))
+      .join('\n');
+    expect(texts).not.toContain('삭제될 항목');
+  });
+
+  it('많은 rows는 section block으로 분할되고 모든 row가 포함된다', () => {
+    const rows = Array.from({ length: 40 }, (_, i) => ({
+      id: i,
+      title: '일정 제목 '.repeat(10) + i, // 각 row 약 60자 → 40개 합쳐 2400자 근처
+      date: '2026-04-23',
+      end_date: null,
+    }));
+
+    const { blocks } = buildConfirmModifyCard({
+      token: 't',
+      operation: 'DELETE',
+      tableName: 'schedules',
+      rowCount: 40,
+      rows,
+    });
+
+    // 모든 row의 고유 제목 부분이 어딘가에 포함되어야 함
+    const combinedText = blocks
+      .filter((b) => b.type === 'section')
+      .map((b) => ('text' in b && b.text && 'text' in b.text ? b.text.text : ''))
+      .join('\n');
+
+    for (let i = 0; i < 40; i++) {
+      expect(combinedText).toContain(`일정 제목 일정 제목 `); // 고정 부분
     }
+    // 끝 ID 포함 확인
+    expect(combinedText).toContain('39');
   });
 });

--- a/src/agents/life/actions.ts
+++ b/src/agents/life/actions.ts
@@ -4,6 +4,7 @@
  */
 
 import type { App } from '@slack/bolt';
+import type { WebClient } from '@slack/web-api';
 import {
   completeRecord,
   queryTodayRecords,
@@ -15,8 +16,9 @@ import {
   toggleScheduleImportant,
   moveScheduleToDate,
 } from '../../shared/life-queries.js';
-import { updateMessage } from '../../shared/slack.js';
+import { updateMessage, postBlockMessage } from '../../shared/slack.js';
 import { queryWithRowLimit } from '../../shared/db.js';
+import { extractTargetTable } from '../../shared/sql-tools.js';
 import {
   findActivePending,
   markExecuted,
@@ -43,6 +45,42 @@ import { publishHomeView } from './home.js';
 
 const CONFIRM_EXECUTE_TIMEOUT_MS = 10_000;
 const CONFIRM_EXECUTE_MAX_ROWS = 50;
+
+/**
+ * schedules 변경 후 영향받은 날짜별로 현재 일정 상태를 재조회하여 Slack 메시지로 전송.
+ * - date IS NULL (백로그) 포함
+ * - 각 고유 date마다 메시지 1개
+ * - 개별 재조회 실패는 로그만 남기고 전체 흐름 유지 (사용자는 이미 완료 메시지 받음)
+ */
+const postScheduleRefreshMessages = async (
+  client: WebClient,
+  channelId: string,
+  userId: number,
+  rows: Array<Record<string, unknown>>,
+): Promise<void> => {
+  const uniqueDates = new Set<string | null>();
+  for (const row of rows) {
+    const date = row['date'];
+    uniqueDates.add(typeof date === 'string' ? date : null);
+  }
+
+  for (const date of uniqueDates) {
+    try {
+      if (date === null) {
+        const items = await queryBacklogSchedules(userId);
+        const { text, blocks } = buildScheduleBlocks(items, 'backlog', undefined, { backlog: true });
+        await postBlockMessage(client, channelId, text, blocks);
+      } else {
+        const items = await queryTodaySchedules(date, userId);
+        const { text, blocks } = buildScheduleBlocks(items, date);
+        await postBlockMessage(client, channelId, text, blocks);
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[Life Action] schedules 재조회 실패 (date=${date}): ${msg}`);
+    }
+  }
+};
 
 /** Slack body에서 userId 해석 (미등록이면 DEFAULT_USER_ID 폴백) */
 const resolveBodyUserId = async (body: { user?: string | { id: string } }): Promise<number> => {
@@ -191,20 +229,27 @@ export const registerLifeActions = (app: App): void => {
     }
 
     try {
-      const result = await queryWithRowLimit(
+      const result = await queryWithRowLimit<Record<string, unknown>>(
         pending.sql_text,
         CONFIRM_EXECUTE_TIMEOUT_MS,
         CONFIRM_EXECUTE_MAX_ROWS,
       );
       await markExecuted(pending.id);
+
       if (channelId && messageTs) {
         await updateMessage(
           client,
           channelId,
           messageTs,
-          `실행 완료. ${result.rowCount ?? 0}개 행 변경됐어.`,
+          `${result.rowCount ?? 0}개 처리 완료.`,
           [],
         );
+      }
+
+      // schedules 후처리 재조회 (약속한 "오늘 일정 다시 보여줄게" 실제 이행)
+      const tableName = extractTargetTable(pending.sql_text);
+      if (tableName === 'schedules' && channelId && result.rows.length > 0) {
+        await postScheduleRefreshMessages(client, channelId, userId, result.rows);
       }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/agents/life/blocks.ts
+++ b/src/agents/life/blocks.ts
@@ -24,7 +24,7 @@ export const MOVE_TO_TODAY_ACTION = 'move_today';
 export const CONFIRM_MODIFY_EXECUTE_ACTION_ID = 'life_confirm_modify_execute';
 export const CONFIRM_MODIFY_CANCEL_ACTION_ID = 'life_confirm_modify_cancel';
 
-const CONFIRM_CARD_SQL_MAX_LEN = 500;
+const CONFIRM_CARD_SECTION_MAX_CHARS = 2800; // Slack section block 3000자 한도 여유
 
 const TIME_SLOT_ORDER = ['낮', '밤'] as const;
 
@@ -174,54 +174,145 @@ export const buildMorningGreetingBlocks = (greetingText: string): KnownBlock[] =
 
 // ─── 대량 변경 확인 카드 ────────────────────────────────
 
+type ConfirmOperation = 'DELETE' | 'UPDATE';
+
+const OPERATION_LABELS: Record<ConfirmOperation, { noun: string; verb: string }> = {
+  DELETE: { noun: '삭제될 항목', verb: '삭제돼' },
+  UPDATE: { noun: '변경될 항목', verb: '변경돼' },
+};
+
+/** 영향받는 레코드 한 줄 포맷 (테이블별 주요 필드 노출) */
+const formatAffectedRow = (
+  tableName: string | null,
+  row: Record<string, unknown>,
+): string => {
+  if (tableName === 'schedules') {
+    const title = typeof row['title'] === 'string' ? row['title'] : '(제목 없음)';
+    const date = typeof row['date'] === 'string' ? row['date'] : null;
+    const endDate = typeof row['end_date'] === 'string' ? row['end_date'] : null;
+    const datePart = date ? (endDate ? `${date}~${endDate}` : date) : '백로그';
+    return `• ${datePart}  ${title}`;
+  }
+  if (tableName === 'sleep_records') {
+    const date = typeof row['date'] === 'string' ? row['date'] : '?';
+    const bedtime = typeof row['bedtime'] === 'string' ? row['bedtime'] : '?';
+    const wakeTime = typeof row['wake_time'] === 'string' ? row['wake_time'] : '?';
+    const sleepType = typeof row['sleep_type'] === 'string' ? row['sleep_type'] : '';
+    return `• ${date}  ${sleepType}  ${bedtime} → ${wakeTime}`;
+  }
+  if (tableName === 'routine_records' || tableName === 'routine_templates') {
+    const name = typeof row['name'] === 'string' ? row['name'] : null;
+    const date = typeof row['date'] === 'string' ? row['date'] : null;
+    if (name) return `• ${date ? date + ' ' : ''}${name}`;
+    return `• id=${row['id'] ?? '?'}`;
+  }
+  if (tableName === 'reminders') {
+    const title = typeof row['title'] === 'string' ? row['title'] : '(제목 없음)';
+    const time = typeof row['time_value'] === 'string' ? row['time_value'] : '';
+    return `• ${time}  ${title}`;
+  }
+  if (tableName === 'custom_instructions') {
+    const instr = typeof row['instruction'] === 'string' ? row['instruction'] : '';
+    return `• ${instr.length > 80 ? instr.slice(0, 80) + '...' : instr}`;
+  }
+  // fallback: id + 주요 string 필드 1개
+  const id = row['id'];
+  const firstString = Object.entries(row).find(
+    ([k, v]) => k !== 'id' && typeof v === 'string',
+  );
+  return `• id=${id ?? '?'}${firstString ? `  ${String(firstString[1])}` : ''}`;
+};
+
+/**
+ * 라인 리스트를 section block 다중으로 분할 (각 블록 3000자 한도 회피).
+ * 한 라인이 한도보다 길어도 그 라인만 포함한 블록으로 생성 (잘림 없음).
+ */
+const splitLinesIntoSections = (lines: string[]): KnownBlock[] => {
+  const blocks: KnownBlock[] = [];
+  let current: string[] = [];
+  let currentLen = 0;
+
+  for (const line of lines) {
+    const addLen = line.length + 1; // newline 포함
+    if (currentLen + addLen > CONFIRM_CARD_SECTION_MAX_CHARS && current.length > 0) {
+      blocks.push({
+        type: 'section',
+        text: { type: 'mrkdwn', text: current.join('\n') },
+      });
+      current = [];
+      currentLen = 0;
+    }
+    current.push(line);
+    currentLen += addLen;
+  }
+
+  if (current.length > 0) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: current.join('\n') },
+    });
+  }
+
+  return blocks;
+};
+
 /**
  * modify_db 확인 카드. value에 pending token 인코딩.
- * ⚠️ 경고 이모지는 Block Kit UI 요소로, 에이전트 대화체 이모지 금지 규칙과는 별개.
+ * 영향받는 레코드를 테이블별 주요 필드로 표시 (RETURNING 결과 기반).
+ * ⚠️ 경고 이모지는 Block Kit UI 요소로, 에이전트 대화체 이모지 금지 규칙과 별개.
  */
 export const buildConfirmModifyCard = (params: {
   token: string;
-  sql: string;
+  operation: ConfirmOperation;
+  tableName: string | null;
   rowCount: number;
+  rows: Array<Record<string, unknown>>;
 }): { text: string; blocks: KnownBlock[] } => {
-  const sqlPreview =
-    params.sql.length > CONFIRM_CARD_SQL_MAX_LEN
-      ? params.sql.slice(0, CONFIRM_CARD_SQL_MAX_LEN) + '...'
-      : params.sql;
+  const { token, operation, tableName, rowCount, rows } = params;
+  const label = OPERATION_LABELS[operation];
 
-  return {
-    text: `${params.rowCount}개 행이 변경될 예정이야. 확인해줘.`,
-    blocks: [
+  const blocks: KnownBlock[] = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*⚠️ 확인 필요* — *${rowCount}개*가 ${label.verb}. 진짜 실행할까?`,
+      },
+    },
+  ];
+
+  if (rows.length > 0) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*${label.noun}:*` },
+    });
+    const lines = rows.map((r) => formatAffectedRow(tableName, r));
+    blocks.push(...splitLinesIntoSections(lines));
+  }
+
+  blocks.push({
+    type: 'actions',
+    elements: [
       {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `*⚠️ 확인 필요* — 이 쿼리로 *${params.rowCount}개* 행이 변경돼. 진짜 실행할까?`,
-        },
+        type: 'button',
+        text: { type: 'plain_text', text: '실행', emoji: true },
+        action_id: CONFIRM_MODIFY_EXECUTE_ACTION_ID,
+        value: token,
+        style: 'primary',
       },
       {
-        type: 'section',
-        text: { type: 'mrkdwn', text: '```' + sqlPreview + '```' },
-      },
-      {
-        type: 'actions',
-        elements: [
-          {
-            type: 'button',
-            text: { type: 'plain_text', text: '실행', emoji: true },
-            action_id: CONFIRM_MODIFY_EXECUTE_ACTION_ID,
-            value: params.token,
-            style: 'primary',
-          },
-          {
-            type: 'button',
-            text: { type: 'plain_text', text: '취소', emoji: true },
-            action_id: CONFIRM_MODIFY_CANCEL_ACTION_ID,
-            value: params.token,
-            style: 'danger',
-          },
-        ],
+        type: 'button',
+        text: { type: 'plain_text', text: '취소', emoji: true },
+        action_id: CONFIRM_MODIFY_CANCEL_ACTION_ID,
+        value: token,
+        style: 'danger',
       },
     ],
+  });
+
+  return {
+    text: `${rowCount}개가 ${label.verb}. 확인해줘.`,
+    blocks,
   };
 };
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,14 +58,20 @@ const startApp = async (): Promise<void> => {
   });
 
   // 대량 변경 확인 카드 전송자 주입
-  setConfirmCardSender(async ({ token, sql, rowCount, context }) => {
+  setConfirmCardSender(async ({ token, operation, tableName, rowCount, rows, context }) => {
     if (!context.slackChannel) {
       console.warn(
         `[Confirm] slackChannel 없음 — 카드 전송 스킵. token: ${token}`,
       );
       return;
     }
-    const { text, blocks } = buildConfirmModifyCard({ token, sql, rowCount });
+    const { text, blocks } = buildConfirmModifyCard({
+      token,
+      operation,
+      tableName,
+      rowCount,
+      rows,
+    });
     await postBlockMessage(
       app.client,
       context.slackChannel,

--- a/src/shared/__tests__/sql-tools.test.ts
+++ b/src/shared/__tests__/sql-tools.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   extractFirstKeyword,
+  extractTargetTable,
+  ensureReturningClause,
   hasMultipleStatements,
   validateSelectQuery,
   validateModifyQuery,
@@ -247,6 +249,59 @@ describe('validateUserIdFilter — user_id 값 제한', () => {
   });
 });
 
+describe('extractTargetTable', () => {
+  it('DELETE의 FROM 뒤 테이블명을 추출한다', () => {
+    expect(extractTargetTable('DELETE FROM schedules WHERE user_id = 1')).toBe('schedules');
+  });
+
+  it('UPDATE의 테이블명을 추출한다', () => {
+    expect(extractTargetTable('UPDATE schedules SET status = \'done\' WHERE id = 1')).toBe('schedules');
+  });
+
+  it('INSERT INTO 뒤 테이블명을 추출한다', () => {
+    expect(extractTargetTable('INSERT INTO sleep_records (date) VALUES (\'2026-04-23\')')).toBe('sleep_records');
+  });
+
+  it('JOIN이 있어도 첫 FROM 테이블을 반환한다', () => {
+    expect(extractTargetTable('SELECT * FROM schedules s JOIN categories c ON s.category = c.name WHERE s.user_id = 1')).toBe('schedules');
+  });
+
+  it('테이블 참조가 없으면 null', () => {
+    expect(extractTargetTable('SELECT 1')).toBeNull();
+  });
+
+  it('대소문자 무관하게 소문자로 정규화', () => {
+    expect(extractTargetTable('delete FROM Schedules WHERE user_id = 1')).toBe('schedules');
+  });
+});
+
+describe('ensureReturningClause', () => {
+  it('RETURNING이 없으면 RETURNING *를 추가한다', () => {
+    const sql = 'DELETE FROM schedules WHERE user_id = 1';
+    expect(ensureReturningClause(sql)).toBe('DELETE FROM schedules WHERE user_id = 1 RETURNING *');
+  });
+
+  it('이미 RETURNING이 있으면 원본 그대로', () => {
+    const sql = 'DELETE FROM schedules WHERE user_id = 1 RETURNING id, title';
+    expect(ensureReturningClause(sql)).toBe(sql);
+  });
+
+  it('세미콜론으로 끝나면 세미콜론 앞에 삽입한다', () => {
+    const sql = 'DELETE FROM schedules WHERE user_id = 1;';
+    expect(ensureReturningClause(sql)).toBe('DELETE FROM schedules WHERE user_id = 1 RETURNING *;');
+  });
+
+  it('UPDATE도 RETURNING을 추가한다', () => {
+    const sql = 'UPDATE schedules SET status = \'done\' WHERE user_id = 1';
+    expect(ensureReturningClause(sql)).toBe('UPDATE schedules SET status = \'done\' WHERE user_id = 1 RETURNING *');
+  });
+
+  it('RETURNING이 대문자든 소문자든 감지한다', () => {
+    const sql = 'DELETE FROM schedules WHERE user_id = 1 returning *';
+    expect(ensureReturningClause(sql)).toBe(sql);
+  });
+});
+
 describe('validateCustomInstruction', () => {
   it('custom_instructions가 없는 쿼리는 통과한다', () => {
     expect(validateCustomInstruction('INSERT INTO schedules (title, user_id) VALUES (\'test\', 1)')).toBeNull();
@@ -484,11 +539,17 @@ describe('executeSQLTool — modify_db 확인 플로우', () => {
     expect(sender).toHaveBeenCalledTimes(1);
     const callArg = sender.mock.calls[0]?.[0] as {
       token: string;
+      operation: 'DELETE' | 'UPDATE';
+      tableName: string | null;
       rowCount: number;
+      rows: Array<Record<string, unknown>>;
       context: { slackChannel?: string; slackThreadTs?: string };
     };
     expect(callArg.rowCount).toBe(5);
     expect(callArg.token).toMatch(/^[a-f0-9]{16}$/);
+    expect(callArg.operation).toBe('DELETE');
+    expect(callArg.tableName).toBe('schedules');
+    expect(Array.isArray(callArg.rows)).toBe(true);
     expect(callArg.context.slackChannel).toBe('C123');
 
     clearConfirmCardSender();

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -103,22 +103,28 @@ export const queryWithRowLimit = async <T extends pg.QueryResultRow = pg.QueryRe
   }
 };
 
+export interface DryRunResult {
+  rowCount: number;
+  rows: Array<Record<string, unknown>>;
+}
+
 /**
- * 쿼리를 BEGIN → 실행 → ROLLBACK으로 실행해 영향 row 수만 얻는다.
- * DB 상태는 변경되지 않는다. DELETE/UPDATE 실행 전 영향 범위 사전 점검용.
+ * 쿼리를 BEGIN → 실행 → ROLLBACK으로 실행해 영향 row 수와 RETURNING 결과를 얻는다.
+ * DB 상태는 변경되지 않는다. RETURNING이 없는 쿼리는 rows가 빈 배열.
+ * DELETE/UPDATE 실행 전 영향 범위 사전 점검 + 확인 카드 상세 표시용.
  */
-export const dryRunRowCount = async (
+export const dryRunQuery = async (
   text: string,
   timeoutMs: number,
-): Promise<number> => {
+): Promise<DryRunResult> => {
   const p = getPool();
   const client = await p.connect();
   try {
     await client.query(`SET statement_timeout = ${Number(timeoutMs)}`);
     await client.query('BEGIN');
-    const result = await client.query(text);
+    const result = await client.query<Record<string, unknown>>(text);
     await client.query('ROLLBACK');
-    return result.rowCount ?? 0;
+    return { rowCount: result.rowCount ?? 0, rows: result.rows };
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {/* 무시 */});
     throw err;

--- a/src/shared/sql-tools.ts
+++ b/src/shared/sql-tools.ts
@@ -84,6 +84,32 @@ export const extractFirstKeyword = (sql: string): string => {
   return (match?.[1] ?? '').toUpperCase();
 };
 
+/**
+ * SQL에서 주 대상 테이블명 추출 (첫 FROM/UPDATE/INTO 뒤).
+ * 여러 테이블이면 첫 번째만 반환. 소문자로 정규화.
+ */
+export const extractTargetTable = (sql: string): string | null => {
+  const stripped = stripCommentsAndStrings(sql);
+  const match = /\b(?:FROM|UPDATE|INTO)\s+(\w+)/i.exec(stripped);
+  return match?.[1]?.toLowerCase() ?? null;
+};
+
+/**
+ * DELETE/UPDATE 쿼리에 RETURNING 절이 없으면 `RETURNING *`을 자동 삽입.
+ * 세미콜론이 있으면 그 앞에 삽입.
+ * 이미 RETURNING이 있으면 원본 그대로 반환.
+ */
+export const ensureReturningClause = (sql: string): string => {
+  const stripped = stripCommentsAndStrings(sql);
+  if (/\bRETURNING\b/i.test(stripped)) return sql;
+
+  const trimmed = sql.trimEnd();
+  if (trimmed.endsWith(';')) {
+    return `${trimmed.slice(0, -1)} RETURNING *;`;
+  }
+  return `${trimmed} RETURNING *`;
+};
+
 /** 복수 SQL 문 감지 (주석·문자열 리터럴 내 세미콜론 제외) */
 export const hasMultipleStatements = (sql: string): boolean => {
   const stripped = stripCommentsAndStrings(sql);
@@ -308,8 +334,10 @@ export interface SQLToolContext {
 
 export type ConfirmCardSender = (params: {
   token: string;
-  sql: string;
+  operation: 'DELETE' | 'UPDATE';
+  tableName: string | null;
   rowCount: number;
+  rows: Array<Record<string, unknown>>;
   context: SQLToolContext & { userId: number };
 }) => Promise<void>;
 
@@ -377,41 +405,46 @@ export const executeSQLTool = async (
       const keyword = extractFirstKeyword(sql);
       if ((keyword === 'DELETE' || keyword === 'UPDATE') && confirmCardSender) {
         const threshold = Number(process.env['MODIFY_CONFIRM_THRESHOLD'] ?? 3);
-        let dryRunCount: number;
+        const sqlWithReturning = ensureReturningClause(sql);
+
+        let dryRun: Awaited<ReturnType<typeof dryRunQuery>>;
         try {
-          const dryRun = await dryRunQuery(sql, SQL_TIMEOUT_MS);
-          dryRunCount = dryRun.rowCount;
+          dryRun = await dryRunQuery(sqlWithReturning, SQL_TIMEOUT_MS);
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
           logSQLExecution('modify_db', sql, { error: `dry-run 실패: ${msg}` });
           return JSON.stringify({ error: `쿼리 검증 실패: ${msg}` });
         }
 
-        if (dryRunCount >= threshold) {
+        if (dryRun.rowCount >= threshold) {
           const token = await createPendingModify({
             userId,
-            sqlText: sql,
-            rowCount: dryRunCount,
+            sqlText: sqlWithReturning,
+            rowCount: dryRun.rowCount,
             slackChannel: context?.slackChannel,
             slackThreadTs: context?.slackThreadTs,
           });
 
+          const tableName = extractTargetTable(sql);
+
           try {
             await confirmCardSender({
               token,
-              sql,
-              rowCount: dryRunCount,
+              operation: keyword,
+              tableName,
+              rowCount: dryRun.rowCount,
+              rows: dryRun.rows,
               context: { userId, ...context },
             });
           } catch (err: unknown) {
             console.error('[SQL Tools] confirm card 전송 실패:', err);
           }
 
-          logSQLExecution('modify_db', sql, { error: `confirm pending (${dryRunCount} rows)` });
+          logSQLExecution('modify_db', sql, { error: `confirm pending (${dryRun.rowCount} rows)` });
           return JSON.stringify({
             pending: true,
-            rowCount: dryRunCount,
-            message: `${dryRunCount}개 행이 변경될 예정이야. Slack 확인 카드에서 실행/취소해줘.`,
+            rowCount: dryRun.rowCount,
+            message: `${dryRun.rowCount}개 행이 변경될 예정이야. Slack 확인 카드에서 실행/취소해줘.`,
           });
         }
       }

--- a/src/shared/sql-tools.ts
+++ b/src/shared/sql-tools.ts
@@ -1,5 +1,5 @@
 import type { LLMToolDefinition } from './llm.js';
-import { query, queryWithClient, queryWithRowLimit, dryRunRowCount } from './db.js';
+import { query, queryWithClient, queryWithRowLimit, dryRunQuery } from './db.js';
 import { createPendingModify } from './pending-modify.js';
 
 // ---- 상수 ----
@@ -379,7 +379,8 @@ export const executeSQLTool = async (
         const threshold = Number(process.env['MODIFY_CONFIRM_THRESHOLD'] ?? 3);
         let dryRunCount: number;
         try {
-          dryRunCount = await dryRunRowCount(sql, SQL_TIMEOUT_MS);
+          const dryRun = await dryRunQuery(sql, SQL_TIMEOUT_MS);
+          dryRunCount = dryRun.rowCount;
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
           logSQLExecution('modify_db', sql, { error: `dry-run 실패: ${msg}` });


### PR DESCRIPTION
## 관련 이슈
Closes #344

## 변경 내용

modify_db 대량 변경 확인 플로우(ADR-0006)의 후속 UX 개선.

### (1) 확인 카드에 영향 레코드 실제 데이터 표시
- SQL 쿼리 텍스트 블록 제거 → 테이블별 포맷터로 주요 필드 표시
- schedules: `• 2026-04-23  아침 운동` 형태 (날짜 + 제목)
- sleep_records / routine / reminders / custom_instructions / fallback 각각 분기
- RETURNING 없는 SQL은 `ensureReturningClause`로 자동 삽입 후 dry-run
- Block Kit 한도 대응: 2800자 기준 section block 다중 분할

### (2) 승인 후 schedules 자동 재조회
- 실행 시 RETURNING 결과의 날짜를 집계해 날짜별 재조회 메시지 1회씩 전송
- date=NULL(백로그)도 별도 메시지
- 재조회 실패는 로그만 남기고 완료 흐름 유지

schedules 외 테이블은 기존 완료 메시지 유지 (도메인별 B안).

## 설계 판단 (계획서: `.claude/plans/344-modify-confirm-ux.md`)
- LLM agent-loop 재개(C안)는 복잡도/비용 대비 효용 낮아 배제 — ADR-0006의 기각 근거 유지
- 도메인별 고정 후처리 재조회(B안) 선택
- 같은 Decision의 세부 확장이라 ADR 추가 없음

## 코드 리뷰 결과
- [x] 보안 감사 통과 (SQL Injection/크리덴셜/any 금지)
- [x] 타입 안전성 확인
- [x] 컨벤션 점검 완료
- [x] 코드 품질 확인

## 테스트
- [x] `ensureReturningClause`: 3케이스 (없음/있음/세미콜론 끝)
- [x] `extractTargetTable`: DELETE/UPDATE/INSERT/JOIN/대소문자
- [x] `buildConfirmModifyCard`: 빈 rows / schedules 포맷 / 기간 일정 / 백로그 / fallback / section 분할
- [x] sender 새 시그니처(operation/tableName/rows) 검증
- [x] 전체 vitest 356개 통과