### PR TITLE
fix(ops): DB 백업 파일명을 KST 기준으로 통일

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+# 파일명/요일 판정을 KST 기준으로 (VM TZ=UTC라 그대로 두면 하루 밀려 혼동)
+export TZ=Asia/Seoul
+
 REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # .env 로드 (POSTGRES_USER, POSTGRES_DB, R2_REMOTE, SLACK_BOT_TOKEN, PROJECT_CHANNEL_ID, LOG_DIR)


### PR DESCRIPTION
## Summary
- `scripts/backup-db.sh` 상단에 `export TZ=Asia/Seoul` 추가
- VM TZ=UTC 환경에서 KST 04:00 크론 실행 시 `DATE`가 전날 UTC 날짜로 계산되던 문제 해결
- 이후 모든 daily/weekly 파일명·요일 판정이 KST 기준으로 통일

## Context
- 크론 스케줄(UTC 19:00 = KST 04:00)은 그대로 유지
- `restore-db.sh`는 인자로 받은 날짜를 그대로 사용하므로 영향 없음
- weekly 복사 시점은 KST 일요일 04:00로 이동 (7일 주기 보장은 동일)

## Test plan
- [ ] main 머지 후 GitHub Actions Deploy 워크플로우 성공 확인
- [ ] 다음 KST 04:00 크론 실행 후 R2 `daily/YYYY-MM-DD.dump`가 실행일 KST 날짜로 저장됐는지 확인
- [ ] `backup.log`에 `=== backup ok ===` 정상 기록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)