### PR TITLE
fix(budget): daily-budget-log cron에 수동 백필용 ?date 파라미터 추가

### DIFF
--- a/web/src/app/api/cron/daily-budget-log/route.ts
+++ b/web/src/app/api/cron/daily-budget-log/route.ts
@@ -14,8 +14,13 @@ export async function GET(request: Request) {
   }
 
   try {
-    // Vercel cron 드리프트 방어: 발화 시각에서 1시간 버퍼를 차감한 KST 날짜로 저장
-    const targetDate = resolveSnapshotDate(new Date());
+    // Vercel cron 드리프트 방어: 발화 시각에서 1시간 버퍼를 차감한 KST 날짜로 저장.
+    // 크론 누락 시 수동 백필 용도로 ?date=YYYY-MM-DD override 허용.
+    const dateParam = new URL(request.url).searchParams.get('date');
+    const targetDate =
+      dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam)
+        ? dateParam
+        : resolveSnapshotDate(new Date());
     const userIds = await listAllUserIds();
 
     const results = await Promise.all(


### PR DESCRIPTION
## Summary
- Vercel cron 단발성 누락이 발생했을 때 수동 재실행할 수 있는 경로가 없었음 (DB 직접 조작이 필요했음)
- `/api/cron/daily-budget-log`에 `?date=YYYY-MM-DD` 쿼리 파라미터 지원 추가
- 파라미터 없으면 기존 `resolveSnapshotDate` 경로 그대로 → 기존 cron 동작 완전 동일
- 인증은 기존 `CRON_SECRET` 헤더 재사용
- `saveDailyBudgetLog`는 이미 `targetDate` 옵션을 받도록 되어 있어 최소 변경

## Test plan
- [ ] 타입체크 통과 확인
- [ ] 파라미터 없이 호출 시 기존 동작 유지 (오늘 날짜 기록)
- [ ] `?date=2026-04-23`로 호출 시 해당 날짜로 로그 기록
- [ ] `daily_budget_logs` 테이블에 날짜별 row가 존재하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)