### PR TITLE
docs: README·아키텍처 SVG·운영 문서 정합성 정비

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ LLM이 SQL을 직접 쓰는 구조는 강력하지만 할루시네이션·비용
 - **Custom Skills**: `/init-project`, `/design`, `/build` — 계획서 파일로 세션 간 핸드오프
 - **MCP**: PostgreSQL(운영 DB 조회), Slack(에이전트 응답 품질 점검)
 - **Scheduled Tasks (비동기 깊은 분석 전용)**:
-  - `nightly-dev-report` (매일 22:00): Opus가 당일 git 활동·대화 이력을 분석 → [developer-profile.md](docs/developer-profile.md)에 관찰 메모 자동 축적 → 다음 날 09:25/09:30 Slack 예약 전송
+  - `nightly-dev-report` (매일 22:00): Opus가 당일 git 활동·대화 이력을 분석 → 로컬 문서에 관찰 메모 자동 축적 → 다음 날 09:25/09:30 Slack으로 예약 전송, 매일 피드백 수신
   - `weekly-saju-review` (일요일 21:31): 최근 4주 일기 × 일운 × 수면 상관 분석 → 사주 패턴 감지/업데이트
   - `weekly-fortune` (일요일 22:37): 7일 일운 + 월운/세운/대운 자동 갱신
   - `nightly-achievements` (매일 23:30): 오늘 해낸 일 3가지 + 일운 코멘트 응원 메시지 — 바쁘게 보낸 날에도 "아무것도 안 한 것 같은" 불안감 극복용
@@ -102,8 +102,6 @@ AI를 "코딩 보조"가 아니라 **협업 개발자**로 취급하고, 작업 
 일정·루틴·수면·일기를 자연어 대화만으로 기록·조회·수정. 하루 2회 크론 알림 + 프로액티브 인사이트 + 생활 맥락 기반 잔소리. 스마트 메모리로 사용자 선호를 자동 학습.
 
 **수면 기록 워크플로우** — 아침에 봇이 기록 알림 → 슬랙에 자연어로 입력(취침시간·기상시간·중간기상·메모) → 자동 파싱·저장 → 웹 대시보드에서 시각화 + 규칙성 점수 → 수면 부족한 날 루틴 달성률·일정 소화율 하락 상관 분석 → 잔소리 근거로 재활용
-
-<img src="docs/images/01-conversation.png" width="49%" />
 
 ### 일기 × 개인 프로파일 맥락 자동 연결
 
@@ -246,4 +244,3 @@ docker compose down             # 전체 정지 (볼륨은 유지 → 데이터 
 | [docs/optimization/](docs/optimization/) | 최적화 기록 — LLM 비용, 응답 속도, 배포 파이프라인, 의도 분류 제거 회고 |
 | [docs/ops/db-backup.md](docs/ops/db-backup.md) | DB 백업/복원 운영 가이드 |
 | [docs/ops/health-monitoring.md](docs/ops/health-monitoring.md) | 업타임 모니터링 운영 가이드 (GitHub Actions 기반) |
-| [docs/developer-profile.md](docs/developer-profile.md) | AI가 분석한 개발자 성향 프로필 (gitignored) |

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -1,21 +1,24 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 460" font-family="'Pretendard', 'Apple SD Gothic Neo', 'Noto Sans KR', -apple-system, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="'Pretendard', 'Apple SD Gothic Neo', 'Noto Sans KR', -apple-system, sans-serif">
   <defs>
     <filter id="shadow" x="-4%" y="-4%" width="108%" height="108%">
       <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.08"/>
     </filter>
-    <marker id="arrow" markerWidth="6" markerHeight="5" refX="5" refY="2.5" orient="auto">
-      <path d="M0,0 L5,2.5 L0,5 Z" fill="#6366f1"/>
+    <marker id="arrow" markerWidth="4" markerHeight="3" refX="4" refY="1.5" orient="auto">
+      <path d="M0,0 L4,1.5 L0,3 Z" fill="#6366f1"/>
     </marker>
-    <marker id="arrowGreen" markerWidth="6" markerHeight="5" refX="5" refY="2.5" orient="auto">
-      <path d="M0,0 L5,2.5 L0,5 Z" fill="#10b981"/>
+    <marker id="arrowGreen" markerWidth="4" markerHeight="3" refX="4" refY="1.5" orient="auto">
+      <path d="M0,0 L4,1.5 L0,3 Z" fill="#10b981"/>
     </marker>
-    <marker id="arrowGray" markerWidth="6" markerHeight="5" refX="5" refY="2.5" orient="auto">
-      <path d="M0,0 L5,2.5 L0,5 Z" fill="#94a3b8"/>
+    <marker id="arrowGray" markerWidth="4" markerHeight="3" refX="4" refY="1.5" orient="auto">
+      <path d="M0,0 L4,1.5 L0,3 Z" fill="#94a3b8"/>
+    </marker>
+    <marker id="arrowPink" markerWidth="4" markerHeight="3" refX="4" refY="1.5" orient="auto">
+      <path d="M0,0 L4,1.5 L0,3 Z" fill="#be185d"/>
     </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="960" height="460" fill="#f8fafc"/>
+  <rect width="960" height="540" fill="#f8fafc"/>
 
   <!-- Title -->
   <text x="480" y="30" text-anchor="middle" fill="#334155" font-size="14" font-weight="700">Slack AI Agent — 자연어로 라이프 데이터를 다루는 에이전트</text>
@@ -31,11 +34,11 @@
     <rect x="40" y="80" width="240" height="38" rx="12" fill="#611f69"/>
     <rect x="40" y="106" width="240" height="12" fill="#611f69"/>
     <text x="60" y="106" fill="#ffffff" font-size="14" font-weight="700">Slack</text>
-    <text x="230" y="106" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.8">Socket Mode</text>
+    <text x="260" y="106" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.85">Socket Mode</text>
   </g>
   <text x="60" y="142" fill="#475569" font-size="12">자연어 대화 · 크론 알림</text>
   <text x="60" y="162" fill="#475569" font-size="12">체크리스트 · App Home</text>
-  <text x="60" y="182" fill="#475569" font-size="12">인사이트 넛지</text>
+  <text x="60" y="182" fill="#475569" font-size="12">프로액티브 인사이트</text>
 
   <!-- ===== Web (Vercel) card ===== -->
   <g filter="url(#shadow)">
@@ -43,79 +46,109 @@
     <rect x="40" y="230" width="240" height="38" rx="12" fill="#171717"/>
     <rect x="40" y="256" width="240" height="12" fill="#171717"/>
     <text x="60" y="256" fill="#ffffff" font-size="14" font-weight="700">Web</text>
-    <text x="230" y="256" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.8">Vercel · Next.js</text>
+    <text x="260" y="256" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.85">Vercel · Next.js</text>
   </g>
   <text x="60" y="292" fill="#475569" font-size="12">캘린더 · 백로그 · 루틴</text>
-  <text x="60" y="312" fill="#475569" font-size="12">지출 · 카테고리 · DnD</text>
+  <text x="60" y="312" fill="#475569" font-size="12">지출 · 수면 기록</text>
 
   <!-- ===== Oracle Cloud VM (center) ===== -->
   <g>
-    <rect x="310" y="76" width="340" height="320" rx="14" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5" stroke-dasharray="6,4"/>
+    <rect x="310" y="76" width="340" height="400" rx="14" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5" stroke-dasharray="6,4"/>
   </g>
+
+  <!-- Caddy (호스트 레이어, Docker 바깥) -->
+  <g filter="url(#shadow)">
+    <rect x="326" y="94" width="308" height="44" rx="10" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  </g>
+  <text x="342" y="114" fill="#065f46" font-size="12" font-weight="700">Caddy (호스트 서비스)</text>
+  <text x="618" y="114" text-anchor="end" fill="#047857" font-size="10" font-weight="600">자동 TLS · :443</text>
+  <text x="342" y="130" fill="#475569" font-size="10">외부 트래픽 입구 — TLS 종료 후 내부로만 라우팅</text>
+
+  <!-- DOCKER 영역 라벨 -->
+  <text x="326" y="158" fill="#94a3b8" font-size="9" font-weight="700" letter-spacing="2">DOCKER COMPOSE</text>
 
   <!-- Slack Bolt App -->
   <g filter="url(#shadow)">
-    <rect x="334" y="100" width="292" height="120" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+    <rect x="326" y="165" width="308" height="158" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
   </g>
-  <text x="354" y="126" fill="#1e3a8a" font-size="13" font-weight="700">Slack Bolt App</text>
-  <text x="354" y="148" fill="#475569" font-size="11">• Agent Loop — LLM ↔ SQL 도구 자율 반복</text>
-  <text x="354" y="167" fill="#475569" font-size="11">• node-cron — 아침/밤/주간 알림 (KST)</text>
-  <text x="354" y="186" fill="#475569" font-size="11">• Fast path — 정규식 → Block Kit (\~1초)</text>
-  <text x="354" y="205" fill="#475569" font-size="11">• Rate Limit · userId 격리 · 인젝션 차단</text>
+  <text x="342" y="188" fill="#1e3a8a" font-size="13" font-weight="700">Slack Bolt App</text>
+  <text x="618" y="188" text-anchor="end" fill="#1e40af" font-size="10" font-weight="600">Node · TS</text>
+  <text x="342" y="210" fill="#475569" font-size="11">• Agent Loop — LLM ↔ SQL 도구 자율 반복</text>
+  <text x="342" y="229" fill="#475569" font-size="11">• Pure SQL 패턴 감지 5종 — streak·sleep·slot…</text>
+  <text x="342" y="248" fill="#475569" font-size="11">• node-cron — 아침/밤/주간 알림 (KST)</text>
+  <text x="342" y="267" fill="#475569" font-size="11">• Fast path — 정규식 → Block Kit (~1초)</text>
+  <text x="342" y="286" fill="#475569" font-size="11">• modify_db 승인 플로우 — dry-run 카드 → 승인</text>
+  <text x="342" y="305" fill="#475569" font-size="11">• Rate Limit · userId 격리 · 인젝션 차단</text>
 
   <!-- DB Proxy API -->
   <g filter="url(#shadow)">
-    <rect x="334" y="240" width="292" height="58" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+    <rect x="326" y="335" width="308" height="62" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
   </g>
-  <text x="354" y="266" fill="#14532d" font-size="13" font-weight="700">DB Proxy API</text>
-  <text x="608" y="266" text-anchor="end" fill="#166534" font-size="10" font-weight="600">:3100 · Bearer</text>
-  <text x="354" y="286" fill="#475569" font-size="11">SQL 화이트리스트 · TLS 종료 (Caddy)</text>
+  <text x="342" y="360" fill="#14532d" font-size="13" font-weight="700">DB Proxy API</text>
+  <text x="618" y="360" text-anchor="end" fill="#166534" font-size="10" font-weight="600">:3100 · Bearer · 루프백 바인딩</text>
+  <text x="342" y="380" fill="#475569" font-size="11">SQL 화이트리스트 · WHERE 필수 · 벌크 50행 제한</text>
 
   <!-- PostgreSQL -->
   <g filter="url(#shadow)">
-    <rect x="334" y="316" width="292" height="58" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+    <rect x="326" y="409" width="308" height="58" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
   </g>
-  <text x="354" y="342" fill="#1e3a8a" font-size="13" font-weight="700">PostgreSQL</text>
-  <text x="608" y="342" text-anchor="end" fill="#1e40af" font-size="10" font-weight="600">내부 전용 · Docker</text>
-  <text x="354" y="362" fill="#475569" font-size="11">일정 · 루틴 · 지출 · 일기 · 사주</text>
+  <text x="342" y="434" fill="#1e3a8a" font-size="13" font-weight="700">PostgreSQL 17</text>
+  <text x="618" y="434" text-anchor="end" fill="#1e40af" font-size="10" font-weight="600">내부 전용 · 포트 미노출</text>
+  <text x="342" y="454" fill="#475569" font-size="11">일정 · 루틴 · 지출 · 일기 · 사주</text>
 
   <!-- VM 내부 수직 연결 (점선) -->
-  <line x1="480" y1="220" x2="480" y2="240" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrowGray)"/>
-  <line x1="480" y1="298" x2="480" y2="316" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrowGray)"/>
+  <line x1="480" y1="323" x2="480" y2="335" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrowGray)"/>
+  <line x1="480" y1="397" x2="480" y2="409" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrowGray)"/>
 
   <!-- ===== Claude Sonnet card ===== -->
   <g filter="url(#shadow)">
-    <rect x="680" y="130" width="240" height="140" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
-    <rect x="680" y="130" width="240" height="38" rx="12" fill="#d97706"/>
-    <rect x="680" y="156" width="240" height="12" fill="#d97706"/>
-    <text x="700" y="156" fill="#ffffff" font-size="14" font-weight="700">Claude Sonnet</text>
-    <text x="910" y="156" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.85">Anthropic API</text>
+    <rect x="680" y="98" width="240" height="140" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+    <rect x="680" y="98" width="240" height="38" rx="12" fill="#d97706"/>
+    <rect x="680" y="124" width="240" height="12" fill="#d97706"/>
+    <text x="700" y="124" fill="#ffffff" font-size="14" font-weight="700">Claude Sonnet</text>
+    <text x="910" y="124" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.85">실시간 대화</text>
   </g>
-  <text x="700" y="192" fill="#475569" font-size="12">자연어 이해 · SQL 생성</text>
-  <text x="700" y="212" fill="#475569" font-size="12">크로스 분석 · 인사이트</text>
-  <text x="700" y="232" fill="#475569" font-size="12">크론/주간 리포트 작성</text>
-  <text x="700" y="256" fill="#b45309" font-size="10" font-weight="600">Tool Use: query_db · modify_db</text>
+  <text x="700" y="160" fill="#475569" font-size="12">자연어 이해 · SQL 생성</text>
+  <text x="700" y="180" fill="#475569" font-size="12">크론 알림 · 인사이트</text>
+  <text x="700" y="200" fill="#475569" font-size="12">프롬프트 캐싱 ephemeral</text>
+  <text x="700" y="224" fill="#b45309" font-size="10" font-weight="600">Tool Use: query_db · modify_db · get_schema</text>
+
+  <!-- ===== Claude Opus card ===== -->
+  <g filter="url(#shadow)">
+    <rect x="680" y="258" width="240" height="130" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+    <rect x="680" y="258" width="240" height="38" rx="12" fill="#be185d"/>
+    <rect x="680" y="284" width="240" height="12" fill="#be185d"/>
+    <text x="700" y="284" fill="#ffffff" font-size="14" font-weight="700">Claude Opus</text>
+    <text x="910" y="284" text-anchor="end" fill="#ffffff" font-size="10" opacity="0.85">비동기 깊은 분석</text>
+  </g>
+  <text x="700" y="320" fill="#475569" font-size="12">주간 사주 패턴 상관 분석</text>
+  <text x="700" y="340" fill="#475569" font-size="12">일간 개발 리포트 (git)</text>
+  <text x="700" y="368" fill="#9d174d" font-size="10" font-weight="600">Scheduled Task · DB 저장 → Slack</text>
 
   <!-- ===== Connections ===== -->
 
   <!-- Slack ↔ Bolt (양방향) -->
-  <line x1="280" y1="135" x2="334" y2="135" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
-  <line x1="334" y1="151" x2="280" y2="151" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="287" y="124" fill="#4338ca" font-size="9" font-weight="600">Socket Mode</text>
+  <line x1="280" y1="135" x2="326" y2="190" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="326" y1="210" x2="280" y2="155" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="284" y="175" fill="#4338ca" font-size="9" font-weight="600" stroke="#f8fafc" stroke-width="3" paint-order="stroke" stroke-linejoin="round">Socket Mode</text>
 
-  <!-- Web → DB Proxy (HTTPS) -->
-  <line x1="280" y1="282" x2="334" y2="269" stroke="#10b981" stroke-width="2" marker-end="url(#arrowGreen)"/>
-  <text x="286" y="258" fill="#059669" font-size="9" font-weight="600">HTTPS</text>
+  <!-- Web → DB Proxy (HTTPS via Caddy) -->
+  <line x1="280" y1="285" x2="326" y2="355" stroke="#10b981" stroke-width="2" marker-end="url(#arrowGreen)"/>
+  <text x="286" y="325" fill="#059669" font-size="9" font-weight="600" stroke="#f8fafc" stroke-width="3" paint-order="stroke" stroke-linejoin="round">HTTPS (Caddy 경유)</text>
 
-  <!-- Bolt ↔ Claude (tool use) -->
-  <line x1="626" y1="158" x2="680" y2="158" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
-  <line x1="680" y1="174" x2="626" y2="174" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="636" y="147" fill="#4338ca" font-size="9" font-weight="600">Tool Use</text>
+  <!-- Bolt ↔ Sonnet (tool use) -->
+  <line x1="634" y1="215" x2="680" y2="170" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="680" y1="190" x2="634" y2="235" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="642" y="180" fill="#4338ca" font-size="9" font-weight="600" stroke="#f8fafc" stroke-width="3" paint-order="stroke" stroke-linejoin="round">Tool Use</text>
+
+  <!-- Opus → PostgreSQL (scheduled task 결과 저장) -->
+  <path d="M 680 345 Q 650 400 634 438" fill="none" stroke="#be185d" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowPink)"/>
+  <text x="676" y="410" text-anchor="end" fill="#9d174d" font-size="9" font-weight="600" stroke="#f8fafc" stroke-width="3" paint-order="stroke" stroke-linejoin="round">분석 결과 저장</text>
 
   <!-- ===== Security Footer ===== -->
   <g>
-    <rect x="40" y="410" width="880" height="32" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
-    <text x="58" y="431" fill="#991b1b" font-size="11" font-weight="700">🛡 보안</text>
-    <text x="108" y="431" fill="#64748b" font-size="11">DB 포트 외부 미노출 · Bearer + 전 구간 TLS · SQL 화이트리스트 · userId 테넌트 격리 · Rate Limit · SQL 감사 로그 · 커밋 전 시크릿 스캔</text>
+    <rect x="40" y="498" width="880" height="32" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+    <text x="58" y="519" fill="#991b1b" font-size="11" font-weight="700">🛡 보안</text>
+    <text x="108" y="519" fill="#64748b" font-size="11">호스트 Caddy TLS 종료 · DB 포트 미노출 · Bearer · SQL 화이트리스트 · modify_db 승인 · userId 격리 · Rate Limit · 감사 로그 · 시크릿 스캔</text>
   </g>
 </svg>

--- a/docs/ops/db-backup.md
+++ b/docs/ops/db-backup.md
@@ -13,7 +13,7 @@
 ### 1.1 Cloudflare R2 버킷 생성
 
 1. Cloudflare 대시보드 → R2 → "Create bucket"
-2. 버킷명: `slack-ai-agents-backup`
+2. 버킷명: `<백업 버킷명>`
 3. R2 → Manage R2 API Tokens → "Create API token"
    - 권한: Object Read & Write
    - 버킷 범위: 위 버킷
@@ -46,13 +46,13 @@ rclone config
 
 ```bash
 rclone lsd r2:
-rclone lsf r2:slack-ai-agents-backup
+rclone lsf r2:<백업 버킷명>
 ```
 
 ### 1.4 .env에 R2_REMOTE 추가
 
 ```bash
-echo "R2_REMOTE=r2:slack-ai-agents-backup" >> ~/slack-ai-agents/.env
+echo "R2_REMOTE=r2:<백업 버킷명>" >> ~/slack-ai-agents/.env
 ```
 
 ### 1.5 스크립트 실행 권한 부여
@@ -72,7 +72,7 @@ chmod +x ~/slack-ai-agents/scripts/restore-db.sh
 cd ~/slack-ai-agents
 ./scripts/backup-db.sh
 tail -20 ~/.local/log/slack-ai-agents/backup.log
-rclone lsf r2:slack-ai-agents-backup/daily/
+rclone lsf r2:<백업 버킷명>/daily/
 ```
 
 ---
@@ -88,7 +88,7 @@ crontab -e
 아래 줄 추가:
 
 ```
-0 19 * * * /home/ubuntu/slack-ai-agents/scripts/backup-db.sh  # UTC 19:00 = KST 04:00
+0 19 * * * ~/slack-ai-agents/scripts/backup-db.sh  # UTC 19:00 = KST 04:00
 ```
 
 등록 확인:
@@ -140,7 +140,7 @@ docker rm -f test-restore
 
 ## 6. 정상 동작 확인 체크리스트 (정기)
 
-- [ ] 매일 R2 버킷에 daily 백업 생성되는지 확인 (`rclone lsf r2:slack-ai-agents-backup/daily/`)
+- [ ] 매일 R2 버킷에 daily 백업 생성되는지 확인 (`rclone lsf r2:<백업 버킷명>/daily/`)
 - [ ] 일요일에 weekly 백업 추가 생성 확인
 - [ ] 14일 이상된 daily 자동 정리 확인
 - [ ] 분기 1회 복원 리허설

--- a/docs/ops/health-monitoring.md
+++ b/docs/ops/health-monitoring.md
@@ -122,8 +122,8 @@ gh workflow run uptime-check.yml
 
 1. Slack `#project` 알림 수신
 2. `/health/detail` 호출해서 컴포넌트별 상태 확인
-   - `db.status: 'error'` → DB 컨테이너 점검 (VM SSH → `docker compose logs db`)
-   - `ok: false` + `db.status: 'ok'` → 봇 프로세스/네트워크 점검 (`docker compose logs app`)
+   - `db.status: 'error'` → DB 컨테이너 로그 점검
+   - `ok: false` + `db.status: 'ok'` → 봇 프로세스/네트워크 로그 점검
    - Vercel `/api/health` 장애 → Vercel 배포 상태 확인
 3. 원인에 따라 복구 → 다음 cron에서 RECOVERY 알림 자동 수신
 


### PR DESCRIPTION
## Summary
- README: 로컬 전용 문서 링크 제거, 무관 이미지 제거, 관련 문서 목록 정리
- 아키텍처 다이어그램을 실제 시스템 구조와 일치시킴
  - AI 영역 2-tier 표기 (Sonnet 실시간 / Opus 비동기 Scheduled Task)
  - Tool Use 목록 보정 (`query_db` · `modify_db` · `get_schema`)
  - Caddy를 호스트 서비스 레이어로 분리 표기
  - Slack Bolt App에 Pure SQL 패턴 감지 5종 · `modify_db` 승인 플로우 추가
  - 화살표 머리 크기 축소 · 라벨 가독성 개선 (stroke 배경)
- 운영 문서 표현 정비 (백업/헬스체크 가이드에서 내부 경로·접근 방식 추상화)

## Test plan
- [ ] README 로컬 렌더링 확인
- [ ] 아키텍처 SVG 렌더링 및 라벨 가독성 확인
- [ ] docs/ops/ 문서 링크 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)