### PR TITLE
fix(life): 일정 삭제 hard delete + 실행 완료 후 줄글 표시

### DIFF
--- a/src/agents/life/blocks.ts
+++ b/src/agents/life/blocks.ts
@@ -444,6 +444,31 @@ const buildBacklogOverflowOptions = (
   },
 ];
 
+/**
+ * 일정 목록을 줄글(단일 mrkdwn 문자열)로 변환.
+ * 프롬프트의 "일정 표시 포맷" 스펙과 동일. 카테고리 헤더 사이 빈 줄.
+ */
+export const formatSchedulesAsText = (
+  items: ScheduleRow[],
+  targetDate: string,
+  options?: { backlog?: boolean },
+): string => {
+  const backlog = options?.backlog ?? false;
+  const formatted = backlog ? '' : formatDateShort(targetDate);
+  const headerLabel = backlog ? `백로그 (${items.length}건)` : `${formatted} 일정`;
+
+  const groups = groupByCategory(items);
+  const sections: string[] = [];
+  for (const group of groups) {
+    const lines = [`*[${group.category}]*`];
+    for (const item of group.items) lines.push(formatScheduleTitle(item));
+    sections.push(lines.join('\n'));
+  }
+
+  if (sections.length === 0) return `*${headerLabel}*\n없음`;
+  return `*${headerLabel}*\n\n${sections.join('\n\n')}`;
+};
+
 /** 일정 목록 Block Kit 빌드 (카테고리별 그룹핑 + overflow 메뉴) */
 export const buildScheduleBlocks = (
   items: ScheduleRow[],

--- a/src/agents/life/prompt.ts
+++ b/src/agents/life/prompt.ts
@@ -152,6 +152,8 @@ ORDER BY CASE WHEN c.type = 'event' THEN 0 ELSE 1 END, s.category NULLS LAST, CA
 - 메모: schedules.memo. "메모 추가" → UPDATE, "메모 삭제" → NULL. 원문 그대로 저장. 단, 응답에 메모 내용은 표시하지 마.
 - 변경 후: 해당 날짜 전체 일정을 3대 필수 규칙으로 조회해서 보여줘. 잔소리 한 문장.
 - 백로그: date IS NULL인 일정. 표시 포맷 동일, 날짜 범위 없음.
+- **삭제: DELETE 실행.** "삭제", "지워", "없애" 요청은 DELETE FROM schedules로 처리. UPDATE status='cancelled' 금지 — soft delete 안 씀.
+- status='cancelled'는 사용자가 명시적으로 "취소"라고 말했을 때만 사용 (예: "그 약속 취소됐어"). 삭제와 취소는 다른 행동.
 
 ## 수면 기록
 

--- a/src/shared/pending-display.ts
+++ b/src/shared/pending-display.ts
@@ -16,6 +16,7 @@ import {
   buildScheduleBlocks,
   buildRoutineBlocks,
   buildSleepBlocks,
+  formatSchedulesAsText,
 } from '../agents/life/blocks.js';
 import { getTodayISO } from './kst.js';
 import { query } from './db.js';
@@ -166,12 +167,16 @@ export const loadCurrentStateBlocks = async (
     case 'schedules': {
       const hasBacklog = ctx.affectedDates?.some((d) => !d) ?? false;
       const targetDate = ctx.affectedDates?.find((d) => !!d) ?? today;
-      if (hasBacklog) {
-        const items = await queryBacklogSchedules(ctx.userId);
-        return buildScheduleBlocks(items, 'backlog', undefined, { backlog: true });
-      }
-      const items = await queryTodaySchedules(targetDate, ctx.userId);
-      return buildScheduleBlocks(items, targetDate);
+      const items = hasBacklog
+        ? await queryBacklogSchedules(ctx.userId)
+        : await queryTodaySchedules(targetDate, ctx.userId);
+      const text = formatSchedulesAsText(items, hasBacklog ? 'backlog' : targetDate, {
+        backlog: hasBacklog,
+      });
+      return {
+        text,
+        blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }],
+      };
     }
     case 'routine_records': {
       const targetDate = ctx.affectedDates?.[0] ?? today;

--- a/src/shared/pending-display.ts
+++ b/src/shared/pending-display.ts
@@ -13,7 +13,6 @@ import {
   querySleepEventsForHome,
 } from './life-queries.js';
 import {
-  buildScheduleBlocks,
   buildRoutineBlocks,
   buildSleepBlocks,
   formatSchedulesAsText,


### PR DESCRIPTION
## 변경 내용

### 1) 일정 삭제 = hard DELETE (soft delete 제거)
기존: LLM이 "삭제" 요청을 받으면 `UPDATE status='cancelled'`로 처리해 웹 대시보드에 잔존.

프롬프트에 명시적 규칙 추가:
- 삭제/지워/없애 → DELETE FROM
- status='cancelled' UPDATE 금지
- 'cancelled' 상태는 사용자가 명시적으로 "취소"라고 할 때만 사용 (삭제와 취소는 다른 행동)

### 2) 실행 완료 후 줄글 표시
기존: `loadCurrentStateBlocks`가 `buildScheduleBlocks`를 호출해 카테고리별 섹션 블록으로 표시.
변경: `formatSchedulesAsText`로 단일 mrkdwn 텍스트 생성. 프롬프트의 "일정 표시 포맷" 스펙과 동일한 줄글.

## 테스트
- [x] 365개 기존 테스트 통과
- [x] 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)