### PR TITLE
docs: 4문서 아키텍처 도입 — design-notebook + features 카탈로그

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ graph LR
 - **Custom Skills**: `/init-project`, `/design`, `/build` — 계획서 파일로 세션 간 핸드오프
 - **MCP**: Slack(에이전트 응답 품질 점검)
 - **Scheduled Tasks (비동기 깊은 분석 전용)**: 개발 리포트(Opus 분석), 주간 사주 패턴 분석, 주간 일운 사전 분석, 밤 응원 메시지
-- **ADR (Architecture Decision Records)**: 되돌리기 어려운 설계 판단을 표준 포맷(Status·Context·Decision·Consequences = 상태·배경·결정·결과)으로 기록 → `/design`·`/build` 스킬에 ADR 판단 로직 내장
+- **설계 사고 4문서 아키텍처**: `plans/`(휘발 메모) · `design-notebook/`(마스터 단위 서사·분기점·회고) · `adr/`(되돌리기 어려운 결정, Michael Nygard 포맷) · `features.md`(현황 카탈로그)로 사고를 분산 → 인터뷰 분기점·포기·회고가 코드만 남고 휘발되는 문제 해결. `/design` 스킬이 단계별로 자동 갱신
 - **자체 업타임 모니터링**: GitHub Actions cron으로 봇·웹 5분 간격 폴링 + Slack DOWN/RECOVERY 알림
 
 AI를 **코딩 보조**가 아니라 협업 개발자로 취급하고, 작업 단위는 GitHub Issues·PR로 리뷰·검증한다.
@@ -334,11 +334,13 @@ yarn dev
 
 ## 관련 문서
 
-문서 운영 — 외부에 보여줄 마일스톤은 `project-history.md`, 되돌리기 어려운 설계 판단은 `adr/`, 일상 작업·성향 분석 등 비공개 정보는 `_personal/`(gitignored)로 분리.
+문서 운영 — 마일스톤은 `project-history.md`, 마스터 단위 설계 서사는 `design-notebook/`, 되돌리기 어려운 판단은 `adr/`, 현재 기능 카탈로그는 `features.md`, 일상 작업·성향 분석 등 비공개 정보는 `_personal/`(gitignored)로 분리.
 
 | 문서                                                           | 내용                                                                                                                         |
 | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [docs/design-notebook/](docs/design-notebook/)                 | 마스터 단위 설계 서사 — Phase 별 분기점·포기·회고 누적                                                                       |
 | [docs/adr/](docs/adr/)                                         | Architecture Decision Records — 되돌리기 어려운 설계 판단의 배경·대안·트레이드오프                                           |
+| [docs/features.md](docs/features.md)                           | 현재 기능 카탈로그 — 도메인별로 작동 중인 기능 한눈에                                                                        |
 | [docs/project-history.md](docs/project-history.md)             | 마일스톤 timeline — 기능 출시·아키텍처 전환·인프라 변화 (2026-04-07 이전: [archive-v1-v2.md](docs/history/archive-v1-v2.md)) |
 | [docs/domains/](docs/domains/)                                 | 도메인별 명세 — 일정·루틴·사주·예산 각 도메인의 DB 스키마·API·로직                                                           |
 | [docs/conventions.md](docs/conventions.md)                     | 코드 컨벤션 & 보안 체크리스트                                                                                                |

--- a/docs/design-notebook/README.md
+++ b/docs/design-notebook/README.md
@@ -1,0 +1,45 @@
+# design-notebook
+
+마스터 단위 기능의 **설계 흐름 서사**를 기록하는 영구 문서.
+
+## 다른 문서와의 차이
+
+| 문서 | 역할 |
+|------|------|
+| `.claude/plans/` | 구현 직전 메모 (휘발) |
+| **`docs/design-notebook/`** | **마스터 단위 서사 — 분기점·포기·회고** |
+| `docs/adr/` | 되돌리기 어려운 결정 (불변 판례) |
+| `docs/features.md` | 현재 어떤 기능이 있는지 한눈에 (카탈로그) |
+
+design-notebook은 ADR이 다루지 않는 **결정에 이르기까지의 사고 흐름**을 담는다:
+- 어떤 분기점이 있었고 왜 그쪽을 택했는지
+- 무엇을 포기했고 왜
+- 어떤 가설로 일단 가는지 (검증 시점 함께)
+- 구현 후 회고
+
+## 구조
+
+```
+docs/design-notebook/
+├── README.md                       # 이 파일
+├── insight-engine-v2.md            # 마스터 #393 — 프로액티브 인사이트 v2
+└── <master-slug>.md                # 다른 마스터 (있을 때마다)
+```
+
+마스터 이슈 1개당 파일 1개. Phase 별로 섹션 누적.
+
+## 작성 시점
+
+- 마스터 이슈 첫 설계 진입 시: 파일 생성
+- 각 Phase 설계 시작 시: 새 섹션 append
+- 각 Phase 머지 후: 회고 섹션 채움
+
+## 작성 방식
+
+[`/design` 스킬](../../.claude/skills/design/) 5-2 단계에서 자동 갱신. 수동 작성도 가능.
+
+섹션 템플릿: 스킬의 `templates/design-notebook-section.md` 참조.
+
+## 목록
+
+- [insight-engine-v2.md](./insight-engine-v2.md) — 프로액티브 인사이트 v2 (마스터 #393)

--- a/docs/design-notebook/insight-engine-v2.md
+++ b/docs/design-notebook/insight-engine-v2.md
@@ -1,0 +1,90 @@
+# 프로액티브 인사이트 v2
+
+> 마스터 이슈: [#393](https://github.com/hyewon3938/slack-ai-agents/issues/393)
+> 시작: 2026-05-10
+> 상태: 진행 중
+
+## 개요
+
+기존 SQL 기반 패턴 5개로 운영되던 프로액티브 인사이트를, **결정론적 잔소리 엔진**(SQL 패턴)과 **LLM 자율 발견**(주간 1회) + **사주 가설-검증**(개인 원국 기반 매핑)으로 재설계하는 마스터.
+
+핵심 철학:
+- **LLM 텍스트 해석 의존도 최소화** — 매일 잔소리는 SQL 패턴 결정론적으로
+- **LLM은 발견 슬롯에서만 자율** — 주간 1회, 가설 제기 → DB 보존 → 사후 검증
+- **사주 가설-검증** — 개인 원국의 십성/오행 매핑을 패턴 임계치 조정에 활용
+
+## 전체 Phase 흐름
+
+- [x] **Phase 1**: 패턴 통합 · 임계치 외부화 · 주간 리포트 재구성 ([#389](https://github.com/hyewon3938/slack-ai-agents/issues/389), 2026-05-14 머지)
+- [ ] **Phase 2**: LLM 자율 슬롯 + 측정 ([#390](https://github.com/hyewon3938/slack-ai-agents/issues/390), 진행 중)
+- [ ] **Phase 3**: 사주 매핑 — 십성/오행을 임계치 가중치로 ([#391](https://github.com/hyewon3938/slack-ai-agents/issues/391))
+- [ ] **Phase 4**: 사주 매핑 — 카테고리/패턴별 임계치 외부화 확장 ([#392](https://github.com/hyewon3938/slack-ai-agents/issues/392))
+
+---
+
+## Phase 1: 패턴 통합 · 임계치 외부화 · 주간 리포트 재구성 (2026-05-14)
+
+- 이슈: [#389](https://github.com/hyewon3938/slack-ai-agents/issues/389)
+- 관련 ADR: [ADR-0014](../adr/0014-insight-engine-unification.md)
+- 관련 PR: [#396](https://github.com/hyewon3938/slack-ai-agents/pull/396)
+- 상태: 머지 완료
+
+### 결정 요약
+
+5개 SQL 패턴(streak / sleepTrend / slotGap / weekComparison / overdueAlert) → 11개로 확장. 임계치 11개 함수 산재 상태 → `src/shared/insight-thresholds.ts` 단일 파일로 외부화. 매일 잔소리 + 주간 리포트가 같은 패턴 엔진 위에서 동작하도록 `Insight.timing: 'morning' | 'night' | 'weekly'` 도입. 주간 리포트는 일요일 23시 → 월요일 09시 + Block Kit 재구성.
+
+### 의사결정 분기점
+
+> Phase 1 backfill — ADR-0014의 Alternatives 정리분 기반.
+
+- **매일 잔소리 + 주간 리포트 통합 여부**:
+  - A. 따로 두기 (현행 유지) — 변경 폭 작지만 매일 잔소리가 작동 중단 상태로 계속됨
+  - B. 통합 + 매일도 Block Kit — UI 일관성 좋지만 카드형은 잔소리꾼 톤(짧고 가벼움)과 충돌
+  - C. 통합 + 매일은 텍스트, 주간만 Block Kit (선택) — 잔소리는 짧을수록 좋다는 원칙 + 시그널·노이즈 분리
+- **임계치 외부화 시점**:
+  - A. 미루고 신규 패턴만 추가 — 11개 함수에 임계치 산재. Phase 4 사주 매핑 시 튜닝 부담 폭증
+  - B. 이번에 같이 외부화 (선택) — 패턴 수가 늘어나는 시점이 외부화 적기
+- **주간 리포트 시간**:
+  - 일요일 23시 유지 vs 월요일 09시 이동 → **월요일 09시 선택**. 일요일 23시는 아직 지난주가 안 끝난 시점 + 회고 시점이 더 자연스러움
+- **매일 동적 노출 정책**:
+  - 기존 `pickByTiming`은 priority 최상위 1개만 → 신규: priority ≥ 5 + 도메인 dedupe + 최대 3개 cap + 0개면 발송 안 함
+  - **잔잔한 날 = 침묵** 원칙. 잔소리 피로도 ↓
+
+### 포기한 안 / 미룬 항목
+
+- **카테고리별 가중치 (categorySkew 등)**: Phase 4로 미룸. 카테고리 메타데이터 확장이 선행되어야 함.
+- **LLM 자율 분석**: Phase 2로 분리. Phase 1은 결정론적 잔소리에 집중.
+- **`Insight.domain`을 'cross-domain'으로 확장**: Phase 2 LLM 자율 슬롯 도입 시 함께 검토.
+
+### 미해결·가설
+
+- **priority 최소치 5가 적정한가**: 운영 1주 후 메시지 빈도 보고 조정 가능 (ADR-0014 후속 작업)
+- **sleep 패턴 priority 8/4 분기**: sleepTrend↑는 priority 4로 두어 매일 노출 안 되게 함. 명시적 의도지만 사용자 반응 미관측.
+
+### 회고
+
+- 매일 cron 연결 복원이 한참 후에야 이루어진 게 가장 큰 발견. 패턴 코드는 있었지만 호출이 주석 처리된 상태로 오래 방치되어 실제로는 잔소리가 안 가고 있었음. 통합 작업이 아니었으면 이 부재를 더 늦게 발견했을 가능성.
+- 임계치 외부화 후 한 파일에서 임계치 11개를 비교하니 sleepTrend의 7시간 컷오프, weekComparison의 ±5%p 등 직관적으로 "이게 너무 빡빡한가?" 싶은 부분이 즉시 보임. Phase 4 튜닝 도구로 잘 작동할 듯.
+
+---
+
+## Phase 2: LLM 자율 슬롯 + 측정 (진행 중)
+
+- 이슈: [#390](https://github.com/hyewon3938/slack-ai-agents/issues/390)
+- 상태: 설계 인터뷰 완료, 계획서 작성 대기
+
+### 결정 요약
+
+> 본 Phase 설계 완료 후 채움.
+
+### 의사결정 분기점
+
+> Phase 2 설계 인터뷰에서 추출 — 계획서 작성 시 통합.
+
+### 포기한 안 / 미룬 항목
+
+### 미해결·가설
+
+### 회고
+
+> Phase 2 머지 후 채움.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,105 @@
+# features
+
+현재 운영 중인 기능 카탈로그. 신규 합류자나 미래의 자신이 "이 프로젝트 뭐가 되지?"를 1분 안에 파악하기 위한 한눈 문서.
+
+> **상세 스키마·API는** `docs/domains/<domain>.md` 참조. 이 문서는 **무엇이 있는지**만 다룬다.
+
+## 도메인별 기능
+
+### 일정 관리 (`#life` 채널)
+
+- Slack 자연어로 일정 추가/조회/수정/삭제
+- 카테고리 분류 (FK 기반, 2026-05-13 마이그레이션)
+- 밀린 일정 자동 감지 + 잔소리
+- 상세: [docs/domains/schedule.md](./domains/schedule.md)
+
+### 루틴 관리 (`#life` 채널)
+
+- 매일/주간/슬롯별 루틴 정의
+- 체크/언체크 인터랙티브 버튼
+- 연속 달성(streak) 추적
+- 슬롯별 달성률 분석
+- 상세: [docs/domains/routine.md](./domains/routine.md)
+
+### 사주 / 일기 (`#insight` 채널)
+
+- 사주 원국 분석 (`saju_profiles`)
+- 일운/월운/세운/대운 운세 분석 (`fortune_analyses`)
+- 일기 자동 저장 (`diary_entries`)
+- 삶의 테마 관리 (`life_themes`, 자동 진화)
+- 사주 패턴 cross-domain 분석 (`saju_patterns`, 28일 롤링 윈도우)
+- 상세: [docs/domains/insight.md](./domains/insight.md)
+
+### 지출 / 예산 (`#money` 채널 / 웹 대시보드)
+
+- 웹 대시보드 기반 입력 (Slack 입력 경로 제거됨)
+- 일일 예산 안정화 로직
+- 할부 / 카드 결제 주기 / 고정비 관리
+- 상세: [docs/domains/budget.md](./domains/budget.md)
+
+## 횡단 기능
+
+### 프로액티브 인사이트 엔진
+
+- SQL 기반 패턴 감지 11종 (streak / sleepTrend / slotGap / weekComparison / overdueAlert / categorySkew / drift / recovery / lapseAlert / weeklyRegression / spottyPattern)
+- 매일 morning(09:05) / night(23:55) — 텍스트 형식 짧은 잔소리
+- 주간 리포트 — 월요일 09:00 Block Kit
+- 임계치 단일 외부 파일 (`src/shared/insight-thresholds.ts`)
+- 설계 흐름: [docs/design-notebook/insight-engine-v2.md](./design-notebook/insight-engine-v2.md)
+- 결정 기록: [ADR-0014](./adr/0014-insight-engine-unification.md)
+
+### 크론 시스템
+
+| 시간 | 내용 |
+|------|------|
+| 09:05 | 오늘 일정 + 낮 루틴 체크리스트 + 어제 리뷰 + morning 인사이트 |
+| 23:55 | 하루 종합 리뷰 + 밤 루틴 + 마무리 잔소리 + night 인사이트 |
+| 월요일 09:00 | 주간 인사이트 리포트 (Block Kit) |
+| 매일 22:00 | 개발 리포트 분석 (Opus) |
+| 다음날 09:25/09:30 | 개발 리포트 전송 (`chat.scheduleMessage`) |
+
+타임존: `Asia/Seoul` 고정.
+
+### 웹 대시보드 (Vercel)
+
+- Next.js 16
+- 일정/루틴/예산/수면/사주 시각화
+- 봇 서버 DB Proxy API 경유 (Vercel은 DB 직결 X)
+
+### DB Proxy API
+
+- 봇 서버(Oracle VM)에서 `/api/db/proxy` 엔드포인트로 SQL 실행 대행
+- `DB_PROXY_URL` + `DB_PROXY_API_KEY` 인증
+- 동적 user_id 보안 검증 적용
+
+### 개발 리포트 자동화
+
+- 매일 22:00 Opus가 git diff/log 분석 → `developer-profile.md` 갱신
+- 다음날 09:25/09:30 Slack에 작업 요약 + 개발 성향 분석 전송
+
+## 인프라
+
+| 항목 | 위치 / 방식 |
+|------|-----------|
+| Slack 봇 | Oracle VM (Docker, Socket Mode) |
+| PostgreSQL | Oracle VM (Docker 컨테이너) |
+| 웹 | Vercel 자동 배포 (GitHub push → 빌드) |
+| 봇 배포 | GitHub Actions `Deploy` 워크플로우 (main push 자동 + 수동 트리거) |
+| 모니터링 | (TBD) |
+
+## 마스터 단위 진행 중 작업
+
+- **프로액티브 인사이트 v2** ([#393](https://github.com/hyewon3938/slack-ai-agents/issues/393)) — Phase 1 완료, Phase 2 진행 중. 흐름: [design-notebook](./design-notebook/insight-engine-v2.md)
+
+## 문서 지도
+
+| 문서 | 역할 |
+|------|------|
+| [README.md](../README.md) | 프로젝트 소개 + 핵심 흐름 다이어그램 |
+| [CLAUDE.md](../CLAUDE.md) | Claude 작업 컨텍스트 |
+| **이 문서 (features.md)** | **현재 어떤 기능이 있는지 한눈에** |
+| `docs/domains/*.md` | 도메인별 스키마·API·로직 상세 |
+| `docs/design-notebook/*.md` | 마스터 단위 설계 흐름 (분기점·포기·회고) |
+| `docs/adr/*.md` | 되돌리기 어려운 결정 (Michael Nygard 포맷) |
+| `docs/conventions.md` | 코드 컨벤션 + 보안 체크리스트 |
+| `docs/project-history.md` | 마일스톤 timeline |


### PR DESCRIPTION
## Summary

설계 사고가 코드만 남으면 휘발되는 문제를 해결하기 위해 **4문서 아키텍처**를 도입.

| 문서 | 역할 | 수명 |
|------|------|------|
| `.claude/plans/<이슈>-*.md` | 구현 직전 메모 | 휘발 (작업 끝나면 `_archive/`) |
| `docs/design-notebook/<master>.md` | 마스터 단위 서사 (분기점·포기·회고) | 영구, 누적 |
| `docs/adr/NNNN-*.md` | 되돌리기 어려운 결정 | 영구, 불변 |
| `docs/features.md` | 현재 기능 카탈로그 | 현황 |

## 변경 파일

- \`docs/design-notebook/README.md\` (신규) — 디렉터리 가이드
- \`docs/design-notebook/insight-engine-v2.md\` (신규) — 마스터 #393 backfill (Phase 1 회고 + Phase 2 빈 섹션)
- \`docs/features.md\` (신규) — 현재 운영 중 기능 카탈로그

## 이 PR 범위 외

- \`/design\` 스킬 변경 (글로벌 사용자 스킬, repo 외부)
- 기존 \`.claude/plans/\` 44개 → \`_archive/\` 이동 (gitignored, 로컬만)
- Phase 2 설계 자체 (별도 PR로 진행 예정)

## Test plan

- [ ] 4문서 역할 분리가 README에 명확히 기술됨
- [ ] design-notebook Phase 1 backfill이 ADR-0014 결정과 일관됨
- [ ] features.md가 현재 운영 상태와 일치 (도메인 4개 + 횡단 기능 + 인프라)

Closes #401