### PR TITLE
feat(budget): 결제주기 종료 자산 자동 차감 + 할부 미래 회차 즉시 반영

### DIFF
--- a/db/migrations/046_assets_is_default.sql
+++ b/db/migrations/046_assets_is_default.sql
@@ -1,0 +1,10 @@
+-- 046: assets.is_default — 자동 차감 우선순위 자산 표시
+-- 결제주기 종료 cron / 할부 미래 회차 INSERT 시 자산이 자동으로 차감될 때
+-- 우선순위가 가장 높은 자산을 가리킨다. user당 최대 1개 (partial unique index).
+-- 부족분은 is_emergency=false인 다른 자산으로 fallback.
+
+ALTER TABLE assets ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT false;
+
+CREATE UNIQUE INDEX IF NOT EXISTS assets_user_default_unique
+  ON assets (user_id)
+  WHERE is_default = true;

--- a/docs/adr/0015-asset-auto-deduction-policy.md
+++ b/docs/adr/0015-asset-auto-deduction-policy.md
@@ -1,0 +1,101 @@
+# 0015. 자산 자동 차감 정책 — 결제주기 종료 cron + 할부 미래 회차 즉시 반영
+
+- Status: Accepted
+- Date: 2026-05-14
+- Related: #397
+- Tags: data, budget
+
+## Context
+
+결제주기 동안 누적된 자유지출이 자산에 반영되지 않아 새 사이클 시작 시 일 예산 권장값이 점프하는 문제가 발생했다.
+
+- `computeTotalAvailable`이 자산 합계를 그대로 반환 → 결제주기 동안 누적 지출이 자산에 미반영
+- 새 결제주기 시작 시 가용자금이 그대로 남아 일 예산 권장값이 갑자기 커짐 (사용자 체감 문제)
+- `monthly_budget_snapshots.available_at_end`는 계산만 되고 가용자금 산출에 미사용 (사실상 데드 스토리지)
+- ADR 0008의 일 예산 이중화 모델(`todayBudget` vs `todayRecommended`)은 "사이클 도중 자산이 흔들리지 않음"을 전제
+
+자산은 사용자 수동 갱신 전제로만 동작했기 때문에, 사용자가 매 결제주기 종료마다 직접 자산을 깎아야 했고, 이 작업을 빠뜨리면 다음 사이클 권장값이 신뢰할 수 없게 된다.
+
+## Decision
+
+결제주기 종료 cron에서 이전 사이클 자유+제외 지출을 default 자산에서 차감, 수입은 증액. 할부 2+회차는 INSERT 즉시 자산 차감하고, allocator의 `installmentSum`에서 미래 회차를 제외(수학적 동등 유지).
+
+### 자산 변동 시점
+
+| 항목 | 자산 변동 시점 | 비고 |
+|------|---------------|------|
+| 일반 자유지출 (`exclude_from_budget=false`) | 결제주기 종료 cron | `runSettlementIfDue`에서 일괄 |
+| 제외지출 (`exclude_from_budget=true`) | 결제주기 종료 cron | 동일 합산 |
+| 수입 (`type='income'`) | 결제주기 종료 cron | 증액 방향 |
+| 할부 1회차 (현재 결제주기) | 변동 없음 | `totalLocked`로 monthBudget에 반영 |
+| 할부 2+회차 (미래 결제주기) | INSERT 즉시 차감 | `installmentSum`에서 제외 |
+
+### Default 자산 + cascading fallback
+
+- `assets.is_default=true` 자산을 차감 우선순위 1순위
+- 부족 시 `is_emergency=false`인 다른 자산으로 cascade (`available_amount` 내림차순)
+- 마지막 fallback 자산은 음수 허용 (마이너스 통장 의미상)
+- 증액(수입)은 default 자산에만 단순 증액 (분배 불필요)
+- `balance`는 건드리지 않음 — 실제 계좌 잔액은 사용자가 가끔 직접 갱신, `available_amount`만 변동
+
+### 이중 차감 회피 — `installmentSum` 미래 회차 제외
+
+자산 100, 3개월 3만원 할부 케이스:
+- 기존: `totalAvailable=100, totalLocked=9, totalFree=91`
+- 신규: `totalAvailable=94(자산-6), totalLocked=3(1회차만), totalFree=91` ✅
+
+수학적 동등성 유지되어 monthBudget 계산은 변하지 않음. 사용자 멘탈 모델만 "자산이 즉시 줄어듦"으로 직관적이 됨.
+
+### Idempotency
+
+`saveSnapshotIfAbsent`가 `UNIQUE(user_id, year_month)` 제약으로 중복 저장을 차단. 자산 변동도 `saveSnapshotIfAbsent.saved === true`일 때만 실행하므로 같은 yearMonth에 cron이 재실행되어도 자산 재차감 없음.
+
+## Alternatives considered
+
+### A. 수동 갱신 + 알림 강화
+
+- 장점: 코드 변경 최소, 기존 모델 유지
+- 단점: 사용자가 결제주기 종료마다 직접 자산을 깎아야 함. 누락 위험 + 인지 부하
+- 기각 이유: 자동화 가능한 작업을 사용자에게 떠넘기는 것은 알림으로도 본질적 해결 안 됨
+
+### B. snapshot 기반 동적 계산 (`available_at_end + 누적 변화`)
+
+- 장점: 자산 테이블은 사용자 수동 갱신값으로 보존, 가용자금은 계산값
+- 단점: 자산 테이블과 가용자금 표시가 분리되어 사용자 멘탈 모델과 충돌. "자산은 100인데 가용자금은 94" 같은 표시 차이를 매번 설명해야 함
+- 기각 이유: 사용자가 자산 화면을 봤을 때 "내가 쓸 수 있는 돈"이 바로 보여야 한다는 직관과 충돌
+
+### C. (선택) 자동 차감 + cascading fallback
+
+- 장점: 자산 = 가용자금 직관 유지. 결제주기 단위 cron 처리로 ADR 0008의 base 안정성 보존. 할부 미래 회차도 시각화됨
+- 단점: 자산 자동 변동과 사용자 수동 갱신이 충돌할 여지 (사용자가 보정 필요할 수 있음)
+
+## Consequences
+
+### 장점
+
+- 사용자가 별도 갱신 없이 가용자금 자동 추적
+- 결제주기 전환 시 일 예산 권장값 점프 문제 해소
+- 할부 미래 회차가 자산에 즉시 반영되어 "쓸 수 있는 돈" 직관 정확
+- ADR 0008의 일 예산 이중화 모델(base 안정성) 보존
+
+### 단점 / 제약
+
+- 자산 자동 변동 ↔ 사용자 수동 갱신이 충돌할 여지 (사용자가 가끔 실잔액 보정 필요)
+- 할부 amount 수정/삭제 시 자산 재조정 로직이 분산됨 (createInstallmentExpenses / updateExpense / deleteExpense 세 곳)
+- DB Proxy API 구조상 트랜잭션 보장이 없어 idempotency를 `saveSnapshotIfAbsent`의 UNIQUE 제약에 의존
+
+### 후속 작업
+
+- [ ] 자동 변동 이력 감사 로그 (운영 중 의문 발생 시 추가)
+- [ ] 할부 1회차 `isNew` 경계 처리 검증 (allocator 테스트)
+- [ ] 기존 할부 잔여 회차 backfill 스크립트 운영 환경 1회 실행
+- [ ] default 자산 시드 SQL 운영 환경 적용
+
+---
+
+**참고 자료**
+
+- ADR 0007 — 자유지출 정의 통일
+- ADR 0008 — 일 예산 산정 모델 이중화
+- ADR 0009 — 일별 로그 평가 기준
+- ADR 0010 — 일별 예산 로그 cron 스케줄

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -121,6 +121,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0012](0012-fortune-personalization.md) | 운세 분석 개인화 — 라이프 테마 두 트랙 + 의사결정 가이드 + 자연 prose | Accepted | 2026-05-08 | data, llm, ux |
 | [0013](0013-schedule-category-fk-migration.md) | 일정 카테고리 — TEXT 참조 → 단일 FK + parent_id 계층화 | Accepted | 2026-05-13 | data, schema, refactor |
 | [0014](0014-insight-engine-unification.md) | 프로액티브 인사이트 엔진 통합 — 매일·주간 단일 엔진 + 임계치 외부화 | Accepted | 2026-05-13 | data, insight, process |
+| [0015](0015-asset-auto-deduction-policy.md) | 자산 자동 차감 정책 — 결제주기 종료 cron + 할부 미래 회차 즉시 반영 | Accepted | 2026-05-14 | data, budget |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/domains/budget.md
+++ b/docs/domains/budget.md
@@ -12,20 +12,17 @@
 ## 핵심 개념
 
 ### 결제주기 (Billing Cycle)
-- 1개 결제월 = **전월 16일 \~ 당월 15일**
-- 예: `2026-04` → `2026-03-16 \~ 2026-04-15`
+- 1개 결제월 = **전월 14일 \~ 당월 13일**
+- 예: `2026-04` → `2026-03-14 \~ 2026-04-13`
 - 모든 예산/정산/고정비 계산의 기준 단위
 - 구현: [billing/cycle.ts](../../web/src/features/budget/lib/billing/cycle.ts)
 
 ### 가용자금 (Total Available)
-두 가지 모드로 계산:
-
-| 조건 | 계산식 |
-|------|--------|
-| 최신 월 스냅샷이 있음 | `available_at_end` + 이후 기간의 배분 가능 수입 − 자유 지출 − 제외 지출 |
-| 스냅샷 없음 | 자산 테이블의 `available_amount` 합계 (비상금 제외) |
-
-- 구현: [facade.ts `computeTotalAvailable`](../../web/src/features/budget/lib/facade.ts)
+- `assets.available_amount` 합계 (`is_emergency=false`)
+- 결제주기 종료 cron이 이전 사이클의 자유+제외 지출을 default 자산에서 자동 차감하고 수입을 default 자산에 증액 — 자산 테이블이 곧 가용자금이 되도록 유지
+- 할부 2+회차는 INSERT 즉시 자산에서 차감 (allocator의 monthBudget 락에서는 제외해 수학적 동등)
+- 구현: [facade.ts `runSettlementIfDue`](../../web/src/features/budget/lib/facade.ts), [assets-repo.ts](../../web/src/features/budget/lib/repository/assets-repo.ts)
+- 판단 근거: [ADR 0015](../adr/0015-asset-auto-deduction-policy.md)
 
 ### 자유 예산 (Free Budget)
 - 월 자유 예산 = 월 가용자금 − (월 고정비 + 할부 월분 + 예정 지출)
@@ -211,8 +208,8 @@ features/budget/
 | 9 | 일 예산 배분 | month-summary 오늘 예산 | `/api/budget/today` | day-allocator.ts | 초과 클램프 |
 | 10 | 장기 예산 시뮬레이션 | runway-card | `/api/budget/runway` | runway-projection.ts | 월별 burn 시뮬 |
 | 11 | 일별 예산 로그 | daily-budget-log | `/api/budget/daily-logs` + cron | `saveDailyBudgetLog` | UNIQUE(user, date) |
-| 12 | 월별 예산 스냅샷 | — (내부) | 정산 cron 진입점 | `buildSettlementSnapshot` | 15일 자정 idempotent |
-| 13 | 결제주기 유틸 | — | — | billing/cycle.ts | 전월 16일\~당월 15일 |
+| 12 | 월별 예산 스냅샷 | — (내부) | 정산 cron 진입점 | `buildSettlementSnapshot` | 13일 종료 → 14일 새벽 cron, idempotent |
+| 13 | 결제주기 유틸 | — | — | billing/cycle.ts | 전월 14일\~당월 13일 |
 
 ### 🟡 부분 구현 (4)
 
@@ -228,7 +225,7 @@ features/budget/
 | # | 항목 | 설명 |
 |---|------|------|
 | A | 수입 "이번 달" 옵션 | `distribute_to_budget=false` 시 예산 계산에 미반영. UI 레이블과 동작 불일치 — 의도 확인 + 구현 필요 |
-| B | 할부 `isNew` 경계 판정 | 빌링 시작일(당월 16일) 전후로 선택된 할부의 신규 여부 판정이 의도대로 동작하는지 경계 테스트 필요 |
+| B | 할부 `isNew` 경계 판정 | 빌링 시작일(당월 14일) 전후로 선택된 할부의 신규 여부 판정이 의도대로 동작하는지 경계 테스트 필요 |
 | C | 고정비 자동 기록 강제 `exclude_from_budget=true` | [queries.ts `ensureFixedCostExpenses`](../../web/src/features/budget/lib/queries.ts)에서 강제. 사용자 정책 재검토 필요 |
 
 ## 데이터 흐름
@@ -256,12 +253,13 @@ expense-form (type=expense)
   → allocateTodayBudget() 의 todayRemaining 감소
 ```
 
-### 월 경계 정산 (15일 자정 cron)
+### 월 경계 정산 (13일 종료 → 14일 새벽 cron)
 ```
-detectSettlementTrigger() → 오늘이 16일 새벽인지 판정
+detectSettlementTrigger() → 어제가 13일(주기 마지막)인지 판정
   → getMonthlyAllocation() 재실행
   → readFlexibleSpent/Excluded/Income (범위: 정산 대상 월)
   → buildSettlementSnapshot() 로 monthly_budget_snapshots 저장 (idempotent)
+  → applyAssetDeduction(flex + excluded) + applyAssetIncrease(income) — 자산 자동 반영
   → 다음 월의 available_at_start 로 연쇄
 ```
 

--- a/web/src/app/api/budget/assets/[id]/route.ts
+++ b/web/src/app/api/budget/assets/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { updateAsset } from '@/features/budget/lib/queries';
+import { updateAsset, setDefaultAsset, clearDefaultAsset } from '@/features/budget/lib/queries';
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const userId = await requireAuth();
@@ -15,13 +15,39 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
       balance?: number;
       available_amount?: number;
       memo?: string | null;
+      is_default?: boolean;
     };
 
     if (body.balance !== undefined && (typeof body.balance !== 'number' || body.balance < 0)) {
       return NextResponse.json({ error: 'balance는 0 이상 숫자여야 합니다' }, { status: 400 });
     }
 
-    const data = await updateAsset(userId, id, body);
+    let data = null;
+    if (body.is_default !== undefined) {
+      try {
+        data =
+          body.is_default === true
+            ? await setDefaultAsset(userId, id)
+            : await clearDefaultAsset(userId, id);
+      } catch (err) {
+        if (err instanceof Error && err.message === 'EMERGENCY_ASSET_CANNOT_BE_DEFAULT') {
+          return NextResponse.json(
+            { error: '비상금 자산은 기본 자산으로 지정할 수 없습니다' },
+            { status: 400 },
+          );
+        }
+        throw err;
+      }
+    }
+
+    if (
+      body.balance !== undefined ||
+      body.available_amount !== undefined ||
+      body.memo !== undefined
+    ) {
+      data = await updateAsset(userId, id, body);
+    }
+
     if (!data) return NextResponse.json({ error: '자산을 찾을 수 없습니다' }, { status: 404 });
     return NextResponse.json({ data });
   } catch (err) {

--- a/web/src/features/budget/components/budget-settings-page.tsx
+++ b/web/src/features/budget/components/budget-settings-page.tsx
@@ -42,7 +42,9 @@ function FixedCostItem({
         <div className="flex items-center gap-2 min-w-0 flex-wrap">
           <span className="text-sm font-medium text-gray-700">{cost.name}</span>
           {cost.category && (
-            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">{cost.category}</span>
+            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+              {cost.category}
+            </span>
           )}
           {cost.is_variable && (
             <span className="rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-500">변동</span>
@@ -50,7 +52,11 @@ function FixedCostItem({
         </div>
         {!editing && (
           <button
-            onClick={() => { setAmount(String(cost.amount)); setDayOfMonth(String(cost.day_of_month ?? '')); setEditing(true); }}
+            onClick={() => {
+              setAmount(String(cost.amount));
+              setDayOfMonth(String(cost.day_of_month ?? ''));
+              setEditing(true);
+            }}
             className="rounded-md p-1 text-gray-300 hover:bg-gray-100 hover:text-gray-500"
           >
             <PencilIcon size={14} />
@@ -62,26 +68,51 @@ function FixedCostItem({
         <div className="mt-2 space-y-2">
           <div className="flex items-center gap-2">
             <label className="w-16 text-xs text-gray-400">금액</label>
-            <input type="number" value={amount} onChange={(e) => setAmount(e.target.value)}
-              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none" />
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+            />
           </div>
           <div className="flex items-center gap-2">
             <label className="w-16 text-xs text-gray-400">결제일</label>
-            <input type="number" min="1" max="31" placeholder="미설정" value={dayOfMonth} onChange={(e) => setDayOfMonth(e.target.value)}
-              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none" />
+            <input
+              type="number"
+              min="1"
+              max="31"
+              placeholder="미설정"
+              value={dayOfMonth}
+              onChange={(e) => setDayOfMonth(e.target.value)}
+              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+            />
             <span className="text-xs text-gray-400">일</span>
           </div>
           <div className="flex justify-between">
             <button
-              onClick={() => { if (confirm('이 고정지출을 삭제할까?')) void onDelete(cost.id); }}
+              onClick={() => {
+                if (confirm('이 고정지출을 삭제할까?')) void onDelete(cost.id);
+              }}
               disabled={saving}
               className="text-xs text-red-400 hover:text-red-600"
             >
               삭제
             </button>
             <div className="flex gap-1.5">
-              <button onClick={() => setEditing(false)} disabled={saving} className="rounded-md p-1 text-gray-400 hover:bg-gray-100"><XMarkIcon size={16} /></button>
-              <button onClick={() => void handleSave()} disabled={saving} className="rounded-md p-1 text-blue-500 hover:bg-blue-50"><CheckCircleIcon size={16} /></button>
+              <button
+                onClick={() => setEditing(false)}
+                disabled={saving}
+                className="rounded-md p-1 text-gray-400 hover:bg-gray-100"
+              >
+                <XMarkIcon size={16} />
+              </button>
+              <button
+                onClick={() => void handleSave()}
+                disabled={saving}
+                className="rounded-md p-1 text-blue-500 hover:bg-blue-50"
+              >
+                <CheckCircleIcon size={16} />
+              </button>
             </div>
           </div>
         </div>
@@ -101,7 +132,16 @@ function FixedCostItem({
 
 // ─── 고정비 추가 폼 ──────────────────────────────────
 
-function FixedCostAddForm({ onAdd }: { onAdd: (data: { name: string; amount: number; category?: string; day_of_month?: number | null }) => Promise<void> }) {
+function FixedCostAddForm({
+  onAdd,
+}: {
+  onAdd: (data: {
+    name: string;
+    amount: number;
+    category?: string;
+    day_of_month?: number | null;
+  }) => Promise<void>;
+}) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState('');
   const [amount, setAmount] = useState('');
@@ -116,8 +156,16 @@ function FixedCostAddForm({ onAdd }: { onAdd: (data: { name: string; amount: num
     if (day !== null && (isNaN(day) || day < 1 || day > 31)) return;
     setSaving(true);
     try {
-      await onAdd({ name: name.trim(), amount: a, category: category || undefined, day_of_month: day });
-      setName(''); setAmount(''); setCategory(''); setDayOfMonth('');
+      await onAdd({
+        name: name.trim(),
+        amount: a,
+        category: category || undefined,
+        day_of_month: day,
+      });
+      setName('');
+      setAmount('');
+      setCategory('');
+      setDayOfMonth('');
       setOpen(false);
     } finally {
       setSaving(false);
@@ -138,28 +186,60 @@ function FixedCostAddForm({ onAdd }: { onAdd: (data: { name: string; amount: num
   return (
     <div className="border-t border-gray-100 px-4 py-3 space-y-2">
       <div className="flex items-center gap-2">
-        <input type="text" placeholder="이름" value={name} onChange={(e) => setName(e.target.value)}
-          className="flex-1 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none" autoFocus />
+        <input
+          type="text"
+          placeholder="이름"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="flex-1 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+          autoFocus
+        />
       </div>
       <div className="flex items-center gap-2">
-        <input type="text" inputMode="numeric" placeholder="금액" value={amount} onChange={(e) => setAmount(e.target.value)}
-          className="flex-1 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none" />
-        <input type="number" min="1" max="31" placeholder="결제일" value={dayOfMonth} onChange={(e) => setDayOfMonth(e.target.value)}
-          className="w-20 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none" />
+        <input
+          type="text"
+          inputMode="numeric"
+          placeholder="금액"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="flex-1 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+        />
+        <input
+          type="number"
+          min="1"
+          max="31"
+          placeholder="결제일"
+          value={dayOfMonth}
+          onChange={(e) => setDayOfMonth(e.target.value)}
+          className="w-20 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+        />
       </div>
       <div className="flex items-center gap-2">
-        <select value={category} onChange={(e) => setCategory(e.target.value)}
-          className="flex-1 rounded-md border border-gray-200 px-2 py-1.5 text-sm text-gray-700 focus:border-blue-400 focus:outline-none">
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="flex-1 rounded-md border border-gray-200 px-2 py-1.5 text-sm text-gray-700 focus:border-blue-400 focus:outline-none"
+        >
           <option value="">카테고리 선택</option>
           {FIXED_COST_CATEGORIES.map((c) => (
-            <option key={c} value={c}>{c}</option>
+            <option key={c} value={c}>
+              {c}
+            </option>
           ))}
         </select>
       </div>
       <div className="flex justify-end gap-1.5">
-        <button onClick={() => setOpen(false)} className="rounded-md px-3 py-1 text-xs text-gray-400 hover:bg-gray-100">취소</button>
-        <button onClick={() => void handleSubmit()} disabled={saving || !name.trim() || !amount}
-          className="rounded-md bg-blue-600 px-3 py-1 text-xs text-white disabled:opacity-40 hover:bg-blue-700">
+        <button
+          onClick={() => setOpen(false)}
+          className="rounded-md px-3 py-1 text-xs text-gray-400 hover:bg-gray-100"
+        >
+          취소
+        </button>
+        <button
+          onClick={() => void handleSubmit()}
+          disabled={saving || !name.trim() || !amount}
+          className="rounded-md bg-blue-600 px-3 py-1 text-xs text-white disabled:opacity-40 hover:bg-blue-700"
+        >
           {saving ? '추가 중...' : '추가'}
         </button>
       </div>
@@ -172,12 +252,15 @@ function FixedCostAddForm({ onAdd }: { onAdd: (data: { name: string; amount: num
 function AssetItem({
   asset,
   onUpdate,
+  onToggleDefault,
 }: {
   asset: AssetRow;
   onUpdate: (id: number, balance: number, available_amount: number) => Promise<void>;
+  onToggleDefault: (id: number, next: boolean) => Promise<void>;
 }) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [togglingDefault, setTogglingDefault] = useState(false);
   const [balance, setBalance] = useState(String(asset.balance));
   const [available, setAvailable] = useState(String(asset.available_amount ?? asset.balance));
 
@@ -194,19 +277,38 @@ function AssetItem({
     }
   };
 
+  const handleToggleDefault = async () => {
+    if (asset.is_emergency || togglingDefault) return;
+    setTogglingDefault(true);
+    try {
+      await onToggleDefault(asset.id, !asset.is_default);
+    } finally {
+      setTogglingDefault(false);
+    }
+  };
+
   return (
     <div className="px-4 py-2.5">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-gray-700">{asset.name}</span>
-          <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">{asset.type}</span>
+          <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+            {asset.type}
+          </span>
           {asset.is_emergency && (
             <span className="rounded bg-amber-50 px-1.5 py-0.5 text-xs text-amber-600">비상금</span>
+          )}
+          {asset.is_default && (
+            <span className="rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-600">기본</span>
           )}
         </div>
         {!editing && (
           <button
-            onClick={() => { setBalance(String(asset.balance)); setAvailable(String(asset.available_amount ?? asset.balance)); setEditing(true); }}
+            onClick={() => {
+              setBalance(String(asset.balance));
+              setAvailable(String(asset.available_amount ?? asset.balance));
+              setEditing(true);
+            }}
             className="rounded-md p-1 text-gray-300 hover:bg-gray-100 hover:text-gray-500"
           >
             <PencilIcon size={14} />
@@ -218,24 +320,61 @@ function AssetItem({
         <div className="mt-2 space-y-2">
           <div className="flex items-center gap-2">
             <label className="w-16 text-xs text-gray-400">잔액</label>
-            <input type="number" value={balance} onChange={(e) => setBalance(e.target.value)}
-              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none" />
+            <input
+              type="number"
+              value={balance}
+              onChange={(e) => setBalance(e.target.value)}
+              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+            />
           </div>
           <div className="flex items-center gap-2">
             <label className="w-16 text-xs text-gray-400">사용가능</label>
-            <input type="number" value={available} onChange={(e) => setAvailable(e.target.value)}
-              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none" />
+            <input
+              type="number"
+              value={available}
+              onChange={(e) => setAvailable(e.target.value)}
+              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+            />
           </div>
+          <label className="flex items-center gap-2 text-xs text-gray-500">
+            <input
+              type="checkbox"
+              checked={asset.is_default}
+              disabled={asset.is_emergency || togglingDefault}
+              onChange={() => void handleToggleDefault()}
+            />
+            기본 자산 (자동 차감 우선순위)
+          </label>
           <div className="flex justify-end gap-1.5">
-            <button onClick={() => setEditing(false)} disabled={saving} className="rounded-md p-1 text-gray-400 hover:bg-gray-100"><XMarkIcon size={16} /></button>
-            <button onClick={() => void handleSave()} disabled={saving} className="rounded-md p-1 text-blue-500 hover:bg-blue-50"><CheckCircleIcon size={16} /></button>
+            <button
+              onClick={() => setEditing(false)}
+              disabled={saving}
+              className="rounded-md p-1 text-gray-400 hover:bg-gray-100"
+            >
+              <XMarkIcon size={16} />
+            </button>
+            <button
+              onClick={() => void handleSave()}
+              disabled={saving}
+              className="rounded-md p-1 text-blue-500 hover:bg-blue-50"
+            >
+              <CheckCircleIcon size={16} />
+            </button>
           </div>
         </div>
       ) : (
         <div className="mt-1 flex items-center gap-4 text-sm">
-          <span><span className="text-xs text-gray-400">잔액 </span><span className="font-semibold text-gray-800">{formatAmount(asset.balance)}</span></span>
+          <span>
+            <span className="text-xs text-gray-400">잔액 </span>
+            <span className="font-semibold text-gray-800">{formatAmount(asset.balance)}</span>
+          </span>
           {asset.available_amount !== null && asset.available_amount !== asset.balance && (
-            <span><span className="text-xs text-gray-400">사용가능 </span><span className="font-semibold text-gray-800">{formatAmount(asset.available_amount)}</span></span>
+            <span>
+              <span className="text-xs text-gray-400">사용가능 </span>
+              <span className="font-semibold text-gray-800">
+                {formatAmount(asset.available_amount)}
+              </span>
+            </span>
           )}
         </div>
       )}
@@ -278,7 +417,7 @@ function TargetDateCard({
     if (savedTarget && /^\d{4}-\d{2}$/.test(savedTarget)) {
       void fetchPreview(savedTarget);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [savedTarget]);
 
   const fetchPreview = async (target: string) => {
@@ -347,13 +486,13 @@ function TargetDateCard({
       </div>
 
       {savedTarget && (
-        <p className="mb-3 text-xs text-gray-400">현재 설정: <span className="font-medium text-gray-600">{savedTarget}</span></p>
+        <p className="mb-3 text-xs text-gray-400">
+          현재 설정: <span className="font-medium text-gray-600">{savedTarget}</span>
+        </p>
       )}
 
       {/* 프리뷰 */}
-      {loadingPreview && (
-        <div className="mt-2 h-20 animate-pulse rounded-lg bg-gray-100" />
-      )}
+      {loadingPreview && <div className="mt-2 h-20 animate-pulse rounded-lg bg-gray-100" />}
 
       {preview && !loadingPreview && (
         <div className="mt-2 rounded-lg border border-gray-100 bg-gray-50 p-3">
@@ -361,11 +500,15 @@ function TargetDateCard({
           <div className="mb-2 flex items-center justify-between">
             <div>
               <span className="text-xs text-gray-500">월 자유 예산</span>
-              <span className="ml-2 text-base font-bold text-gray-800">{formatAmount(preview.free_per_month)}</span>
+              <span className="ml-2 text-base font-bold text-gray-800">
+                {formatAmount(preview.free_per_month)}
+              </span>
             </div>
             <div className="text-right">
               <span className="text-xs text-gray-500">하루</span>
-              <span className={`ml-1 text-base font-bold ${isDailyLow ? 'text-red-500' : 'text-gray-800'}`}>
+              <span
+                className={`ml-1 text-base font-bold ${isDailyLow ? 'text-red-500' : 'text-gray-800'}`}
+              >
                 {formatAmount(preview.daily_estimate)}
               </span>
             </div>
@@ -373,14 +516,18 @@ function TargetDateCard({
 
           {isDailyLow && (
             <div className="mb-2 rounded-md bg-red-50 px-2.5 py-1.5 text-xs text-red-600">
-              하루 {formatAmount(preview.daily_estimate)}으로 설정됩니다. 기간을 줄이거나 자금을 늘리면 더 여유로워져요.
+              하루 {formatAmount(preview.daily_estimate)}으로 설정됩니다. 기간을 줄이거나 자금을
+              늘리면 더 여유로워져요.
             </div>
           )}
 
           {/* 월별 브레이크다운 */}
           <div className="divide-y divide-gray-100">
             {displayMonths?.map((m, i) => (
-              <div key={m.month} className={`flex items-center justify-between py-1.5 text-xs ${i === 0 ? 'pt-0' : ''}`}>
+              <div
+                key={m.month}
+                className={`flex items-center justify-between py-1.5 text-xs ${i === 0 ? 'pt-0' : ''}`}
+              >
                 <span className="text-gray-500">{m.month.slice(2)}</span>
                 <div className="flex items-center gap-3">
                   <span className="text-gray-400">잠긴 {formatAmount(m.locked)}</span>
@@ -444,9 +591,16 @@ export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: ()
     }
   }, []);
 
-  useEffect(() => { void fetchAll(); }, [fetchAll]);
+  useEffect(() => {
+    void fetchAll();
+  }, [fetchAll]);
 
-  const handleAddFixedCost = async (data: { name: string; amount: number; category?: string; day_of_month?: number | null }) => {
+  const handleAddFixedCost = async (data: {
+    name: string;
+    amount: number;
+    category?: string;
+    day_of_month?: number | null;
+  }) => {
     const res = await fetch('/api/budget/fixed-costs', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -489,6 +643,18 @@ export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: ()
     onSettingsChange?.();
   };
 
+  const handleToggleDefault = async (id: number, next: boolean) => {
+    const res = await fetch(`/api/budget/assets/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_default: next }),
+    });
+    if (!res.ok) throw new Error('기본 자산 설정 실패');
+    // 다른 자산의 is_default가 변경되었을 수 있어 전체 재조회
+    await fetchAll();
+    onSettingsChange?.();
+  };
+
   const activeCosts = fixedCosts.filter((c) => c.active);
   const inactiveCosts = fixedCosts.filter((c) => !c.active);
   const totalFixed = activeCosts.reduce((s, c) => s + c.amount, 0);
@@ -507,7 +673,10 @@ export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: ()
       {/* 목표 기간 설정 */}
       <TargetDateCard
         savedTarget={savedTarget}
-        onSaved={(target) => { setSavedTarget(target); onSettingsChange?.(); }}
+        onSaved={(target) => {
+          setSavedTarget(target);
+          onSettingsChange?.();
+        }}
       />
 
       {/* 고정 지출 */}
@@ -522,7 +691,12 @@ export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: ()
         ) : (
           <div className="divide-y divide-gray-100">
             {activeCosts.map((cost) => (
-              <FixedCostItem key={cost.id} cost={cost} onUpdate={handleUpdateFixedCost} onDelete={handleDeleteFixedCost} />
+              <FixedCostItem
+                key={cost.id}
+                cost={cost}
+                onUpdate={handleUpdateFixedCost}
+                onDelete={handleDeleteFixedCost}
+              />
             ))}
 
             {inactiveCosts.length > 0 && (
@@ -531,7 +705,10 @@ export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: ()
                   <span className="text-xs font-medium text-gray-400">비활성</span>
                 </div>
                 {inactiveCosts.map((cost) => (
-                  <div key={cost.id} className="flex items-center justify-between px-4 py-2.5 opacity-50">
+                  <div
+                    key={cost.id}
+                    className="flex items-center justify-between px-4 py-2.5 opacity-50"
+                  >
                     <span className="text-sm text-gray-500">{cost.name}</span>
                     <span className="text-sm text-gray-500">{formatAmount(cost.amount)}</span>
                   </div>
@@ -561,7 +738,12 @@ export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: ()
         ) : (
           <div className="divide-y divide-gray-100">
             {assets.map((asset) => (
-              <AssetItem key={asset.id} asset={asset} onUpdate={handleUpdateAsset} />
+              <AssetItem
+                key={asset.id}
+                asset={asset}
+                onUpdate={handleUpdateAsset}
+                onToggleDefault={handleToggleDefault}
+              />
             ))}
           </div>
         )}

--- a/web/src/features/budget/lib/__tests__/update-expense.test.ts
+++ b/web/src/features/budget/lib/__tests__/update-expense.test.ts
@@ -47,16 +47,26 @@ describe('updateExpense — source=fixed 행 exclude_from_budget 가드', () => 
     await expect(updateExpense(1, 200, { exclude_from_budget: false })).resolves.toBeTruthy();
   });
 
-  it("source='fixed' 행 + amount만 변경(exclude_from_budget 미포함) → 가드 미발동, 정상 진행", async () => {
-    vi.mocked(queryOne).mockResolvedValueOnce({ id: 686, amount: 167776 } as Any);
+  it("source='fixed' 행 + amount만 변경(exclude_from_budget 미포함) → 자산 보정용 SELECT + UPDATE", async () => {
+    vi.mocked(queryOne)
+      .mockResolvedValueOnce({
+        amount: 100000,
+        is_installment: false,
+        installment_num: null,
+        type: 'expense',
+        exclude_from_budget: true,
+      } as Any) // 자산 보정용 사전 조회
+      .mockResolvedValueOnce({ id: 686, amount: 167776 } as Any); // UPDATE RETURNING
 
     const result = await updateExpense(1, 686, { amount: 167776 });
 
     expect(result).toEqual({ id: 686, amount: 167776 });
-    // 가드 SELECT 없이 바로 UPDATE 1회
-    expect(queryOne).toHaveBeenCalledTimes(1);
-    const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
-    expect(sql).toMatch(/UPDATE\s+expenses\s+SET/i);
+    // amount 변경 시 사전 SELECT(자산 보정 판정용) + UPDATE
+    expect(queryOne).toHaveBeenCalledTimes(2);
+    const selectSql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+    expect(selectSql).toMatch(/SELECT/i);
+    const updateSql = vi.mocked(queryOne).mock.calls[1]![0] as string;
+    expect(updateSql).toMatch(/UPDATE\s+expenses\s+SET/i);
   });
 
   it('허용되지 않는 컬럼만 포함된 updates → SELECT (현재 행 반환), UPDATE 미실행', async () => {

--- a/web/src/features/budget/lib/allocator/__tests__/edge-cases.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/edge-cases.test.ts
@@ -8,8 +8,8 @@ const BASE: MonthAllocatorInput = {
   installments: [],
   plannedExpenses: [],
   currentBillingMonth: '2026-04',
-  targetMonth: '2026-06',   // 3개월: Apr, May, Jun
-  today: '2026-04-11',      // Apr 주기: 03-14~04-13 (31일)
+  targetMonth: '2026-06', // 3개월: Apr, May, Jun
+  today: '2026-04-11', // Apr 주기: 03-14~04-13 (31일)
 };
 
 describe('F. 엣지 케이스', () => {
@@ -24,7 +24,7 @@ describe('F. 엣지 케이스', () => {
       expect(apr.installments).toBe(10000);
     });
 
-    it('isNew=true → 현재 월 installments=0, 미래 월은 포함', () => {
+    it('isNew=true → 현재 월/미래 월 모두 installments=0 (ADR 0015: 미래 월 INSERT 즉시 자산 차감)', () => {
       const result = allocateMonthlyBudgets({
         ...BASE,
         installments: [{ monthlyAmount: 10000, remainingCount: 3, isNew: true }],
@@ -32,12 +32,12 @@ describe('F. 엣지 케이스', () => {
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
       const may = result.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
       const jun = result.monthlyBudgets.find((m) => m.yearMonth === '2026-06')!;
-      expect(apr.installments).toBe(0);     // 현재 월 제외
-      expect(may.installments).toBe(10000); // 미래 월 포함
-      expect(jun.installments).toBe(10000); // 미래 월 포함
+      expect(apr.installments).toBe(0); // 현재 월 isNew=true 제외 (자유지출에 잡힘)
+      expect(may.installments).toBe(0); // 미래 월 — ADR 0015로 자산 차감 완료
+      expect(jun.installments).toBe(0); // 미래 월 — ADR 0015로 자산 차감 완료
     });
 
-    it('isNew=true vs isNew=false — 총 locked 차이는 현재 월 할부 전액', () => {
+    it('isNew=true vs isNew=false — totalLocked 차이는 현재 월 할부 전액 (미래 월은 양쪽 모두 0)', () => {
       const rOld = allocateMonthlyBudgets({
         ...BASE,
         installments: [{ monthlyAmount: 10000, remainingCount: 3, isNew: false }],
@@ -46,7 +46,7 @@ describe('F. 엣지 케이스', () => {
         ...BASE,
         installments: [{ monthlyAmount: 10000, remainingCount: 3, isNew: true }],
       });
-      // isNew=false는 현재 월에 round(10000*1)=10000 추가
+      // 현재 월: isNew=false→10000, isNew=true→0. 미래 월: 양쪽 모두 0.
       expect(rOld.totalLocked - rNew.totalLocked).toBe(10000);
     });
   });

--- a/web/src/features/budget/lib/allocator/__tests__/month-allocator.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/month-allocator.test.ts
@@ -115,7 +115,9 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
     it('미설정(undefined) → 기본 동작과 동일', () => {
       const r1 = allocateMonthlyBudgets({ ...BASE, totalAvailable: 35000 });
       const r2 = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000, currentMonthOnlyIncome: undefined,
+        ...BASE,
+        totalAvailable: 35000,
+        currentMonthOnlyIncome: undefined,
       });
       expect(r1).toEqual(r2);
     });
@@ -123,7 +125,9 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
     it('0 → 기본 동작과 동일', () => {
       const r1 = allocateMonthlyBudgets({ ...BASE, totalAvailable: 35000 });
       const r2 = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000, currentMonthOnlyIncome: 0,
+        ...BASE,
+        totalAvailable: 35000,
+        currentMonthOnlyIncome: 0,
       });
       expect(r1).toEqual(r2);
     });
@@ -133,7 +137,9 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
       // totalFree=31500, dailyFree=31500/61≈516.39
       // apr=round(516.39*31)+3500=16008+3500=19508, may=round(516.39*30)=15492
       const result = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000, currentMonthOnlyIncome: 3500,
+        ...BASE,
+        totalAvailable: 35000,
+        currentMonthOnlyIncome: 3500,
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
       const may = result.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
@@ -145,7 +151,9 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
     it('bonus 추가 시 미래 월 free 는 bonus 없을 때보다 감소', () => {
       const base = allocateMonthlyBudgets({ ...BASE, totalAvailable: 35000 });
       const withBonus = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000, currentMonthOnlyIncome: 3500,
+        ...BASE,
+        totalAvailable: 35000,
+        currentMonthOnlyIncome: 3500,
       });
       const baseMay = base.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
       const bonusMay = withBonus.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
@@ -156,7 +164,9 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
       // totalAvailable=10000, bonus=50000 → totalFree=max(0, 10000-50000)=0, dailyFree=0
       // apr=0+50000=50000, may=0
       const result = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 10000, currentMonthOnlyIncome: 50000,
+        ...BASE,
+        totalAvailable: 10000,
+        currentMonthOnlyIncome: 50000,
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
       const may = result.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
@@ -166,17 +176,23 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
 
     it('targetMonth null → bonus 무시 (monthlyBudgets 빈 배열)', () => {
       const result = allocateMonthlyBudgets({
-        ...BASE, targetMonth: null, currentMonthOnlyIncome: 5000,
+        ...BASE,
+        targetMonth: null,
+        currentMonthOnlyIncome: 5000,
       });
       expect(result.monthlyBudgets).toEqual([]);
     });
 
     it('음수 bonus → 0 으로 클램프 (방어적)', () => {
       const neg = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000, currentMonthOnlyIncome: -1000,
+        ...BASE,
+        totalAvailable: 35000,
+        currentMonthOnlyIncome: -1000,
       });
       const zero = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000, currentMonthOnlyIncome: 0,
+        ...BASE,
+        totalAvailable: 35000,
+        currentMonthOnlyIncome: 0,
       });
       expect(neg).toEqual(zero);
     });
@@ -185,7 +201,8 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
   describe('할부 isNew 경계 판정', () => {
     it('isNew=true → 현재 월 installments 제외 (자유 지출에서 이미 차감됐다고 간주)', () => {
       const result = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000,
+        ...BASE,
+        totalAvailable: 35000,
         installments: [{ monthlyAmount: 1000, remainingCount: 3, isNew: true }],
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
@@ -195,33 +212,38 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
     it('isNew=false → 현재 월 installments 전액 포함 (ratio=1)', () => {
       // 현재 월 ratio=1, installmentSum=1000 → round(1000 * 1) = 1000
       const result = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000,
+        ...BASE,
+        totalAvailable: 35000,
         installments: [{ monthlyAmount: 1000, remainingCount: 3, isNew: false }],
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
       expect(apr.installments).toBe(1000);
     });
 
-    it('미래 월 installments 는 isNew 무관 — 항상 전액', () => {
+    it('미래 월 installments 는 항상 0 — INSERT 즉시 자산 차감되어 monthBudget 락에서 제외 (ADR 0015)', () => {
       const rTrue = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000,
+        ...BASE,
+        totalAvailable: 35000,
         installments: [{ monthlyAmount: 1000, remainingCount: 3, isNew: true }],
       });
       const rFalse = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000,
+        ...BASE,
+        totalAvailable: 35000,
         installments: [{ monthlyAmount: 1000, remainingCount: 3, isNew: false }],
       });
       const mayTrue = rTrue.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
       const mayFalse = rFalse.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
-      expect(mayTrue.installments).toBe(1000);
-      expect(mayTrue.installments).toBe(mayFalse.installments);
+      expect(mayTrue.installments).toBe(0);
+      expect(mayFalse.installments).toBe(0);
     });
 
     it('isNew=true + remainingCount=1 → 현재 월/미래 월 모두 제외 (할부가 예산에서 완전 증발)', () => {
       // index=0: isNew=true 이므로 제외
       // index=1: remainingCount(1) > index(1) 거짓 → 제외
       const result = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000, targetMonth: '2026-05',
+        ...BASE,
+        totalAvailable: 35000,
+        targetMonth: '2026-05',
         installments: [{ monthlyAmount: 1000, remainingCount: 1, isNew: true }],
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
@@ -230,27 +252,32 @@ describe('B. 월 배분 (allocateMonthlyBudgets)', () => {
       expect(may.installments).toBe(0);
     });
 
-    it('remainingCount 초과 월은 제외 (할부 종료 경계)', () => {
-      // remainingCount=2 → index 0,1 포함 / index 2 이후 제외
+    it('remainingCount 초과 월은 제외 (할부 종료 경계) — 미래 월은 ADR 0015로 항상 0', () => {
+      // 현재 월(index=0): isNew=false 이므로 포함 (>0)
+      // 미래 월(index>=1): ADR 0015 정책으로 항상 0 (INSERT 즉시 자산 차감)
       const result = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000, targetMonth: '2026-06',
+        ...BASE,
+        totalAvailable: 35000,
+        targetMonth: '2026-06',
         installments: [{ monthlyAmount: 1000, remainingCount: 2, isNew: false }],
       });
       const apr = result.monthlyBudgets.find((m) => m.yearMonth === '2026-04')!;
       const may = result.monthlyBudgets.find((m) => m.yearMonth === '2026-05')!;
       const jun = result.monthlyBudgets.find((m) => m.yearMonth === '2026-06')!;
       expect(apr.installments).toBeGreaterThan(0);
-      expect(may.installments).toBe(1000);
+      expect(may.installments).toBe(0);
       expect(jun.installments).toBe(0);
     });
 
     it('isNew 미설정(undefined) → isNew=false 와 동일', () => {
       const rUndef = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000,
+        ...BASE,
+        totalAvailable: 35000,
         installments: [{ monthlyAmount: 1000, remainingCount: 3 }],
       });
       const rFalse = allocateMonthlyBudgets({
-        ...BASE, totalAvailable: 35000,
+        ...BASE,
+        totalAvailable: 35000,
         installments: [{ monthlyAmount: 1000, remainingCount: 3, isNew: false }],
       });
       expect(rUndef).toEqual(rFalse);

--- a/web/src/features/budget/lib/allocator/month-allocator.ts
+++ b/web/src/features/budget/lib/allocator/month-allocator.ts
@@ -1,7 +1,11 @@
 import { addBillingMonths, getBillingRange, calcCycleDays } from '../billing/cycle';
 import type {
-  BillingCycle, InstallmentInput, MonthAllocatorInput, MonthAllocatorResult,
-  MonthlyBudget, PlannedInput,
+  BillingCycle,
+  InstallmentInput,
+  MonthAllocatorInput,
+  MonthAllocatorResult,
+  MonthlyBudget,
+  PlannedInput,
 } from '../types-v2';
 
 interface MonthEntryInput {
@@ -19,9 +23,14 @@ function buildMonthEntry(p: MonthEntryInput): { entry: MonthlyBudget; locked: nu
   const cycleDays = calcCycleDays(from, to);
   const allocatedDays = p.index === 0 ? p.currentAllocatedDays : cycleDays;
 
-  const installmentSum = p.installments
-    .filter((inst) => inst.remainingCount > p.index && (p.index > 0 || !inst.isNew))
-    .reduce((s, inst) => s + inst.monthlyAmount, 0);
+  // 미래 결제주기 할부(p.index >= 1)는 INSERT 즉시 자산에서 차감되므로 monthBudget 락에서 제외.
+  // 현재 월의 신규 할부(isNew=true)는 자유지출로 잡혀있어 락에서 제외 — 이중 카운트 방지.
+  const installmentSum =
+    p.index === 0
+      ? p.installments
+          .filter((inst) => inst.remainingCount > 0 && !inst.isNew)
+          .reduce((s, inst) => s + inst.monthlyAmount, 0)
+      : 0;
   const plannedSum = p.plannedExpenses
     .filter((e) => e.yearMonth === month)
     .reduce((s, e) => s + e.amount, 0);
@@ -33,8 +42,13 @@ function buildMonthEntry(p: MonthEntryInput): { entry: MonthlyBudget; locked: nu
 
   return {
     entry: {
-      yearMonth: month, allocatedDays, fixed, installments: instVal, planned,
-      free: 0, isCurrent: p.index === 0,
+      yearMonth: month,
+      allocatedDays,
+      fixed,
+      installments: instVal,
+      planned,
+      free: 0,
+      isCurrent: p.index === 0,
     },
     locked: fixed + instVal + planned,
   };
@@ -43,7 +57,10 @@ function buildMonthEntry(p: MonthEntryInput): { entry: MonthlyBudget; locked: nu
 /** 자산/런웨이/고정비/할부/예정 → 월별 자유 예산 배분 */
 export function allocateMonthlyBudgets(input: MonthAllocatorInput): MonthAllocatorResult {
   const empty: MonthAllocatorResult = {
-    monthlyBudgets: [], dailyFree: 0, freePerMonth: null, totalLocked: 0,
+    monthlyBudgets: [],
+    dailyFree: 0,
+    freePerMonth: null,
+    totalLocked: 0,
   };
   if (!input.targetMonth || !/^\d{4}-\d{2}$/.test(input.targetMonth)) return empty;
 
@@ -54,7 +71,10 @@ export function allocateMonthlyBudgets(input: MonthAllocatorInput): MonthAllocat
 
   const { from: cf, to: ct } = getBillingRange(input.currentBillingMonth);
   const currentCycle: BillingCycle = {
-    yearMonth: input.currentBillingMonth, from: cf, to: ct, totalDays: calcCycleDays(cf, ct),
+    yearMonth: input.currentBillingMonth,
+    from: cf,
+    to: ct,
+    totalDays: calcCycleDays(cf, ct),
   };
   const currentAllocatedDays = currentCycle.totalDays;
 

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -5,7 +5,11 @@ vi.mock('./snapshot/monthly-snapshot-repo', () => ({
   readSnapshotByMonth: vi.fn(),
   saveSnapshotIfAbsent: vi.fn(),
 }));
-vi.mock('./repository/assets-repo', () => ({ readDistributableAssetBalance: vi.fn() }));
+vi.mock('./repository/assets-repo', () => ({
+  readDistributableAssetBalance: vi.fn(),
+  applyAssetDeduction: vi.fn(),
+  applyAssetIncrease: vi.fn(),
+}));
 vi.mock('./repository/fixed-costs-repo', () => ({ readFixedCostsMonthlyTotal: vi.fn() }));
 vi.mock('./repository/installments-repo', () => ({ readActiveInstallments: vi.fn() }));
 vi.mock('./repository/planned-repo', () => ({ readPlannedExpenses: vi.fn() }));
@@ -32,7 +36,11 @@ import {
   runSettlementIfDue,
 } from './facade';
 import { readLatestSnapshot, saveSnapshotIfAbsent } from './snapshot/monthly-snapshot-repo';
-import { readDistributableAssetBalance } from './repository/assets-repo';
+import {
+  readDistributableAssetBalance,
+  applyAssetDeduction,
+  applyAssetIncrease,
+} from './repository/assets-repo';
 import { readFixedCostsMonthlyTotal } from './repository/fixed-costs-repo';
 import { readActiveInstallments } from './repository/installments-repo';
 import { readPlannedExpenses } from './repository/planned-repo';
@@ -62,6 +70,8 @@ function setupCommonMocks() {
   vi.mocked(readIncomeTotal).mockResolvedValue(0);
   vi.mocked(readCurrentMonthOnlyIncome).mockResolvedValue(0);
   vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: false });
+  vi.mocked(applyAssetDeduction).mockResolvedValue([]);
+  vi.mocked(applyAssetIncrease).mockResolvedValue([]);
 }
 
 describe('getMonthlyAllocation', () => {
@@ -181,6 +191,40 @@ describe('runSettlementIfDue', () => {
     // availableAtEnd = 5_000_000 + 200_000 - 300_000 - 50_000 = 4_850_000
     expect(result.snapshot?.available_at_end).toBe(4_850_000);
     expect(result.snapshot?.available_at_start).toBe(5_000_000);
+  });
+
+  it('snapshot 신규 저장 시 자산 자동 차감/증액 호출 (flex + excluded, income 분리)', async () => {
+    const settlementNow = new Date('2026-04-14T12:00:00Z');
+
+    vi.mocked(readLatestSnapshot).mockResolvedValue(null);
+    vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
+    vi.mocked(readFlexibleSpent).mockResolvedValue(300_000);
+    vi.mocked(readExcludedSpent).mockResolvedValue(50_000);
+    vi.mocked(readIncomeTotal).mockResolvedValue(200_000);
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
+
+    await runSettlementIfDue(1, settlementNow);
+
+    expect(applyAssetDeduction).toHaveBeenCalledWith(1, 350_000); // flex + excluded
+    expect(applyAssetIncrease).toHaveBeenCalledWith(1, 200_000); // income
+  });
+
+  it('snapshot 재실행(saved=false) 시 자산 변동 호출 없음 — idempotency', async () => {
+    const settlementNow = new Date('2026-04-14T12:00:00Z');
+
+    vi.mocked(readLatestSnapshot).mockResolvedValue(null);
+    vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
+    vi.mocked(readFlexibleSpent).mockResolvedValue(300_000);
+    vi.mocked(readExcludedSpent).mockResolvedValue(50_000);
+    vi.mocked(readIncomeTotal).mockResolvedValue(200_000);
+    // 이미 같은 yearMonth 저장됨 — UNIQUE 제약으로 saved=false
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: false });
+
+    const result = await runSettlementIfDue(1, settlementNow);
+
+    expect(result.settled).toBe(false);
+    expect(applyAssetDeduction).not.toHaveBeenCalled();
+    expect(applyAssetIncrease).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -5,7 +5,11 @@ import { allocateTodayBudget } from './allocator/day-allocator';
 import { projectRunway, projectFromAllocator } from './allocator/runway-projection';
 import { detectSettlementTrigger, buildSettlementSnapshot } from './settlement/settle';
 
-import { readDistributableAssetBalance } from './repository/assets-repo';
+import {
+  readDistributableAssetBalance,
+  applyAssetDeduction,
+  applyAssetIncrease,
+} from './repository/assets-repo';
 import { readFixedCostsMonthlyTotal } from './repository/fixed-costs-repo';
 import { readActiveInstallments } from './repository/installments-repo';
 import { readPlannedExpenses } from './repository/planned-repo';
@@ -276,5 +280,13 @@ export async function runSettlementIfDue(
     availableAtEnd,
   });
   const result = await saveSnapshotIfAbsent(userId, snapshot);
+
+  // snapshot 신규 저장 시에만 자산 변동 (UNIQUE(user, year_month)로 재실행 시 중복 차감 방지).
+  // 자유+제외 지출은 default 자산에서 차감, 수입은 default 자산에 증액.
+  if (result.saved) {
+    await applyAssetDeduction(userId, flex + excluded);
+    await applyAssetIncrease(userId, income);
+  }
+
   return { settled: result.saved, snapshot };
 }

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -5,6 +5,7 @@ import { getCurrentBillingMonth, getBillingRange, calcCycleDays } from './billin
 import { resolveFixedCostExpenseDate } from './billing/fixed-cost-date';
 import { getBillingMonthForExpense } from './billing/card-billing';
 import { readFlexibleSpent, readTodayFlexSpent } from './repository/expenses-repo';
+import { applyAssetDeduction, applyAssetIncrease } from './repository/assets-repo';
 import type {
   ExpenseRow,
   FixedCostRow,
@@ -154,6 +155,7 @@ export async function createInstallmentExpenses(
   const excludeFromBudget = data.exclude_from_budget ?? false;
 
   let firstRow: ExpenseRow | null = null;
+  let futureSum = 0;
 
   for (let i = 0; i < data.months; i++) {
     const amount = i === data.months - 1 ? lastMonthAmount : monthlyAmount;
@@ -190,9 +192,19 @@ export async function createInstallmentExpenses(
       ],
     );
     if (i === 0) firstRow = row ?? null;
+    else futureSum += amount;
   }
 
   if (!firstRow) throw new Error('createInstallmentExpenses: INSERT returned no rows');
+
+  // 할부 2+회차는 INSERT 즉시 자산에서 차감 (allocator는 미래 회차를 installmentSum에서 제외).
+  // 1회차는 현재 결제주기에서 자유지출로 잡혀 결제주기 종료 cron에서 일괄 차감되므로 제외.
+  // 수입/제외지출 할부는 결제주기 종료 cron에서 일괄 처리되므로 즉시 차감 안 함.
+  const isCountable = (data.type ?? 'expense') === 'expense' && !excludeFromBudget;
+  if (isCountable && futureSum > 0) {
+    await applyAssetDeduction(userId, futureSum);
+  }
+
   return firstRow;
 }
 
@@ -212,6 +224,23 @@ const EXPENSE_COLUMNS = new Set([
 
 /** source='fixed' 행의 exclude_from_budget 변경 시도 시 throw되는 sentinel error */
 export const FIXED_SOURCE_EXCLUDE_LOCKED = 'FIXED_SOURCE_EXCLUDE_LOCKED';
+
+interface ExistingForAsset {
+  amount: number;
+  is_installment: boolean | null;
+  installment_num: number | null;
+  type: string;
+  exclude_from_budget: boolean;
+}
+
+function isFutureInstallment(row: ExistingForAsset): boolean {
+  return (
+    row.is_installment === true &&
+    (row.installment_num ?? 0) >= 2 &&
+    row.type === 'expense' &&
+    !row.exclude_from_budget
+  );
+}
 
 export async function updateExpense(
   userId: number,
@@ -233,9 +262,21 @@ export async function updateExpense(
     }
   }
 
+  // 할부 미래 회차 amount 변경 시 자산 보정용 사전 조회
+  const amountChanging = keys.includes('amount');
+  const existingForAsset = amountChanging
+    ? await queryOne<ExistingForAsset>(
+        `SELECT amount, is_installment, installment_num,
+                COALESCE(type, 'expense') as type,
+                COALESCE(exclude_from_budget, false) as exclude_from_budget
+         FROM expenses WHERE id = $1 AND user_id = $2`,
+        [id, userId],
+      )
+    : null;
+
   const setClauses = keys.map((k, i) => `${k} = $${i + 3}`);
   const values = keys.map((k) => updates[k]);
-  return queryOne<ExpenseRow>(
+  const row = await queryOne<ExpenseRow>(
     `UPDATE expenses SET ${setClauses.join(', ')}
      WHERE id = $1 AND user_id = $2
      RETURNING id, date::text, amount, category, description, payment_method,
@@ -245,12 +286,31 @@ export async function updateExpense(
             COALESCE(distribute_to_budget, false) as distribute_to_budget`,
     [id, userId, ...values],
   );
+
+  if (row && existingForAsset && isFutureInstallment(existingForAsset)) {
+    const diff = Number(updates['amount']) - existingForAsset.amount;
+    if (diff > 0) await applyAssetDeduction(userId, diff);
+    else if (diff < 0) await applyAssetIncrease(userId, -diff);
+  }
+
+  return row;
 }
 
-/** 지출 삭제 */
+/** 지출 삭제 — 할부 미래 회차 삭제 시 자산 복원 */
 export async function deleteExpense(userId: number, id: number): Promise<boolean> {
+  const existing = await queryOne<ExistingForAsset>(
+    `SELECT amount, is_installment, installment_num,
+            COALESCE(type, 'expense') as type,
+            COALESCE(exclude_from_budget, false) as exclude_from_budget
+     FROM expenses WHERE id = $1 AND user_id = $2`,
+    [id, userId],
+  );
   const result = await query('DELETE FROM expenses WHERE id = $1 AND user_id = $2', [id, userId]);
-  return (result.rowCount ?? 0) > 0;
+  const deleted = (result.rowCount ?? 0) > 0;
+  if (deleted && existing && isFutureInstallment(existing)) {
+    await applyAssetIncrease(userId, existing.amount);
+  }
+  return deleted;
 }
 
 // ─── 월간 요약 ────────────────────────────────────────
@@ -470,8 +530,10 @@ export async function ensureFixedCostExpenses(userId: number, yearMonth: string)
 /** 자산 목록 */
 export async function queryAssets(userId: number): Promise<AssetRow[]> {
   const { rows } = await query<AssetRow>(
-    `SELECT id, name, balance, type, available_amount, is_emergency, memo, updated_at::text
-     FROM assets WHERE user_id = $1 ORDER BY is_emergency ASC, type, name`,
+    `SELECT id, name, balance, type, available_amount, is_emergency,
+            COALESCE(is_default, false) as is_default, memo, updated_at::text
+     FROM assets WHERE user_id = $1
+     ORDER BY is_emergency ASC, is_default DESC, type, name`,
     [userId],
   );
   return rows;
@@ -490,8 +552,46 @@ export async function updateAsset(
          memo = COALESCE($5, memo),
          updated_at = NOW()
      WHERE id = $1 AND user_id = $2
-     RETURNING id, name, balance, type, available_amount, is_emergency, memo, updated_at::text`,
+     RETURNING id, name, balance, type, available_amount, is_emergency,
+               COALESCE(is_default, false) as is_default, memo, updated_at::text`,
     [id, userId, data.balance ?? null, data.available_amount ?? null, data.memo ?? null],
+  );
+}
+
+/**
+ * 기본 자산 지정 — user당 1개만 true.
+ * 비상금(is_emergency=true) 자산은 default로 지정 불가.
+ * 기존 default가 있으면 해제 후 신규 지정 (partial unique index 충돌 방지).
+ */
+export async function setDefaultAsset(userId: number, id: number): Promise<AssetRow | null> {
+  const target = await queryOne<{ is_emergency: boolean }>(
+    `SELECT is_emergency FROM assets WHERE id = $1 AND user_id = $2`,
+    [id, userId],
+  );
+  if (!target) return null;
+  if (target.is_emergency) {
+    throw new Error('EMERGENCY_ASSET_CANNOT_BE_DEFAULT');
+  }
+  await query(`UPDATE assets SET is_default = false WHERE user_id = $1 AND is_default = true`, [
+    userId,
+  ]);
+  return queryOne<AssetRow>(
+    `UPDATE assets SET is_default = true, updated_at = NOW()
+     WHERE id = $1 AND user_id = $2
+     RETURNING id, name, balance, type, available_amount, is_emergency,
+               COALESCE(is_default, false) as is_default, memo, updated_at::text`,
+    [id, userId],
+  );
+}
+
+/** 기본 자산 해제 */
+export async function clearDefaultAsset(userId: number, id: number): Promise<AssetRow | null> {
+  return queryOne<AssetRow>(
+    `UPDATE assets SET is_default = false, updated_at = NOW()
+     WHERE id = $1 AND user_id = $2
+     RETURNING id, name, balance, type, available_amount, is_emergency,
+               COALESCE(is_default, false) as is_default, memo, updated_at::text`,
+    [id, userId],
   );
 }
 

--- a/web/src/features/budget/lib/repository/__tests__/assets-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/assets-repo.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '@/lib/db';
+import { applyAssetDeduction, applyAssetIncrease, getDefaultAssetId } from '../assets-repo';
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
+type Any = any;
+
+function mockCandidates(rows: Array<{ id: number; available_amount: number }>) {
+  vi.mocked(query).mockResolvedValueOnce({ rows } as Any);
+}
+
+describe('applyAssetDeduction — cascading 차감', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('amount <= 0 → 빈 배열, DB 호출 없음', async () => {
+    const result = await applyAssetDeduction(1, 0);
+    expect(result).toEqual([]);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('default 자산이 충분 → default 자산에만 차감', async () => {
+    mockCandidates([
+      { id: 10, available_amount: 100_000 },
+      { id: 20, available_amount: 50_000 },
+    ]);
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE
+
+    const result = await applyAssetDeduction(1, 30_000);
+
+    expect(result).toEqual([{ assetId: 10, delta: -30_000 }]);
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it('default 자산 부족 → fallback 자산으로 cascade', async () => {
+    mockCandidates([
+      { id: 10, available_amount: 50_000 }, // default
+      { id: 20, available_amount: 100_000 }, // fallback 후보
+    ]);
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE 1
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE 2
+
+    const result = await applyAssetDeduction(1, 70_000);
+
+    expect(result).toEqual([
+      { assetId: 10, delta: -50_000 }, // default 전액 소진
+      { assetId: 20, delta: -20_000 }, // 나머지 fallback
+    ]);
+  });
+
+  it('마지막 자산은 음수 허용 (마이너스 통장 의미상)', async () => {
+    mockCandidates([
+      { id: 10, available_amount: 10_000 },
+      { id: 20, available_amount: 5_000 }, // last = 마이너스 통장
+    ]);
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+
+    const result = await applyAssetDeduction(1, 50_000);
+
+    // default 10k 소진 → 마지막 자산에서 잔여 40k 차감 (음수 허용)
+    expect(result).toEqual([
+      { assetId: 10, delta: -10_000 },
+      { assetId: 20, delta: -40_000 }, // available 5k인데 40k 차감 → 음수 허용
+    ]);
+  });
+
+  it('available_amount가 음수인 자산은 skip (last 제외)', async () => {
+    mockCandidates([
+      { id: 10, available_amount: 100_000 },
+      { id: 20, available_amount: -5_000 }, // 음수 - skip 대상이지만 last면 음수 허용
+      { id: 30, available_amount: 50_000 }, // last
+    ]);
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+
+    const result = await applyAssetDeduction(1, 130_000);
+
+    // id=10: 100k, id=20: skip (delta=0), id=30 (last): 잔여 30k
+    expect(result).toEqual([
+      { assetId: 10, delta: -100_000 },
+      { assetId: 30, delta: -30_000 },
+    ]);
+  });
+
+  it('후보 자산이 없으면 빈 배열', async () => {
+    mockCandidates([]);
+
+    const result = await applyAssetDeduction(1, 10_000);
+
+    expect(result).toEqual([]);
+    expect(query).toHaveBeenCalledTimes(1); // SELECT만, UPDATE 없음
+  });
+});
+
+describe('applyAssetIncrease — default 자산 증액', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('amount <= 0 → 빈 배열', async () => {
+    const result = await applyAssetIncrease(1, 0);
+    expect(result).toEqual([]);
+  });
+
+  it('default 자산 있으면 거기에 증액', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ id: 42 }] } as Any); // getDefaultAssetId
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE
+
+    const result = await applyAssetIncrease(1, 100_000);
+
+    expect(result).toEqual([{ assetId: 42, delta: 100_000 }]);
+  });
+
+  it('default 없으면 is_emergency=false 첫 자산으로 fallback', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // getDefaultAssetId → null
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ id: 7 }] } as Any); // fallback
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE
+
+    const result = await applyAssetIncrease(1, 50_000);
+
+    expect(result).toEqual([{ assetId: 7, delta: 50_000 }]);
+  });
+
+  it('default도 fallback도 없으면 빈 배열 (DB 변동 없음)', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // getDefaultAssetId → null
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // fallback → null
+
+    const result = await applyAssetIncrease(1, 50_000);
+
+    expect(result).toEqual([]);
+    expect(query).toHaveBeenCalledTimes(2); // UPDATE 없음
+  });
+});
+
+describe('getDefaultAssetId', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('is_default=true 자산 있으면 ID 반환', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ id: 99 }] } as Any);
+    const id = await getDefaultAssetId(1);
+    expect(id).toBe(99);
+  });
+
+  it('없으면 null', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    const id = await getDefaultAssetId(1);
+    expect(id).toBeNull();
+  });
+});

--- a/web/src/features/budget/lib/repository/assets-repo.ts
+++ b/web/src/features/budget/lib/repository/assets-repo.ts
@@ -13,3 +13,83 @@ export async function readDistributableAssetBalance(userId: number): Promise<num
   );
   return Number(result.rows[0]?.total ?? 0);
 }
+
+/** 자동 차감/증액 실제 반영 내역 (감사/로그용) */
+export interface AssetMutation {
+  assetId: number;
+  delta: number;
+}
+
+/** is_default=true 자산 ID 반환. 없으면 null */
+export async function getDefaultAssetId(userId: number): Promise<number | null> {
+  const result = await query<{ id: number }>(
+    `SELECT id FROM assets WHERE user_id = $1 AND is_default = true LIMIT 1`,
+    [userId],
+  );
+  return result.rows[0]?.id ?? null;
+}
+
+/**
+ * 자산 차감 — default 자산 우선, 부족 시 is_emergency=false 자산으로 fallback.
+ * 마지막 fallback 자산에선 음수 허용 (마이너스 통장 의미상).
+ * available_amount만 변동 (balance는 사용자가 수기로 갱신).
+ */
+export async function applyAssetDeduction(
+  userId: number,
+  amount: number,
+): Promise<AssetMutation[]> {
+  if (amount <= 0) return [];
+
+  const candidates = await query<{ id: number; available_amount: number }>(
+    `SELECT id, available_amount
+     FROM assets
+     WHERE user_id = $1 AND is_emergency = false
+     ORDER BY is_default DESC, available_amount DESC, id ASC`,
+    [userId],
+  );
+
+  if (candidates.rows.length === 0) return [];
+
+  let remaining = amount;
+  const mutations: AssetMutation[] = [];
+  const last = candidates.rows[candidates.rows.length - 1]!;
+
+  for (const asset of candidates.rows) {
+    if (remaining <= 0) break;
+    const isLast = asset.id === last.id;
+    const available = Math.max(0, asset.available_amount);
+    const delta = isLast ? remaining : Math.min(available, remaining);
+    if (delta <= 0) continue;
+    await query(
+      `UPDATE assets SET available_amount = available_amount - $1, updated_at = NOW() WHERE id = $2`,
+      [delta, asset.id],
+    );
+    mutations.push({ assetId: asset.id, delta: -delta });
+    remaining -= delta;
+  }
+  return mutations;
+}
+
+/**
+ * 자산 증액 — default 자산에 단순 증액 (분배 없음).
+ * default 없으면 is_emergency=false인 첫 자산.
+ */
+export async function applyAssetIncrease(userId: number, amount: number): Promise<AssetMutation[]> {
+  if (amount <= 0) return [];
+
+  let assetId = await getDefaultAssetId(userId);
+  if (assetId === null) {
+    const fallback = await query<{ id: number }>(
+      `SELECT id FROM assets WHERE user_id = $1 AND is_emergency = false ORDER BY id LIMIT 1`,
+      [userId],
+    );
+    assetId = fallback.rows[0]?.id ?? null;
+  }
+  if (assetId === null) return [];
+
+  await query(
+    `UPDATE assets SET available_amount = available_amount + $1, updated_at = NOW() WHERE id = $2`,
+    [amount, assetId],
+  );
+  return [{ assetId, delta: amount }];
+}

--- a/web/src/features/budget/lib/types.ts
+++ b/web/src/features/budget/lib/types.ts
@@ -56,6 +56,8 @@ export interface AssetRow {
   type: string;
   available_amount: number | null;
   is_emergency: boolean;
+  /** 자동 차감 우선순위 자산 (user당 최대 1개) */
+  is_default: boolean;
   memo: string | null;
   updated_at: string;
 }


### PR DESCRIPTION
## 관련 이슈
Closes #397

## 변경 내용

결제주기 전환 시 일 예산 권장값이 비정상적으로 점프하는 문제 해결. 자산이 사용자 수동 갱신 전제로만 동작했기 때문에, 결제주기 동안 누적된 자유지출이 자산에 반영되지 않아 새 사이클 시작 시 가용자금이 그대로 남아 일 예산이 갑자기 커짐.

### 핵심 변경
- **결제주기 종료 cron** (`runSettlementIfDue`)에서 이전 사이클 자유+제외 지출을 default 자산에서 차감, 수입은 증액. `saveSnapshotIfAbsent` UNIQUE로 idempotency 보장.
- **할부 2회차 이상**은 INSERT 즉시 자산 차감 (`createInstallmentExpenses`/`updateExpense`/`deleteExpense`). monthly allocator의 `installmentSum`에서 미래 회차 제외 → 수학적 동등 유지.
- **Default 자산 fallback**: `assets.is_default` 컬럼 + partial unique index. 부족 시 비상금 아닌 자산으로 cascading.
- **설정 UI**: AssetItem에 "기본 자산" 토글 추가.

### 자산 변동 시점

| 항목 | 자산 변동 시점 |
|------|---------------|
| 일반 자유지출 | 결제주기 종료 cron |
| 제외지출 | 결제주기 종료 cron |
| 수입 | 결제주기 종료 cron (증액) |
| 할부 1회차 | 변동 없음 (`totalLocked` 반영) |
| 할부 2+회차 | INSERT 즉시 차감 |

### 설계 기록
- ADR 0015 작성 — Status: Accepted
- `docs/domains/budget.md` 결제주기 정의 정정 (전월 14일 ~ 당월 13일) + 자동 차감 정책

## 코드 리뷰 결과
- [x] 보안 감사 통과 (민감 정보 없음, SQL injection 가드)
- [x] 타입 안전성 확인 (any 없음, AssetMutation/InstallmentInput 명시 타입)
- [x] 컨벤션 점검 완료 (named export, kebab-case 파일, camelCase 변수)
- [x] 코드 품질 확인

## 테스트
- [x] `assets-repo.test.ts`: cascading 차감 (default 충분/부족, 마지막 자산 음수 허용), 증액, 12 테스트
- [x] `facade.test.ts`: `runSettlementIfDue` 자산 변동 호출 + idempotency 검증
- [x] `update-expense.test.ts`: 할부 amount 변경 시 자산 보정 SELECT/UPDATE 순서
- [x] `month-allocator.test.ts` + `edge-cases.test.ts`: 미래 회차 `installmentSum` 항상 0
- [x] 전체 budget 테스트 통과 (194 tests, 17 files)

## 운영 적용 절차 (PR 머지 후)
1. 마이그레이션 046 자동 적용 (Vercel 배포 시)
2. VM DB에서 default 자산 시드: `UPDATE assets SET is_default = true WHERE id = <id>`
3. 기존 할부 잔여 회차 자산 backfill 스크립트 1회 실행
4. 사용자 자산 실잔액 1차 보정