### PR TITLE
fix(budget): 자유지출 정의 통일 — 예정지출 초과분 가산으로 화면/정산 정합성 보강 (#374)

### DIFF
--- a/docs/adr/0007-flexible-spent-unified-definition.md
+++ b/docs/adr/0007-flexible-spent-unified-definition.md
@@ -1,0 +1,87 @@
+# 0007. 자유지출 정의 통일 — directFlex + plannedOverflow
+
+- Status: Accepted
+- Date: 2026-05-06
+- Related: #374
+- Tags: data, budget
+
+## Context
+
+v2 예산 시스템에서 자유지출 정의가 코드 4곳에 분산되어 있었다.
+
+- `repository/expenses-repo.ts` — `readFlexibleSpent`, `readTodayFlexSpent`
+- `lib/queries.ts` — `queryMonthSummary` 인라인 SQL, `saveDailyBudgetLog` 인라인 SQL
+
+그 중 예산 계산/정산 경로(`readFlexibleSpent`, `readTodayFlexSpent`)는 예정지출 연결 건(`planned_expense_id IS NOT NULL`)을 통째로 제외하는 반면, 월간 요약 카드 경로(`queryMonthSummary`)는 예정지출 예산 초과분만 별도로 가산하고 있었다.
+
+결과:
+
+- 같은 화면에서 "이번달 자유 지출"(요약 카드)과 "오늘/이번달 남은 예산"(allocator)이 어긋남
+- 정산 스냅샷의 `flexible_spent` 가 초과분을 누락
+- 일별 예산 로그(`daily_budget_logs.spent`) 도 옛 정의 사용
+
+PR #371(자유지출과 사이클 락 정합화) / #373(고정비 자동 등록 누수 차단) 에서 자유지출 정의를 일부 정합화한 흐름의 후속이다.
+
+## Decision
+
+자유지출을 다음 단일 정의로 통일한다:
+
+```
+flexibleSpent(billingMonth, upToDate)
+  = directFlex(billingMonth, upToDate) + plannedOverflow(billingMonth, upToDate)
+```
+
+- `directFlex`: 비할부 + 신규 할부 1회차, `planned_expense_id IS NULL`, `exclude_from_budget = false`
+- `plannedOverflow(upToDate) = Σ_p max(0, used(p, upToDate) − p.amount)`
+  - `used(p, upToDate)` = `expenses` 중 `e.planned_expense_id = p.id` AND `billing_month` 일치 AND `e.date <= upToDate` 의 합
+
+일 단위 plannedOverflow 산식은 **누적 차이**를 사용한다:
+
+```
+dailyOverflow(today) = max(0, plannedOverflow(today) − plannedOverflow(yesterday))
+```
+
+모든 사용처는 `readFlexibleSpent` / `readTodayFlexSpent` 두 함수만 호출한다 (인라인 SQL 금지).
+
+## Alternatives considered
+
+### A. `planned_expense_id` 를 자유지출에 통째로 포함
+
+- 장점: 산식 단순. `planned_expense_id` 필터 자체를 제거.
+- 단점: 예정지출 락의 의미가 사라짐. 매월 N만원 예정지출을 잡아두는 의도가 무력화되어, 예정지출 풀 자체가 자유지출과 구분되지 않음.
+- 기각 이유: 예정지출 기능 자체의 설계 목적과 충돌.
+
+### B. 초과분 발생 시 사용자에게 묻고 수동으로 자산 차감
+
+- 장점: 사용자 의사 명확히 반영.
+- 단점: UX 부담. 이미 결제한 지출을 사후 분류하는 데 매번 확인 단계가 들어감. 자동화 가치 손실.
+- 기각 이유: 라이프 데이터 봇의 자동 정산 기조와 어긋남.
+
+### C. 일 단위 산식으로 `min(today_used, max(0, cum_overflow))` 사용
+
+- 장점: 단일 SQL로 일별 오버플로우 산출 가능.
+- 단점: 누적 차이 방식과 같은 결과를 산출하지만 SQL 표현이 더 복잡하고, `readPlannedOverflow` 함수를 그대로 재사용할 수 없어 별도 함수가 필요함.
+- 기각 이유: 동일 결과인데 함수 재사용성이 더 낮음.
+
+### D. 누적 차이 방식 (선택, Decision 섹션에 상세)
+
+- 장점: `readPlannedOverflow` 단일 함수로 일/월 단위 모두 커버. 의미 명확. 환불·조정 케이스에서도 `Math.max(0, ...)` 한 줄로 안전.
+- 단점: `readTodayFlexSpent` 호출당 SQL 3회로 증가 (직접 자유지출 1 + today overflow 1 + yesterday overflow 1). 인덱스 있으면 무시 가능 수준.
+
+## Consequences
+
+### 장점
+
+- SSOT 1개 함수 (`readFlexibleSpent` / `readTodayFlexSpent`).
+- 화면 요약 / 정산 스냅샷 / 일별 로그 자동 정합. 예정지출 예산 초과 시 그 초과분이 자유지출에 즉시 반영되어 월/일 남은 예산이 자동 갱신됨.
+- 향후 자유지출 의미가 변경되어도 1개 함수만 수정하면 모든 사용처에 반영.
+
+### 단점 / 제약
+
+- `readTodayFlexSpent` 가 SQL 3회 호출 (기존 1회). `Promise.all` 로 병렬화했고 인덱스(`expenses(planned_expense_id, billing_month, date)`)가 있어 실측 영향은 무시 가능 수준이지만, 데이터 규모가 커지면 재검토 필요.
+- 기존 `daily_budget_logs.spent` 와 `monthly_budget_snapshots.flexible_spent` 의 과거 값은 옛 정의로 저장되어 있다. 신규 데이터부터 새 정의가 적용되며, 과거 백필은 하지 않는다.
+
+### 후속 작업
+
+- [ ] 예정지출 미달분(언더플로우)을 자유 예산 풀에 환원할지 — 별도 ADR 대상.
+- [ ] 정산 스냅샷 재계산 도구 필요 여부 검토 (과거 월에 대해 새 정의 적용한 값을 보고 싶은 경우).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -113,6 +113,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0004](0004-db-proxy-api.md) | DB Proxy API 패턴 — Vercel→VM DB 직결 제거 | Accepted | 2026-04-09 | infra, security |
 | [0005](0005-uptime-monitoring-github-actions.md) | GitHub Actions 기반 자체 업타임 모니터링 | Accepted | 2026-04-22 | infra, observability |
 | [0006](0006-modify-db-confirm-flow.md) | modify_db 대량 변경 확인 플로우 | Accepted | 2026-04-22 | security, llm, ux |
+| [0007](0007-flexible-spent-unified-definition.md) | 자유지출 정의 통일 — directFlex + plannedOverflow | Accepted | 2026-05-06 | data, budget |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -4,6 +4,7 @@ import { getTodayAllocation } from './facade';
 import { getCurrentBillingMonth, getBillingRange, calcCycleDays } from './billing/cycle';
 import { resolveFixedCostExpenseDate } from './billing/fixed-cost-date';
 import { getBillingMonthForExpense } from './billing/card-billing';
+import { readFlexibleSpent, readTodayFlexSpent } from './repository/expenses-repo';
 import type {
   ExpenseRow,
   FixedCostRow,
@@ -306,34 +307,8 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
   );
   const installmentTotal = Number(installmentResult.rows[0]?.total ?? 0);
 
-  // 예정 지출 연결 건: 예정 금액 초과분만 자유 지출에 가산 (capped 금액은 예정 락에 귀속)
-  const plannedLinkedResult = await query<{ overflow: string }>(
-    `SELECT COALESCE(SUM(GREATEST(used - budget, 0)), 0) as overflow
-     FROM (
-       SELECT p.amount as budget, COALESCE(SUM(e.amount), 0) as used
-       FROM planned_expenses p
-       LEFT JOIN expenses e ON e.planned_expense_id = p.id
-         AND e.billing_month = $2
-       WHERE p.user_id = $1
-       GROUP BY p.id, p.amount
-     ) sub`,
-    [userId, yearMonth],
-  );
-  const plannedOverflow = Number(plannedLinkedResult.rows[0]?.overflow ?? 0);
-
-  // 자유 지출 정의 (readFlexibleSpent와 동일):
-  // 비할부 + 신규 할부 1회차(billing_month=대상 사이클), 예정지출 연결 건 제외, 예정 overflow 가산.
-  const flexResult = await queryOne<{ total: string }>(
-    `SELECT COALESCE(SUM(amount), 0)::text as total FROM expenses
-     WHERE user_id = $1 AND billing_month = $2
-       AND exclude_from_budget = false
-       AND COALESCE(type, 'expense') = 'expense'
-       AND planned_expense_id IS NULL
-       AND (is_installment = false OR (is_installment = true AND installment_num = 1))`,
-    [userId, yearMonth],
-  );
-  const directFlex = Number(flexResult?.total ?? 0);
-  const flexibleSpent = directFlex + plannedOverflow;
+  // 자유 지출 정의는 readFlexibleSpent 단일 정의에 의존 (SSOT)
+  const flexibleSpent = await readFlexibleSpent(userId, yearMonth, to);
 
   // 수입 합계 (type='income')
   const incomeResult = await query<{ total: string }>(
@@ -668,19 +643,8 @@ export async function saveDailyBudgetLog(
   const budget = daily.todayBudget;
   const billingMonth = getCurrentBillingMonth(now);
 
-  // targetDate의 자유 지출을 DB에서 직접 조회 (드리프트로 인해 live today 기준이 다를 수 있음).
-  // readFlexibleSpent와 동일 정의: 비할부 + 신규 할부 1회차(billing_month=현재 사이클).
-  const targetSpentRow = await queryOne<{ spent: string }>(
-    `SELECT COALESCE(SUM(amount), 0)::text as spent
-     FROM expenses
-     WHERE user_id=$1 AND date=$2
-       AND (is_installment=false OR (is_installment=true AND installment_num=1 AND billing_month=$3))
-       AND exclude_from_budget = false
-       AND COALESCE(type,'expense')='expense'
-       AND planned_expense_id IS NULL`,
-    [userId, targetDate, billingMonth],
-  );
-  const spent = Number(targetSpentRow?.spent ?? 0);
+  // targetDate의 자유 지출은 readTodayFlexSpent 단일 정의 사용 (SSOT)
+  const spent = await readTodayFlexSpent(userId, targetDate, billingMonth);
 
   const saved = budget - spent;
 

--- a/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
@@ -5,7 +5,7 @@ vi.mock('@/lib/db', () => ({
 }));
 
 import { query } from '@/lib/db';
-import { readFlexibleSpent, readTodayFlexSpent } from '../expenses-repo';
+import { readFlexibleSpent, readPlannedOverflow, readTodayFlexSpent } from '../expenses-repo';
 
 // biome-ignore lint/suspicious/noExplicitAny: test mock convenience
 type Any = any;
@@ -16,17 +16,21 @@ describe('readFlexibleSpent', () => {
   });
 
   it('planned_expense_id IS NULL 조건이 SQL에 포함되어야 함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '50000' }] } as Any);
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '50000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
 
     await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledTimes(2);
     const sql = vi.mocked(query).mock.calls[0]![0] as string;
     expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
   });
 
-  it('예정지출 연결 건이 자유지출 합계에 포함되지 않아야 함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '30000' }] } as Any);
+  it('예정지출 연결 건이 자유지출 합계에 포함되지 않아야 함 (direct만 합산)', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '30000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
 
     const result = await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
@@ -35,8 +39,20 @@ describe('readFlexibleSpent', () => {
     expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
   });
 
+  it('plannedOverflow 가산: direct 30000 + overflow 5000 = 35000', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '30000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '5000' }] } as Any);
+
+    const result = await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
+
+    expect(result).toBe(35000);
+  });
+
   it('기본 필터 조건: expense 타입, exclude_from_budget=false', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
 
     await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
@@ -46,18 +62,21 @@ describe('readFlexibleSpent', () => {
   });
 
   it('비할부 또는 신규 할부 1회차만 포함하는 조건이 SQL에 있어야 함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
 
     await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
     const sql = vi.mocked(query).mock.calls[0]![0] as string;
-    // 비할부(is_installment=false) OR (is_installment=true AND installment_num=1) 조건 포함
     expect(sql).toMatch(/is_installment\s*=\s*false/i);
     expect(sql).toMatch(/installment_num\s*=\s*1/i);
   });
 
   it('billing_month / date 범위 필터가 SQL에 포함되어야 함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
 
     await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
@@ -75,17 +94,23 @@ describe('readTodayFlexSpent', () => {
   });
 
   it('planned_expense_id IS NULL 조건이 SQL에 포함되어야 함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '15000' }] } as Any);
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '15000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
 
     await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledTimes(3);
     const sql = vi.mocked(query).mock.calls[0]![0] as string;
     expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
   });
 
-  it('예정지출 연결 건이 오늘 자유지출에 포함되지 않아야 함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '10000' }] } as Any);
+  it('예정지출 연결 건이 오늘 자유지출에 포함되지 않아야 함 (direct만)', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '10000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
 
     const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
@@ -95,25 +120,137 @@ describe('readTodayFlexSpent', () => {
   });
 
   it('billingMonth 인자를 받고 SQL의 1회차 조건에 전달되어야 함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
 
     await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
     const sql = vi.mocked(query).mock.calls[0]![0] as string;
     const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
     expect(sql).toMatch(/installment_num\s*=\s*1/i);
-    // 1회차 조건이 billing_month = $3 으로 묶여 있는지
     expect(sql).toMatch(/billing_month\s*=\s*\$3/i);
     expect(params).toEqual([1, '2026-04-10', '2026-04']);
   });
 
   it('비할부 또는 신규 할부 1회차만 포함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any);
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
 
     await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
     const sql = vi.mocked(query).mock.calls[0]![0] as string;
     expect(sql).toMatch(/is_installment\s*=\s*false/i);
     expect(sql).toMatch(/installment_num\s*=\s*1/i);
+  });
+
+  it('일 단위 overflow: today 10000 - yesterday 0 → 10000 가산', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '5000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '10000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+
+    const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
+
+    expect(result).toBe(15000);
+  });
+
+  it('이미 초과 상태에서 추가 지출: today 15000 - yesterday 10000 → 5000 가산', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '15000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '10000' }] } as Any);
+
+    const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
+
+    expect(result).toBe(5000);
+  });
+
+  it('아직 미달이면 0 가산: today 0 - yesterday 0', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '8000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+
+    const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
+
+    expect(result).toBe(8000);
+  });
+
+  it('환불·조정으로 today < yesterday: 음수 방어 → 0 가산', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '3000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '5000' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '8000' }] } as Any);
+
+    const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
+
+    expect(result).toBe(3000);
+  });
+
+  it('어제 날짜를 정확히 -1일로 계산해 readPlannedOverflow에 전달', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+
+    await readTodayFlexSpent(1, '2026-04-01', '2026-04');
+
+    const todayParams = vi.mocked(query).mock.calls[1]![1] as unknown[];
+    const yesterdayParams = vi.mocked(query).mock.calls[2]![1] as unknown[];
+    expect(todayParams).toEqual([1, '2026-04', '2026-04-01']);
+    expect(yesterdayParams).toEqual([1, '2026-04', '2026-03-31']);
+  });
+});
+
+describe('readPlannedOverflow', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('예정지출 합계가 예산 미달이면 0', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+
+    const result = await readPlannedOverflow(1, '2026-04', '2026-04-15');
+
+    expect(result).toBe(0);
+  });
+
+  it('예정지출 초과분만 합산', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '15000' }] } as Any);
+
+    const result = await readPlannedOverflow(1, '2026-04', '2026-04-15');
+
+    expect(result).toBe(15000);
+  });
+
+  it('GREATEST(used - budget, 0) 산식이 SQL에 포함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+
+    await readPlannedOverflow(1, '2026-04', '2026-04-15');
+
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/GREATEST\s*\(\s*used\s*-\s*budget\s*,\s*0\s*\)/i);
+  });
+
+  it('billing_month / date 필터 파라미터 전달', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+
+    await readPlannedOverflow(1, '2026-04', '2026-04-15');
+
+    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    expect(params).toEqual([1, '2026-04', '2026-04-15']);
+  });
+
+  it('user_id 필터가 LEFT JOIN 안에도 명시되어야 함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+
+    await readPlannedOverflow(1, '2026-04', '2026-04-15');
+
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    expect(sql).toMatch(/e\.user_id\s*=\s*p\.user_id/i);
   });
 });

--- a/web/src/features/budget/lib/repository/expenses-repo.ts
+++ b/web/src/features/budget/lib/repository/expenses-repo.ts
@@ -61,6 +61,32 @@ export async function readTodayFlexSpent(
   return Number(result.rows[0]?.total ?? 0);
 }
 
+// 예정지출별 누적 사용량이 예산을 초과한 부분의 합.
+// Σ max(0, used(p, upToDate) - p.amount). 미달/일치는 0, 초과한 만큼만 가산.
+// upToDate 파라미터화로 일/월 단위 모두 같은 함수 재사용.
+export async function readPlannedOverflow(
+  userId: number,
+  billingMonth: string,
+  upToDate: string,
+): Promise<number> {
+  const result = await query<{ overflow: string }>(
+    `SELECT COALESCE(SUM(GREATEST(used - budget, 0)), 0)::text AS overflow
+     FROM (
+       SELECT p.amount AS budget, COALESCE(SUM(e.amount), 0) AS used
+       FROM planned_expenses p
+       LEFT JOIN expenses e
+         ON e.planned_expense_id = p.id
+         AND e.user_id = p.user_id
+         AND e.billing_month = $2
+         AND e.date <= $3
+       WHERE p.user_id = $1
+       GROUP BY p.id, p.amount
+     ) sub`,
+    [userId, billingMonth, upToDate],
+  );
+  return Number(result.rows[0]?.overflow ?? 0);
+}
+
 /** 최근 N개월 변동 지출 월평균 (고정비 제외 일반 지출만) */
 export async function readAvgVariableMonthly(userId: number, months = 3): Promise<number> {
   const result = await query<{ avg_monthly: string }>(

--- a/web/src/features/budget/lib/repository/expenses-repo.ts
+++ b/web/src/features/budget/lib/repository/expenses-repo.ts
@@ -1,29 +1,39 @@
 import { query } from '@/lib/db';
 
-// 신규 할부 1회차(billing_month가 현재 사이클인 1회차)는 자유 지출에 포함.
-// month-allocator의 isNew 조건과 동일 정의 — 신규 할부 1회차는 현재 사이클 락에서 제외되므로
-// 자유 지출에 포함되어야 일/월 단위 예산 정의가 일치.
+function subtractOneDay(dateStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+// 자유 지출 = directFlex + plannedOverflow.
+// directFlex: 비할부 + 신규 할부 1회차, 예정지출 연결 건 제외.
+// plannedOverflow: 예정지출 예산 초과분 (capped 금액은 예정 락에 귀속).
+// 두 정의가 통합되어야 화면/정산/일별 로그가 정합.
 export async function readFlexibleSpent(
   userId: number,
   billingMonth: string,
   upToDate: string,
 ): Promise<number> {
-  const result = await query<{ total: string }>(
-    `SELECT COALESCE(SUM(amount), 0)::text AS total
-     FROM expenses
-     WHERE user_id = $1
-       AND COALESCE(type, 'expense') = 'expense'
-       AND exclude_from_budget = false
-       AND planned_expense_id IS NULL
-       AND billing_month = $2
-       AND date <= $3
-       AND (
-         is_installment = false
-         OR (is_installment = true AND installment_num = 1)
-       )`,
-    [userId, billingMonth, upToDate],
-  );
-  return Number(result.rows[0]?.total ?? 0);
+  const [directResult, overflow] = await Promise.all([
+    query<{ total: string }>(
+      `SELECT COALESCE(SUM(amount), 0)::text AS total
+       FROM expenses
+       WHERE user_id = $1
+         AND COALESCE(type, 'expense') = 'expense'
+         AND exclude_from_budget = false
+         AND planned_expense_id IS NULL
+         AND billing_month = $2
+         AND date <= $3
+         AND (
+           is_installment = false
+           OR (is_installment = true AND installment_num = 1)
+         )`,
+      [userId, billingMonth, upToDate],
+    ),
+    readPlannedOverflow(userId, billingMonth, upToDate),
+  ]);
+  return Number(directResult.rows[0]?.total ?? 0) + overflow;
 }
 
 export async function readExcludedSpent(userId: number, billingMonth: string): Promise<number> {
@@ -39,26 +49,37 @@ export async function readExcludedSpent(userId: number, billingMonth: string): P
   return Number(result.rows[0]?.total ?? 0);
 }
 
+// 일 단위 plannedOverflow 산식: today까지의 누적 overflow - yesterday까지의 누적 overflow.
+// 누적 초과가 처음 발생한 날 그 증가분만 그날 자유지출로 가산되고,
+// 이미 초과 상태에서 추가 지출하면 그 지출 전체가 그날 자유지출로 가산된다.
+// Math.max(0, ...)는 환불·조정 케이스 음수 방어.
 export async function readTodayFlexSpent(
   userId: number,
   today: string,
   billingMonth: string,
 ): Promise<number> {
-  const result = await query<{ total: string }>(
-    `SELECT COALESCE(SUM(amount), 0)::text AS total
-     FROM expenses
-     WHERE user_id = $1
-       AND COALESCE(type, 'expense') = 'expense'
-       AND exclude_from_budget = false
-       AND planned_expense_id IS NULL
-       AND date = $2::date
-       AND (
-         is_installment = false
-         OR (is_installment = true AND installment_num = 1 AND billing_month = $3)
-       )`,
-    [userId, today, billingMonth],
-  );
-  return Number(result.rows[0]?.total ?? 0);
+  const yesterday = subtractOneDay(today);
+  const [directResult, todayOverflow, yesterdayOverflow] = await Promise.all([
+    query<{ total: string }>(
+      `SELECT COALESCE(SUM(amount), 0)::text AS total
+       FROM expenses
+       WHERE user_id = $1
+         AND COALESCE(type, 'expense') = 'expense'
+         AND exclude_from_budget = false
+         AND planned_expense_id IS NULL
+         AND date = $2::date
+         AND (
+           is_installment = false
+           OR (is_installment = true AND installment_num = 1 AND billing_month = $3)
+         )`,
+      [userId, today, billingMonth],
+    ),
+    readPlannedOverflow(userId, billingMonth, today),
+    readPlannedOverflow(userId, billingMonth, yesterday),
+  ]);
+  const direct = Number(directResult.rows[0]?.total ?? 0);
+  const dailyOverflow = Math.max(0, todayOverflow - yesterdayOverflow);
+  return direct + dailyOverflow;
 }
 
 // 예정지출별 누적 사용량이 예산을 초과한 부분의 합.


### PR DESCRIPTION
## 관련 이슈
Closes #374

## 변경 내용
- `readPlannedOverflow` 공통 함수 추가 — 예정지출 예산 초과분 산출 (월/일 단위 재사용)
- `readFlexibleSpent`/`readTodayFlexSpent`에 plannedOverflow 가산 (자유지출 = directFlex + plannedOverflow)
- 일 단위 산식: 누적 차이 방식 (`max(0, today − yesterday)`)
- `queryMonthSummary`/`saveDailyBudgetLog`의 인라인 자유지출 SQL 제거 → 단일 출처(SSOT)로 위임
- ADR 0007 추가: 자유지출 정의 통일 결정 기록 (4개 대안 비교 포함)

## 코드 리뷰 결과
- [x] 보안 감사 통과 (SQL 파라미터 바인딩, 민감 정보 노출 없음)
- [x] 타입 안전성 확인 (`any` 미사용, 제네릭 row shape 명시)
- [x] 컨벤션 점검 완료 (kebab-case, named export, Conventional Commits)
- [x] 코드 품질 확인 (단일 책임, 함수 길이, WHY 주석)

## 테스트
- [x] 신규 9 케이스 추가 (readPlannedOverflow 5 + 가산/일 단위 산식 4)
- [x] vitest 전체 208/208 통과
- [x] facade.test.ts 회귀 없음

## 문서
- [x] ADR 0007 작성 — Decision/Alternatives/Consequences 명시
- [x] ADR README 인덱스 갱신