### PR TITLE
fix(budget): 고정비 자동 등록 행의 자유지출 누수 차단

### DIFF
--- a/web/src/app/api/expenses/[id]/route.ts
+++ b/web/src/app/api/expenses/[id]/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { updateExpense, deleteExpense } from '@/features/budget/lib/queries';
+import {
+  updateExpense,
+  deleteExpense,
+  FIXED_SOURCE_EXCLUDE_LOCKED,
+} from '@/features/budget/lib/queries';
 import { ALL_EXPENSE_CATEGORIES, INCOME_CATEGORIES } from '@/features/budget/lib/types';
 import { validateFields } from '@/lib/validation';
 
@@ -51,6 +55,12 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     if (!data) return NextResponse.json({ error: '지출을 찾을 수 없습니다' }, { status: 404 });
     return NextResponse.json({ data });
   } catch (err) {
+    if (err instanceof Error && err.message === FIXED_SOURCE_EXCLUDE_LOCKED) {
+      return NextResponse.json(
+        { error: '자동 등록 고정비 항목은 예산 제외 설정을 변경할 수 없습니다' },
+        { status: 400 },
+      );
+    }
     console.error('[Expense API]', request.url, err);
     return NextResponse.json({ error: '지출 수정 실패' }, { status: 500 });
   }

--- a/web/src/features/budget/lib/__tests__/update-expense.test.ts
+++ b/web/src/features/budget/lib/__tests__/update-expense.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  query: vi.fn(),
+  queryOne: vi.fn(),
+}));
+
+import { query, queryOne } from '@/lib/db';
+import { updateExpense, FIXED_SOURCE_EXCLUDE_LOCKED } from '../queries';
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
+type Any = any;
+
+describe('updateExpense — source=fixed 행 exclude_from_budget 가드', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("source='fixed' 행 + exclude_from_budget 변경 → 에러 throw, UPDATE 미실행", async () => {
+    vi.mocked(queryOne).mockResolvedValueOnce({ source: 'fixed' } as Any);
+
+    await expect(updateExpense(1, 686, { exclude_from_budget: true })).rejects.toThrow(
+      FIXED_SOURCE_EXCLUDE_LOCKED,
+    );
+
+    // SELECT만 1회, UPDATE는 호출되지 않음
+    expect(queryOne).toHaveBeenCalledTimes(1);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("source='manual' 행 + exclude_from_budget 변경 → 정상 진행", async () => {
+    vi.mocked(queryOne)
+      .mockResolvedValueOnce({ source: 'manual' } as Any) // 가드 SELECT
+      .mockResolvedValueOnce({ id: 100, exclude_from_budget: true } as Any); // UPDATE RETURNING
+
+    const result = await updateExpense(1, 100, { exclude_from_budget: true });
+
+    expect(result).toEqual({ id: 100, exclude_from_budget: true });
+    expect(queryOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('source=null 행 + exclude_from_budget 변경 → 정상 진행', async () => {
+    vi.mocked(queryOne)
+      .mockResolvedValueOnce({ source: null } as Any)
+      .mockResolvedValueOnce({ id: 200 } as Any);
+
+    await expect(updateExpense(1, 200, { exclude_from_budget: false })).resolves.toBeTruthy();
+  });
+
+  it("source='fixed' 행 + amount만 변경(exclude_from_budget 미포함) → 가드 미발동, 정상 진행", async () => {
+    vi.mocked(queryOne).mockResolvedValueOnce({ id: 686, amount: 167776 } as Any);
+
+    const result = await updateExpense(1, 686, { amount: 167776 });
+
+    expect(result).toEqual({ id: 686, amount: 167776 });
+    // 가드 SELECT 없이 바로 UPDATE 1회
+    expect(queryOne).toHaveBeenCalledTimes(1);
+    const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/UPDATE\s+expenses\s+SET/i);
+  });
+
+  it('허용되지 않는 컬럼만 포함된 updates → SELECT (현재 행 반환), UPDATE 미실행', async () => {
+    vi.mocked(queryOne).mockResolvedValueOnce({ id: 1, amount: 100 } as Any);
+
+    const result = await updateExpense(1, 1, { unknown_col: 'x' });
+
+    expect(result).toEqual({ id: 1, amount: 100 });
+    expect(queryOne).toHaveBeenCalledTimes(1);
+    const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/SELECT/i);
+    expect(sql).not.toMatch(/UPDATE/i);
+  });
+});

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -209,6 +209,9 @@ const EXPENSE_COLUMNS = new Set([
   'distribute_to_budget',
 ]);
 
+/** source='fixed' 행의 exclude_from_budget 변경 시도 시 throw되는 sentinel error */
+export const FIXED_SOURCE_EXCLUDE_LOCKED = 'FIXED_SOURCE_EXCLUDE_LOCKED';
+
 export async function updateExpense(
   userId: number,
   id: number,
@@ -216,6 +219,18 @@ export async function updateExpense(
 ): Promise<ExpenseRow | null> {
   const keys = Object.keys(updates).filter((k) => EXPENSE_COLUMNS.has(k));
   if (keys.length === 0) return queryExpense(userId, id);
+
+  // source='fixed' 행: 자유지출/고정비 이중 카운트 방지 — exclude_from_budget 변경 차단.
+  // amount 등 다른 필드는 자유 수정 가능 (변동성 있는 고정비 케이스 지원).
+  if (keys.includes('exclude_from_budget')) {
+    const existing = await queryOne<{ source: string | null }>(
+      `SELECT source FROM expenses WHERE id = $1 AND user_id = $2`,
+      [id, userId],
+    );
+    if (existing?.source === 'fixed') {
+      throw new Error(FIXED_SOURCE_EXCLUDE_LOCKED);
+    }
+  }
 
   const setClauses = keys.map((k, i) => `${k} = $${i + 3}`);
   const values = keys.map((k) => updates[k]);


### PR DESCRIPTION
## Summary

- `source='fixed'` 행은 자동 등록 시점에 `exclude_from_budget=true`로 들어오지만, 이후 사용자 수정 경로에서 `false`로 바뀌면 동일 금액이 고정비 합계와 자유지출 합계에 동시 집계되는 이중 카운트가 발생.
- 백엔드에서 `source='fixed'` 행의 `exclude_from_budget` 변경을 거부하도록 가드 추가. `amount` 등 다른 필드는 변동성 케이스(예: 변동 이자) 지원을 위해 자유 수정 허용.
- API 라우트에 sentinel error 변환 — 사용자에게 400 응답으로 안내.

## Changes

- `web/src/features/budget/lib/queries.ts`: `updateExpense`에 가드 + `FIXED_SOURCE_EXCLUDE_LOCKED` sentinel export.
- `web/src/app/api/expenses/[id]/route.ts`: sentinel catch → 400 응답.
- `web/src/features/budget/lib/__tests__/update-expense.test.ts`: 5개 케이스 (가드 발동 / manual·null 통과 / amount만 변경 / 허용되지 않은 컬럼).

## Test plan

- [x] web 단위 테스트 197/197 통과 (신규 5개 포함)
- [x] root 테스트 376/376 통과
- [x] 타입 체크 / lint 통과
- [ ] 머지 후 사용자 화면에서 자유지출 합계가 기대값에 정합한지 확인

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)