### PR TITLE
fix(ops): DB 백업 로그 디렉토리를 홈 하위로 이동

### DIFF
--- a/docs/operations/db-backup.md
+++ b/docs/operations/db-backup.md
@@ -55,14 +55,7 @@ rclone lsf r2:slack-ai-agents-backup
 echo "R2_REMOTE=r2:slack-ai-agents-backup" >> ~/slack-ai-agents/.env
 ```
 
-### 1.5 로그 디렉토리 권한 설정
-
-```bash
-sudo mkdir -p /var/log/slack-ai-agents
-sudo chown ubuntu:ubuntu /var/log/slack-ai-agents
-```
-
-### 1.6 스크립트 실행 권한 부여
+### 1.5 스크립트 실행 권한 부여
 
 ```bash
 chmod +x ~/slack-ai-agents/scripts/backup-db.sh
@@ -78,7 +71,7 @@ chmod +x ~/slack-ai-agents/scripts/restore-db.sh
 ```bash
 cd ~/slack-ai-agents
 ./scripts/backup-db.sh
-tail -20 /var/log/slack-ai-agents/backup.log
+tail -20 ~/.local/log/slack-ai-agents/backup.log
 rclone lsf r2:slack-ai-agents-backup/daily/
 ```
 
@@ -136,7 +129,7 @@ docker rm -f test-restore
 
 | 증상 | 원인 / 해결 |
 |------|------------|
-| Slack 알림 없는데 백업 누락 | crontab 미등록 확인 `crontab -l` / `/var/log/slack-ai-agents/backup.log` 권한 문제 |
+| Slack 알림 없는데 백업 누락 | crontab 미등록 확인 `crontab -l` / `~/.local/log/slack-ai-agents/backup.log` 확인 |
 | `R2_REMOTE 필요` 에러 | `.env`에 `R2_REMOTE` 항목 누락 |
 | `permission denied` on script | `chmod +x scripts/backup-db.sh` |
 | dump 파일 너무 작음 에러 | DB 컨테이너 다운 상태 확인 `docker ps` / pg 권한 문제 |

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -12,7 +12,7 @@ if [ -f "$REPO_DIR/.env" ]; then
   set -a; . "$REPO_DIR/.env"; set +a
 fi
 
-LOG_DIR="${LOG_DIR:-/var/log/slack-ai-agents}"
+LOG_DIR="${LOG_DIR:-$HOME/.local/log/slack-ai-agents}"
 LOG_FILE="$LOG_DIR/backup.log"
 
 : "${POSTGRES_USER:?POSTGRES_USER 필요}"


### PR DESCRIPTION
## Summary
- `scripts/backup-db.sh`의 LOG_DIR 기본값을 `/var/log/slack-ai-agents` → `$HOME/.local/log/slack-ai-agents`로 변경
- 셋업 문서의 `sudo mkdir` + `chown` 단계 제거 (스크립트가 `mkdir -p`로 자동 생성)

## Why
기존 기본값은 루트 권한이 필요해서 사전 셋업이 빠지면 `mkdir -p` 단계에서 `set -e`로 종료됨. 종료 지점이 `notify_failure` 호출보다 앞이라 실패 알림도 못 보내고 조용히 죽는 구조였음.

## Test plan
- [ ] 머지 후 VM `git pull` → `./scripts/backup-db.sh` 수동 실행
- [ ] `~/.local/log/slack-ai-agents/backup.log` 생성 확인
- [ ] R2에 `daily/$(date +%Y-%m-%d).dump` 업로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)