### PR TITLE
docs(insight): 사주 패턴 cross-domain 분석 도메인 명시 (#382)

### DIFF
--- a/docs/adr/0011-saju-patterns-cross-domain.md
+++ b/docs/adr/0011-saju-patterns-cross-domain.md
@@ -1,0 +1,100 @@
+# 0011. 사주 패턴 cross-domain 통합 + evidence JSONB 표준화
+
+- Status: Accepted
+- Date: 2026-05-08
+- Related: #382
+- Tags: data, insight, process
+
+## Context
+
+`weekly-saju-review` routine은 매주 일요일 밤 최근 4주 데이터를 일운과 교차 분석하여 사주 패턴을 감지/저장한다. 초기에는 일기 ↔ 일운 상관만 다뤘고 이후 수면 ↔ 일운이 추가됐다. 분석 도메인이 일기·수면 2종으로 제한되어 있어, 사주 시그널이 cross-domain으로 발현되는 특성을 충분히 포착하지 못했다.
+
+같은 사화일에 일기에서는 가족 갈등이, 수면에서는 짧은 수면이, 지출에서는 충동 소비가 동시에 나타나는 식의 cross-domain 시그널은 한 도메인만 보면 파편적으로만 보인다. 분석 도메인을 지출/일정/루틴/식사 등으로 확장할 계획이 있어, **패턴 저장 구조를 어떻게 잡을지** 결정이 필요했다.
+
+또한 현재 evidence JSONB는 도메인마다 자유 형식이라(`{date, diary_excerpt, fortune_element}` vs `{date, sleep_data, fortune_element}`), 분석 코드가 형식을 일관되게 처리하기 어려웠고 새 도메인을 추가할 때마다 형식 협의가 필요했다.
+
+## Decision
+
+### 1. saju_patterns 테이블 통합 유지
+
+도메인별로 테이블을 쪼개지 않는다. `pattern_type`은 사주 구조 분류(`sipsin`/`ganji`/`relation`/`sibiunsung`)로 유지하며, 도메인은 `evidence` 안에서 추적한다.
+
+### 2. evidence JSONB 형식 표준화
+
+```json
+{
+  "date": "YYYY-MM-DD",
+  "domain": "diary" | "sleep" | "expense" | "schedule" | "routine" | ...,
+  "summary": "1~2문장 요약",
+  "fortune_element": "편재" | "사화" | "사해충" | "장생" | ...,
+  ...domain_specific_fields
+}
+```
+
+도메인별 추가 필드 예시:
+- diary: `{event_keywords, emotion}`
+- sleep: `{deviation_minutes, sleep_type, mid_wake_count}`
+- expense: `{category, amount, over_budget, memo_excerpt}`
+- schedule: `{signal_type, count, categories}`
+- routine: `{rate, slot_rates}`
+
+### 3. 분석 윈도우 28일 통일
+
+지출/일정/루틴을 포함한 모든 도메인을 4주(28일) 롤링으로 통일. 패턴 감지의 본질이 반복성 검증이므로 더 짧은 윈도우(예: 1주)는 우연을 패턴으로 오인할 위험이 있다.
+
+### 4. 예산 초과 판정 — 기준 일 예산 사용
+
+`daily_budget_logs.budget`(=todayBudget, [ADR 0009](0009-daily-log-baseline-anchor.md))과 `spent`를 비교해 `saved < 0`인 날을 초과일로 본다. 동적 추천 예산(todayRecommended) 초과 판정은 retroactive 추적이 불가능하므로 본 작업 범위에서는 다루지 않는다.
+
+## Alternatives considered
+
+### A. 도메인별 테이블 분리 (`saju_patterns_diary`, `saju_patterns_sleep`, ...)
+
+- 장점: 도메인별 스키마 최적화, 도메인 추가 시 영향 범위 작음
+- 단점: 같은 trigger_element가 여러 도메인에 동시 발현하는 cross-domain 시그널을 통합적으로 추적 못 함. 패턴 매칭 로직이 도메인 수만큼 복잡해짐.
+- 기각 이유: 사주 패턴의 본질이 cross-domain이라 분리는 시그널 손실.
+
+### B. evidence 자유 형식 유지 (도메인별 ad-hoc 필드)
+
+- 장점: 마이그레이션/표준화 없음
+- 단점: 도메인 추가 시 매번 형식 협의 필요. 분석 코드가 evidence 형식을 일관되게 처리하지 못함.
+- 기각 이유: 도메인 추가가 예정된 상황에서 표준 없이 시작하면 부채.
+
+### C. 표준 컬럼 추가 (`evidence_domain TEXT`)
+
+- 장점: SQL 쿼리에서 도메인 필터링 직접 가능
+- 단점: 한 패턴의 evidence가 멀티 도메인일 수 있음(같은 trigger의 cross-domain 발현 누적). 단일 컬럼으로는 표현 불가.
+- 기각 이유: cross-domain 표현력 손실.
+
+### D. 본 결정 — 통합 + JSONB 표준화 (선택)
+
+- 장점: cross-domain 통합 추적 + 도메인 추가 시 마이그레이션 불필요
+- 단점: 도메인 필터링은 JSONB 쿼리 필요 (`evidence @> '[{"domain": "expense"}]'`)
+
+## Consequences
+
+### 장점
+
+- cross-domain 시그널 통합 추적 — 한 trigger_element가 여러 도메인에 발현한 누적 evidence가 한 row에 모임
+- 도메인 추가 시 마이그레이션 불필요 — evidence 안에서 새 domain 값과 추가 필드만 정의하면 끝
+- pattern_type을 사주 구조(sipsin/ganji/relation/sibiunsung)로 유지하므로 기존 분석 코드(insight prompt 등) 무영향
+- 28일 윈도우 통일로 도메인 간 비교 가능, 분석 일관성 확보
+
+### 단점 / 제약
+
+- evidence 안에서 도메인별 필터링은 JSONB 쿼리 필요. 활성 패턴이 누적되면 인덱스 추가가 필요해질 수 있음
+- evidence 형식이 표준 외로 어긋나면 분석 코드가 깨짐 — SKILL.md에 형식 명시 + 검증 책임은 분석 routine(LLM)에 위임
+- 동적 추천 예산 초과 판정은 본 ADR 범위 밖. 추후 별도 결정 필요
+
+### 후속 작업
+
+- [ ] 식사·운동 등 신규 도메인 추가 시 본 ADR의 domain enum 갱신
+- [ ] evidence JSONB의 domain별 인덱스 필요성 모니터링 (활성 패턴이 100건 이상이고 도메인 필터 쿼리가 잦아질 때)
+- [ ] 동적 추천 예산 초과 판정을 위한 `daily_budget_logs.recommended_budget` 컬럼 도입 검토 (별도 이슈)
+
+---
+
+**참고 자료**
+
+- [ADR 0009 — 일별 로그 평가 기준 (기준 일 예산 단일 anchor)](0009-daily-log-baseline-anchor.md)
+- [docs/domains/insight.md](../domains/insight.md) — saju_patterns 스키마 및 cross-domain 분석 도메인 정의

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -117,6 +117,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0008](0008-daily-budget-base-vs-recommended.md) | 일 예산 산정 모델 이중화 — 기준 일 예산 + 오늘 예산 | Accepted | 2026-05-06 | data, budget, ux |
 | [0009](0009-daily-log-baseline-anchor.md) | 일별 로그 평가 기준 — 기준 일 예산 단일 anchor | Accepted | 2026-05-06 | data, budget, ux |
 | [0010](0010-daily-log-cron-schedule.md) | 일별 예산 로그 cron 시각 — KST 새벽 5시 + 전일 스냅샷 | Accepted | 2026-05-07 | infra, data, process |
+| [0011](0011-saju-patterns-cross-domain.md) | 사주 패턴 cross-domain 통합 + evidence JSONB 표준화 | Accepted | 2026-05-08 | data, insight, process |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -66,14 +66,15 @@ life_themes:
   mention_count INTEGER,
   created_at TIMESTAMPTZ
 
--- 사주 패턴 (일기 x 일운 상관 분석)
+-- 사주 패턴 (cross-domain x 일운 상관 분석)
 saju_patterns:
   id SERIAL PK,
   user_id INTEGER,
   pattern_type TEXT,     -- 'sipsin' | 'ganji' | 'relation' | 'sibiunsung'
   trigger_element TEXT,
   description TEXT,
-  evidence JSONB,
+  evidence JSONB,        -- [{date, domain, summary, fortune_element, ...domain_specific}]
+                         -- domain: 'diary' | 'sleep' | 'expense' | 'schedule' | 'routine'
   active BOOLEAN,
   detection_count INTEGER,
   first_detected TIMESTAMPTZ,
@@ -116,8 +117,11 @@ saju_patterns:
 - 해결 시 `active = false`
 
 ### 4. 사주 패턴 (saju_patterns)
-- 월간 자동 분석(Opus)으로 감지, 사용자 수동 관리 가능
+- 주간 자동 분석(weekly-saju-review)으로 감지, 사용자 수동 관리 가능
 - pattern_type: sipsin(십신) / ganji(특정 글자) / relation(합/형/충) / sibiunsung(십이운성)
+- **분석 도메인**: 일기, 수면, 지출, 일정, 루틴 (cross-domain 통합 분석, 28일 롤링 윈도우)
+- **evidence 표준 형식**: `{date, domain, summary, fortune_element, ...domain_specific}` — 도메인 추가(식사·운동 등) 시 마이그레이션 없이 확장 가능. 상세는 [ADR 0011](../adr/0011-saju-patterns-cross-domain.md) 참조
+- 같은 trigger_element가 여러 도메인에 발현하면 분리하지 않고 같은 row의 evidence에 누적
 - 감지 횟수 추적 (detection_count), 신뢰도 평가 (confidence)
 - 비활성화 시 `active = false`, `deactivated_at = NOW()`
 


### PR DESCRIPTION
## 관련 이슈
Closes #382

## 변경 내용

`weekly-saju-review` routine의 분석 도메인이 일기·수면 외(지출/일정/루틴/중간기상)로 확장되며, 패턴 저장 구조 결정 + 문서 정합성 작업을 진행했다.

- **ADR 0011 신규 작성**: 사주 패턴 cross-domain 통합 + evidence JSONB 표준화 결정 기록
  - saju_patterns 테이블 통합 유지 (도메인별 분리 X)
  - evidence 표준 형식: `{date, domain, summary, fortune_element, ...domain_specific}`
  - 모든 도메인 28일 롤링 윈도우 통일
  - 예산 초과 판정은 [ADR 0009](../../docs/adr/0009-daily-log-baseline-anchor.md) 기준 일 예산 사용
- **ADR README 인덱스에 0011 한 줄 추가**
- **docs/domains/insight.md 갱신**:
  - saju_patterns 스키마 주석을 "일기 x 일운"에서 "cross-domain x 일운"으로 변경
  - evidence JSONB 형식 + 도메인 enum 명시
  - cross-domain 누적 원칙 + ADR 0011 링크 추가
  - 분석 주기를 "월간(Opus)" → "주간(weekly-saju-review)"로 정정

> 외부 routine 파일(`~/.claude/scheduled-tasks/weekly-saju-review/SKILL.md`)은 git 비추적이라 PR 미포함. 8단계 구조로 별도 동기화 완료.

## 코드 리뷰 결과
- [x] 보안 감사 통과 (개인 정보·내부 경로·재정 단서 없음)
- [x] 문서 형식 일관성 확인 (Michael Nygard, 인덱스 정렬)
- [x] insight.md 스키마와 ADR 0011 도메인 enum 일치
- [x] 마크다운 틸드 이스케이프 규칙 준수 (CLAUDE.md)

## 테스트
코드 변경 없음 (문서 PR). routine 동작 검증은 외부 SKILL.md 수동 실행으로 진행:
- [ ] 다음 주 일요일 weekly-saju-review 발화 시 8단계 모두 정상 진행
- [ ] 도메인별 graceful skip (데이터 부족 시) 확인
- [ ] evidence JSONB가 표준 형식으로 저장되는지 sample 1\~2건 확인

## 후속 작업 (별도 이슈 예정)
- 동적 추천 예산 초과 판정용 `daily_budget_logs.recommended_budget` 컬럼 도입 검토
- 활성 패턴 누적 시 evidence JSONB의 domain별 인덱스 필요성 모니터링