### PR TITLE
refactor(insight): formatFortune wrapper 제거 + FortuneRow.summary 타입 정합

### DIFF
--- a/src/agents/insight/index.ts
+++ b/src/agents/insight/index.ts
@@ -27,14 +27,11 @@ interface FortuneRow {
   period: string;
   day_pillar: string | null;
   analysis: string;
-  summary: string;
+  summary: string | null;
   warnings: unknown;
   recommendations: unknown;
   advice: string | null;
 }
-
-/** fortune_analyses 조회 → Slack mrkdwn 포맷 (summary + analysis + advice) */
-const formatFortune = (row: FortuneRow): string => formatFortuneText(row);
 
 /** fast path 운세 조회 시도. 매칭되면 응답 전송 후 true 반환. */
 const tryFortuneFastPath = async (
@@ -87,7 +84,7 @@ const tryFortuneFastPath = async (
     if (!row) {
       await sendMessage(say, `아직 ${label} 분석이 준비되지 않았어.`);
     } else {
-      await sendMessage(say, formatFortune(row));
+      await sendMessage(say, formatFortuneText(row));
     }
   } catch (error: unknown) {
     console.error(`[Insight Agent] ${label} fast path 오류:`, error);


### PR DESCRIPTION
## 관련 이슈
Closes #386

## 변경 내용
- `src/agents/insight/index.ts:37` — `formatFortune` 한 줄짜리 wrapper 제거. 호출부에서 `formatFortuneText` 직접 사용.
- `src/agents/insight/index.ts:30` — `FortuneRow.summary` 타입을 `string | null`로 변경 (DB 스키마 nullable + `FortuneFormatInput` 시그니처와 정합).

PR #385 코드 리뷰에서 후속 처리로 분류된 두 항목 정리. 동작 변화 없음.

## 코드 리뷰 결과
- [x] 보안 감사 통과 (변경 없음)
- [x] 타입 안전성 확인 (string → string | null로 정합 강화)
- [x] 컨벤션 점검 완료
- [x] 코드 품질 확인 (불필요한 wrapper 제거)

## 테스트
- [x] 전체 vitest 382/382 통과
- [x] tsc --noEmit 통과