### PR TITLE
refactor(budget): 일별 로그 cron 시각 KST 05:00 이동 + snapshot 시맨틱 명시화

### DIFF
--- a/docs/adr/0010-daily-log-cron-schedule.md
+++ b/docs/adr/0010-daily-log-cron-schedule.md
@@ -1,0 +1,78 @@
+# 0010. 일별 예산 로그 cron 시각 — KST 새벽 5시 + 전일 스냅샷
+
+- Status: Accepted
+- Date: 2026-05-07
+- Related: #380
+- Tags: infra, data, process
+
+## Context
+
+`daily-budget-log` Vercel cron이 KST 23:50에 발화해 발화 당일 데이터를 저장하는 구조였다. 두 가지 약점이 누적됐다.
+
+1. **발화 당일 마지막 10분 지출 누락** — 23:50 시점에 그날을 닫으니 23:50~24:00 사이 입력은 빠진다.
+2. **자정 슬롯 부하 + 배포 충돌로 cron 스킵 발생** — Vercel cron은 best-effort 스케줄링이며, 자정 근처 슬롯은 글로벌 부하가 높고 배포 진행 중 슬롯이 통과하면 누락된다. 실제 누락 사례 발생.
+
+모닝 크론(node-cron, KST 09:05)에 백필 안전망이 있어 데이터 공백은 막았으나, 근본 개선이 필요했다.
+
+또한 기존 `resolveSnapshotDate(now, driftBufferMs)` 함수는 "발화 당일에서 N시간 차감 후 KST 변환"이라는 모호한 시맨틱이라, 호출 시점만 봐서는 어느 날짜가 저장되는지 즉시 읽히지 않았다.
+
+## Decision
+
+**cron 시각**: KST 05:00 (UTC 20:00, `0 20 * * *`)
+**저장 대상**: 발화 시각 기준 **전일** KST 날짜
+**날짜 계산 함수**: `resolveSnapshotDate` → `resolvePreviousDayDate` 로 시맨틱 명시 변경
+
+```typescript
+export function resolvePreviousDayDate(nowUtc: Date): string {
+  const kstMs = nowUtc.getTime() + 9 * 3_600_000;
+  const previousDayMs = kstMs - 24 * 3_600_000;
+  const kst = new Date(previousDayMs);
+  // ... YYYY-MM-DD 반환
+}
+```
+
+`web/vercel.json`:
+
+```json
+{ "path": "/api/cron/daily-budget-log", "schedule": "0 20 * * *" }
+```
+
+## Alternatives considered
+
+### A. 발화 시각 유지 + 드리프트 버퍼 확대
+
+- 장점: 코드 변경 최소
+- 단점: 자정 슬롯 부하·배포 충돌 문제 미해결. 함수 시맨틱이 여전히 모호("발화 당일에서 N시간 차감")
+- 기각 이유: 운영 약점은 그대로
+
+### B. 새벽 5시 + "전일 스냅샷" 명시 시맨틱 (선택)
+
+- 장점:
+  - 자정 슬롯 회피 → cron 누락률 감소
+  - 데이터 finalized 후 산정 → 마지막 10분 누락 해소
+  - 함수 의도("전일")가 시그니처에 명시 → 향후 cron 시각을 다시 옮겨도 안전
+- 단점: 호출부·테스트 전면 재작성 필요 (소규모, 1회성)
+
+### C. 외부 모니터링 + 알림으로만 처리
+
+- 장점: cron 시각·로직 변경 불필요
+- 단점: 누락 자체는 여전히 발생, 추가 인프라 의존
+- 기각 이유: 근본 개선이 아님
+
+## Consequences
+
+### 장점
+
+- Vercel cron 누락률 감소 (자정 슬롯 회피)
+- 발화 당일 마지막 10분 누락 해소
+- 함수 시그니처가 의도를 표현 → 미래 변경 시 안전성 확보
+
+### 단점 / 제약
+
+- KST 자정~05:00 사이 cron이 누락되면 09:05 모닝 백필까지 4시간 지연 (기존 9시간보다 짧으니 개선)
+- 모든 호출부·테스트가 새 시맨틱에 맞춰 갱신돼야 함
+
+### 후속 작업
+
+- [ ] PR 머지 후 다음 발화(다음날 05:00) 정상 동작 확인
+- [ ] 다른 Vercel cron(`monthly-settlement` 등) 추가 시 동일 패턴 검토

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -116,6 +116,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0007](0007-flexible-spent-unified-definition.md) | 자유지출 정의 통일 — directFlex + plannedOverflow | Accepted | 2026-05-06 | data, budget |
 | [0008](0008-daily-budget-base-vs-recommended.md) | 일 예산 산정 모델 이중화 — 기준 일 예산 + 오늘 예산 | Accepted | 2026-05-06 | data, budget, ux |
 | [0009](0009-daily-log-baseline-anchor.md) | 일별 로그 평가 기준 — 기준 일 예산 단일 anchor | Accepted | 2026-05-06 | data, budget, ux |
+| [0010](0010-daily-log-cron-schedule.md) | 일별 예산 로그 cron 시각 — KST 새벽 5시 + 전일 스냅샷 | Accepted | 2026-05-07 | infra, data, process |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/web/src/app/api/cron/daily-budget-log/route.ts
+++ b/web/src/app/api/cron/daily-budget-log/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { saveDailyBudgetLog } from '@/features/budget/lib/queries';
-import { resolveSnapshotDate } from '@/features/budget/lib/billing/snapshot-date';
+import { resolvePreviousDayDate } from '@/features/budget/lib/billing/snapshot-date';
 import { listAllUserIds } from '@/lib/users';
 
 export const dynamic = 'force-dynamic';
@@ -14,13 +14,13 @@ export async function GET(request: Request) {
   }
 
   try {
-    // Vercel cron 드리프트 방어: 발화 시각에서 1시간 버퍼를 차감한 KST 날짜로 저장.
+    // 새벽 5시(KST) cron 발화 → 전일 KST 날짜로 스냅샷 저장.
     // 크론 누락 시 수동 백필 용도로 ?date=YYYY-MM-DD override 허용.
     const dateParam = new URL(request.url).searchParams.get('date');
     const targetDate =
       dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam)
         ? dateParam
-        : resolveSnapshotDate(new Date());
+        : resolvePreviousDayDate(new Date());
     const userIds = await listAllUserIds();
 
     const results = await Promise.all(

--- a/web/src/features/budget/lib/billing/__tests__/snapshot-date.test.ts
+++ b/web/src/features/budget/lib/billing/__tests__/snapshot-date.test.ts
@@ -1,49 +1,55 @@
 import { describe, expect, it } from 'vitest';
-import { resolveSnapshotDate } from '../snapshot-date';
+import { resolvePreviousDayDate } from '../snapshot-date';
 
-// cron 예약: 14:50 UTC (KST 23:50)
-// 버퍼 차감 후: 13:50 UTC (KST 22:50) → 당일
+// cron 예약: 20:00 UTC (KST 05:00, 익일)
+// 전일 기준: KST 05:00 - 24h = 전날 KST 05:00 → 전일 날짜 반환
 
-describe('resolveSnapshotDate', () => {
-  it('정시 발화 — 당일 KST 날짜 반환', () => {
-    // 14:50 UTC → 13:50 UTC → KST 22:50 → 2026-04-15
-    const utc = new Date('2026-04-15T14:50:00Z');
-    expect(resolveSnapshotDate(utc)).toBe('2026-04-15');
+describe('resolvePreviousDayDate', () => {
+  it('정시 발화(KST 05:00) — 전일 KST 날짜 반환', () => {
+    // 2026-04-15 20:00 UTC = KST 2026-04-16 05:00 → 전일 = 2026-04-15
+    const utc = new Date('2026-04-15T20:00:00Z');
+    expect(resolvePreviousDayDate(utc)).toBe('2026-04-15');
   });
 
-  it('30분 드리프트 — 당일 KST 날짜 유지', () => {
-    // 15:20 UTC → 14:20 UTC → KST 23:20 → 2026-04-15
-    const utc = new Date('2026-04-15T15:20:00Z');
-    expect(resolveSnapshotDate(utc)).toBe('2026-04-15');
+  it('30분 드리프트 — 전일 유지', () => {
+    // 2026-04-15 20:30 UTC = KST 2026-04-16 05:30 → 전일 = 2026-04-15
+    const utc = new Date('2026-04-15T20:30:00Z');
+    expect(resolvePreviousDayDate(utc)).toBe('2026-04-15');
   });
 
-  it('1시간 드리프트 — 당일 KST 날짜 유지', () => {
-    // 15:50 UTC → 14:50 UTC → KST 23:50 → 2026-04-15
-    const utc = new Date('2026-04-15T15:50:00Z');
-    expect(resolveSnapshotDate(utc)).toBe('2026-04-15');
+  it('수 시간 드리프트 — KST 날짜가 같은 한 전일 유지', () => {
+    // 2026-04-15 23:59 UTC = KST 2026-04-16 08:59 → 전일 = 2026-04-15
+    const utc = new Date('2026-04-15T23:59:00Z');
+    expect(resolvePreviousDayDate(utc)).toBe('2026-04-15');
   });
 
-  it('1시간 초과 드리프트 — 다음날로 넘어감 (버퍼 한계)', () => {
-    // 16:10 UTC → 15:10 UTC → KST 00:10 → 2026-04-16
-    const utc = new Date('2026-04-15T16:10:00Z');
-    expect(resolveSnapshotDate(utc)).toBe('2026-04-16');
+  it('발화 시각이 KST 다음날로 넘어가면 그날의 전일 반환', () => {
+    // 2026-04-16 00:00 UTC = KST 2026-04-16 09:00 → 전일 = 2026-04-15
+    const utc = new Date('2026-04-16T00:00:00Z');
+    expect(resolvePreviousDayDate(utc)).toBe('2026-04-15');
   });
 
-  it('KST 자정 직전 — 당일 유지', () => {
-    // 14:59:59 UTC → 13:59:59 UTC → KST 22:59:59 → 2026-04-15
-    const utc = new Date('2026-04-15T14:59:59Z');
-    expect(resolveSnapshotDate(utc)).toBe('2026-04-15');
+  it('월말 경계 — 4월 30일 발화 시 전일은 4월 30일 (당해)', () => {
+    // 2026-04-30 20:00 UTC = KST 2026-05-01 05:00 → 전일 = 2026-04-30
+    const utc = new Date('2026-04-30T20:00:00Z');
+    expect(resolvePreviousDayDate(utc)).toBe('2026-04-30');
   });
 
-  it('월말 경계 — 올바른 날짜 반환', () => {
-    // 2026-04-30 15:00 UTC → 14:00 UTC → KST 23:00 → 2026-04-30
-    const utc = new Date('2026-04-30T15:00:00Z');
-    expect(resolveSnapshotDate(utc)).toBe('2026-04-30');
+  it('월 초 경계 — 5월 1일 발화 시 전일은 5월 1일 (당해)', () => {
+    // 2026-05-01 20:00 UTC = KST 2026-05-02 05:00 → 전일 = 2026-05-01
+    const utc = new Date('2026-05-01T20:00:00Z');
+    expect(resolvePreviousDayDate(utc)).toBe('2026-05-01');
   });
 
-  it('커스텀 버퍼 적용', () => {
-    // 버퍼 30분: 2026-04-15T15:00Z → 14:30Z → KST 23:30 → 2026-04-15
-    const utc = new Date('2026-04-15T15:00:00Z');
-    expect(resolveSnapshotDate(utc, 30 * 60 * 1000)).toBe('2026-04-15');
+  it('연말 경계 — 12월 31일 발화 시 전일은 12월 31일 (당해)', () => {
+    // 2026-12-31 20:00 UTC = KST 2027-01-01 05:00 → 전일 = 2026-12-31
+    const utc = new Date('2026-12-31T20:00:00Z');
+    expect(resolvePreviousDayDate(utc)).toBe('2026-12-31');
+  });
+
+  it('윤년 2월 29일 — 정상 처리', () => {
+    // 2028-02-29 20:00 UTC = KST 2028-03-01 05:00 → 전일 = 2028-02-29
+    const utc = new Date('2028-02-29T20:00:00Z');
+    expect(resolvePreviousDayDate(utc)).toBe('2028-02-29');
   });
 });

--- a/web/src/features/budget/lib/billing/snapshot-date.ts
+++ b/web/src/features/budget/lib/billing/snapshot-date.ts
@@ -1,16 +1,14 @@
 /**
- * Vercel cron 드리프트를 흡수하는 스냅샷 대상 날짜 계산 (순수 함수).
+ * 전일 스냅샷 대상 날짜 계산 (순수 함수).
  *
- * - 입력 시각에서 driftBufferMs(기본 1시간)를 차감
- * - 차감 후 시각을 KST(UTC+9)로 환산해 YYYY-MM-DD 반환
- * - 최대 ~1시간 드리프트까지 당일 날짜 보장
+ * - 발화 시각의 KST 날짜에서 1일을 차감해 YYYY-MM-DD 반환
+ * - 새벽 발화(KST 05:00)에서 어제 데이터를 저장하기 위한 용도
+ * - 발화 시각이 KST 자정~새벽 시간대여도 전일을 안전하게 가리킴
  */
-export function resolveSnapshotDate(
-  nowUtc: Date,
-  driftBufferMs = 3_600_000,
-): string {
-  const anchor = new Date(nowUtc.getTime() - driftBufferMs);
-  const kst = new Date(anchor.getTime() + 9 * 3_600_000);
+export function resolvePreviousDayDate(nowUtc: Date): string {
+  const kstMs = nowUtc.getTime() + 9 * 3_600_000;
+  const previousDayMs = kstMs - 24 * 3_600_000;
+  const kst = new Date(previousDayMs);
   const yyyy = kst.getUTCFullYear();
   const mm = String(kst.getUTCMonth() + 1).padStart(2, '0');
   const dd = String(kst.getUTCDate()).padStart(2, '0');

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -625,11 +625,11 @@ export interface DailyBudgetLogSummary {
 }
 
 /**
- * 오늘의 예산 스냅샷 저장 (Vercel cron에서 호출)
+ * 일별 예산 스냅샷 저장 (Vercel cron에서 호출 — 전일 데이터)
  *
  * @param userId
  * @param opts.targetDate 스냅샷 대상 날짜 (생략 시 KST 오늘).
- *   Vercel cron 드리프트 방지용으로 cron 핸들러에서 `resolveSnapshotDate(new Date())` 를 넘긴다.
+ *   Cron 핸들러는 `resolvePreviousDayDate(new Date())` 로 전일 날짜를 넘긴다.
  */
 export async function saveDailyBudgetLog(
   userId: number,

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/cron/daily-budget-log",
-      "schedule": "50 14 * * *"
+      "schedule": "0 20 * * *"
     },
     {
       "path": "/api/cron/monthly-settlement",


### PR DESCRIPTION
## 관련 이슈
Closes #380

## 변경 내용

- Vercel cron `daily-budget-log` 시각: KST 23:50 → KST 05:00(익일)
- 날짜 계산 함수 시맨틱 변경: `resolveSnapshotDate` (드리프트 버퍼 차감) → `resolvePreviousDayDate` (전일 KST 날짜 명시)
- 호출부(route.ts, queries.ts JSDoc) 갱신
- 테스트 8개 케이스 재작성 — 정시 / 드리프트 / 자정 경계 / 월말·월초 / 연말 / 윤년
- ADR-0010 작성 — 판단 근거·대안 검토 정리

## 개선 효과

- 자정 슬롯 회피로 cron 신뢰성 개선
- 일자 마감 후 산정 → 23:50~24:00 사이 데이터 누락 해소
- 함수 시그니처가 의도("전일")를 명시 → 향후 cron 시각 변경 시 안전성 확보

## 코드 리뷰 결과
- [x] 보안 감사 통과 (외부 입력 정규식 검증, parameterized query)
- [x] 타입 안전성 확인 (`tsc --noEmit` 통과)
- [x] 컨벤션 점검 완료 (named export, any 없음)
- [x] 코드 품질 확인

## 테스트
- [x] snapshot-date 신규 8개 케이스 PASS
- [x] 전체 222개 회귀 테스트 PASS
- [x] TypeScript 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)