### PR TITLE
perf(web): DB 쿼리 N+1 패턴 3곳을 일괄 쿼리로 개선

### DIFF
--- a/web/src/features/budget/lib/__tests__/ensure-fixed-cost-expenses.test.ts
+++ b/web/src/features/budget/lib/__tests__/ensure-fixed-cost-expenses.test.ts
@@ -37,6 +37,7 @@ describe('ensureFixedCostExpenses', () => {
     vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
+    expect(query).toHaveBeenCalledTimes(1); // SELECT만
     expect(queryOne).not.toHaveBeenCalled();
   });
 
@@ -46,7 +47,7 @@ describe('ensureFixedCostExpenses', () => {
     } as Any);
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
-    expect(queryOne).not.toHaveBeenCalled();
+    expect(query).toHaveBeenCalledTimes(1);
   });
 
   it('active=false 고정비는 skip', async () => {
@@ -55,7 +56,7 @@ describe('ensureFixedCostExpenses', () => {
     } as Any);
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
-    expect(queryOne).not.toHaveBeenCalled();
+    expect(query).toHaveBeenCalledTimes(1);
   });
 
   it('결제일이 오늘 이후 → skip (아직 안 지났음)', async () => {
@@ -65,69 +66,70 @@ describe('ensureFixedCostExpenses', () => {
     } as Any);
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
-    expect(queryOne).not.toHaveBeenCalled();
+    expect(query).toHaveBeenCalledTimes(1);
   });
 
   it('이미 같은 날짜에 기록된 고정비는 skip (idempotent)', async () => {
-    vi.mocked(query).mockResolvedValueOnce({
-      rows: [{ ...baseFC, name: 'netflix', day_of_month: 10 }],
-    } as Any);
-    vi.mocked(queryOne).mockResolvedValueOnce({ id: 99 } as Any); // existing
+    vi.mocked(query)
+      .mockResolvedValueOnce({
+        rows: [{ ...baseFC, name: 'netflix', day_of_month: 10 }],
+      } as Any)
+      .mockResolvedValueOnce({ rowCount: 0 } as Any); // NOT EXISTS가 전부 필터
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
-    expect(queryOne).toHaveBeenCalledTimes(1); // INSERT 호출 X
+    expect(query).toHaveBeenCalledTimes(2);
+    const insertCall = vi.mocked(query).mock.calls[1];
+    expect(insertCall[0]).toMatch(/NOT EXISTS/);
   });
 
   it('결제일 16일 이상 → 전월로 기록 (결제주기 반영)', async () => {
     vi.mocked(getTodayISO).mockReturnValue('2026-04-10');
-    vi.mocked(query).mockResolvedValueOnce({
-      rows: [{ ...baseFC, name: 'rent', day_of_month: 20 }],
-    } as Any);
-    vi.mocked(queryOne)
-      .mockResolvedValueOnce(null) // existing check
-      .mockResolvedValueOnce({ id: 100 } as Any); // insert
+    vi.mocked(query)
+      .mockResolvedValueOnce({
+        rows: [{ ...baseFC, name: 'rent', day_of_month: 20 }],
+      } as Any)
+      .mockResolvedValueOnce({ rowCount: 1 } as Any);
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(1);
-    // existing check: 2026-03-20 (전월로 이동)
-    expect(queryOne).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('SELECT id FROM expenses'),
-      [1, '2026-03-20', 'rent'],
-    );
+    // INSERT 파라미터의 date 배열이 '2026-03-20' 을 포함 (전월로 이동)
+    const params = vi.mocked(query).mock.calls[1][1] as Any[];
+    expect(params[0]).toBe(1); // userId
+    expect(params[1]).toEqual(['2026-03-20']); // date 배열
+    expect(params[4]).toEqual(['rent']); // description 배열
   });
 
   it('INSERT 시 exclude_from_budget=true + source=fixed 로 저장', async () => {
     vi.mocked(getTodayISO).mockReturnValue('2026-04-15');
-    vi.mocked(query).mockResolvedValueOnce({
-      rows: [{ ...baseFC, name: '건보', day_of_month: 5 }],
-    } as Any);
-    vi.mocked(queryOne)
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({ id: 200 } as Any);
+    vi.mocked(query)
+      .mockResolvedValueOnce({
+        rows: [{ ...baseFC, name: '건보', day_of_month: 5 }],
+      } as Any)
+      .mockResolvedValueOnce({ rowCount: 1 } as Any);
 
     await ensureFixedCostExpenses(1, '2026-04');
-    const insertCall = vi.mocked(queryOne).mock.calls[1];
+    const insertCall = vi.mocked(query).mock.calls[1];
     expect(insertCall[0]).toMatch(/INSERT INTO expenses/);
     expect(insertCall[0]).toMatch(/'fixed'/);
-    expect(insertCall[0]).toMatch(/exclude_from_budget.*true|true.*\)/i);
+    expect(insertCall[0]).toMatch(/true/); // exclude_from_budget 리터럴
   });
 
   it('여러 고정비 혼합 — created count 정확', async () => {
     vi.mocked(getTodayISO).mockReturnValue('2026-04-15');
-    vi.mocked(query).mockResolvedValueOnce({
-      rows: [
-        { ...baseFC, id: 1, name: 'a', day_of_month: 5 },           // 2026-04-05 ← 기록 대상
-        { ...baseFC, id: 2, name: 'b', day_of_month: null },        // skip
-        { ...baseFC, id: 3, name: 'c', day_of_month: 25, active: false }, // skip
-        { ...baseFC, id: 4, name: 'd', day_of_month: 18 },          // 2026-03-18 ← 이미 존재
-      ],
-    } as Any);
-    vi.mocked(queryOne)
-      .mockResolvedValueOnce(null)                  // a: existing → null
-      .mockResolvedValueOnce({ id: 101 } as Any)    // a: insert
-      .mockResolvedValueOnce({ id: 50 } as Any);    // d: existing → 있음 (skip)
+    vi.mocked(query)
+      .mockResolvedValueOnce({
+        rows: [
+          { ...baseFC, id: 1, name: 'a', day_of_month: 5 }, // 2026-04-05 ← 기록 대상
+          { ...baseFC, id: 2, name: 'b', day_of_month: null }, // skip
+          { ...baseFC, id: 3, name: 'c', day_of_month: 25, active: false }, // skip
+          { ...baseFC, id: 4, name: 'd', day_of_month: 18 }, // 2026-03-18 ← 이미 존재
+        ],
+      } as Any)
+      .mockResolvedValueOnce({ rowCount: 1 } as Any); // NOT EXISTS로 d는 필터, a만 INSERT
 
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(1);
+    // INSERT 대상 후보는 a, d (필터 통과) — 배열 길이 2
+    const params = vi.mocked(query).mock.calls[1][1] as Any[];
+    expect(params[1]).toHaveLength(2);
   });
 });

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -196,7 +196,18 @@ export async function createInstallmentExpenses(
 }
 
 /** 지출 수정 (허용 컬럼 화이트리스트) */
-const EXPENSE_COLUMNS = new Set(['date', 'amount', 'category', 'description', 'payment_method', 'memo', 'type', 'planned_expense_id', 'exclude_from_budget', 'distribute_to_budget']);
+const EXPENSE_COLUMNS = new Set([
+  'date',
+  'amount',
+  'category',
+  'description',
+  'payment_method',
+  'memo',
+  'type',
+  'planned_expense_id',
+  'exclude_from_budget',
+  'distribute_to_budget',
+]);
 
 export async function updateExpense(
   userId: number,
@@ -350,7 +361,15 @@ export async function queryFixedCosts(userId: number): Promise<FixedCostRow[]> {
 }
 
 /** 고정비 수정 */
-const FIXED_COST_COLUMNS = new Set(['name', 'amount', 'category', 'is_variable', 'day_of_month', 'active', 'memo']);
+const FIXED_COST_COLUMNS = new Set([
+  'name',
+  'amount',
+  'category',
+  'is_variable',
+  'day_of_month',
+  'active',
+  'memo',
+]);
 
 export async function updateFixedCost(
   userId: number,
@@ -387,10 +406,10 @@ export async function createFixedCost(
 
 /** 고정비 삭제 */
 export async function deleteFixedCost(userId: number, id: number): Promise<boolean> {
-  const result = await query(
-    `DELETE FROM fixed_costs WHERE id = $1 AND user_id = $2`,
-    [id, userId],
-  );
+  const result = await query(`DELETE FROM fixed_costs WHERE id = $1 AND user_id = $2`, [
+    id,
+    userId,
+  ]);
   return (result.rowCount ?? 0) > 0;
 }
 
@@ -406,32 +425,42 @@ export async function ensureFixedCostExpenses(userId: number, yearMonth: string)
 
   const todayStr = getTodayISO();
 
-  let created = 0;
+  const candidates = activeCostsWithDay
+    .map((fc) => {
+      const expenseDate = resolveFixedCostExpenseDate(yearMonth, fc.day_of_month!);
+      return { fc, expenseDate };
+    })
+    .filter((c) => c.expenseDate <= todayStr)
+    .map((c) => ({
+      ...c,
+      billingMonth: getBillingMonthForExpense(c.expenseDate, '현대카드'),
+    }));
 
-  for (const fc of activeCostsWithDay) {
-    const expenseDate = resolveFixedCostExpenseDate(yearMonth, fc.day_of_month!);
+  if (candidates.length === 0) return 0;
 
-    if (expenseDate > todayStr) continue;
+  const result = await query(
+    `INSERT INTO expenses
+       (user_id, date, amount, category, description, payment_method, source, memo, type, exclude_from_budget, billing_month)
+     SELECT $1, d.date, d.amount, d.category, d.description, '현대카드', 'fixed', d.memo, 'expense', true, d.billing_month
+     FROM UNNEST(
+       $2::date[], $3::numeric[], $4::text[], $5::text[], $6::text[], $7::text[]
+     ) AS d(date, amount, category, description, memo, billing_month)
+     WHERE NOT EXISTS (
+       SELECT 1 FROM expenses e
+       WHERE e.user_id = $1 AND e.source = 'fixed' AND e.date = d.date AND e.description = d.description
+     )`,
+    [
+      userId,
+      candidates.map((c) => c.expenseDate),
+      candidates.map((c) => c.fc.amount),
+      candidates.map((c) => c.fc.category ?? '기타'),
+      candidates.map((c) => c.fc.name),
+      candidates.map((c) => `고정비 자동 기록 (fixed_cost_id: ${c.fc.id})`),
+      candidates.map((c) => c.billingMonth),
+    ],
+  );
 
-    const existing = await queryOne<{ id: number }>(
-      `SELECT id FROM expenses
-       WHERE user_id = $1 AND source = 'fixed' AND date = $2 AND description = $3`,
-      [userId, expenseDate, fc.name],
-    );
-
-    if (existing) continue;
-
-    const fixedBillingMonth = getBillingMonthForExpense(expenseDate, '현대카드');
-    await queryOne(
-      `INSERT INTO expenses (user_id, date, amount, category, description, payment_method, source, memo, type, exclude_from_budget, billing_month)
-       VALUES ($1, $2, $3, $4, $5, '현대카드', 'fixed', $6, 'expense', true, $7)
-       RETURNING id`,
-      [userId, expenseDate, fc.amount, fc.category ?? '기타', fc.name, `고정비 자동 기록 (fixed_cost_id: ${fc.id})`, fixedBillingMonth],
-    );
-    created++;
-  }
-
-  return created;
+  return result.rowCount ?? 0;
 }
 
 // ─── 자산 ─────────────────────────────────────────────
@@ -467,7 +496,10 @@ export async function updateAsset(
 // ─── 예정 지출 ────────────────────────────────────────
 
 /** 예정 지출 목록 조회 (사용 금액 포함) */
-export async function queryPlannedExpenses(userId: number, yearMonth?: string): Promise<PlannedExpenseRow[]> {
+export async function queryPlannedExpenses(
+  userId: number,
+  yearMonth?: string,
+): Promise<PlannedExpenseRow[]> {
   const condition = yearMonth ? 'AND p.year_month = $2' : '';
   const params: unknown[] = yearMonth ? [userId, yearMonth] : [userId];
   const { rows } = await query<PlannedExpenseRow>(
@@ -525,20 +557,20 @@ export async function updatePlannedExpense(
 
 /** 예정 지출 삭제 */
 export async function deletePlannedExpense(userId: number, id: number): Promise<boolean> {
-  const result = await query(
-    'DELETE FROM planned_expenses WHERE id = $1 AND user_id = $2',
-    [id, userId],
-  );
+  const result = await query('DELETE FROM planned_expenses WHERE id = $1 AND user_id = $2', [
+    id,
+    userId,
+  ]);
   return (result.rowCount ?? 0) > 0;
 }
 
 // ─── 가용자금 실시간 계산 ────────────────────────────────
 
 interface EffectiveAvailable {
-  snapshot_total: number;  // 자산 스냅샷 합계
-  expense_since: number;   // 스냅샷 이후 지출
-  income_since: number;    // 스냅샷 이후 수입
-  effective: number;       // 실시간 가용자금
+  snapshot_total: number; // 자산 스냅샷 합계
+  expense_since: number; // 스냅샷 이후 지출
+  income_since: number; // 스냅샷 이후 수입
+  effective: number; // 실시간 가용자금
   latest_update: string | null;
 }
 
@@ -585,8 +617,8 @@ export type { DailyBudgetLog };
 
 export interface DailyBudgetLogSummary {
   logs: DailyBudgetLog[];
-  total_saved: number;     // 해당 월 누적 세이브 (음수 = 누적 초과)
-  days_logged: number;     // 기록된 일수
+  total_saved: number; // 해당 월 누적 세이브 (음수 = 누적 초과)
+  days_logged: number; // 기록된 일수
   avg_daily_saved: number; // 일평균 세이브
 }
 

--- a/web/src/features/routine/lib/queries.ts
+++ b/web/src/features/routine/lib/queries.ts
@@ -161,10 +161,11 @@ export async function updateRoutineRecordMemo(
   id: number,
   memo: string | null,
 ): Promise<void> {
-  await query(
-    `UPDATE routine_records SET memo = $3 WHERE id = $1 AND user_id = $2`,
-    [id, userId, memo],
-  );
+  await query(`UPDATE routine_records SET memo = $3 WHERE id = $1 AND user_id = $2`, [
+    id,
+    userId,
+    memo,
+  ]);
 }
 
 // ─── 빈도 판별 ───────────────────────────────────────
@@ -172,8 +173,7 @@ export async function updateRoutineRecordMemo(
 function daysBetween(from: string, to: string): number {
   const msPerDay = 86_400_000;
   return Math.round(
-    (new Date(to + 'T00:00:00+09:00').getTime() -
-      new Date(from + 'T00:00:00+09:00').getTime()) /
+    (new Date(to + 'T00:00:00+09:00').getTime() - new Date(from + 'T00:00:00+09:00').getTime()) /
       msPerDay,
   );
 }
@@ -185,7 +185,12 @@ function parseIntervalDays(frequency: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
-function shouldCreateToday(frequency: string | null, lastDate: string | null, today: string, startDate?: string): boolean {
+function shouldCreateToday(
+  frequency: string | null,
+  lastDate: string | null,
+  today: string,
+  startDate?: string,
+): boolean {
   // 시작일이 미래면 생성하지 않음 (YYYY-MM-DD는 사전순 비교 = 시간순 비교)
   if (startDate && today < startDate) return false;
 
@@ -207,7 +212,11 @@ function shouldCreateToday(frequency: string | null, lastDate: string | null, to
 
 /** 오늘 기록 자동 생성 (아직 없는 active 템플릿만) */
 export async function ensureTodayRecords(userId: number, date: string): Promise<number> {
-  const { rows: templates } = await query<{ id: number; frequency: string | null; start_date: string }>(
+  const { rows: templates } = await query<{
+    id: number;
+    frequency: string | null;
+    start_date: string;
+  }>(
     `SELECT id, frequency, start_date::text FROM routine_templates WHERE active = true AND deleted_at IS NULL AND user_id = $1`,
     [userId],
   );
@@ -227,17 +236,22 @@ export async function ensureTodayRecords(userId: number, date: string): Promise<
   );
   const lastDateMap = new Map(lastRecords.map((r) => [r.template_id, r.last_date]));
 
-  let created = 0;
-  for (const t of templates) {
-    if (existingIds.has(t.id)) continue;
-    if (!shouldCreateToday(t.frequency, lastDateMap.get(t.id) ?? null, date, t.start_date)) continue;
-    await query(
-      `INSERT INTO routine_records (user_id, template_id, date, completed) VALUES ($1, $2, $3, false)`,
-      [userId, t.id, date],
-    );
-    created++;
-  }
-  return created;
+  const toInsertIds = templates
+    .filter((t) => !existingIds.has(t.id))
+    .filter((t) =>
+      shouldCreateToday(t.frequency, lastDateMap.get(t.id) ?? null, date, t.start_date),
+    )
+    .map((t) => t.id);
+
+  if (toInsertIds.length === 0) return 0;
+
+  const result = await query(
+    `INSERT INTO routine_records (user_id, template_id, date, completed)
+     SELECT $1, t.id, $2, false
+     FROM UNNEST($3::int[]) AS t(id)`,
+    [userId, date, toInsertIds],
+  );
+  return result.rowCount ?? 0;
 }
 
 // ─── 통계 ────────────────────────────────────────────
@@ -370,10 +384,7 @@ export async function updateInactivePeriod(
 }
 
 /** 비활성 기간 삭제 */
-export async function deleteInactivePeriod(
-  userId: number,
-  periodId: number,
-): Promise<boolean> {
+export async function deleteInactivePeriod(userId: number, periodId: number): Promise<boolean> {
   const result = await query(
     `DELETE FROM routine_inactive_periods WHERE id = $1 AND user_id = $2`,
     [periodId, userId],

--- a/web/src/features/schedule/lib/queries.ts
+++ b/web/src/features/schedule/lib/queries.ts
@@ -81,7 +81,14 @@ export const createSchedule = async (
 };
 
 const SCHEDULE_COLUMNS = new Set([
-  'title', 'date', 'end_date', 'status', 'category', 'subcategory', 'memo', 'important',
+  'title',
+  'date',
+  'end_date',
+  'status',
+  'category',
+  'subcategory',
+  'memo',
+  'important',
 ]);
 
 export const updateSchedule = async (
@@ -156,7 +163,14 @@ export const createCategory = async (
     `INSERT INTO categories (user_id, name, color, type, sort_order, parent_id)
      VALUES ($1, $2, $3, $4, $5, $6)
      RETURNING id, name, color, COALESCE(type, 'task') as type, sort_order, parent_id`,
-    [userId, data.name, data.color ?? 'gray', data.type ?? 'task', (maxOrder?.max ?? 0) + 1, parentId],
+    [
+      userId,
+      data.name,
+      data.color ?? 'gray',
+      data.type ?? 'task',
+      (maxOrder?.max ?? 0) + 1,
+      parentId,
+    ],
   );
   const row = result.rows[0];
   if (!row) throw new Error('createCategory: INSERT returned no rows');
@@ -203,9 +217,16 @@ export const reorderCategories = async (
   userId: number,
   orders: { id: number; sort_order: number }[],
 ): Promise<void> => {
-  for (const { id, sort_order } of orders) {
-    await query('UPDATE categories SET sort_order = $1 WHERE user_id = $2 AND id = $3', [sort_order, userId, id]);
-  }
+  if (orders.length === 0) return;
+  const ids = orders.map((o) => o.id);
+  const sortOrders = orders.map((o) => o.sort_order);
+  await query(
+    `UPDATE categories AS c
+     SET sort_order = u.sort_order
+     FROM UNNEST($1::int[], $2::int[]) AS u(id, sort_order)
+     WHERE c.user_id = $3 AND c.id = u.id`,
+    [ids, sortOrders, userId],
+  );
 };
 
 /** 일정에서 사용 중인 카테고리가 categories 테이블에 없으면 자동 추가 */


### PR DESCRIPTION
## 관련 이슈
Closes #361

## 변경 내용
웹 대시보드의 DB 쿼리 함수 3곳에서 루프 내 쿼리 반복 실행(N+1) 패턴을 PostgreSQL `UNNEST` 기반 일괄 쿼리로 치환. 기존 동작(반환값·조건 분기·중복 방지)은 유지하며 쿼리 횟수만 O(N) → O(1)로 축약.

### 1. 카테고리 순서 일괄 업데이트 (`schedule/lib/queries.ts`)
- 루프 내 개별 `UPDATE` 반복 → `UNNEST($1::int[], $2::int[])` 기반 단일 UPDATE
- 카테고리 드래그 앤 드롭 시 쿼리 수 대폭 감소 (UI에서 직접 체감)

### 2. 루틴 기록 자동 생성 (`routine/lib/queries.ts`)
- 템플릿별 개별 `INSERT` 반복 → `INSERT ... SELECT FROM UNNEST($3::int[])` 일괄 INSERT
- 기존 JS 필터(`shouldCreateToday`) 로직은 보존, 삽입만 일괄 처리

### 3. 고정비 자동 지출 기록 (`budget/lib/queries.ts`)
- 루프마다 `SELECT`(존재 체크) + `INSERT` 반복 → `UNNEST` 다중 컬럼 + `NOT EXISTS` 중복 제거의 단일 쿼리
- 기존 중복 판정 키(`user_id + source='fixed' + date + description`) 유지
- 관련 단위 테스트 mock도 새 쿼리 구조에 맞춰 갱신

## 코드 리뷰 결과
- [x] 보안 감사 통과 (SQL Injection / user_id 스코프 / 크리덴셜 없음)
- [x] 타입 안전성 확인 (`any` 미사용, 배열 타입 명시)
- [x] 컨벤션 점검 완료 (Conventional Commits 한글, 파일 크기 / 함수 크기 유지)
- [x] 코드 품질 확인 (빈 배열 early return으로 `UNNEST` 파싱 이슈 회피)

## 테스트
- [x] `yarn --cwd web test` — 188/188 통과
- [x] `yarn --cwd web test ensure-fixed-cost-expenses` — 8/8 통과 (mock 갱신 포함)
- [x] `tsc --noEmit` — 타입 오류 없음
- [ ] 수동 검증 (merge 후 운영 환경):
  - 카테고리 드래그 앤 드롭 → DB 값 반영 확인
  - 크론/엔드포인트에서 루틴·고정비 자동 생성 1회 실행 → 동일 입력 재실행 시 중복 없음