### PR TITLE
fix(budget): 고정비 카테고리 지출 수정 시 검증 실패 해결

### DIFF
--- a/web/src/app/api/expenses/[id]/route.ts
+++ b/web/src/app/api/expenses/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
 import { updateExpense, deleteExpense } from '@/features/budget/lib/queries';
-import { EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/features/budget/lib/types';
+import { ALL_EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/features/budget/lib/types';
 import { validateFields } from '@/lib/validation';
 
-const VALID_CATEGORIES = new Set<string>([...EXPENSE_CATEGORIES, ...INCOME_CATEGORIES]);
+const VALID_CATEGORIES = new Set<string>([...ALL_EXPENSE_CATEGORIES, ...INCOME_CATEGORIES]);
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const userId = await requireAuth();
@@ -21,14 +21,21 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     if ('amount' in body && (typeof body.amount !== 'number' || body.amount <= 0)) {
       return NextResponse.json({ error: 'amount는 양수 숫자여야 합니다' }, { status: 400 });
     }
-    if ('category' in body && typeof body.category === 'string' && !VALID_CATEGORIES.has(body.category)) {
+    if (
+      'category' in body &&
+      typeof body.category === 'string' &&
+      !VALID_CATEGORIES.has(body.category)
+    ) {
       return NextResponse.json({ error: '유효하지 않은 category입니다' }, { status: 400 });
     }
     if ('date' in body && typeof body.date === 'string' && !/^\d{4}-\d{2}-\d{2}$/.test(body.date)) {
       return NextResponse.json({ error: 'date 형식이 올바르지 않습니다' }, { status: 400 });
     }
     if ('exclude_from_budget' in body && typeof body.exclude_from_budget !== 'boolean') {
-      return NextResponse.json({ error: 'exclude_from_budget는 boolean이어야 합니다' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'exclude_from_budget는 boolean이어야 합니다' },
+        { status: 400 },
+      );
     }
 
     const lengthError = validateFields([

--- a/web/src/app/api/expenses/route.ts
+++ b/web/src/app/api/expenses/route.ts
@@ -1,13 +1,18 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { queryExpenses, queryExpensesByBillingMonth, createExpense, createInstallmentExpenses } from '@/features/budget/lib/queries';
-import { EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/features/budget/lib/types';
+import {
+  queryExpenses,
+  queryExpensesByBillingMonth,
+  createExpense,
+  createInstallmentExpenses,
+} from '@/features/budget/lib/queries';
+import { ALL_EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/features/budget/lib/types';
 import { getTodayISO } from '@/lib/kst';
 import { validateFields } from '@/lib/validation';
 
-const VALID_EXPENSE_CATEGORIES = new Set<string>(EXPENSE_CATEGORIES);
+const VALID_EXPENSE_CATEGORIES = new Set<string>(ALL_EXPENSE_CATEGORIES);
 const VALID_INCOME_CATEGORIES = new Set<string>(INCOME_CATEGORIES);
-const VALID_CATEGORIES = new Set<string>([...EXPENSE_CATEGORIES, ...INCOME_CATEGORIES]);
+const VALID_CATEGORIES = new Set<string>([...ALL_EXPENSE_CATEGORIES, ...INCOME_CATEGORIES]);
 
 export async function GET(request: Request) {
   const userId = await requireAuth();
@@ -25,7 +30,10 @@ export async function GET(request: Request) {
     const yearMonth = searchParams.get('yearMonth');
     if (yearMonth) {
       if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
-        return NextResponse.json({ error: 'yearMonth 형식이 올바르지 않습니다 (YYYY-MM)' }, { status: 400 });
+        return NextResponse.json(
+          { error: 'yearMonth 형식이 올바르지 않습니다 (YYYY-MM)' },
+          { status: 400 },
+        );
       }
       const data = await queryExpensesByBillingMonth(userId, yearMonth, category);
       return NextResponse.json({ data });
@@ -38,10 +46,19 @@ export async function GET(request: Request) {
     const plannedExpenseId = searchParams.get('planned_expense_id');
 
     if (!/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
-      return NextResponse.json({ error: 'from/to 날짜 형식이 올바르지 않습니다 (YYYY-MM-DD)' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'from/to 날짜 형식이 올바르지 않습니다 (YYYY-MM-DD)' },
+        { status: 400 },
+      );
     }
 
-    const data = await queryExpenses(userId, from, to, category, plannedExpenseId ? Number(plannedExpenseId) : undefined);
+    const data = await queryExpenses(
+      userId,
+      from,
+      to,
+      category,
+      plannedExpenseId ? Number(plannedExpenseId) : undefined,
+    );
     return NextResponse.json({ data });
   } catch (err) {
     console.error('[Expense API]', request.url, err);
@@ -77,7 +94,10 @@ export async function POST(request: Request) {
 
     const entryType = body.type ?? 'expense';
     if (entryType !== 'expense' && entryType !== 'income') {
-      return NextResponse.json({ error: 'type은 expense 또는 income이어야 합니다' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'type은 expense 또는 income이어야 합니다' },
+        { status: 400 },
+      );
     }
 
     // 수입이면 수입 카테고리, 지출이면 지출 카테고리 검증
@@ -95,7 +115,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: lengthError }, { status: 400 });
     }
 
-    const excludeFromBudget = typeof body.exclude_from_budget === 'boolean' ? body.exclude_from_budget : false;
+    const excludeFromBudget =
+      typeof body.exclude_from_budget === 'boolean' ? body.exclude_from_budget : false;
 
     // 할부 처리 (카드 2~12개월)
     const installmentMonths = body.installment_months ?? 1;

--- a/web/src/features/budget/components/expense-edit-modal.tsx
+++ b/web/src/features/budget/components/expense-edit-modal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import type { ExpenseRow, PlannedExpenseRow } from '@/features/budget/lib/types';
-import { EXPENSE_CATEGORIES, BUDGET_EXCLUDED_CATEGORIES } from '@/features/budget/lib/types';
+import { ALL_EXPENSE_CATEGORIES, BUDGET_EXCLUDED_CATEGORIES } from '@/features/budget/lib/types';
 import { formatAmount } from '@/lib/types';
 import { XMarkIcon } from '@/components/ui/icons';
 import { Button } from '@/components/ui/button';
@@ -12,19 +12,28 @@ interface ExpenseEditModalProps {
   expense: ExpenseRow;
   /** 현재 보고 있는 결제주기 월 (예정 지출 목록용) */
   yearMonth?: string;
-  onSave: (id: number, updates: {
-    date: string;
-    amount: number;
-    category: string;
-    description: string | null;
-    exclude_from_budget: boolean;
-    planned_expense_id: number | null;
-  }) => Promise<void>;
+  onSave: (
+    id: number,
+    updates: {
+      date: string;
+      amount: number;
+      category: string;
+      description: string | null;
+      exclude_from_budget: boolean;
+      planned_expense_id: number | null;
+    },
+  ) => Promise<void>;
   onDelete: (id: number) => Promise<void>;
   onClose: () => void;
 }
 
-export function ExpenseEditModal({ expense, yearMonth, onSave, onDelete, onClose }: ExpenseEditModalProps) {
+export function ExpenseEditModal({
+  expense,
+  yearMonth,
+  onSave,
+  onDelete,
+  onClose,
+}: ExpenseEditModalProps) {
   const [deleting, setDeleting] = useState(false);
   const [date, setDate] = useState(expense.date);
   const [amountStr, setAmountStr] = useState(expense.amount.toLocaleString('ko-KR'));
@@ -106,13 +115,15 @@ export function ExpenseEditModal({ expense, yearMonth, onSave, onDelete, onClose
         </div>
 
         {/* Installment badge */}
-        {expense.is_installment && expense.installment_num != null && expense.installment_total != null && (
-          <div className="mb-3">
-            <span className="inline-block rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-600">
-              {expense.installment_num}/{expense.installment_total} 할부
-            </span>
-          </div>
-        )}
+        {expense.is_installment &&
+          expense.installment_num != null &&
+          expense.installment_total != null && (
+            <div className="mb-3">
+              <span className="inline-block rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-600">
+                {expense.installment_num}/{expense.installment_total} 할부
+              </span>
+            </div>
+          )}
 
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-3">
           {/* 날짜 */}
@@ -141,8 +152,10 @@ export function ExpenseEditModal({ expense, yearMonth, onSave, onDelete, onClose
             value={category}
             onChange={(e) => handleCategoryChange(e.target.value)}
           >
-            {EXPENSE_CATEGORIES.map((c) => (
-              <option key={c} value={c}>{c}</option>
+            {ALL_EXPENSE_CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
             ))}
           </Select>
 
@@ -163,7 +176,9 @@ export function ExpenseEditModal({ expense, yearMonth, onSave, onDelete, onClose
                 type="button"
                 onClick={() => setExcludeFromBudget(false)}
                 className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                  !excludeFromBudget ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700'
+                  !excludeFromBudget
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-500 hover:text-gray-700'
                 }`}
               >
                 포함
@@ -197,7 +212,9 @@ export function ExpenseEditModal({ expense, yearMonth, onSave, onDelete, onClose
                 ))}
               </Select>
               {selectedPlanned && (
-                <p className="mt-1 text-[10px] text-blue-500">이 지출은 일일 예산에 영향을 주지 않습니다</p>
+                <p className="mt-1 text-[10px] text-blue-500">
+                  이 지출은 일일 예산에 영향을 주지 않습니다
+                </p>
               )}
             </div>
           )}
@@ -219,7 +236,9 @@ export function ExpenseEditModal({ expense, yearMonth, onSave, onDelete, onClose
               onClick={() => {
                 if (!confirm('이 내역을 삭제할까요?')) return;
                 setDeleting(true);
-                void onDelete(expense.id).then(onClose).finally(() => setDeleting(false));
+                void onDelete(expense.id)
+                  .then(onClose)
+                  .finally(() => setDeleting(false));
               }}
             >
               {deleting ? '삭제 중...' : '삭제'}

--- a/web/src/features/budget/components/expense-form.tsx
+++ b/web/src/features/budget/components/expense-form.tsx
@@ -2,7 +2,12 @@
 
 import { useState, useEffect } from 'react';
 import type { ExpenseRow, PlannedExpenseRow } from '@/features/budget/lib/types';
-import { EXPENSE_CATEGORIES, INCOME_CATEGORIES, BUDGET_EXCLUDED_CATEGORIES } from '@/features/budget/lib/types';
+import {
+  ALL_EXPENSE_CATEGORIES,
+  EXPENSE_CATEGORIES,
+  INCOME_CATEGORIES,
+  BUDGET_EXCLUDED_CATEGORIES,
+} from '@/features/budget/lib/types';
 import { PlusIcon, XMarkIcon } from '@/components/ui/icons';
 import { formatAmount } from '@/lib/types';
 import { Input, Select } from '@/components/ui/input';
@@ -94,7 +99,8 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
         type: entryType,
         planned_expense_id: selectedPlanned,
         payment_method: entryType === 'expense' ? paymentMethod : '기타',
-        installment_months: entryType === 'expense' && paymentMethod !== '현금' ? installmentMonths : undefined,
+        installment_months:
+          entryType === 'expense' && paymentMethod !== '현금' ? installmentMonths : undefined,
         exclude_from_budget: entryType === 'expense' ? excludeFromBudget : false,
         distribute_to_budget: entryType === 'income' ? distributeToBudget : false,
       });
@@ -118,19 +124,24 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
     setAmountStr(raw ? num.toLocaleString('ko-KR') : '');
   };
 
-  const currentCategories = entryType === 'expense' ? EXPENSE_CATEGORIES : INCOME_CATEGORIES;
+  const currentCategories: readonly string[] =
+    entryType === 'expense' ? ALL_EXPENSE_CATEGORIES : INCOME_CATEGORIES;
 
   // 할부 미리보기 금액 계산
   const rawAmount = parseInt(amountStr.replace(/,/g, ''), 10);
-  const monthlyPreview = !isNaN(rawAmount) && rawAmount > 0 && installmentMonths > 1
-    ? Math.round(rawAmount / installmentMonths)
-    : null;
+  const monthlyPreview =
+    !isNaN(rawAmount) && rawAmount > 0 && installmentMonths > 1
+      ? Math.round(rawAmount / installmentMonths)
+      : null;
 
   // 귀속 월 계산 (지출 모드에서 실시간 표시)
   const billingMonthNum = parseInt(getBillingMonthForExpense(date, paymentMethod).slice(5), 10);
 
   return (
-    <form onSubmit={(e) => void handleSubmit(e)} className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+    <form
+      onSubmit={(e) => void handleSubmit(e)}
+      className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
+    >
       {/* 지출 / 수입 토글 */}
       <div className="mb-3 flex items-center gap-2">
         <div className="flex rounded-lg border border-gray-200 p-0.5">
@@ -138,7 +149,9 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
             type="button"
             onClick={() => handleTypeChange('expense')}
             className={`rounded-md px-3 py-1 text-xs font-medium transition ${
-              entryType === 'expense' ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700'
+              entryType === 'expense'
+                ? 'bg-blue-600 text-white'
+                : 'text-gray-500 hover:text-gray-700'
             }`}
           >
             지출
@@ -147,7 +160,9 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
             type="button"
             onClick={() => handleTypeChange('income')}
             className={`rounded-md px-3 py-1 text-xs font-medium transition ${
-              entryType === 'income' ? 'bg-green-600 text-white' : 'text-gray-500 hover:text-gray-700'
+              entryType === 'income'
+                ? 'bg-green-600 text-white'
+                : 'text-gray-500 hover:text-gray-700'
             }`}
           >
             수입
@@ -157,9 +172,7 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
           <PlusIcon size={14} />
           {entryType === 'expense' ? '지출 추가' : '수입 추가'}
           {entryType === 'expense' && (
-            <span className="ml-1 text-xs font-normal text-gray-400">
-              {billingMonthNum}월 대금
-            </span>
+            <span className="ml-1 text-xs font-normal text-gray-400">{billingMonthNum}월 대금</span>
           )}
         </h2>
       </div>
@@ -167,7 +180,13 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
         {/* 날짜 */}
         <div className="col-span-1">
-          <Input label="날짜" type="date" value={date} onChange={(e) => setDate(e.target.value)} required />
+          <Input
+            label="날짜"
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            required
+          />
         </div>
 
         {/* 금액 */}
@@ -185,9 +204,15 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
 
         {/* 카테고리 */}
         <div className="col-span-1">
-          <Select label="카테고리" value={category} onChange={(e) => handleCategoryChange(e.target.value)}>
+          <Select
+            label="카테고리"
+            value={category}
+            onChange={(e) => handleCategoryChange(e.target.value)}
+          >
             {currentCategories.map((c) => (
-              <option key={c} value={c}>{c}</option>
+              <option key={c} value={c}>
+                {c}
+              </option>
             ))}
           </Select>
         </div>
@@ -217,7 +242,9 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
                   type="button"
                   onClick={() => handlePaymentMethodChange(method)}
                   className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                    paymentMethod === method ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700'
+                    paymentMethod === method
+                      ? 'bg-blue-600 text-white'
+                      : 'text-gray-500 hover:text-gray-700'
                   }`}
                 >
                   {method}
@@ -236,7 +263,9 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
               >
                 <option value={1}>일시불</option>
                 {INSTALLMENT_OPTIONS.map((m) => (
-                  <option key={m} value={m}>{m}개월</option>
+                  <option key={m} value={m}>
+                    {m}개월
+                  </option>
                 ))}
               </Select>
             </div>
@@ -257,7 +286,9 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
                 type="button"
                 onClick={() => setExcludeFromBudget(false)}
                 className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                  !excludeFromBudget ? 'bg-blue-600 text-white' : 'text-gray-500 hover:text-gray-700'
+                  !excludeFromBudget
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-500 hover:text-gray-700'
                 }`}
               >
                 포함
@@ -285,7 +316,9 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
               type="button"
               onClick={() => setDistributeToBudget(false)}
               className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                !distributeToBudget ? 'bg-green-600 text-white' : 'text-gray-500 hover:text-gray-700'
+                !distributeToBudget
+                  ? 'bg-green-600 text-white'
+                  : 'text-gray-500 hover:text-gray-700'
               }`}
             >
               이번 달
@@ -325,7 +358,9 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
             ))}
           </Select>
           {selectedPlanned && (
-            <p className="mt-1 text-[10px] text-blue-500">이 지출은 일일 예산에 영향을 주지 않습니다</p>
+            <p className="mt-1 text-[10px] text-blue-500">
+              이 지출은 일일 예산에 영향을 주지 않습니다
+            </p>
           )}
         </div>
       )}
@@ -341,7 +376,9 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
         type="submit"
         disabled={loading}
         className={`mt-3 ml-auto flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition disabled:opacity-50 ${
-          entryType === 'expense' ? 'bg-blue-600 hover:bg-blue-700' : 'bg-green-600 hover:bg-green-700'
+          entryType === 'expense'
+            ? 'bg-blue-600 hover:bg-blue-700'
+            : 'bg-green-600 hover:bg-green-700'
         }`}
       >
         <PlusIcon size={13} />

--- a/web/src/features/budget/lib/types.ts
+++ b/web/src/features/budget/lib/types.ts
@@ -100,28 +100,33 @@ export interface MonthSummary {
 export interface DailyBudgetLog {
   date: string;
   billing_month: string;
-  budget: number;   // 그날 할당 예산
-  spent: number;    // 그날 자유 지출
-  saved: number;    // budget - spent (음수 = 초과)
+  budget: number; // 그날 할당 예산
+  spent: number; // 그날 자유 지출
+  saved: number; // budget - spent (음수 = 초과)
 }
 
 /** 월별 시뮬레이션 프로젝션 */
 export interface MonthProjection {
-  month: string;          // YYYY-MM (결제주기 기준)
-  fixed: number;          // 고정비
-  installments: number;   // 할부 합계
-  locked: number;         // fixed + installments (줄일 수 없는 돈)
-  free_budget: number;    // 자유 예산
-  income: number;         // 수입
-  net_burn: number;       // locked + free_budget - income
-  remaining: number;      // 남은 가용자금
+  month: string; // YYYY-MM (결제주기 기준)
+  fixed: number; // 고정비
+  installments: number; // 할부 합계
+  locked: number; // fixed + installments (줄일 수 없는 돈)
+  free_budget: number; // 자유 예산
+  income: number; // 수입
+  net_burn: number; // locked + free_budget - income
+  remaining: number; // 남은 가용자금
 }
 
 /**
  * 예산 제외 기본 카테고리 (UI 토글 기본값 결정용).
  * SQL 쿼리에서는 사용하지 않음 — exclude_from_budget 컬럼으로 판단.
  */
-export const BUDGET_EXCLUDED_CATEGORIES = new Set(['통신비', '공과금', '리커밋 사업', '리커밋 택배']);
+export const BUDGET_EXCLUDED_CATEGORIES = new Set([
+  '통신비',
+  '공과금',
+  '리커밋 사업',
+  '리커밋 택배',
+]);
 
 /** 하루 최소 자유 예산 경고 기준 (원) */
 export const MIN_DAILY_BUDGET = 10000;
@@ -152,13 +157,14 @@ export const EXPENSE_CATEGORIES = [
 export type ExpenseCategory = (typeof EXPENSE_CATEGORIES)[number];
 
 /** 수입 카테고리 목록 */
-export const INCOME_CATEGORIES = [
-  '환불',
-  '수입',
-  '기타수입',
-] as const;
+export const INCOME_CATEGORIES = ['환불', '수입', '기타수입'] as const;
 
 export type IncomeCategory = (typeof INCOME_CATEGORIES)[number];
 
 /** 고정지출 카테고리 목록 */
 export const FIXED_COST_CATEGORIES = ['주거', '보험', '통신', '구독', '교육', '기타'] as const;
+
+/** 지출 select에 표시·검증할 전체 카테고리 (일반 지출 + 고정비 카테고리). 고정비 자동 생성 지출도 수정 가능하도록 둘 다 포함. */
+export const ALL_EXPENSE_CATEGORIES: readonly string[] = Array.from(
+  new Set<string>([...EXPENSE_CATEGORIES, ...FIXED_COST_CATEGORIES]),
+);


### PR DESCRIPTION
## Summary
- 고정비 자동 생성으로 추가된 지출(`주거`/`보험`/`통신`/`구독`/`교육`/`기타` 카테고리)을 수정하면 "유효하지 않은 category" 에러가 발생하던 버그 수정
- 지출 카테고리 단일 소스 `ALL_EXPENSE_CATEGORIES` 신설 — 기존 `EXPENSE_CATEGORIES` ∪ `FIXED_COST_CATEGORIES`
- API 검증(GET/POST/PATCH)과 UI select(추가/수정 모달) 모두 동일한 목록 사용하도록 정리

## Changes
- `web/src/features/budget/lib/types.ts` — `ALL_EXPENSE_CATEGORIES` 추가
- `web/src/app/api/expenses/route.ts` — GET 카테고리 필터, POST 검증을 통합 목록으로 전환
- `web/src/app/api/expenses/[id]/route.ts` — PATCH 검증 통합 목록으로 전환
- `web/src/features/budget/components/expense-edit-modal.tsx` — select 옵션 통합
- `web/src/features/budget/components/expense-form.tsx` — select 옵션 통합

## Test plan
- [x] `pnpm test` 통과 (188 tests)
- [x] `tsc --noEmit` 통과
- [x] 고정비로 등록된 지출(예: 관리비)을 실제 금액으로 수정 → 정상 저장 확인
- [x] 일반 지출 추가/수정도 종전대로 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)