### PR TITLE
feat(insight): 프로액티브 인사이트 v2 Phase 1 — 패턴 통합·임계치 외부화·주간 리포트 재구성

### DIFF
--- a/docs/adr/0014-insight-engine-unification.md
+++ b/docs/adr/0014-insight-engine-unification.md
@@ -1,0 +1,122 @@
+# 0014. 프로액티브 인사이트 엔진 통합 — 매일·주간 단일 엔진 + 임계치 외부화
+
+- Status: Accepted
+- Date: 2026-05-13
+- Related: #389 (Phase 1), #393 (마스터)
+- Tags: data, insight, process
+
+## Context
+
+기존 `src/shared/insights.ts`의 5개 SQL 패턴(streak / sleepTrend / slotGap / weekComparison / overdueAlert)은:
+- 함수 내부에 임계치가 하드코딩되어 있어 한눈에 비교·튜닝 불가
+- 단일 도메인 한정이라 cross-domain 시그널 부재
+- timing이 morning/night 2종이라 주간 회고에 활용 불가
+- 호출 자체가 한때 제거된 상태(주석으로 복원 가능 표시) — 패턴 엔진이 실제로 작동하지 않고 있었음
+
+그리고 별도 동선으로 돌아가던 `weekly-report.ts`는 집계 위주(평균/best/worst/카테고리 분포)였고, 사용자가 거의 읽지 않는다고 명시. 시그널이 noise에 묻혀 잔소리꾼 친구 톤이 살지 않음.
+
+Phase 1 (#389) 진입 시 SQL 패턴을 6개 추가하기로 결정했고, 이 시점에 인사이트 엔진 전체를 통합·재정렬할 필요가 생겼다. 추가로 마스터 #393 v2 철학은 "LLM 텍스트 해석 의존도 최소화 + 결정론적 잔소리 + 사주 가설-검증"이라, 임계치 튜닝(Phase 4)과 도메인 매핑(Phase 4)을 위해서 임계치가 한 곳에 모여있어야 한다.
+
+## Decision
+
+세 가지 결정을 한 묶음으로 채택한다.
+
+### 1. 매일 잔소리 + 주간 리포트를 단일 패턴 엔진 위에서 동작
+
+- `Insight` 타입에 `timing: 'morning' | 'night' | 'weekly'` 추가
+- 패턴 함수(`detect*`)가 timing 매개변수를 받거나, 결과의 timing 필드로 분류
+- 매일 잔소리 = `pickMorningNudges` / `pickNightNudges`
+- 주간 리포트 = `pickWeeklyInsights` + 집계 데이터를 함께 노출
+- 기존 weekly-report.ts의 집계 SQL은 유지(LLM 총평 컨텍스트로 활용), 다만 Block Kit 표시는 압축
+
+### 2. 임계치 단일 외부 파일
+
+`src/shared/insight-thresholds.ts`에 `INSIGHT_THRESHOLDS`로 전체 임계치 export.
+
+```typescript
+export const INSIGHT_THRESHOLDS = {
+  streak: { ... },
+  sleepTrend: { ... },
+  // ...
+  pickByTiming: { minPriority: 5, maxItems: 3 },
+} as const;
+```
+
+각 detect 함수는 함수 진입부에서 `INSIGHT_THRESHOLDS.<type>`을 구조 분해하여 사용.
+
+### 3. 매일 동적 노출 (priority threshold + 도메인 dedupe + cap)
+
+기존 `pickByTiming`은 priority 최상위 1개만 반환. 신규 로직:
+
+```
+1. 모든 detect* 실행 → 후보 수집
+2. priority ≥ 5 필터
+3. priority 내림차순 정렬
+4. 같은 domain(routine/sleep/schedule) 중복 시 priority 최상위 1개만
+5. 최대 3개 cap
+6. 0개면 메시지 발송 안 함 (no-news is good news)
+```
+
+표시는 단순 텍스트 줄바꿈 (Block Kit은 주간 리포트만 사용).
+
+### 4. 주간 리포트 시간 이동 + 구조 재구성
+
+- 일요일 23:00 → 월요일 09:00 (지난주 회고 시점이 더 자연스러움 + 일요일 23:00은 아직 안 끝난 시점)
+- 월요일 매일 morning 인사이트는 스킵 (주간 리포트가 대체)
+- Block Kit 구조: 인사이트 → 한눈에 보기 → 총평. 이모지 X.
+
+## Alternatives considered
+
+### A. 매일/주간 따로 두기 (현행 유지)
+
+- 장점: 변경 폭 최소
+- 단점:
+  - 매일 잔소리가 작동하지 않는 상태(호출 주석 처리)
+  - 임계치 산재 상태 유지 — Phase 4 튜닝 시 부담
+  - 주간 리포트가 안 읽힘 문제 미해결
+- 기각 이유: Phase 1 패턴 추가 시점에 손대지 않으면 동일 코드 흩어진 채 부채 누적.
+
+### B. 매일/주간 모두 같은 엔진 + 매일도 Block Kit
+
+- 장점: UI 일관성
+- 단점:
+  - 매일 잔소리가 카드형이 되면 잔소리꾼 친구 톤(짧고 가벼움)과 어긋남
+  - "신호 적은 날도 풀 카드 발송" → 무게감 과잉
+- 기각 이유: 잔소리는 짧을수록 좋다는 프로젝트 톤 원칙(CLAUDE.md "잔소리는 짧게 한 문장")과 충돌.
+
+### C. 임계치 외부화 미수행, 새 패턴만 추가
+
+- 장점: 변경 폭 작음
+- 단점: 11개 패턴(기존 5 + 신규 6) 임계치가 11개 함수에 흩어짐. Phase 4 튜닝 부담 폭증.
+- 기각 이유: 패턴 수가 늘어나는 시점이 외부화 적기. 미루면 부채 커짐.
+
+### D. 본 결정 — 통합 + 외부화 + 재구성 (선택)
+
+- 장점: 11개 패턴이 같은 구조 위에서 동작, 임계치 한 곳, 매일/주간 일관된 메시지 톤, 주간 리포트 시그널 명확화
+- 단점:
+  - 변경 폭 큼 (1 PR에 cron/insights/weekly-report/thresholds 모두 포함)
+  - 단일 PR이라 리뷰 부담
+
+## Consequences
+
+### 장점
+
+- **임계치 단일 튜닝 지점**: Phase 4 사주 매핑 시 카테고리/패턴별 임계치를 한 파일에서 조정 가능
+- **잔소리 톤 회복**: 매일은 짧은 텍스트(0\~3개), 주간은 카드형 — 시그널·노이즈 분리
+- **단일 패턴 엔진**: 신규 패턴 추가 시 timing 필드만 결정하면 매일/주간 자동 분류
+- **잔잔한 날 = 침묵**: 패턴 0개면 매일 메시지 skip — 잔소리 피로도 ↓
+- **주간 리포트 가독성**: 인사이트가 최상단, 집계는 1\~2줄 요약
+- **이모지 미포함**: 사용자 선호 반영 (CLAUDE.md "이모지/존댓말 금지" 강화)
+
+### 단점 / 제약
+
+- Insight 인터페이스에 `domain` 필드 추가 — 기존 detect\* 함수 5개 모두 갱신 필요
+- weekly-report.ts의 기존 Block Kit이 재작성됨 — 기존 best/worst day 등의 정보는 LLM 총평 컨텍스트로만 활용
+- 동적 노출 정책상 priority 4 이하 패턴(sleepTrend↑ 등)이 매일 노출 안 됨 — 명시적 의도로 sleep 패턴은 priority 8/4 분기 유지
+
+### 후속 작업
+
+- [ ] 1주 운영 후 `INSIGHT_THRESHOLDS.pickByTiming.minPriority` 튜닝 (메시지 빈도 관찰)
+- [ ] Phase 2 (#390) LLM 자율 슬롯 도입 시 `Insight.domain`을 'cross-domain'으로 확장 검토
+- [ ] Phase 4 (#392) categories 메타데이터 확장 시 categorySkew의 카테고리별 가중치 추가
+- [ ] `notification_settings.weeklyReport` 시간 변경 마이그레이션 운영 DB 적용 — 사용자가 직접 실행 (보안 크리티컬 작업 원칙)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -120,6 +120,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0011](0011-saju-patterns-cross-domain.md) | 사주 패턴 cross-domain 통합 + evidence JSONB 표준화 | Accepted | 2026-05-08 | data, insight, process |
 | [0012](0012-fortune-personalization.md) | 운세 분석 개인화 — 라이프 테마 두 트랙 + 의사결정 가이드 + 자연 prose | Accepted | 2026-05-08 | data, llm, ux |
 | [0013](0013-schedule-category-fk-migration.md) | 일정 카테고리 — TEXT 참조 → 단일 FK + parent_id 계층화 | Accepted | 2026-05-13 | data, schema, refactor |
+| [0014](0014-insight-engine-unification.md) | 프로액티브 인사이트 엔진 통합 — 매일·주간 단일 엔진 + 임계치 외부화 | Accepted | 2026-05-13 | data, insight, process |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -161,6 +161,40 @@ weekly-fortune routine이 일운/월운/세운/대운을 생성. fortune_analyse
 - `ChatHistory` 클래스로 채널별 대화 기록 유지
 - LLM 에이전트 루프에 이전 대화 맥락 전달
 
+### 8. 프로액티브 인사이트 엔진 (Phase 1)
+
+`src/shared/insights.ts`의 SQL 기반 패턴 감지 엔진. LLM 호출 없음 (비용 0).
+
+#### 패턴 일람
+
+| type | timing | domain | 톤 | 트리거 |
+|------|--------|--------|----|--------|
+| streak | morning | routine | 칭찬 | 매일 루틴 3·5·7·10·14·21·30일 연속 |
+| sleepTrend ↓ | night | sleep | 잔소리 | 최근 3일 수면 감소 + 7h 미만 |
+| sleepTrend ↑ | night | sleep | 칭찬 | 최근 3일 수면 증가 |
+| slotGap | night | routine | 관찰 | 시간대별 달성률 격차 30%p+ |
+| weekComparison ↑ | morning | routine | 칭찬 | 이번주 - 지난주 ≥5%p |
+| weekComparison ↓ | night | routine | 잔소리 | 이번주 - 지난주 ≤-5%p |
+| overdueAlert | morning | schedule | 잔소리 | 밀린 일정 3건+ |
+| categorySkew | night/weekly | schedule | 관찰 | 7일/지난주 1위 카테고리 ≥50% |
+| drift | weekly | sleep | 관찰/잔소리 | 4주 평균 대비 취침·기상 30분+ 또는 중간기상 1.5배+ |
+| recovery | morning | routine | 칭찬 | streak 5일+ 깨진 후 1일 만에 재시작 |
+| lapseAlert | night | routine | 잔소리 | 7일 100% 루틴이 오늘 빠짐 |
+| weeklyRegression | weekly | routine | 잔소리 | 지난주 ≥90% → 이번주 ≤60% |
+| spottyPattern | night | routine | 잔소리 | 7일 중 3\~4일 산발 빠짐 |
+
+#### 동적 노출
+
+- 매일 morning(09:05) / night(23:55): priority ≥5인 패턴 최대 3개, 같은 도메인은 priority 최상위 1개만
+- 주간 리포트(월요일 09:00): weekly 패턴 전체 (cap 없음, Block Kit으로 표시)
+- 0건이면 매일 메시지 발송 안 함 (no-news is good news). 주간 리포트는 "잔잔했어" 한 줄 발송.
+
+#### 임계치
+
+모든 임계치는 `src/shared/insight-thresholds.ts`의 `INSIGHT_THRESHOLDS`에서 단일 관리. Phase 4 사주 매핑 단계에서 튜닝 가능.
+
+상세 배경 및 대안 비교는 [ADR 0014](../adr/0014-insight-engine-unification.md) 참조.
+
 ## 파일 구조
 
 ```

--- a/scripts/migrations/2026-05-13-weekly-report-monday/migrate.sql
+++ b/scripts/migrations/2026-05-13-weekly-report-monday/migrate.sql
@@ -1,0 +1,11 @@
+-- 주간 리포트 발송 시각 이동: 일요일 23:00 → 월요일 09:00
+-- 배경: 지난주 회고가 월요일 아침에 더 자연스러우며, 일요일 23:00은 아직 하루가 끝나지 않은 시점
+
+BEGIN;
+
+UPDATE notification_settings
+SET time_value = '09:00',
+    label = '주간 리포트 (월요일 아침)'
+WHERE slot_name = 'weeklyReport';
+
+COMMIT;

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -45,8 +45,7 @@ import {
   buildNightScheduleText,
   buildYesterdayIncompleteText,
 } from '../agents/life/blocks.js';
-// insights.ts 넛지는 제거 — Sonnet이 생활 맥락에서 직접 인사이트 도출
-// 복원 시: import { pickMorningNudge, pickNightNudge } from '../shared/insights.js';
+import { pickMorningNudges, pickNightNudges } from '../shared/insights.js';
 import { weeklyReportTask } from './weekly-report.js';
 import { buildLifeContext } from '../shared/life-context.js';
 import { publishHomeView } from '../agents/life/home.js';
@@ -417,6 +416,16 @@ const morningTask = async (app: App, config: LifeCronConfig): Promise<void> => {
       await postToChannel(app.client, channelId, yesterdayIncompleteText);
     }
 
+    // 1-3. 프로액티브 인사이트 (priority ≥5인 패턴 0~3개)
+    // 월요일은 09:00 주간 리포트가 별도 발송 → 중복 방지
+    if (getKSTDayOfWeek() !== 1) {
+      const insights = await pickMorningNudges(today, userId);
+      if (insights.length > 0) {
+        const text = insights.map((i) => i.message).join('\n');
+        await postToChannel(app.client, channelId, text);
+      }
+    }
+
     // 2. 오늘 루틴 기록 생성
     const created = await createTodayRecords(today, userId);
 
@@ -497,6 +506,13 @@ const nightTask = async (app: App, config: LifeCronConfig): Promise<void> => {
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       console.error(`[Life Cron] 밤 마무리 메시지 전송 실패 (유저=${userId}): ${msg}`);
+    }
+
+    // 프로액티브 인사이트 (priority ≥5인 패턴 0~3개)
+    const insights = await pickNightNudges(today, userId);
+    if (insights.length > 0) {
+      const text = insights.map((i) => i.message).join('\n');
+      await postToChannel(app.client, channelId, text);
     }
 
     console.warn(`[Life Cron] 밤 요약 전송 완료 (유저=${userId})`);

--- a/src/cron/weekly-report.ts
+++ b/src/cron/weekly-report.ts
@@ -1,12 +1,14 @@
 /**
  * 주간 리포트.
- * 매주 일요일 실행: SQL 집계 → Block Kit + LLM 한줄 총평.
- * 일요일 아닌 날은 early return.
+ * 매주 월요일 09:00 실행 (지난주 회고): SQL 집계 + 인사이트 + LLM 총평.
+ * 월요일 아닌 날은 early return.
  */
 
 import type { App } from '@slack/bolt';
 import type { LifeCronConfig } from './life-cron.js';
 import type { LLMMessage } from '../shared/llm.js';
+import type { Insight } from '../shared/insights.js';
+import { pickWeeklyInsights } from '../shared/insights.js';
 import { query } from '../shared/db.js';
 import { getTodayISO, getKSTDayOfWeek, addDays, formatDateShort } from '../shared/kst.js';
 import { postBlockMessage } from '../shared/slack.js';
@@ -381,106 +383,54 @@ const formatDuration = (minutes: number): string => {
   return m > 0 ? `${h}시간 ${m}분` : `${h}시간`;
 };
 
-/** 주간 리포트 Block Kit 빌드 */
-const buildWeeklyReportBlocks = (data: WeeklyReportData, summary: string): KnownBlock[] => {
-  const { sleep, routine, schedule, correlation, weekStart, weekEnd } = data;
+/** 주간 리포트 Block Kit 빌드: 인사이트 우선 → 한눈에 보기 → 총평. */
+const buildWeeklyReportBlocks = (
+  data: WeeklyReportData,
+  insights: Insight[],
+  summary: string,
+): KnownBlock[] => {
+  const { sleep, routine, schedule, weekStart, weekEnd } = data;
   const blocks: KnownBlock[] = [];
 
   blocks.push({
     type: 'header',
     text: {
       type: 'plain_text',
-      text: `📊 주간 리포트 (${formatDateShort(weekStart)} ~ ${formatDateShort(weekEnd)})`,
-      emoji: true,
+      text: `지난주 리포트 (${formatDateShort(weekStart)} ~ ${formatDateShort(weekEnd)})`,
+      emoji: false,
     },
   });
 
-  // ── 수면 ──
+  // ── 인사이트 ──
   blocks.push({ type: 'divider' });
-  if (sleep.recordCount < 2) {
+  if (insights.length > 0) {
+    const lines = ['*이번 주 인사이트*', ...insights.map((i) => `• ${i.message}`)];
+    blocks.push({ type: 'section', text: { type: 'mrkdwn', text: lines.join('\n') } });
+  } else {
     blocks.push({
       type: 'section',
-      text: { type: 'mrkdwn', text: '*수면*\n데이터 부족 (2건 미만)' },
+      text: { type: 'mrkdwn', text: '이번 주는 특별한 패턴 없이 잔잔했어' },
     });
-  } else {
-    const lines = [
-      `*수면*`,
-      `평균 ${formatDuration(sleep.avgDuration)} (${sleep.recordCount}일 기록)`,
-    ];
-    if (sleep.bestDay && sleep.worstDay && sleep.bestDay.date !== sleep.worstDay.date) {
-      lines.push(
-        `가장 잘 잔 날: ${formatDateShort(sleep.bestDay.date)} ${formatDuration(sleep.bestDay.duration)} | 가장 못 잔 날: ${formatDateShort(sleep.worstDay.date)} ${formatDuration(sleep.worstDay.duration)}`,
-      );
-    }
-    blocks.push({ type: 'section', text: { type: 'mrkdwn', text: lines.join('\n') } });
   }
 
-  // ── 루틴 ──
+  // ── 한눈에 보기 (집계 압축) ──
   blocks.push({ type: 'divider' });
-  if (routine.thisWeekTotal < 2) {
-    blocks.push({
-      type: 'section',
-      text: { type: 'mrkdwn', text: '*루틴*\n데이터 부족 (2건 미만)' },
-    });
-  } else {
-    const lastPart = routine.lastWeekRate != null ? ` — 지난주 ${routine.lastWeekRate}%` : '';
-    const lines = [
-      `*루틴*`,
-      `주간 달성률: ${routine.thisWeekRate}% (${routine.thisWeekCompleted}/${routine.thisWeekTotal})${lastPart}`,
-    ];
-    if (routine.slotBreakdown.length > 0) {
-      lines.push(
-        `시간대별: ${routine.slotBreakdown.map((s) => `${s.slot} ${s.rate}%`).join(', ')}`,
-      );
-    }
-    if (routine.bestRoutine) {
-      const worstPart = routine.worstRoutine
-        ? ` | 최저: ${routine.worstRoutine.name} ${routine.worstRoutine.rate}%`
-        : '';
-      lines.push(`최고: ${routine.bestRoutine.name} ${routine.bestRoutine.rate}%${worstPart}`);
-    }
-    blocks.push({ type: 'section', text: { type: 'mrkdwn', text: lines.join('\n') } });
+  const glance: string[] = ['*한눈에 보기*'];
+  if (sleep.recordCount >= 2) {
+    glance.push(`수면 평균 ${formatDuration(sleep.avgDuration)} (${sleep.recordCount}일 기록)`);
   }
-
-  // ── 일정 ──
-  blocks.push({ type: 'divider' });
-  const total = schedule.completedCount + schedule.incompleteCount + schedule.cancelledCount;
-  if (total < 2) {
-    blocks.push({
-      type: 'section',
-      text: { type: 'mrkdwn', text: '*일정*\n데이터 부족 (2건 미만)' },
-    });
-  } else {
-    const lines = [
-      `*일정*`,
-      `완료 ${schedule.completedCount}건 / 미완료 ${schedule.incompleteCount}건 / 취소 ${schedule.cancelledCount}건`,
-    ];
-    if (schedule.categories.length > 0) {
-      lines.push(
-        `카테고리: ${schedule.categories.map((c) => `${c.category} ${c.count}건`).join(', ')}`,
-      );
-    }
-    if (schedule.overdueCount > 0) {
-      lines.push(`밀린 일정: ${schedule.overdueCount}건`);
-    }
-    blocks.push({ type: 'section', text: { type: 'mrkdwn', text: lines.join('\n') } });
+  if (routine.thisWeekTotal >= 2) {
+    const lastPart = routine.lastWeekRate != null ? ` (지난주 ${routine.lastWeekRate}%)` : '';
+    glance.push(`루틴 달성률 ${routine.thisWeekRate}%${lastPart}`);
   }
-
-  // ── 수면 × 루틴 상관관계 ──
-  if (correlation.goodSleepRate != null && correlation.badSleepRate != null) {
-    blocks.push({ type: 'divider' });
-    blocks.push({
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `*🔗 수면 × 루틴 상관관계*\n7시간+ 잔 날 루틴 ${correlation.goodSleepRate}% vs 6시간 미만 ${correlation.badSleepRate}%`,
-      },
-    });
+  if (schedule.completedCount + schedule.incompleteCount >= 2) {
+    glance.push(`일정 완료 ${schedule.completedCount}건 / 미완료 ${schedule.incompleteCount}건`);
   }
+  blocks.push({ type: 'section', text: { type: 'mrkdwn', text: glance.join('\n') } });
 
   // ── 총평 ──
   blocks.push({ type: 'divider' });
-  blocks.push({ type: 'section', text: { type: 'mrkdwn', text: summary } });
+  blocks.push({ type: 'section', text: { type: 'mrkdwn', text: `*총평*\n${summary}` } });
 
   return blocks;
 };
@@ -490,17 +440,24 @@ const buildWeeklyReportBlocks = (data: WeeklyReportData, summary: string): Known
 const generateWeeklySummary = async (
   llmClient: LifeCronConfig['llmClient'],
   data: WeeklyReportData,
+  insights: Insight[],
 ): Promise<string> => {
   const { sleep, routine, schedule, correlation } = data;
 
+  const insightContext =
+    insights.length > 0
+      ? `\n감지된 인사이트:\n${insights.map((i) => `- ${i.message}`).join('\n')}`
+      : '';
+
   const context = [
-    `주간 리포트 데이터를 보고 총평을 써줘. 잘한 점은 칭찬하고, 개선할 점은 잔소리해. 반말로, 따뜻하게.`,
+    `지난주 리포트 데이터를 보고 총평을 써줘. 잘한 점은 칭찬하고, 개선할 점은 잔소리해. 반말로, 따뜻하게.`,
     `수면: 평균 ${Math.floor(sleep.avgDuration / 60)}시간 ${sleep.avgDuration % 60}분 (${sleep.recordCount}일)`,
     `루틴: ${routine.thisWeekRate}% (${routine.thisWeekCompleted}/${routine.thisWeekTotal})${routine.lastWeekRate != null ? `, 지난주 ${routine.lastWeekRate}%` : ''}`,
     `일정: 완료 ${schedule.completedCount}, 미완료 ${schedule.incompleteCount}`,
     correlation.goodSleepRate != null && correlation.badSleepRate != null
       ? `수면-루틴 상관: 7시간+ ${correlation.goodSleepRate}% vs 6시간 미만 ${correlation.badSleepRate}%`
       : '',
+    insightContext,
   ]
     .filter(Boolean)
     .join('\n');
@@ -509,27 +466,27 @@ const generateWeeklySummary = async (
     const messages: LLMMessage[] = [
       {
         role: 'system',
-        content: `${CHARACTER_PROMPT}\n주간 리포트 데이터를 보고 총평 써줘. 잘한 점 칭찬, 개선점 잔소리. 자연스러운 길이로.`,
+        content: `${CHARACTER_PROMPT}\n지난주 리포트 데이터를 보고 총평 써줘. 잘한 점 칭찬, 개선점 잔소리. 자연스러운 길이로.`,
       },
       { role: 'user', content: context },
     ];
     const response = await llmClient.chat(messages);
-    return response.text ?? '이번 주도 수고했어!';
+    return response.text ?? '지난주도 수고했어!';
   } catch {
-    return '이번 주도 수고했어!';
+    return '지난주도 수고했어!';
   }
 };
 
 // ─── 주간 리포트 크론 태스크 ────────────────────────────
 
 export const weeklyReportTask = async (app: App, config: LifeCronConfig): Promise<void> => {
-  // 일요일(0)만 실행
-  if (getKSTDayOfWeek() !== 0) return;
+  // 월요일(1)만 실행 — 지난주 회고 시점
+  if (getKSTDayOfWeek() !== 1) return;
 
   const today = getTodayISO();
-  const weekStart = addDays(today, -6); // 월요일
-  const weekEnd = today; // 일요일
-  const headerText = `📊 주간 리포트 (${formatDateShort(weekStart)} ~ ${formatDateShort(weekEnd)})`;
+  const weekStart = addDays(today, -7); // 지난주 월요일
+  const weekEnd = addDays(today, -1); // 지난주 일요일
+  const headerText = `지난주 리포트 (${formatDateShort(weekStart)} ~ ${formatDateShort(weekEnd)})`;
 
   const mappings = await queryAllUserMappings();
 
@@ -542,8 +499,10 @@ export const weeklyReportTask = async (app: App, config: LifeCronConfig): Promis
     if (!target.channelId) continue;
     try {
       const data = await aggregateWeeklyReport(weekStart, weekEnd, target.userId);
-      const summary = await generateWeeklySummary(config.llmClient, data);
-      const blocks = buildWeeklyReportBlocks(data, summary);
+      // 인사이트는 지난주 마지막 날 기준으로 추출
+      const insights = await pickWeeklyInsights(weekEnd, target.userId);
+      const summary = await generateWeeklySummary(config.llmClient, data, insights);
+      const blocks = buildWeeklyReportBlocks(data, insights, summary);
       await postBlockMessage(app.client, target.channelId, headerText, blocks);
       console.warn(`[Life Cron] 주간 리포트 전송 완료 (유저=${target.userId})`);
     } catch (error: unknown) {

--- a/src/shared/__tests__/insights.test.ts
+++ b/src/shared/__tests__/insights.test.ts
@@ -28,8 +28,8 @@ import {
   detectSlotGap,
   detectWeekComparison,
   detectOverdue,
-  pickMorningNudge,
-  pickNightNudge,
+  pickMorningNudges,
+  pickNightNudges,
 } from '../insights.js';
 
 /** null이 아님을 보장하고 타입 좁히기 */
@@ -346,7 +346,7 @@ describe('pickMorningNudge', () => {
       ],
     });
 
-    const result = await pickMorningNudge('2026-03-15', 1);
+    const result = await pickMorningNudges('2026-03-15', 1);
     expect(result).not.toBeNull();
     // overdue(7) > streak 5일(10) → streak이 높음
     expect(result).toContain('유산균 먹기');
@@ -361,7 +361,7 @@ describe('pickMorningNudge', () => {
       ],
     });
 
-    const result = await pickMorningNudge('2026-03-15', 1);
+    const result = await pickMorningNudges('2026-03-15', 1);
     // slotGap은 night only → 아침에는 null
     expect(result).toBeNull();
   });
@@ -369,7 +369,7 @@ describe('pickMorningNudge', () => {
   it('모든 감지가 임계값 미달이면 null', async () => {
     setupQueryMock();
 
-    const result = await pickMorningNudge('2026-03-15', 1);
+    const result = await pickMorningNudges('2026-03-15', 1);
     expect(result).toBeNull();
   });
 });
@@ -390,7 +390,7 @@ describe('pickNightNudge', () => {
       ],
     });
 
-    const result = await pickNightNudge('2026-03-15', 1);
+    const result = await pickNightNudges('2026-03-15', 1);
     expect(result).not.toBeNull();
     // sleepTrend(8) > slotGap(5)
     expect(result).toContain('줄고');
@@ -399,7 +399,7 @@ describe('pickNightNudge', () => {
   it('모든 감지가 임계값 미달이면 null', async () => {
     setupQueryMock();
 
-    const result = await pickNightNudge('2026-03-15', 1);
+    const result = await pickNightNudges('2026-03-15', 1);
     expect(result).toBeNull();
   });
 });
@@ -420,7 +420,7 @@ describe('에러 처리', () => {
   it('DB 오류 시 pickMorningNudge는 null 반환', async () => {
     mockQuery.mockRejectedValue(new Error('DB connection lost'));
 
-    const result = await pickMorningNudge('2026-03-15', 1);
+    const result = await pickMorningNudges('2026-03-15', 1);
     expect(result).toBeNull();
   });
 });

--- a/src/shared/__tests__/insights.test.ts
+++ b/src/shared/__tests__/insights.test.ts
@@ -28,8 +28,15 @@ import {
   detectSlotGap,
   detectWeekComparison,
   detectOverdue,
+  detectCategorySkew,
+  detectDrift,
+  detectRecovery,
+  detectLapseAlert,
+  detectWeeklyRegression,
+  detectSpottyPattern,
   pickMorningNudges,
   pickNightNudges,
+  pickWeeklyInsights,
 } from '../insights.js';
 
 /** null이 아님을 보장하고 타입 좁히기 */
@@ -49,6 +56,7 @@ beforeEach(async () => {
 type MockRow = Record<string, unknown>;
 
 const setupQueryMock = (overrides: Record<string, MockRow[]> = {}): void => {
+  // 패턴 순서 주의: 더 구체적인 패턴을 먼저 두어야 더 일반적인 패턴이 가로채지 않는다.
   const defaultResponses: Record<string, MockRow[]> = {
     // streak: 연속 달성 쿼리
     'grp = 0': [],
@@ -56,10 +64,32 @@ const setupQueryMock = (overrides: Record<string, MockRow[]> = {}): void => {
     'sleep_type.*night.*ORDER BY date DESC.*LIMIT 3': [],
     // slotGap: 시간대별 달성률
     'time_slot.*GROUP BY.*time_slot.*HAVING': [],
-    // weekComparison: 이번주 vs 지난주
-    'this_week.*last_week': [{ this_rate: null, last_rate: null }],
     // overdue: 밀린 일정
     "status = 'todo'.*date < ": [{ overdue_count: 0 }],
+    // categorySkew: 카테고리 편향
+    'window_schedules.*top_category': [],
+    // drift: 수면 드리프트
+    this_week_avg_bedtime_minutes: [
+      {
+        this_week_avg_bedtime_minutes: null,
+        prev_weeks_avg_bedtime_minutes: null,
+        this_week_avg_wake_minutes: null,
+        prev_weeks_avg_wake_minutes: null,
+        this_week_mid_wake: 0,
+        prev_weeks_mid_wake_per_week: 0,
+        this_week_nights: 0,
+      },
+    ],
+    // recovery: 루틴 회복
+    'recent_records.*break_events.*next_completion': [],
+    // lapseAlert: 연속 누락
+    'today_miss.*prev_streaks': [],
+    // spottyPattern: 산발성 누락
+    'miss_groups.*max_consecutive_miss': [],
+    // weeklyRegression: 주간 회귀 (weekComparison 패턴보다 먼저 — WHERE last_week.rate가 있는 경우 먼저 매칭)
+    'this_week.*last_week.*WHERE last_week.rate': [],
+    // weekComparison: 이번주 vs 지난주 (가장 일반적이므로 마지막)
+    'this_week.*last_week': [{ this_rate: null, last_rate: null }],
   };
 
   const responses = { ...defaultResponses, ...overrides };
@@ -330,52 +360,308 @@ describe('detectOverdue', () => {
   });
 });
 
-// ─── pickMorningNudge / pickNightNudge ────────────────────
+// ─── detectCategorySkew ──────────────────────────────────
 
-describe('pickMorningNudge', () => {
-  it('아침 타이밍 인사이트만 선택', async () => {
+describe('detectCategorySkew', () => {
+  it('지배 카테고리 ≥50%이면 감지', async () => {
     setupQueryMock({
-      // streak: morning
-      'grp = 0': [{ name: '유산균 먹기', streak: '5' }],
-      // overdue: morning, priority 7
-      "status = 'todo'.*date < ": [{ overdue_count: 4 }],
-      // slotGap: night only → 아침에 선택 안 됨
-      'time_slot.*GROUP BY.*time_slot.*HAVING': [
-        { time_slot: '낮', total: '14', done: '14', rate: 100 },
-        { time_slot: '밤', total: '12', done: '2', rate: 17 },
-      ],
+      'window_schedules.*top_category': [{ category_name: '사업', count: 6, total: 10 }],
     });
 
-    const result = await pickMorningNudges('2026-03-15', 1);
-    expect(result).not.toBeNull();
-    // overdue(7) > streak 5일(10) → streak이 높음
-    expect(result).toContain('유산균 먹기');
+    const result = defined(await detectCategorySkew('2026-03-15', 1));
+    expect(result.type).toBe('categorySkew');
+    expect(result.priority).toBe(5);
+    expect(result.timing).toBe('night');
+    expect(result.message).toContain('사업');
   });
 
-  it('아침 타이밍에 밤 전용 인사이트는 제외', async () => {
-    // slotGap은 night only
+  it('weekly timing 전달 시 메시지 톤 변경', async () => {
     setupQueryMock({
-      'time_slot.*GROUP BY.*time_slot.*HAVING': [
-        { time_slot: '낮', total: '14', done: '14', rate: 100 },
-        { time_slot: '밤', total: '12', done: '2', rate: 17 },
-      ],
+      'window_schedules.*top_category': [{ category_name: '사업', count: 6, total: 10 }],
     });
 
-    const result = await pickMorningNudges('2026-03-15', 1);
-    // slotGap은 night only → 아침에는 null
+    const result = defined(await detectCategorySkew('2026-03-15', 1, 'weekly'));
+    expect(result.timing).toBe('weekly');
+    expect(result.message).toContain('지난주');
+  });
+
+  it('전체 일정 5건 미만이면 null', async () => {
+    setupQueryMock({
+      'window_schedules.*top_category': [{ category_name: '사업', count: 3, total: 4 }],
+    });
+
+    const result = await detectCategorySkew('2026-03-15', 1);
     expect(result).toBeNull();
   });
 
-  it('모든 감지가 임계값 미달이면 null', async () => {
-    setupQueryMock();
+  it('지배 비율 50% 미만이면 null', async () => {
+    setupQueryMock({
+      'window_schedules.*top_category': [{ category_name: '사업', count: 4, total: 10 }],
+    });
 
-    const result = await pickMorningNudges('2026-03-15', 1);
+    const result = await detectCategorySkew('2026-03-15', 1);
     expect(result).toBeNull();
   });
 });
 
-describe('pickNightNudge', () => {
-  it('밤 타이밍 인사이트만 선택', async () => {
+// ─── detectDrift ─────────────────────────────────────────
+
+describe('detectDrift', () => {
+  it('취침 시간 30분+ 늦어지면 감지', async () => {
+    setupQueryMock({
+      this_week_avg_bedtime_minutes: [
+        {
+          this_week_avg_bedtime_minutes: 1470, // 24:30
+          prev_weeks_avg_bedtime_minutes: 1410, // 23:30
+          this_week_avg_wake_minutes: 480,
+          prev_weeks_avg_wake_minutes: 480,
+          this_week_mid_wake: 0,
+          prev_weeks_mid_wake_per_week: 0,
+          this_week_nights: 5,
+        },
+      ],
+    });
+
+    const result = defined(await detectDrift('2026-03-15', 1));
+    expect(result.type).toBe('drift');
+    expect(result.timing).toBe('weekly');
+    expect(result.message).toContain('취침');
+  });
+
+  it('중간기상 1.5배 이상 증가하면 감지', async () => {
+    setupQueryMock({
+      this_week_avg_bedtime_minutes: [
+        {
+          this_week_avg_bedtime_minutes: 1410,
+          prev_weeks_avg_bedtime_minutes: 1410,
+          this_week_avg_wake_minutes: 480,
+          prev_weeks_avg_wake_minutes: 480,
+          this_week_mid_wake: 6,
+          prev_weeks_mid_wake_per_week: 3,
+          this_week_nights: 5,
+        },
+      ],
+    });
+
+    const result = defined(await detectDrift('2026-03-15', 1));
+    expect(result.message).toContain('중간기상');
+  });
+
+  it('이번주 표본 4박 미만이면 null', async () => {
+    setupQueryMock({
+      this_week_avg_bedtime_minutes: [
+        {
+          this_week_avg_bedtime_minutes: 1470,
+          prev_weeks_avg_bedtime_minutes: 1410,
+          this_week_avg_wake_minutes: 480,
+          prev_weeks_avg_wake_minutes: 480,
+          this_week_mid_wake: 0,
+          prev_weeks_mid_wake_per_week: 0,
+          this_week_nights: 3,
+        },
+      ],
+    });
+
+    const result = await detectDrift('2026-03-15', 1);
+    expect(result).toBeNull();
+  });
+
+  it('드리프트 없으면 null', async () => {
+    setupQueryMock({
+      this_week_avg_bedtime_minutes: [
+        {
+          this_week_avg_bedtime_minutes: 1410,
+          prev_weeks_avg_bedtime_minutes: 1410,
+          this_week_avg_wake_minutes: 480,
+          prev_weeks_avg_wake_minutes: 480,
+          this_week_mid_wake: 1,
+          prev_weeks_mid_wake_per_week: 1,
+          this_week_nights: 6,
+        },
+      ],
+    });
+
+    const result = await detectDrift('2026-03-15', 1);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── detectRecovery ──────────────────────────────────────
+
+describe('detectRecovery', () => {
+  it('5일+ 연속 후 빠졌다가 다음 날 회복하면 감지', async () => {
+    setupQueryMock({
+      'recent_records.*break_events.*next_completion': [
+        { name: '스트레칭하기', break_date: '2026-03-14', recovery_gap_days: 1 },
+      ],
+    });
+
+    const result = defined(await detectRecovery('2026-03-15', 1));
+    expect(result.type).toBe('recovery');
+    expect(result.timing).toBe('morning');
+    expect(result.message).toContain('스트레칭하기');
+  });
+
+  it('회복 케이스 없으면 null', async () => {
+    setupQueryMock();
+
+    const result = await detectRecovery('2026-03-15', 1);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── detectLapseAlert ────────────────────────────────────
+
+describe('detectLapseAlert', () => {
+  it('7일 연속 달성 후 오늘 빠지면 감지', async () => {
+    setupQueryMock({
+      'today_miss.*prev_streaks': [{ name: '유산균 먹기' }],
+    });
+
+    const result = defined(await detectLapseAlert('2026-03-15', 1));
+    expect(result.type).toBe('lapseAlert');
+    expect(result.timing).toBe('night');
+    expect(result.priority).toBe(7);
+    expect(result.message).toContain('유산균 먹기');
+  });
+
+  it('조건 미달이면 null', async () => {
+    setupQueryMock();
+
+    const result = await detectLapseAlert('2026-03-15', 1);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── detectWeeklyRegression ──────────────────────────────
+
+describe('detectWeeklyRegression', () => {
+  it('지난주 90%+ → 이번주 60% 이하면 감지', async () => {
+    setupQueryMock({
+      'this_week.*last_week.*WHERE last_week.rate': [
+        { name: '스트레칭하기', this_rate: 45, last_rate: 95 },
+      ],
+    });
+
+    const result = defined(await detectWeeklyRegression('2026-03-15', 1));
+    expect(result.type).toBe('weeklyRegression');
+    expect(result.timing).toBe('weekly');
+    expect(result.message).toContain('스트레칭하기');
+    expect(result.message).toContain('45%');
+  });
+
+  it('해당 없으면 null', async () => {
+    setupQueryMock();
+
+    const result = await detectWeeklyRegression('2026-03-15', 1);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── detectSpottyPattern ─────────────────────────────────
+
+describe('detectSpottyPattern', () => {
+  it('7일 중 3~4번 산발 누락 + 연속 누락 아님이면 감지', async () => {
+    setupQueryMock({
+      'miss_groups.*max_consecutive_miss': [
+        { name: '스트레칭하기', miss_count: 3, max_consecutive_miss: 1 },
+      ],
+    });
+
+    const result = defined(await detectSpottyPattern('2026-03-15', 1));
+    expect(result.type).toBe('spottyPattern');
+    expect(result.timing).toBe('night');
+    expect(result.message).toContain('스트레칭하기');
+    expect(result.message).toContain('3번');
+  });
+
+  it('연속 누락이면 (spotty 아님) null', async () => {
+    setupQueryMock({
+      'miss_groups.*max_consecutive_miss': [
+        // max_consecutive_miss === miss_count → 연속이라 spotty 패턴 아님
+      ],
+    });
+
+    const result = await detectSpottyPattern('2026-03-15', 1);
+    expect(result).toBeNull();
+  });
+
+  it('해당 없으면 null', async () => {
+    setupQueryMock();
+
+    const result = await detectSpottyPattern('2026-03-15', 1);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── pickMorningNudges / pickNightNudges / pickWeeklyInsights ──
+
+describe('pickMorningNudges (priority threshold + domain dedupe + max items)', () => {
+  it('priority ≥5인 morning 인사이트만 반환', async () => {
+    setupQueryMock({
+      // streak: morning, priority = streak * 2 = 10 (routine)
+      'grp = 0': [{ name: '유산균 먹기', streak: '5' }],
+      // overdue: morning, priority 7 (schedule)
+      "status = 'todo'.*date < ": [{ overdue_count: 4 }],
+    });
+
+    const insights = await pickMorningNudges('2026-03-15', 1);
+    expect(insights.length).toBeGreaterThan(0);
+    // priority desc 정렬: streak(10) > overdue(7)
+    expect(insights[0]?.type).toBe('streak');
+    expect(insights[0]?.message).toContain('유산균 먹기');
+  });
+
+  it('같은 도메인 인사이트는 priority 높은 것만 선택', async () => {
+    setupQueryMock({
+      // streak: morning, priority 10 (routine)
+      'grp = 0': [{ name: '유산균 먹기', streak: '5' }],
+      // recovery: morning, priority 6 (routine) — 같은 도메인이라 dedupe 대상
+      'recent_records.*break_events.*next_completion': [
+        { name: '스트레칭하기', break_date: '2026-03-14', recovery_gap_days: 1 },
+      ],
+    });
+
+    const insights = await pickMorningNudges('2026-03-15', 1);
+    const routineCount = insights.filter((i) => i.domain === 'routine').length;
+    expect(routineCount).toBe(1); // dedupe: priority 높은 streak만 남음
+    expect(insights[0]?.type).toBe('streak');
+  });
+
+  it('최대 3개만 반환 (도메인은 routine/sleep/schedule 3종)', async () => {
+    setupQueryMock({
+      'grp = 0': [{ name: '유산균 먹기', streak: '5' }], // routine, prio 10
+      "status = 'todo'.*date < ": [{ overdue_count: 5 }], // schedule, prio 7
+    });
+
+    const insights = await pickMorningNudges('2026-03-15', 1);
+    expect(insights.length).toBeLessThanOrEqual(3);
+  });
+
+  it('priority <5인 인사이트는 제외', async () => {
+    setupQueryMock({
+      // sleepTrend(증가): priority 4 (임계값 미달)
+      'sleep_type.*night.*ORDER BY date DESC.*LIMIT 3': [
+        { date: '2026-03-15', duration_minutes: 480 },
+        { date: '2026-03-14', duration_minutes: 420 },
+        { date: '2026-03-13', duration_minutes: 360 },
+      ],
+    });
+
+    const insights = await pickMorningNudges('2026-03-15', 1);
+    expect(insights.length).toBe(0);
+  });
+
+  it('아무 인사이트도 없으면 빈 배열', async () => {
+    setupQueryMock();
+
+    const insights = await pickMorningNudges('2026-03-15', 1);
+    expect(insights).toEqual([]);
+  });
+});
+
+describe('pickNightNudges', () => {
+  it('night 타이밍 인사이트만 선택', async () => {
     setupQueryMock({
       // sleepTrend: night, priority 8
       'sleep_type.*night.*ORDER BY date DESC.*LIMIT 3': [
@@ -383,24 +669,35 @@ describe('pickNightNudge', () => {
         { date: '2026-03-14', duration_minutes: 360 },
         { date: '2026-03-13', duration_minutes: 420 },
       ],
-      // slotGap: night, priority 5
-      'time_slot.*GROUP BY.*time_slot.*HAVING': [
-        { time_slot: '낮', total: '14', done: '14', rate: 100 },
-        { time_slot: '밤', total: '12', done: '2', rate: 17 },
+    });
+
+    const insights = await pickNightNudges('2026-03-15', 1);
+    expect(insights[0]?.type).toBe('sleepTrend');
+    expect(insights[0]?.message).toContain('줄고');
+  });
+});
+
+describe('pickWeeklyInsights', () => {
+  it('weekly 타이밍 인사이트만 선택', async () => {
+    setupQueryMock({
+      // weeklyRegression: weekly, priority 6
+      'this_week.*last_week.*WHERE last_week.rate': [
+        { name: '스트레칭하기', this_rate: 50, last_rate: 95 },
       ],
     });
 
-    const result = await pickNightNudges('2026-03-15', 1);
-    expect(result).not.toBeNull();
-    // sleepTrend(8) > slotGap(5)
-    expect(result).toContain('줄고');
+    const insights = await pickWeeklyInsights('2026-03-15', 1);
+    expect(insights[0]?.type).toBe('weeklyRegression');
   });
 
-  it('모든 감지가 임계값 미달이면 null', async () => {
-    setupQueryMock();
+  it('weekly 타이밍에 morning 인사이트는 제외', async () => {
+    setupQueryMock({
+      // streak는 morning만 → weekly에서는 안 잡힘
+      'grp = 0': [{ name: '유산균 먹기', streak: '5' }],
+    });
 
-    const result = await pickNightNudges('2026-03-15', 1);
-    expect(result).toBeNull();
+    const insights = await pickWeeklyInsights('2026-03-15', 1);
+    expect(insights.find((i) => i.type === 'streak')).toBeUndefined();
   });
 });
 
@@ -415,12 +712,18 @@ describe('에러 처리', () => {
     expect(await detectSlotGap('2026-03-15', 1)).toBeNull();
     expect(await detectWeekComparison('2026-03-15', 1)).toBeNull();
     expect(await detectOverdue('2026-03-15', 1)).toBeNull();
+    expect(await detectCategorySkew('2026-03-15', 1)).toBeNull();
+    expect(await detectDrift('2026-03-15', 1)).toBeNull();
+    expect(await detectRecovery('2026-03-15', 1)).toBeNull();
+    expect(await detectLapseAlert('2026-03-15', 1)).toBeNull();
+    expect(await detectWeeklyRegression('2026-03-15', 1)).toBeNull();
+    expect(await detectSpottyPattern('2026-03-15', 1)).toBeNull();
   });
 
-  it('DB 오류 시 pickMorningNudge는 null 반환', async () => {
+  it('DB 오류 시 pickMorningNudges는 빈 배열 반환', async () => {
     mockQuery.mockRejectedValue(new Error('DB connection lost'));
 
-    const result = await pickMorningNudges('2026-03-15', 1);
-    expect(result).toBeNull();
+    const insights = await pickMorningNudges('2026-03-15', 1);
+    expect(insights).toEqual([]);
   });
 });

--- a/src/shared/insight-thresholds.ts
+++ b/src/shared/insight-thresholds.ts
@@ -1,0 +1,59 @@
+/**
+ * 프로액티브 인사이트 엔진의 모든 패턴 임계치.
+ * 한 곳에서 튜닝하여 Phase 4 사주 매핑 단계에서 일관된 조정 가능.
+ */
+export const INSIGHT_THRESHOLDS = {
+  streak: {
+    minStreak: 3,
+    milestones: [3, 5, 7, 10, 14, 21, 30] as const,
+    lookbackDays: 30,
+  },
+  sleepTrend: {
+    windowDays: 3,
+    shortSleepMinutes: 420,
+  },
+  slotGap: {
+    minGap: 30,
+    minSampleSize: 3,
+    lookbackDays: 7,
+  },
+  weekComparison: {
+    significantDiff: 5,
+    largeDiff: 10,
+  },
+  overdueAlert: {
+    minCount: 3,
+  },
+  categorySkew: {
+    lookbackDays: 7,
+    minTotalSchedules: 5,
+    dominantRatio: 0.5,
+  },
+  drift: {
+    windowWeeks: 4,
+    bedtimeShiftMinutes: 30,
+    wakeShiftMinutes: 30,
+    midWakeIncreaseRatio: 1.5,
+    minSampleNights: 4,
+  },
+  recovery: {
+    minStreakBeforeBreak: 5,
+    fastRecoveryDays: 1,
+  },
+  lapseAlert: {
+    consecutiveDaysBeforeMiss: 7,
+  },
+  weeklyRegression: {
+    prevWeekMinRate: 90,
+    thisWeekMaxRate: 60,
+  },
+  spottyPattern: {
+    lookbackDays: 7,
+    minMissCount: 3,
+    maxMissCount: 4,
+  },
+  pickByTiming: {
+    minPriority: 5,
+    maxItems: 3,
+  },
+} as const;

--- a/src/shared/insights.ts
+++ b/src/shared/insights.ts
@@ -5,6 +5,7 @@
  */
 
 import { query } from './db.js';
+import { INSIGHT_THRESHOLDS } from './insight-thresholds.js';
 
 // ─── 타입 ───────────────────────────────────────────────
 
@@ -20,8 +21,7 @@ export interface Insight {
 
 // ─── 상수 ───────────────────────────────────────────────
 
-/** streak 넛지를 보내는 마일스톤 일수 */
-const STREAK_MILESTONES = new Set([3, 5, 7, 10, 14, 21, 30]);
+const STREAK_MILESTONES = new Set<number>(INSIGHT_THRESHOLDS.streak.milestones);
 
 // ─── 감지: 루틴 연속 달성 ────────────────────────────────
 
@@ -31,13 +31,14 @@ interface StreakRow {
 }
 
 export const detectStreak = async (today: string, userId: number): Promise<Insight | null> => {
+  const { lookbackDays, minStreak } = INSIGHT_THRESHOLDS.streak;
   try {
     const result = await query<StreakRow>(
       `WITH daily AS (
         SELECT r.template_id, t.name, r.date, r.completed
         FROM routine_records r
         JOIN routine_templates t ON r.template_id = t.id
-        WHERE r.date BETWEEN ($1::date - 30) AND $1
+        WHERE r.date BETWEEN ($1::date - ${lookbackDays}) AND $1
           AND t.active = true AND t.frequency = '매일'
           AND r.user_id = $2
         ORDER BY r.template_id, r.date DESC
@@ -55,7 +56,7 @@ export const detectStreak = async (today: string, userId: number): Promise<Insig
         GROUP BY template_id, name
       )
       SELECT name, streak::text FROM streaks
-      WHERE streak >= 3
+      WHERE streak >= ${minStreak}
       ORDER BY streak DESC LIMIT 1`,
       [today, userId],
     );
@@ -85,26 +86,27 @@ interface SleepTrendRow {
 }
 
 export const detectSleepTrend = async (today: string, userId: number): Promise<Insight | null> => {
+  const { windowDays, shortSleepMinutes } = INSIGHT_THRESHOLDS.sleepTrend;
   try {
     const result = await query<SleepTrendRow>(
       `SELECT date::text, duration_minutes
        FROM sleep_records
        WHERE sleep_type = 'night'
-         AND date BETWEEN ($1::date - 3) AND $1
+         AND date BETWEEN ($1::date - ${windowDays}) AND $1
          AND duration_minutes IS NOT NULL
          AND user_id = $2
        ORDER BY date DESC
-       LIMIT 3`,
+       LIMIT ${windowDays}`,
       [today, userId],
     );
 
-    if (result.rows.length < 3) return null;
+    if (result.rows.length < windowDays) return null;
 
     const durations = result.rows.map((r) => r.duration_minutes);
     const isDecreasing = durations[0] < durations[1] && durations[1] < durations[2];
     const isIncreasing = durations[0] > durations[1] && durations[1] > durations[2];
 
-    if (isDecreasing && durations[0] < 420) {
+    if (isDecreasing && durations[0] < shortSleepMinutes) {
       return {
         type: 'sleepTrend',
         priority: 8,
@@ -138,6 +140,7 @@ interface SlotRow {
 }
 
 export const detectSlotGap = async (today: string, userId: number): Promise<Insight | null> => {
+  const { minGap, minSampleSize, lookbackDays } = INSIGHT_THRESHOLDS.slotGap;
   try {
     const result = await query<SlotRow>(
       `SELECT t.time_slot,
@@ -147,11 +150,11 @@ export const detectSlotGap = async (today: string, userId: number): Promise<Insi
           / NULLIF(COUNT(*), 0) * 100)::int AS rate
        FROM routine_records r
        JOIN routine_templates t ON r.template_id = t.id
-       WHERE r.date BETWEEN ($1::date - 6) AND $1
+       WHERE r.date BETWEEN ($1::date - ${lookbackDays - 1}) AND $1
          AND r.date >= t.created_at::date
          AND r.user_id = $2
        GROUP BY t.time_slot
-       HAVING COUNT(*) >= 3
+       HAVING COUNT(*) >= ${minSampleSize}
        ORDER BY rate`,
       [today, userId],
     );
@@ -162,7 +165,7 @@ export const detectSlotGap = async (today: string, userId: number): Promise<Insi
     const worst = result.rows[0];
     const gap = best.rate - worst.rate;
 
-    if (gap < 30) return null;
+    if (gap < minGap) return null;
 
     return {
       type: 'slotGap',
@@ -182,7 +185,11 @@ interface WeekCompRow {
   last_rate: number | null;
 }
 
-export const detectWeekComparison = async (today: string, userId: number): Promise<Insight | null> => {
+export const detectWeekComparison = async (
+  today: string,
+  userId: number,
+): Promise<Insight | null> => {
+  const { significantDiff, largeDiff } = INSIGHT_THRESHOLDS.weekComparison;
   try {
     const result = await query<WeekCompRow>(
       `WITH this_week AS (
@@ -208,12 +215,12 @@ export const detectWeekComparison = async (today: string, userId: number): Promi
     if (!row || row.this_rate == null || row.last_rate == null) return null;
 
     const diff = row.this_rate - row.last_rate;
-    if (Math.abs(diff) < 5) return null;
+    if (Math.abs(diff) < significantDiff) return null;
 
     const isPositive = diff > 0;
     return {
       type: 'weekComparison',
-      priority: Math.abs(diff) >= 10 ? 6 : 4,
+      priority: Math.abs(diff) >= largeDiff ? 6 : 4,
       timing: isPositive ? 'morning' : 'night',
       message: isPositive
         ? `이번 주 루틴 ${row.this_rate}%, 지난주 ${row.last_rate}%에서 올랐어!`
@@ -231,6 +238,7 @@ interface OverdueRow {
 }
 
 export const detectOverdue = async (today: string, userId: number): Promise<Insight | null> => {
+  const { minCount } = INSIGHT_THRESHOLDS.overdueAlert;
   try {
     const result = await query<OverdueRow>(
       `SELECT COUNT(*)::int AS overdue_count
@@ -240,7 +248,7 @@ export const detectOverdue = async (today: string, userId: number): Promise<Insi
     );
 
     const count = result.rows[0]?.overdue_count ?? 0;
-    if (count < 3) return null;
+    if (count < minCount) return null;
 
     return {
       type: 'overdueAlert',
@@ -266,7 +274,11 @@ const detectAll = async (today: string, userId: number): Promise<Insight[]> => {
   return results.filter((r): r is Insight => r !== null);
 };
 
-const pickByTiming = async (today: string, userId: number, timing: InsightTiming): Promise<string | null> => {
+const pickByTiming = async (
+  today: string,
+  userId: number,
+  timing: InsightTiming,
+): Promise<string | null> => {
   const all = await detectAll(today, userId);
   const candidates = all.filter((i) => i.timing === timing);
   if (candidates.length === 0) return null;

--- a/src/shared/insights.ts
+++ b/src/shared/insights.ts
@@ -9,13 +9,28 @@ import { INSIGHT_THRESHOLDS } from './insight-thresholds.js';
 
 // ─── 타입 ───────────────────────────────────────────────
 
-export type InsightType = 'streak' | 'sleepTrend' | 'slotGap' | 'weekComparison' | 'overdueAlert';
-type InsightTiming = 'morning' | 'night';
+export type InsightType =
+  | 'streak'
+  | 'sleepTrend'
+  | 'slotGap'
+  | 'weekComparison'
+  | 'overdueAlert'
+  | 'categorySkew'
+  | 'drift'
+  | 'recovery'
+  | 'lapseAlert'
+  | 'weeklyRegression'
+  | 'spottyPattern';
+
+export type InsightTiming = 'morning' | 'night' | 'weekly';
+
+export type InsightDomain = 'routine' | 'sleep' | 'schedule';
 
 export interface Insight {
   type: InsightType;
   priority: number;
   timing: InsightTiming;
+  domain: InsightDomain;
   message: string;
 }
 
@@ -71,6 +86,7 @@ export const detectStreak = async (today: string, userId: number): Promise<Insig
       type: 'streak',
       priority: streak * 2,
       timing: 'morning',
+      domain: 'routine',
       message: `${row.name} ${streak}일 연속 달성 중! 대단하다`,
     };
   } catch {
@@ -111,6 +127,7 @@ export const detectSleepTrend = async (today: string, userId: number): Promise<I
         type: 'sleepTrend',
         priority: 8,
         timing: 'night',
+        domain: 'sleep',
         message: '수면 시간이 3일째 줄고 있어. 좀 일찍 자자',
       };
     }
@@ -120,6 +137,7 @@ export const detectSleepTrend = async (today: string, userId: number): Promise<I
         type: 'sleepTrend',
         priority: 4,
         timing: 'night',
+        domain: 'sleep',
         message: '수면 시간이 3일째 늘고 있어. 좋은 흐름이야!',
       };
     }
@@ -171,6 +189,7 @@ export const detectSlotGap = async (today: string, userId: number): Promise<Insi
       type: 'slotGap',
       priority: 5,
       timing: 'night',
+      domain: 'routine',
       message: `${best.time_slot} 루틴은 ${best.rate}%인데 ${worst.time_slot} 루틴이 ${worst.rate}%야`,
     };
   } catch {
@@ -222,6 +241,7 @@ export const detectWeekComparison = async (
       type: 'weekComparison',
       priority: Math.abs(diff) >= largeDiff ? 6 : 4,
       timing: isPositive ? 'morning' : 'night',
+      domain: 'routine',
       message: isPositive
         ? `이번 주 루틴 ${row.this_rate}%, 지난주 ${row.last_rate}%에서 올랐어!`
         : `이번 주 루틴 ${row.this_rate}%, 지난주 ${row.last_rate}%에서 떨어졌어. 힘내자`,
@@ -254,6 +274,7 @@ export const detectOverdue = async (today: string, userId: number): Promise<Insi
       type: 'overdueAlert',
       priority: 7,
       timing: 'morning',
+      domain: 'schedule',
       message: `밀린 일정이 ${count}건이야. 오늘 하나라도 정리하자`,
     };
   } catch {

--- a/src/shared/insights.ts
+++ b/src/shared/insights.ts
@@ -282,6 +282,398 @@ export const detectOverdue = async (today: string, userId: number): Promise<Insi
   }
 };
 
+// ─── 감지: 카테고리 편향 ────────────────────────────────
+
+interface CategorySkewRow {
+  category_name: string;
+  count: number;
+  total: number;
+}
+
+export const detectCategorySkew = async (
+  today: string,
+  userId: number,
+  timing: 'night' | 'weekly' = 'night',
+): Promise<Insight | null> => {
+  const { lookbackDays, minTotalSchedules, dominantRatio } = INSIGHT_THRESHOLDS.categorySkew;
+  try {
+    const result = await query<CategorySkewRow>(
+      `WITH window_schedules AS (
+        SELECT s.id, COALESCE(p.name, c.name, '미분류') AS top_category
+        FROM schedules s
+        LEFT JOIN categories c ON c.id = s.category_id
+        LEFT JOIN categories p ON p.id = c.parent_id
+        WHERE s.user_id = $2
+          AND s.date BETWEEN ($1::date - ${lookbackDays - 1}) AND $1
+          AND s.status != 'cancelled'
+          AND COALESCE(c.type, p.type, 'task') = 'task'
+      )
+      SELECT top_category AS category_name,
+             COUNT(*)::int AS count,
+             (SELECT COUNT(*) FROM window_schedules)::int AS total
+      FROM window_schedules
+      GROUP BY top_category
+      ORDER BY count DESC
+      LIMIT 1`,
+      [today, userId],
+    );
+    const row = result.rows[0];
+    if (!row || row.total < minTotalSchedules) return null;
+    const ratio = row.count / row.total;
+    if (ratio < dominantRatio) return null;
+    return {
+      type: 'categorySkew',
+      priority: 5,
+      timing,
+      domain: 'schedule',
+      message:
+        timing === 'weekly'
+          ? `지난주 ${row.category_name} 위주의 일정이었네`
+          : `최근 며칠 ${row.category_name} 위주의 일정이네`,
+    };
+  } catch {
+    return null;
+  }
+};
+
+// ─── 감지: 수면 드리프트 ────────────────────────────────
+
+interface DriftRow {
+  this_week_avg_bedtime_minutes: number | null;
+  prev_weeks_avg_bedtime_minutes: number | null;
+  this_week_avg_wake_minutes: number | null;
+  prev_weeks_avg_wake_minutes: number | null;
+  this_week_mid_wake: number;
+  prev_weeks_mid_wake_per_week: number;
+  this_week_nights: number;
+}
+
+export const detectDrift = async (today: string, userId: number): Promise<Insight | null> => {
+  const {
+    windowWeeks,
+    bedtimeShiftMinutes,
+    wakeShiftMinutes,
+    midWakeIncreaseRatio,
+    minSampleNights,
+  } = INSIGHT_THRESHOLDS.drift;
+  try {
+    const result = await query<DriftRow>(
+      `WITH this_week_sleep AS (
+        SELECT
+          CASE WHEN bedtime::time < '06:00'
+            THEN (EXTRACT(HOUR FROM bedtime::time) + 24) * 60 + EXTRACT(MINUTE FROM bedtime::time)
+            ELSE EXTRACT(HOUR FROM bedtime::time) * 60 + EXTRACT(MINUTE FROM bedtime::time)
+          END AS bedtime_minutes,
+          EXTRACT(HOUR FROM wake_time::time) * 60 + EXTRACT(MINUTE FROM wake_time::time) AS wake_minutes,
+          duration_minutes
+        FROM sleep_records
+        WHERE user_id = $2 AND sleep_type = 'night'
+          AND date BETWEEN ($1::date - 6) AND $1
+      ),
+      prev_weeks_sleep AS (
+        SELECT
+          CASE WHEN bedtime::time < '06:00'
+            THEN (EXTRACT(HOUR FROM bedtime::time) + 24) * 60 + EXTRACT(MINUTE FROM bedtime::time)
+            ELSE EXTRACT(HOUR FROM bedtime::time) * 60 + EXTRACT(MINUTE FROM bedtime::time)
+          END AS bedtime_minutes,
+          EXTRACT(HOUR FROM wake_time::time) * 60 + EXTRACT(MINUTE FROM wake_time::time) AS wake_minutes,
+          duration_minutes
+        FROM sleep_records
+        WHERE user_id = $2 AND sleep_type = 'night'
+          AND date BETWEEN ($1::date - ${windowWeeks * 7 - 1}) AND ($1::date - 7)
+      ),
+      this_week_events AS (
+        SELECT COUNT(*)::int AS cnt FROM sleep_events
+        WHERE date BETWEEN ($1::date - 6) AND $1
+      ),
+      prev_weeks_events AS (
+        SELECT COUNT(*)::int AS cnt FROM sleep_events
+        WHERE date BETWEEN ($1::date - ${windowWeeks * 7 - 1}) AND ($1::date - 7)
+      )
+      SELECT
+        (SELECT AVG(bedtime_minutes) FROM this_week_sleep WHERE bedtime_minutes IS NOT NULL) AS this_week_avg_bedtime_minutes,
+        (SELECT AVG(bedtime_minutes) FROM prev_weeks_sleep WHERE bedtime_minutes IS NOT NULL) AS prev_weeks_avg_bedtime_minutes,
+        (SELECT AVG(wake_minutes) FROM this_week_sleep WHERE wake_minutes IS NOT NULL) AS this_week_avg_wake_minutes,
+        (SELECT AVG(wake_minutes) FROM prev_weeks_sleep WHERE wake_minutes IS NOT NULL) AS prev_weeks_avg_wake_minutes,
+        (SELECT cnt FROM this_week_events) AS this_week_mid_wake,
+        (SELECT cnt::numeric / ${windowWeeks} FROM prev_weeks_events) AS prev_weeks_mid_wake_per_week,
+        (SELECT COUNT(*)::int FROM this_week_sleep WHERE duration_minutes IS NOT NULL) AS this_week_nights`,
+      [today, userId],
+    );
+    const row = result.rows[0];
+    if (!row || row.this_week_nights < minSampleNights) return null;
+
+    const messages: string[] = [];
+
+    if (
+      row.this_week_avg_bedtime_minutes != null &&
+      row.prev_weeks_avg_bedtime_minutes != null &&
+      row.this_week_avg_bedtime_minutes - row.prev_weeks_avg_bedtime_minutes >= bedtimeShiftMinutes
+    ) {
+      const diff = Math.round(
+        row.this_week_avg_bedtime_minutes - row.prev_weeks_avg_bedtime_minutes,
+      );
+      messages.push(`취침 시간이 ${windowWeeks}주 평균보다 ${diff}분 늦어졌어`);
+    }
+
+    if (
+      row.this_week_avg_wake_minutes != null &&
+      row.prev_weeks_avg_wake_minutes != null &&
+      row.this_week_avg_wake_minutes - row.prev_weeks_avg_wake_minutes >= wakeShiftMinutes
+    ) {
+      const diff = Math.round(row.this_week_avg_wake_minutes - row.prev_weeks_avg_wake_minutes);
+      messages.push(`기상 시간이 ${windowWeeks}주 평균보다 ${diff}분 늦어졌어`);
+    }
+
+    if (
+      row.prev_weeks_mid_wake_per_week > 0 &&
+      row.this_week_mid_wake >= row.prev_weeks_mid_wake_per_week * midWakeIncreaseRatio
+    ) {
+      messages.push(`이번주 중간기상 ${row.this_week_mid_wake}회. 평소보다 잦아`);
+    }
+
+    if (messages.length === 0) return null;
+    return {
+      type: 'drift',
+      priority: 6,
+      timing: 'weekly',
+      domain: 'sleep',
+      message: messages[0],
+    };
+  } catch {
+    return null;
+  }
+};
+
+// ─── 감지: 루틴 회복 ────────────────────────────────────
+
+interface RecoveryRow {
+  name: string;
+  break_date: string;
+  recovery_gap_days: number;
+}
+
+export const detectRecovery = async (today: string, userId: number): Promise<Insight | null> => {
+  const { minStreakBeforeBreak, fastRecoveryDays } = INSIGHT_THRESHOLDS.recovery;
+  try {
+    const result = await query<RecoveryRow>(
+      `WITH recent_records AS (
+        SELECT t.id AS template_id, t.name, r.date, r.completed
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.user_id = $2 AND t.active = true AND t.frequency = '매일'
+          AND r.date BETWEEN ($1::date - 30) AND $1
+      ),
+      break_events AS (
+        SELECT template_id, name, date AS break_date,
+          (SELECT COUNT(*) FROM recent_records r2
+            WHERE r2.template_id = r1.template_id
+              AND r2.date < r1.date
+              AND r2.completed = true
+              AND NOT EXISTS (
+                SELECT 1 FROM recent_records r3
+                WHERE r3.template_id = r1.template_id
+                  AND r3.date BETWEEN r2.date AND (r1.date - INTERVAL '1 day')
+                  AND r3.completed = false
+              )
+          ) AS streak_before
+        FROM recent_records r1
+        WHERE r1.completed = false
+      ),
+      next_completion AS (
+        SELECT b.template_id, b.name, b.break_date, b.streak_before,
+          (SELECT MIN(r.date) FROM recent_records r
+            WHERE r.template_id = b.template_id AND r.date > b.break_date AND r.completed = true
+          ) AS next_done_date
+        FROM break_events b
+        WHERE b.streak_before >= ${minStreakBeforeBreak}
+      )
+      SELECT name, break_date::text,
+        (next_done_date - break_date)::int AS recovery_gap_days
+      FROM next_completion
+      WHERE next_done_date IS NOT NULL
+        AND (next_done_date - break_date)::int <= ${fastRecoveryDays}
+        AND next_done_date = $1::date
+      ORDER BY streak_before DESC LIMIT 1`,
+      [today, userId],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return {
+      type: 'recovery',
+      priority: 6,
+      timing: 'morning',
+      domain: 'routine',
+      message: `${row.name} 어제 빠졌는데 오늘 바로 다시 시작했네. 회복 속도 좋다`,
+    };
+  } catch {
+    return null;
+  }
+};
+
+// ─── 감지: 연속 달성 후 첫 누락 ─────────────────────────
+
+interface LapseRow {
+  name: string;
+}
+
+export const detectLapseAlert = async (today: string, userId: number): Promise<Insight | null> => {
+  const { consecutiveDaysBeforeMiss } = INSIGHT_THRESHOLDS.lapseAlert;
+  try {
+    const result = await query<LapseRow>(
+      `WITH today_miss AS (
+        SELECT r.template_id, t.name
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.user_id = $2 AND t.active = true AND t.frequency = '매일'
+          AND r.date = $1 AND r.completed = false
+      ),
+      prev_streaks AS (
+        SELECT tm.template_id, tm.name,
+          (SELECT COUNT(*) FROM routine_records r
+            WHERE r.template_id = tm.template_id
+              AND r.user_id = $2
+              AND r.date BETWEEN ($1::date - ${consecutiveDaysBeforeMiss}) AND ($1::date - 1)
+              AND r.completed = true) AS prev_done_count
+        FROM today_miss tm
+      )
+      SELECT name FROM prev_streaks
+      WHERE prev_done_count >= ${consecutiveDaysBeforeMiss}
+      ORDER BY name LIMIT 1`,
+      [today, userId],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return {
+      type: 'lapseAlert',
+      priority: 7,
+      timing: 'night',
+      domain: 'routine',
+      message: `${row.name} ${consecutiveDaysBeforeMiss}일 연속 잘 지키다가 오늘 빠졌네`,
+    };
+  } catch {
+    return null;
+  }
+};
+
+// ─── 감지: 주간 루틴 회귀 ───────────────────────────────
+
+interface RegressionRow {
+  name: string;
+  this_rate: number;
+  last_rate: number;
+}
+
+export const detectWeeklyRegression = async (
+  today: string,
+  userId: number,
+): Promise<Insight | null> => {
+  const { prevWeekMinRate, thisWeekMaxRate } = INSIGHT_THRESHOLDS.weeklyRegression;
+  try {
+    const result = await query<RegressionRow>(
+      `WITH this_week AS (
+        SELECT t.id, t.name,
+          ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric
+            / NULLIF(COUNT(*), 0) * 100)::int AS rate
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.user_id = $2 AND t.frequency = '매일'
+          AND r.date BETWEEN ($1::date - 6) AND $1
+          AND r.date >= t.created_at::date
+        GROUP BY t.id, t.name
+        HAVING COUNT(*) >= 4
+      ),
+      last_week AS (
+        SELECT t.id,
+          ROUND(COUNT(*) FILTER (WHERE r.completed)::numeric
+            / NULLIF(COUNT(*), 0) * 100)::int AS rate
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.user_id = $2 AND t.frequency = '매일'
+          AND r.date BETWEEN ($1::date - 13) AND ($1::date - 7)
+          AND r.date >= t.created_at::date
+        GROUP BY t.id
+        HAVING COUNT(*) >= 4
+      )
+      SELECT this_week.name, this_week.rate AS this_rate, last_week.rate AS last_rate
+      FROM this_week JOIN last_week ON this_week.id = last_week.id
+      WHERE last_week.rate >= ${prevWeekMinRate} AND this_week.rate <= ${thisWeekMaxRate}
+      ORDER BY (last_week.rate - this_week.rate) DESC LIMIT 1`,
+      [today, userId],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return {
+      type: 'weeklyRegression',
+      priority: 6,
+      timing: 'weekly',
+      domain: 'routine',
+      message: `지난주 ${row.name} 잘 지켰는데 이번주는 ${row.this_rate}%로 떨어졌네`,
+    };
+  } catch {
+    return null;
+  }
+};
+
+// ─── 감지: 산발성 누락 ──────────────────────────────────
+
+interface SpottyRow {
+  name: string;
+  miss_count: number;
+  max_consecutive_miss: number;
+}
+
+export const detectSpottyPattern = async (
+  today: string,
+  userId: number,
+): Promise<Insight | null> => {
+  const { lookbackDays, minMissCount, maxMissCount } = INSIGHT_THRESHOLDS.spottyPattern;
+  try {
+    const result = await query<SpottyRow>(
+      `WITH window_records AS (
+        SELECT t.id AS template_id, t.name, r.date, r.completed,
+          ROW_NUMBER() OVER (PARTITION BY t.id ORDER BY r.date) AS rn
+        FROM routine_records r
+        JOIN routine_templates t ON r.template_id = t.id
+        WHERE r.user_id = $2 AND t.active = true AND t.frequency = '매일'
+          AND r.date BETWEEN ($1::date - ${lookbackDays - 1}) AND $1
+      ),
+      miss_groups AS (
+        SELECT template_id, name, date, completed,
+          rn - ROW_NUMBER() OVER (PARTITION BY template_id, completed ORDER BY rn) AS grp
+        FROM window_records WHERE completed = false
+      ),
+      stats AS (
+        SELECT m.template_id, m.name,
+          (SELECT COUNT(*) FROM window_records w
+            WHERE w.template_id = m.template_id AND w.completed = false) AS miss_count,
+          MAX(sub.consecutive) AS max_consecutive_miss
+        FROM miss_groups m,
+          LATERAL (SELECT COUNT(*)::int AS consecutive FROM miss_groups m2
+            WHERE m2.template_id = m.template_id AND m2.grp = m.grp) sub
+        GROUP BY m.template_id, m.name
+      )
+      SELECT name, miss_count::int, max_consecutive_miss::int
+      FROM stats
+      WHERE miss_count BETWEEN ${minMissCount} AND ${maxMissCount}
+        AND max_consecutive_miss < miss_count
+      ORDER BY miss_count DESC LIMIT 1`,
+      [today, userId],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return {
+      type: 'spottyPattern',
+      priority: 6,
+      timing: 'night',
+      domain: 'routine',
+      message: `${row.name} 이번주 듬성듬성 빠지고 있어. 7일 중 ${row.miss_count}번`,
+    };
+  } catch {
+    return null;
+  }
+};
+
 // ─── 통합 감지 + 넛지 선택 ──────────────────────────────
 
 const detectAll = async (today: string, userId: number): Promise<Insight[]> => {

--- a/src/shared/insights.ts
+++ b/src/shared/insights.ts
@@ -676,34 +676,64 @@ export const detectSpottyPattern = async (
 
 // ─── 통합 감지 + 넛지 선택 ──────────────────────────────
 
-const detectAll = async (today: string, userId: number): Promise<Insight[]> => {
-  const results = await Promise.all([
+const detectAllForTiming = async (
+  today: string,
+  userId: number,
+  timing: InsightTiming,
+): Promise<Insight[]> => {
+  const morning = timing === 'morning';
+  const weekly = timing === 'weekly';
+
+  const tasks: Array<Promise<Insight | null>> = [
     detectStreak(today, userId),
     detectSleepTrend(today, userId),
     detectSlotGap(today, userId),
     detectWeekComparison(today, userId),
     detectOverdue(today, userId),
-  ]);
-  return results.filter((r): r is Insight => r !== null);
+  ];
+
+  if (!morning) tasks.push(detectCategorySkew(today, userId, weekly ? 'weekly' : 'night'));
+  if (weekly) tasks.push(detectDrift(today, userId));
+  if (morning) tasks.push(detectRecovery(today, userId));
+  if (!morning && !weekly) tasks.push(detectLapseAlert(today, userId));
+  if (weekly) tasks.push(detectWeeklyRegression(today, userId));
+  if (!morning && !weekly) tasks.push(detectSpottyPattern(today, userId));
+
+  const results = await Promise.all(tasks);
+  return results.filter((r): r is Insight => r !== null && r.timing === timing);
 };
 
 const pickByTiming = async (
   today: string,
   userId: number,
   timing: InsightTiming,
-): Promise<string | null> => {
-  const all = await detectAll(today, userId);
-  const candidates = all.filter((i) => i.timing === timing);
-  if (candidates.length === 0) return null;
+): Promise<Insight[]> => {
+  const { minPriority, maxItems } = INSIGHT_THRESHOLDS.pickByTiming;
+  const all = await detectAllForTiming(today, userId, timing);
 
-  candidates.sort((a, b) => b.priority - a.priority);
-  return candidates[0].message;
+  const filtered = all.filter((i) => i.priority >= minPriority);
+  filtered.sort((a, b) => b.priority - a.priority);
+
+  const seen = new Set<InsightDomain>();
+  const deduped: Insight[] = [];
+  for (const insight of filtered) {
+    if (seen.has(insight.domain)) continue;
+    seen.add(insight.domain);
+    deduped.push(insight);
+    if (deduped.length >= maxItems) break;
+  }
+
+  return deduped;
 };
 
-/** 아침 크론용: 아침 타이밍 인사이트 중 최고 우선순위 1개 */
-export const pickMorningNudge = (today: string, userId: number): Promise<string | null> =>
+/** 아침 크론용: priority ≥5인 morning 인사이트, 같은 도메인 dedupe, 최대 3개 */
+export const pickMorningNudges = (today: string, userId: number): Promise<Insight[]> =>
   pickByTiming(today, userId, 'morning');
 
-/** 밤 크론용: 밤 타이밍 인사이트 중 최고 우선순위 1개 */
-export const pickNightNudge = (today: string, userId: number): Promise<string | null> =>
+/** 밤 크론용: priority ≥5인 night 인사이트, 같은 도메인 dedupe, 최대 3개 */
+export const pickNightNudges = (today: string, userId: number): Promise<Insight[]> =>
   pickByTiming(today, userId, 'night');
+
+/** 주간 리포트용: weekly 인사이트 (도메인 dedupe + cap 동일) */
+export const pickWeeklyInsights = (today: string, userId: number): Promise<Insight[]> =>
+  pickByTiming(today, userId, 'weekly');


### PR DESCRIPTION
## 관련 이슈
Closes #389

부분 진척: #393 (마스터 — Phase 1)

## 변경 내용

### 1. 임계치 외부화
- `src/shared/insight-thresholds.ts` 신규 — 모든 패턴 임계치 단일 export (Phase 4 사주 매핑 튜닝 대비)
- 기존 5개 detect 함수(streak/sleepTrend/slotGap/weekComparison/overdueAlert)도 외부 임계치 사용

### 2. SQL 패턴 6개 신설
| type | timing | domain | 트리거 |
|------|--------|--------|--------|
| categorySkew | night/weekly | schedule | 1위 카테고리 ≥50% |
| drift | weekly | sleep | 4주 평균 대비 취침/기상 30분+ 또는 중간기상 1.5배+ |
| recovery | morning | routine | streak 5일+ 깨진 후 1일 만에 재시작 |
| lapseAlert | night | routine | 7일 100% → 오늘 빠짐 |
| weeklyRegression | weekly | routine | 지난주 ≥90% → 이번주 ≤60% |
| spottyPattern | night | routine | 7일 중 3~4일 산발 빠짐 |

### 3. Insight 타입 확장
- `timing: 'morning' | 'night' | 'weekly'`
- `domain: 'routine' | 'sleep' | 'schedule'` 신규 필드

### 4. 동적 노출 정책
- 기존: priority 최상위 1개
- 변경: priority ≥5 + domain dedupe + 최대 3개 cap, 0개면 메시지 발송 안 함

### 5. life-cron 연결 복원
- 매일 morning(09:05) / night(23:55) 패턴 호출 복원 (이전 주석 처리 상태)
- 월요일 morning은 주간 리포트로 대체 → 중복 방지 guard

### 6. 주간 리포트 재구성
- 일요일 23:00 → 월요일 09:00 이동 (지난주 회고 시점 자연스러움)
- Block Kit: 인사이트 → 한눈에 보기 → 총평 순서로 재구성
- 이모지 미사용, 집계는 압축 표시
- 기존 best/worst day 등은 LLM 총평 컨텍스트로 활용

### 7. 마이그레이션
- `scripts/migrations/2026-05-13-weekly-report-monday/migrate.sql` — `notification_settings.weeklyReport` 시간 변경
- 운영 DB 적용은 사용자가 직접 실행 (보안 크리티컬 원칙)

### 8. 문서
- ADR 0014: 통합·외부화·재구성 판단 근거 + 대안 비교
- `docs/domains/insight.md`: 프로액티브 인사이트 엔진 섹션 신설

## 코드 리뷰 결과
- [x] 보안 감사 통과 (크리덴셜·SQL injection·민감정보 노출 없음)
- [x] 타입 안전성 (any 없음, unknown + 타입 가드)
- [x] 컨벤션 점검 (kebab-case 파일명, named export, ESM .js 확장자)
- [x] 코드 품질 (단일 책임, 에러 처리, fallback)

## 테스트
- [x] 신규 6개 패턴 happy path + skip 케이스
- [x] pickByTiming 동적 노출 (priority 필터/도메인 dedupe/cap)
- [x] morning/night/weekly 타이밍별 인사이트 분류
- [x] DB 오류 시 null/빈 배열 graceful 반환
- [x] 전 테스트 401개 통과, 타입 체크 통과

## 후속 작업 (이 PR 머지 후)
1. 운영 DB에 마이그레이션 SQL 적용 (사용자 직접 실행)
2. 1주 운영 후 `INSIGHT_THRESHOLDS.pickByTiming.minPriority` 튜닝
3. Phase 2 (#390): LLM 자율 슬롯 도입
4. Phase 4 (#392): 카테고리 메타데이터 확장 + 사주 십성 매핑