### PR TITLE
fix(budget): 자유 지출 정의를 사이클 락 정의와 정합

### DIFF
--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -10,7 +10,12 @@ import { readFixedCostsMonthlyTotal } from './repository/fixed-costs-repo';
 import { readActiveInstallments } from './repository/installments-repo';
 import { readPlannedExpenses } from './repository/planned-repo';
 import { readIncomeTotal, readCurrentMonthOnlyIncome } from './repository/incomes-repo';
-import { readFlexibleSpent, readExcludedSpent, readTodayFlexSpent, readAvgVariableMonthly } from './repository/expenses-repo';
+import {
+  readFlexibleSpent,
+  readExcludedSpent,
+  readTodayFlexSpent,
+  readAvgVariableMonthly,
+} from './repository/expenses-repo';
 import { readTargetMonth } from './repository/settings-repo';
 import { readLatestSnapshot, saveSnapshotIfAbsent } from './snapshot/monthly-snapshot-repo';
 
@@ -65,21 +70,27 @@ export async function getMonthlyAllocation(
 ): Promise<MonthAllocatorResult> {
   const cycle = getBillingCycle(now);
   const todayStr = formatKSTDate(now);
-  const [totalAvailable, fixedMonthly, installments, targetMonth, currentMonthOnlyIncome] = await Promise.all([
-    computeTotalAvailable(userId, todayStr),
-    readFixedCostsMonthlyTotal(userId),
-    readActiveInstallments(userId, cycle.yearMonth),
-    readTargetMonth(userId),
-    readCurrentMonthOnlyIncome(userId, cycle.yearMonth, todayStr),
-  ]);
+  const [totalAvailable, fixedMonthly, installments, targetMonth, currentMonthOnlyIncome] =
+    await Promise.all([
+      computeTotalAvailable(userId, todayStr),
+      readFixedCostsMonthlyTotal(userId),
+      readActiveInstallments(userId, cycle.yearMonth),
+      readTargetMonth(userId),
+      readCurrentMonthOnlyIncome(userId, cycle.yearMonth, todayStr),
+    ]);
   const planned = await readPlannedExpenses(
-    userId, cycle.yearMonth, targetMonth ?? cycle.yearMonth,
+    userId,
+    cycle.yearMonth,
+    targetMonth ?? cycle.yearMonth,
   );
   return allocateMonthlyBudgets({
-    totalAvailable, fixedMonthly, installments,
+    totalAvailable,
+    fixedMonthly,
+    installments,
     plannedExpenses: planned,
     currentBillingMonth: cycle.yearMonth,
-    targetMonth, today: todayStr,
+    targetMonth,
+    today: todayStr,
     currentMonthOnlyIncome,
   });
 }
@@ -93,12 +104,18 @@ export async function getTodayAllocation(
   const monthly = await getMonthlyAllocation(userId, now);
   const currentMonth = monthly.monthlyBudgets.find((m) => m.isCurrent);
   if (!currentMonth) {
-    return { todayBudget: 0, todayRemaining: 0, monthBudgetRemaining: 0, todayFlexSpent: 0, targetDate: null };
+    return {
+      todayBudget: 0,
+      todayRemaining: 0,
+      monthBudgetRemaining: 0,
+      todayFlexSpent: 0,
+      targetDate: null,
+    };
   }
   const todayStr = formatKSTDate(now);
   const [flex, todayFlex, targetDate] = await Promise.all([
     readFlexibleSpent(userId, cycle.yearMonth, todayStr),
-    readTodayFlexSpent(userId, todayStr),
+    readTodayFlexSpent(userId, todayStr, cycle.yearMonth),
     readTargetMonth(userId),
   ]);
   return {
@@ -237,13 +254,18 @@ export async function runSettlementIfDue(
   }
 
   const prevSnapshot = await readLatestSnapshot(userId);
-  const availableAtStart = prevSnapshot?.available_at_end ?? await readDistributableAssetBalance(userId);
+  const availableAtStart =
+    prevSnapshot?.available_at_end ?? (await readDistributableAssetBalance(userId));
   const availableAtEnd = availableAtStart + income - flex - excluded;
 
   const snapshot = buildSettlementSnapshot({
-    yearMonth: targetMonth, monthlyBudget,
-    actualFlexibleSpent: flex, actualExcludedSpent: excluded, actualIncome: income,
-    availableAtStart, availableAtEnd,
+    yearMonth: targetMonth,
+    monthlyBudget,
+    actualFlexibleSpent: flex,
+    actualExcludedSpent: excluded,
+    actualIncome: income,
+    availableAtStart,
+    availableAtEnd,
   });
   const result = await saveSnapshotIfAbsent(userId, snapshot);
   return { settled: result.saved, snapshot };

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -291,11 +291,9 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
   );
   const installmentTotal = Number(installmentResult.rows[0]?.total ?? 0);
 
-  // 예정 지출 연결 건: 예정 금액까지만 제외, 초과분은 자유 지출에 포함
-  const plannedLinkedResult = await query<{ linked: string; overflow: string }>(
-    `SELECT
-       COALESCE(SUM(LEAST(used, budget)), 0) as linked,
-       COALESCE(SUM(GREATEST(used - budget, 0)), 0) as overflow
+  // 예정 지출 연결 건: 예정 금액 초과분만 자유 지출에 가산 (capped 금액은 예정 락에 귀속)
+  const plannedLinkedResult = await query<{ overflow: string }>(
+    `SELECT COALESCE(SUM(GREATEST(used - budget, 0)), 0) as overflow
      FROM (
        SELECT p.amount as budget, COALESCE(SUM(e.amount), 0) as used
        FROM planned_expenses p
@@ -306,8 +304,21 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
      ) sub`,
     [userId, yearMonth],
   );
-  const plannedLinkedTotal = Number(plannedLinkedResult.rows[0]?.linked ?? 0);
-  const flexibleSpent = variableTotal - installmentTotal - plannedLinkedTotal;
+  const plannedOverflow = Number(plannedLinkedResult.rows[0]?.overflow ?? 0);
+
+  // 자유 지출 정의 (readFlexibleSpent와 동일):
+  // 비할부 + 신규 할부 1회차(billing_month=대상 사이클), 예정지출 연결 건 제외, 예정 overflow 가산.
+  const flexResult = await queryOne<{ total: string }>(
+    `SELECT COALESCE(SUM(amount), 0)::text as total FROM expenses
+     WHERE user_id = $1 AND billing_month = $2
+       AND exclude_from_budget = false
+       AND COALESCE(type, 'expense') = 'expense'
+       AND planned_expense_id IS NULL
+       AND (is_installment = false OR (is_installment = true AND installment_num = 1))`,
+    [userId, yearMonth],
+  );
+  const directFlex = Number(flexResult?.total ?? 0);
+  const flexibleSpent = directFlex + plannedOverflow;
 
   // 수입 합계 (type='income')
   const incomeResult = await query<{ total: string }>(
@@ -640,27 +651,23 @@ export async function saveDailyBudgetLog(
   // v2 facade로 오늘 예산 계산
   const daily = await getTodayAllocation(userId, now);
   const budget = daily.todayBudget;
+  const billingMonth = getCurrentBillingMonth(now);
 
-  // targetDate의 자유 지출을 DB에서 직접 조회 (드리프트로 인해 live today 기준이 다를 수 있음)
-  const budgetStartRow = await queryOne<{ updated_at: string }>(
-    'SELECT updated_at::text FROM budget_settings WHERE user_id = $1',
-    [userId],
-  );
-  const budgetStartAtParam = budgetStartRow?.updated_at ?? '9999-12-31T00:00:00Z';
+  // targetDate의 자유 지출을 DB에서 직접 조회 (드리프트로 인해 live today 기준이 다를 수 있음).
+  // readFlexibleSpent와 동일 정의: 비할부 + 신규 할부 1회차(billing_month=현재 사이클).
   const targetSpentRow = await queryOne<{ spent: string }>(
     `SELECT COALESCE(SUM(amount), 0)::text as spent
      FROM expenses
      WHERE user_id=$1 AND date=$2
-       AND (is_installment=false OR (is_installment=true AND created_at>=$3))
+       AND (is_installment=false OR (is_installment=true AND installment_num=1 AND billing_month=$3))
        AND exclude_from_budget = false
        AND COALESCE(type,'expense')='expense'
        AND planned_expense_id IS NULL`,
-    [userId, targetDate, budgetStartAtParam],
+    [userId, targetDate, billingMonth],
   );
   const spent = Number(targetSpentRow?.spent ?? 0);
 
   const saved = budget - spent;
-  const billingMonth = getCurrentBillingMonth(now);
 
   // UPSERT: 같은 날 다시 실행해도 최신 값으로 갱신
   await query(

--- a/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
@@ -31,20 +31,41 @@ describe('readFlexibleSpent', () => {
     const result = await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
     expect(result).toBe(30000);
-    // SQL이 planned_expense_id IS NULL을 포함하므로, 연결된 건은 이미 제외됨
     const sql = vi.mocked(query).mock.calls[0]![0] as string;
     expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
   });
 
-  it('기본 필터 조건: expense 타입, exclude_from_budget=false, is_installment=false', async () => {
+  it('기본 필터 조건: expense 타입, exclude_from_budget=false', async () => {
     vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
 
     await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
     const sql = vi.mocked(query).mock.calls[0]![0] as string;
     expect(sql).toMatch(/exclude_from_budget\s*=\s*false/i);
-    expect(sql).toMatch(/is_installment\s*=\s*false/i);
     expect(sql).toMatch(/type.*expense/i);
+  });
+
+  it('비할부 또는 신규 할부 1회차만 포함하는 조건이 SQL에 있어야 함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+
+    await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
+
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    // 비할부(is_installment=false) OR (is_installment=true AND installment_num=1) 조건 포함
+    expect(sql).toMatch(/is_installment\s*=\s*false/i);
+    expect(sql).toMatch(/installment_num\s*=\s*1/i);
+  });
+
+  it('billing_month / date 범위 필터가 SQL에 포함되어야 함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+
+    await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
+
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    expect(sql).toMatch(/billing_month\s*=\s*\$2/i);
+    expect(sql).toMatch(/date\s*<=\s*\$3/i);
+    expect(params).toEqual([1, '2026-03-16', '2026-04-15']);
   });
 });
 
@@ -56,7 +77,7 @@ describe('readTodayFlexSpent', () => {
   it('planned_expense_id IS NULL 조건이 SQL에 포함되어야 함', async () => {
     vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '15000' }] } as Any);
 
-    await readTodayFlexSpent(1, '2026-04-10');
+    await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
     expect(query).toHaveBeenCalledTimes(1);
     const sql = vi.mocked(query).mock.calls[0]![0] as string;
@@ -66,10 +87,33 @@ describe('readTodayFlexSpent', () => {
   it('예정지출 연결 건이 오늘 자유지출에 포함되지 않아야 함', async () => {
     vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '10000' }] } as Any);
 
-    const result = await readTodayFlexSpent(1, '2026-04-10');
+    const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
     expect(result).toBe(10000);
     const sql = vi.mocked(query).mock.calls[0]![0] as string;
     expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
+  });
+
+  it('billingMonth 인자를 받고 SQL의 1회차 조건에 전달되어야 함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+
+    await readTodayFlexSpent(1, '2026-04-10', '2026-04');
+
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    expect(sql).toMatch(/installment_num\s*=\s*1/i);
+    // 1회차 조건이 billing_month = $3 으로 묶여 있는지
+    expect(sql).toMatch(/billing_month\s*=\s*\$3/i);
+    expect(params).toEqual([1, '2026-04-10', '2026-04']);
+  });
+
+  it('비할부 또는 신규 할부 1회차만 포함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+
+    await readTodayFlexSpent(1, '2026-04-10', '2026-04');
+
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/is_installment\s*=\s*false/i);
+    expect(sql).toMatch(/installment_num\s*=\s*1/i);
   });
 });

--- a/web/src/features/budget/lib/repository/expenses-repo.ts
+++ b/web/src/features/budget/lib/repository/expenses-repo.ts
@@ -1,5 +1,8 @@
 import { query } from '@/lib/db';
 
+// 신규 할부 1회차(billing_month가 현재 사이클인 1회차)는 자유 지출에 포함.
+// month-allocator의 isNew 조건과 동일 정의 — 신규 할부 1회차는 현재 사이클 락에서 제외되므로
+// 자유 지출에 포함되어야 일/월 단위 예산 정의가 일치.
 export async function readFlexibleSpent(
   userId: number,
   billingMonth: string,
@@ -11,19 +14,19 @@ export async function readFlexibleSpent(
      WHERE user_id = $1
        AND COALESCE(type, 'expense') = 'expense'
        AND exclude_from_budget = false
-       AND is_installment = false
        AND planned_expense_id IS NULL
        AND billing_month = $2
-       AND date <= $3`,
+       AND date <= $3
+       AND (
+         is_installment = false
+         OR (is_installment = true AND installment_num = 1)
+       )`,
     [userId, billingMonth, upToDate],
   );
   return Number(result.rows[0]?.total ?? 0);
 }
 
-export async function readExcludedSpent(
-  userId: number,
-  billingMonth: string,
-): Promise<number> {
+export async function readExcludedSpent(userId: number, billingMonth: string): Promise<number> {
   const result = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0)::text AS total
      FROM expenses
@@ -39,6 +42,7 @@ export async function readExcludedSpent(
 export async function readTodayFlexSpent(
   userId: number,
   today: string,
+  billingMonth: string,
 ): Promise<number> {
   const result = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0)::text AS total
@@ -46,19 +50,19 @@ export async function readTodayFlexSpent(
      WHERE user_id = $1
        AND COALESCE(type, 'expense') = 'expense'
        AND exclude_from_budget = false
-       AND is_installment = false
        AND planned_expense_id IS NULL
-       AND date = $2::date`,
-    [userId, today],
+       AND date = $2::date
+       AND (
+         is_installment = false
+         OR (is_installment = true AND installment_num = 1 AND billing_month = $3)
+       )`,
+    [userId, today, billingMonth],
   );
   return Number(result.rows[0]?.total ?? 0);
 }
 
 /** 최근 N개월 변동 지출 월평균 (고정비 제외 일반 지출만) */
-export async function readAvgVariableMonthly(
-  userId: number,
-  months = 3,
-): Promise<number> {
+export async function readAvgVariableMonthly(userId: number, months = 3): Promise<number> {
   const result = await query<{ avg_monthly: string }>(
     `SELECT COALESCE(AVG(monthly_total), 0) AS avg_monthly
      FROM (


### PR DESCRIPTION
## Summary

- 월 단위 요약과 일별 현황 탭의 자유 지출 계산식이 서로 어긋나 두 화면이 같은 사이클에서 다른 값을 보이던 문제 해결
- 사이클 락에서 제외되는 신규 할부 1회차가 자유 지출에도 누락되어 일일 예산에서 사라지던 케이스 수정
- 자유 지출 정의를 한 곳(SQL 조건)으로 통일해 추가 화면이 생겨도 분기되지 않도록 정리

## 변경 파일
- `web/src/features/budget/lib/repository/expenses-repo.ts` — `readFlexibleSpent` / `readTodayFlexSpent` 조건 정렬, 후자에 `billingMonth` 인자 추가
- `web/src/features/budget/lib/queries.ts` — `saveDailyBudgetLog` 와 `queryMonthSummary` 의 자유 지출 정의 통일
- `web/src/features/budget/lib/facade.ts` — `readTodayFlexSpent` 호출 시 `cycle.yearMonth` 전달
- `web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts` — 새 조건 검증 테스트 추가/보강

## 정의 일관성

자유 지출에 포함되는 조건을 다음으로 통일:
- 비할부 지출, 또는
- 할부 1회차이면서 해당 사이클이 1회차 빌링먼스인 경우 (= month-allocator 의 `isNew` 정의와 동일)

## Test plan
- [x] `yarn test` (web 192 + root 376) 통과
- [x] `yarn tsc --noEmit` (web/root) 통과
- [x] `yarn lint` (root) 0 errors
- [ ] 머지 후 운영 환경에서 두 화면(월 요약, 일별 현황) 값 일치 확인
- [ ] 신규 할부 1회차가 등록된 당일 일일 예산에 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)