### PR TITLE
feat(budget): 카테고리별 결제주기 한도 트래커

### DIFF
--- a/db/migrations/047_category_limits.sql
+++ b/db/migrations/047_category_limits.sql
@@ -1,0 +1,16 @@
+-- 047: category_limits — 카테고리별 결제주기 한도
+-- 사용자가 카테고리당 N회로 한도를 정하면, 매 결제주기마다 expenses 테이블에서 집계해
+-- 사용 횟수를 동적으로 계산한다 (별도 cycle 저장 없음, target만 보존).
+-- UNIQUE(user_id, category): 동일 카테고리에 한도 두 개 불가.
+
+CREATE TABLE IF NOT EXISTS category_limits (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  category TEXT NOT NULL,
+  target_count INTEGER NOT NULL CHECK (target_count > 0 AND target_count <= 50),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_category_limits_user ON category_limits(user_id);

--- a/web/src/app/api/budget/category-limits/[id]/route.ts
+++ b/web/src/app/api/budget/category-limits/[id]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import {
+  updateCategoryLimit,
+  deleteCategoryLimit,
+} from '@/features/budget/lib/repository/category-limits-repo';
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const userId = await requireAuth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const { id: idStr } = await params;
+    const id = Number(idStr);
+    if (Number.isNaN(id)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+
+    const body = (await request.json()) as { target_count?: number };
+    if (
+      body.target_count === undefined ||
+      typeof body.target_count !== 'number' ||
+      body.target_count < 1 ||
+      body.target_count > 50
+    ) {
+      return NextResponse.json({ error: '한도는 1~50 사이여야 해' }, { status: 400 });
+    }
+    const data = await updateCategoryLimit(userId, id, { target_count: body.target_count });
+    if (!data) return NextResponse.json({ error: '한도를 찾을 수 없어' }, { status: 404 });
+    return NextResponse.json({ data });
+  } catch (err) {
+    console.error('[Budget API] category-limits PATCH', err);
+    return NextResponse.json({ error: '한도 수정 실패' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const userId = await requireAuth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const { id: idStr } = await params;
+    const id = Number(idStr);
+    if (Number.isNaN(id)) return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+
+    const deleted = await deleteCategoryLimit(userId, id);
+    if (!deleted) return NextResponse.json({ error: '한도를 찾을 수 없어' }, { status: 404 });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('[Budget API] category-limits DELETE', err);
+    return NextResponse.json({ error: '한도 삭제 실패' }, { status: 500 });
+  }
+}

--- a/web/src/app/api/budget/category-limits/route.ts
+++ b/web/src/app/api/budget/category-limits/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import {
+  readCategoryLimitsWithUsage,
+  createCategoryLimit,
+} from '@/features/budget/lib/repository/category-limits-repo';
+import { getCurrentBillingMonth } from '@/features/budget/lib/billing/cycle';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const userId = await requireAuth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const billingMonth = searchParams.get('billingMonth') ?? getCurrentBillingMonth(new Date());
+    if (!/^\d{4}-\d{2}$/.test(billingMonth)) {
+      return NextResponse.json({ error: 'billingMonth 형식: YYYY-MM' }, { status: 400 });
+    }
+    const data = await readCategoryLimitsWithUsage(userId, billingMonth);
+    return NextResponse.json({ data });
+  } catch (err) {
+    console.error('[Budget API] category-limits GET', err);
+    return NextResponse.json({ error: '한도 조회 실패' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const userId = await requireAuth();
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  try {
+    const body = (await request.json()) as { category?: string; target_count?: number };
+    const category = body.category?.trim();
+    if (!category) return NextResponse.json({ error: '카테고리를 선택해줘' }, { status: 400 });
+    if (typeof body.target_count !== 'number' || body.target_count < 1 || body.target_count > 50) {
+      return NextResponse.json({ error: '한도는 1~50 사이여야 해' }, { status: 400 });
+    }
+    const data = await createCategoryLimit(userId, { category, target_count: body.target_count });
+    return NextResponse.json({ data }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '한도 생성 실패';
+    const isDuplicate = message.includes('duplicate') || message.includes('unique');
+    return NextResponse.json(
+      { error: isDuplicate ? '이미 한도가 있는 카테고리야' : '한도 생성 실패' },
+      { status: isDuplicate ? 409 : 500 },
+    );
+  }
+}

--- a/web/src/app/budget/manage/page.tsx
+++ b/web/src/app/budget/manage/page.tsx
@@ -11,6 +11,7 @@ import { IncomeEditModal } from '@/features/budget/components/income-edit-modal'
 import { CategoryChart } from '@/features/budget/components/category-chart';
 import { DailyBudgetLogView } from '@/features/budget/components/daily-budget-log';
 import { PlannedExpenseList } from '@/features/budget/components/planned-expense-list';
+import { CategoryLimitTracker } from '@/features/budget/components/category-limit-tracker';
 import { MonthNavigator } from '@/features/budget/components/month-navigator';
 import { PillTabs } from '@/components/ui/tabs';
 import { CardSkeleton, ListSkeleton } from '@/components/ui/skeleton';
@@ -62,6 +63,11 @@ export default function ManagePage() {
           <MonthSummaryCard summary={summary} />
         </div>
       ) : null}
+
+      {/* 카테고리 한도 트래커 */}
+      <div className="mb-4">
+        <CategoryLimitTracker yearMonth={selectedMonth} refreshTrigger={expenseVersion} />
+      </div>
 
       {/* 예정 지출 */}
       <div className="mb-4">

--- a/web/src/features/budget/components/budget-settings-page.tsx
+++ b/web/src/features/budget/components/budget-settings-page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import type { FixedCostRow, AssetRow } from '@/features/budget/lib/types';
-import { MIN_DAILY_BUDGET, FIXED_COST_CATEGORIES } from '@/features/budget/lib/types';
+import type { FixedCostRow, AssetRow, CategoryLimitWithUsage } from '@/features/budget/lib/types';
+import {
+  MIN_DAILY_BUDGET,
+  FIXED_COST_CATEGORIES,
+  ALL_EXPENSE_CATEGORIES,
+} from '@/features/budget/lib/types';
 import { formatAmount } from '@/lib/types';
 import { PencilIcon, CheckCircleIcon, XMarkIcon } from '@/components/ui/icons';
 
@@ -239,6 +243,186 @@ function FixedCostAddForm({
           onClick={() => void handleSubmit()}
           disabled={saving || !name.trim() || !amount}
           className="rounded-md bg-blue-600 px-3 py-1 text-xs text-white disabled:opacity-40 hover:bg-blue-700"
+        >
+          {saving ? '추가 중...' : '추가'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── 카테고리 한도 아이템 ─────────────────────────────
+
+function CategoryLimitItem({
+  limit,
+  onUpdate,
+  onDelete,
+}: {
+  limit: CategoryLimitWithUsage;
+  onUpdate: (id: number, target_count: number) => Promise<void>;
+  onDelete: (id: number) => Promise<void>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [target, setTarget] = useState(String(limit.target_count));
+
+  const handleSave = async () => {
+    const t = Number(target);
+    if (Number.isNaN(t) || t < 1 || t > 50) return;
+    setSaving(true);
+    try {
+      await onUpdate(limit.id, t);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="px-4 py-2.5">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-700">{limit.category}</span>
+        {!editing && (
+          <button
+            onClick={() => {
+              setTarget(String(limit.target_count));
+              setEditing(true);
+            }}
+            className="rounded-md p-1 text-gray-300 hover:bg-gray-100 hover:text-gray-500"
+          >
+            <PencilIcon size={14} />
+          </button>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="mt-2 space-y-2">
+          <div className="flex items-center gap-2">
+            <label className="w-16 text-xs text-gray-400">한도</label>
+            <input
+              type="number"
+              min="1"
+              max="50"
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+              className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+            />
+            <span className="text-xs text-gray-400">회</span>
+          </div>
+          <div className="flex justify-between">
+            <button
+              onClick={() => {
+                if (confirm('이 한도를 삭제할까?')) void onDelete(limit.id);
+              }}
+              disabled={saving}
+              className="text-xs text-red-400 hover:text-red-600"
+            >
+              삭제
+            </button>
+            <div className="flex gap-1.5">
+              <button
+                onClick={() => setEditing(false)}
+                disabled={saving}
+                className="rounded-md p-1 text-gray-400 hover:bg-gray-100"
+              >
+                <XMarkIcon size={16} />
+              </button>
+              <button
+                onClick={() => void handleSave()}
+                disabled={saving}
+                className="rounded-md p-1 text-blue-500 hover:bg-blue-50"
+              >
+                <CheckCircleIcon size={16} />
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-1 text-sm text-gray-500">주기당 {limit.target_count}회</div>
+      )}
+    </div>
+  );
+}
+
+// ─── 카테고리 한도 추가 폼 ──────────────────────────────
+
+function CategoryLimitAddForm({
+  existingCategories,
+  onAdd,
+}: {
+  existingCategories: string[];
+  onAdd: (data: { category: string; target_count: number }) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [category, setCategory] = useState('');
+  const [target, setTarget] = useState('5');
+  const [saving, setSaving] = useState(false);
+
+  const available = ALL_EXPENSE_CATEGORIES.filter((c) => !existingCategories.includes(c));
+
+  const handleSubmit = async () => {
+    const t = Number(target);
+    if (!category || Number.isNaN(t) || t < 1 || t > 50) return;
+    setSaving(true);
+    try {
+      await onAdd({ category, target_count: t });
+      setCategory('');
+      setTarget('5');
+      setOpen(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        disabled={available.length === 0}
+        className="w-full border-t border-gray-100 px-4 py-2.5 text-left text-xs text-blue-500 hover:bg-blue-50 disabled:text-gray-300 disabled:hover:bg-transparent"
+      >
+        {available.length === 0 ? '모든 카테고리에 한도가 설정됨' : '+ 카테고리 한도 추가'}
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-2 border-t border-gray-100 px-4 py-3">
+      <select
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+        className="w-full rounded-md border border-gray-200 px-2 py-1.5 text-sm text-gray-700 focus:border-blue-400 focus:outline-none"
+      >
+        <option value="">카테고리 선택</option>
+        {available.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-gray-400">주기당</label>
+        <input
+          type="number"
+          min="1"
+          max="50"
+          value={target}
+          onChange={(e) => setTarget(e.target.value)}
+          className="w-20 rounded-md border border-gray-200 px-2 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+        />
+        <span className="text-xs text-gray-400">회까지</span>
+      </div>
+      <div className="flex justify-end gap-1.5">
+        <button
+          onClick={() => setOpen(false)}
+          className="rounded-md px-3 py-1 text-xs text-gray-400 hover:bg-gray-100"
+        >
+          취소
+        </button>
+        <button
+          onClick={() => void handleSubmit()}
+          disabled={saving || !category}
+          className="rounded-md bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-40"
         >
           {saving ? '추가 중...' : '추가'}
         </button>
@@ -563,16 +747,18 @@ function TargetDateCard({
 export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: () => void }) {
   const [fixedCosts, setFixedCosts] = useState<FixedCostRow[]>([]);
   const [assets, setAssets] = useState<AssetRow[]>([]);
+  const [categoryLimits, setCategoryLimits] = useState<CategoryLimitWithUsage[]>([]);
   const [savedTarget, setSavedTarget] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
     try {
-      const [fixedRes, assetsRes, settingsRes] = await Promise.all([
+      const [fixedRes, assetsRes, settingsRes, limitsRes] = await Promise.all([
         fetch('/api/budget/fixed-costs'),
         fetch('/api/budget/assets'),
         fetch('/api/budget/settings'),
+        fetch('/api/budget/category-limits'),
       ]);
       if (fixedRes.ok) {
         const d = (await fixedRes.json()) as { data: FixedCostRow[] };
@@ -585,6 +771,10 @@ export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: ()
       if (settingsRes.ok) {
         const d = (await settingsRes.json()) as { data: { target_date: string | null } };
         setSavedTarget(d.data.target_date);
+      }
+      if (limitsRes.ok) {
+        const d = (await limitsRes.json()) as { data: CategoryLimitWithUsage[] };
+        setCategoryLimits(d.data);
       }
     } finally {
       setLoading(false);
@@ -652,6 +842,38 @@ export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: ()
     if (!res.ok) throw new Error('기본 자산 설정 실패');
     // 다른 자산의 is_default가 변경되었을 수 있어 전체 재조회
     await fetchAll();
+    onSettingsChange?.();
+  };
+
+  const handleAddCategoryLimit = async (data: { category: string; target_count: number }) => {
+    const res = await fetch('/api/budget/category-limits', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error ?? '한도 추가 실패');
+    }
+    await fetchAll();
+    onSettingsChange?.();
+  };
+
+  const handleUpdateCategoryLimit = async (id: number, target_count: number) => {
+    const res = await fetch(`/api/budget/category-limits/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target_count }),
+    });
+    if (!res.ok) throw new Error('한도 수정 실패');
+    setCategoryLimits((prev) => prev.map((l) => (l.id === id ? { ...l, target_count } : l)));
+    onSettingsChange?.();
+  };
+
+  const handleDeleteCategoryLimit = async (id: number) => {
+    const res = await fetch(`/api/budget/category-limits/${id}`, { method: 'DELETE' });
+    if (!res.ok) throw new Error('한도 삭제 실패');
+    setCategoryLimits((prev) => prev.filter((l) => l.id !== id));
     onSettingsChange?.();
   };
 
@@ -725,6 +947,36 @@ export function BudgetSettingsPage({ onSettingsChange }: { onSettingsChange?: ()
             결제일 설정 시 해당 날짜에 자동으로 지출 내역에 기록됩니다.
           </p>
         </div>
+      </div>
+
+      {/* 카테고리 한도 */}
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-t-xl">
+          <h2 className="text-sm font-semibold text-gray-700">카테고리 한도</h2>
+          <span className="text-xs text-gray-500">{categoryLimits.length}개</span>
+        </div>
+
+        {categoryLimits.length === 0 ? (
+          <div className="px-4 py-6 text-center text-xs text-gray-400">
+            카테고리별 결제주기 한도를 설정해두면 지출 페이지에서 트래커 카드로 보여줄게.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {categoryLimits.map((limit) => (
+              <CategoryLimitItem
+                key={limit.id}
+                limit={limit}
+                onUpdate={handleUpdateCategoryLimit}
+                onDelete={handleDeleteCategoryLimit}
+              />
+            ))}
+          </div>
+        )}
+
+        <CategoryLimitAddForm
+          existingCategories={categoryLimits.map((l) => l.category)}
+          onAdd={handleAddCategoryLimit}
+        />
       </div>
 
       {/* 자산/자금 */}

--- a/web/src/features/budget/components/category-limit-tracker.tsx
+++ b/web/src/features/budget/components/category-limit-tracker.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import type { CategoryLimitWithUsage } from '@/features/budget/lib/types';
+
+interface Props {
+  yearMonth: string;
+  refreshTrigger?: number;
+}
+
+function LimitRow({ limit }: { limit: CategoryLimitWithUsage }) {
+  const used = limit.used_count;
+  const target = limit.target_count;
+  const isOver = used > target;
+  const isWarn = !isOver && used >= Math.ceil(target * 0.8);
+  const remaining = Math.max(0, target - used);
+
+  const dotColor = isOver
+    ? 'bg-red-500 border-red-500'
+    : isWarn
+      ? 'bg-amber-500 border-amber-500'
+      : 'bg-blue-500 border-blue-500';
+  const labelColor = isOver ? 'text-red-500' : isWarn ? 'text-amber-700' : 'text-gray-600';
+
+  const dots = Array.from({ length: target }, (_, i) => {
+    const filled = i < Math.min(used, target);
+    return (
+      <span
+        key={i}
+        className={`inline-block h-[18px] w-[18px] rounded-full border-2 ${
+          filled ? dotColor : 'border-gray-300 bg-white'
+        }`}
+      />
+    );
+  });
+
+  return (
+    <div className="border-b border-gray-100 py-3 last:border-b-0">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-700">{limit.category}</span>
+        <span className={`text-xs font-medium ${labelColor}`}>
+          {isOver ? (
+            <>
+              {used - target}회 초과 · 한도 {target}
+            </>
+          ) : (
+            <>
+              남은 {remaining}회 · 한도 {target}
+            </>
+          )}
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2">{dots}</div>
+    </div>
+  );
+}
+
+export function CategoryLimitTracker({ yearMonth, refreshTrigger }: Props) {
+  const [limits, setLimits] = useState<CategoryLimitWithUsage[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchLimits = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/budget/category-limits?billingMonth=${yearMonth}`);
+      if (!res.ok) return;
+      const { data } = (await res.json()) as { data: CategoryLimitWithUsage[] };
+      setLimits(data);
+    } finally {
+      setLoading(false);
+    }
+  }, [yearMonth]);
+
+  useEffect(() => {
+    void fetchLimits();
+  }, [fetchLimits, refreshTrigger]);
+
+  if (loading) return null;
+  if (limits.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-gray-700">이번 주기 한도</h2>
+        <span className="text-xs text-gray-400">설정에서 관리</span>
+      </div>
+      <div>
+        {limits.map((l) => (
+          <LimitRow key={l.id} limit={l} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/budget/lib/repository/__tests__/category-limits-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/category-limits-repo.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  query: vi.fn(),
+  queryOne: vi.fn(),
+}));
+
+import { query, queryOne } from '@/lib/db';
+import {
+  readCategoryLimitsWithUsage,
+  readCategoryLimits,
+  createCategoryLimit,
+  updateCategoryLimit,
+  deleteCategoryLimit,
+} from '../category-limits-repo';
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
+type Any = any;
+
+describe('category-limits-repo', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('readCategoryLimitsWithUsage', () => {
+    it('used_count는 expenses COUNT 결과를 그대로 반환', async () => {
+      vi.mocked(query).mockResolvedValueOnce({
+        rows: [
+          { id: 1, category: '카페', target_count: 5, used_count: 2 },
+          { id: 2, category: '배달음식', target_count: 4, used_count: 5 },
+        ],
+        rowCount: 2,
+      } as Any);
+
+      const result = await readCategoryLimitsWithUsage(1, '2026-05');
+
+      expect(result).toEqual([
+        { id: 1, category: '카페', target_count: 5, used_count: 2 },
+        { id: 2, category: '배달음식', target_count: 4, used_count: 5 },
+      ]);
+      const sql = vi.mocked(query).mock.calls[0]![0] as string;
+      expect(sql).toMatch(/SELECT/i);
+      expect(sql).toMatch(/COUNT/i);
+      expect(sql).toMatch(/billing_month/);
+      expect(sql).toMatch(/is_installment = false OR e\.installment_num = 1/);
+      // userId, billingMonth 파라미터 전달 확인
+      expect(vi.mocked(query).mock.calls[0]![1]).toEqual([1, '2026-05']);
+    });
+
+    it('비어있는 경우 빈 배열 반환', async () => {
+      vi.mocked(query).mockResolvedValueOnce({ rows: [], rowCount: 0 } as Any);
+      const result = await readCategoryLimitsWithUsage(1, '2026-05');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('readCategoryLimits', () => {
+    it('user의 모든 한도 반환', async () => {
+      vi.mocked(query).mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            user_id: 1,
+            category: '카페',
+            target_count: 5,
+            created_at: '2026-05-14',
+            updated_at: '2026-05-14',
+          },
+        ],
+        rowCount: 1,
+      } as Any);
+
+      const result = await readCategoryLimits(1);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.category).toBe('카페');
+    });
+  });
+
+  describe('createCategoryLimit', () => {
+    it('INSERT 후 row 반환', async () => {
+      vi.mocked(queryOne).mockResolvedValueOnce({
+        id: 1,
+        user_id: 1,
+        category: '카페',
+        target_count: 5,
+        created_at: '2026-05-14',
+        updated_at: '2026-05-14',
+      } as Any);
+
+      const result = await createCategoryLimit(1, { category: '카페', target_count: 5 });
+
+      expect(result.id).toBe(1);
+      expect(result.category).toBe('카페');
+      expect(result.target_count).toBe(5);
+      const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+      expect(sql).toMatch(/INSERT INTO category_limits/i);
+      expect(vi.mocked(queryOne).mock.calls[0]![1]).toEqual([1, '카페', 5]);
+    });
+
+    it('INSERT가 row를 반환하지 않으면 throw', async () => {
+      vi.mocked(queryOne).mockResolvedValueOnce(null);
+
+      await expect(createCategoryLimit(1, { category: '카페', target_count: 5 })).rejects.toThrow(
+        /INSERT returned no rows/,
+      );
+    });
+  });
+
+  describe('updateCategoryLimit', () => {
+    it('target_count 없으면 null (UPDATE 호출 안 됨)', async () => {
+      const result = await updateCategoryLimit(1, 1, {});
+      expect(result).toBeNull();
+      expect(queryOne).not.toHaveBeenCalled();
+    });
+
+    it('target_count 있으면 UPDATE 호출 + row 반환', async () => {
+      vi.mocked(queryOne).mockResolvedValueOnce({
+        id: 1,
+        user_id: 1,
+        category: '카페',
+        target_count: 10,
+      } as Any);
+
+      const result = await updateCategoryLimit(1, 1, { target_count: 10 });
+
+      expect(result?.target_count).toBe(10);
+      const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+      expect(sql).toMatch(/UPDATE category_limits/i);
+      expect(sql).toMatch(/WHERE id = \$2 AND user_id = \$1/i);
+      expect(vi.mocked(queryOne).mock.calls[0]![1]).toEqual([1, 1, 10]);
+    });
+
+    it('user_id 불일치 시 null 반환 (RETURNING 없음)', async () => {
+      vi.mocked(queryOne).mockResolvedValueOnce(null);
+      const result = await updateCategoryLimit(99, 1, { target_count: 10 });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteCategoryLimit', () => {
+    it('rowCount > 0이면 true', async () => {
+      vi.mocked(query).mockResolvedValueOnce({ rows: [], rowCount: 1 } as Any);
+      const result = await deleteCategoryLimit(1, 1);
+      expect(result).toBe(true);
+    });
+
+    it('rowCount 0이면 false (user_id 불일치 등)', async () => {
+      vi.mocked(query).mockResolvedValueOnce({ rows: [], rowCount: 0 } as Any);
+      const result = await deleteCategoryLimit(1, 999);
+      expect(result).toBe(false);
+    });
+
+    it('rowCount null이면 false', async () => {
+      vi.mocked(query).mockResolvedValueOnce({ rows: [], rowCount: null } as Any);
+      const result = await deleteCategoryLimit(1, 1);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/web/src/features/budget/lib/repository/category-limits-repo.ts
+++ b/web/src/features/budget/lib/repository/category-limits-repo.ts
@@ -1,0 +1,76 @@
+import { query, queryOne } from '@/lib/db';
+import type { CategoryLimitRow, CategoryLimitWithUsage } from '../types';
+
+/**
+ * 카테고리 한도 + 현재 주기 사용 횟수 조회.
+ * used_count는 expenses에서 live 집계 — 할부는 1회차만 카운트, income 제외.
+ */
+export async function readCategoryLimitsWithUsage(
+  userId: number,
+  billingMonth: string,
+): Promise<CategoryLimitWithUsage[]> {
+  const result = await query<CategoryLimitWithUsage>(
+    `SELECT
+       cl.id,
+       cl.category,
+       cl.target_count,
+       COALESCE((
+         SELECT COUNT(*)::int FROM expenses e
+         WHERE e.user_id = cl.user_id
+           AND e.billing_month = $2
+           AND e.category = cl.category
+           AND e.type = 'expense'
+           AND (e.is_installment = false OR e.installment_num = 1)
+       ), 0) AS used_count
+     FROM category_limits cl
+     WHERE cl.user_id = $1
+     ORDER BY cl.id`,
+    [userId, billingMonth],
+  );
+  return result.rows;
+}
+
+export async function readCategoryLimits(userId: number): Promise<CategoryLimitRow[]> {
+  const result = await query<CategoryLimitRow>(
+    `SELECT * FROM category_limits WHERE user_id = $1 ORDER BY id`,
+    [userId],
+  );
+  return result.rows;
+}
+
+export async function createCategoryLimit(
+  userId: number,
+  input: { category: string; target_count: number },
+): Promise<CategoryLimitRow> {
+  const row = await queryOne<CategoryLimitRow>(
+    `INSERT INTO category_limits (user_id, category, target_count)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [userId, input.category, input.target_count],
+  );
+  if (!row) throw new Error('createCategoryLimit: INSERT returned no rows');
+  return row;
+}
+
+export async function updateCategoryLimit(
+  userId: number,
+  id: number,
+  updates: { target_count?: number },
+): Promise<CategoryLimitRow | null> {
+  if (updates.target_count === undefined) return null;
+  return queryOne<CategoryLimitRow>(
+    `UPDATE category_limits
+     SET target_count = $3, updated_at = NOW()
+     WHERE id = $2 AND user_id = $1
+     RETURNING *`,
+    [userId, id, updates.target_count],
+  );
+}
+
+export async function deleteCategoryLimit(userId: number, id: number): Promise<boolean> {
+  const result = await query(`DELETE FROM category_limits WHERE id = $2 AND user_id = $1`, [
+    userId,
+    id,
+  ]);
+  return (result.rowCount ?? 0) > 0;
+}

--- a/web/src/features/budget/lib/types.ts
+++ b/web/src/features/budget/lib/types.ts
@@ -68,6 +68,22 @@ export interface CategoryStat {
   count: number;
 }
 
+export interface CategoryLimitRow {
+  id: number;
+  user_id: number;
+  category: string;
+  target_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CategoryLimitWithUsage {
+  id: number;
+  category: string;
+  target_count: number;
+  used_count: number;
+}
+
 export interface MonthSummary {
   year_month: string;
   total: number;


### PR DESCRIPTION
## 관련 이슈
Closes #399

## 변경 내용
- `category_limits` 테이블 + repository + REST API (GET/POST/PATCH/DELETE)
- 결제주기 종료까지 카테고리별 사용 횟수 자동 집계 (할부는 첫 회차만)
- 지출 관리 페이지에 점 진행도 트래커 카드 추가 (파랑 → 80% 노랑 → 초과 빨강)
- 설정 페이지에 카테고리 한도 추가/수정/삭제 섹션 추가

## 코드 리뷰 결과
- [x] 보안 감사 통과 (인증·소유권 체크 모두 `userId` 파라미터화, SQL 인젝션 없음)
- [x] 타입 안전성 확인 (`CategoryLimitRow` / `CategoryLimitWithUsage` 분리)
- [x] 컨벤션 점검 완료 (kebab-case 파일, camelCase 함수, named export)
- [x] 에러 처리 (외부 경계만 try-catch, 400/404/409 분기)

## 테스트
- [x] vitest budget 전체 통과 (18 files / 205 tests, 신규 11개 포함)
- [x] repository: read/create/update/delete + 빈 결과 / target_count 부재 / user_id 불일치 케이스
- [x] SQL 정규식 검증 (`billing_month`, `is_installment` 회차 필터)