### PR TITLE
feat(insight): 프로액티브 인사이트 v2 Phase 2 — LLM 자율 발견 + outcome 검증 (#390)

### DIFF
--- a/db/migrations/048_llm_insights.sql
+++ b/db/migrations/048_llm_insights.sql
@@ -1,0 +1,35 @@
+-- 프로액티브 인사이트 v2 Phase 2 — LLM 자율 발견 + outcome 검증
+-- ADR-0016 참조: docs/adr/0016-llm-autonomous-slot-outcome-verification.md
+
+CREATE TABLE IF NOT EXISTS llm_insights (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  discovered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  slot TEXT NOT NULL,
+  signal_text TEXT NOT NULL,
+  hypothesis_text TEXT NOT NULL,
+  domains TEXT[] NOT NULL,
+  confidence TEXT NOT NULL
+    CHECK (confidence IN ('high','medium')),
+  verification_sql TEXT NOT NULL,
+  verification_result_type TEXT NOT NULL
+    CHECK (verification_result_type IN ('boolean','scalar_count','ratio')),
+  verify_at TIMESTAMPTZ NOT NULL,
+  outcome TEXT NOT NULL DEFAULT 'pending'
+    CHECK (outcome IN ('pending','hit','miss','inconclusive')),
+  verified_at TIMESTAMPTZ,
+  verification_result_json JSONB,
+  verification_error TEXT,
+  shown_in_slot_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_insights_user_pending ON llm_insights (user_id, verify_at)
+  WHERE outcome = 'pending';
+CREATE INDEX IF NOT EXISTS idx_llm_insights_user_outcome ON llm_insights (user_id, outcome, discovered_at DESC);
+
+INSERT INTO notification_settings (slot_name, time_value, label, active)
+VALUES
+  ('weeklyLlmInsight',  '09:30', '주간 LLM 자율 발견', true),
+  ('monthlyLlmInsight', '09:30', '월간 LLM 자율 발견', true),
+  ('verifyLlmInsights', '09:10', 'LLM 발견 자동 검증', true)
+ON CONFLICT (slot_name) DO NOTHING;

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -195,6 +195,64 @@ weekly-fortune routine이 일운/월운/세운/대운을 생성. fortune_analyse
 
 상세 배경 및 대안 비교는 [ADR 0014](../adr/0014-insight-engine-unification.md) 참조.
 
+### 9. 프로액티브 인사이트 v2 — Phase 2 (LLM 자율 슬롯)
+
+Phase 1(결정론적 SQL 11종)에 더해 **주간/월간 한정 LLM 자율 발견 슬롯**을 운영. LLM이 사용자 데이터 요약 컨텍스트를 보고 "신호 → 가설 → 검증 SQL"을 스스로 작성하면, N일 뒤 cron이 SQL을 실행해 outcome(hit/miss/inconclusive)을 채점한다. 텍스트(일기/사주)는 컨텍스트에서 배제 — 정량 데이터만 사용.
+
+#### 슬롯 시각
+
+| slot | cron | 트리거 |
+|------|------|--------|
+| weeklyLlmInsight | 월요일 09:30 | 28일 윈도우 → 1\~2개 finding |
+| monthlyLlmInsight | 매월 1일 09:30 | 90일 윈도우 → 1\~2개 finding |
+| verifyLlmInsights | 매일 09:10 | `verify_at <= NOW()` 대기열 50건 채점 |
+
+#### 컨텍스트 도메인 (텍스트 제외)
+
+`buildLlmInsightContext(userId, slot)` 가 LLM에 전달하는 데이터:
+- **수면**: 평균 / 취침·기상 시각 / 중간기상 횟수 / 일수
+- **루틴**: 전체 달성률 / 슬롯별 달성률 / 산발 빠짐 일자
+- **일정**: 카테고리 분포 (제목 미포함)
+- **지출**: 카테고리 발생 빈도 (금액 미포함)
+
+#### 4중 안전장치
+
+LLM 응답을 `validateLlmInsightResponse(text)` 가 순서대로 검사 — 하나라도 실패하면 해당 finding 폐기:
+
+1. **JSON 파싱 폴백**: 본문 추출 실패 시 빈 배열
+2. **SELECT-only 정규식**: `insert|update|delete|drop|truncate|alter|create|grant|revoke` 포함 시 제외
+3. **result_type 화이트리스트**: `boolean | scalar_count | ratio` 만 허용
+4. **verify_after_days clamp**: 1\~28 범위로 강제
+
+검증 SQL 실행은 `executeVerificationSql`이 `SET statement_timeout = 5000ms` 트랜잭션 안에서 처리. 에러 시 `outcome='inconclusive'` + errorText 보관.
+
+#### outcome 분류 (`classifyOutcome`)
+
+| result_type | hit | miss | inconclusive |
+|-------------|-----|------|--------------|
+| boolean | first col truthy (true / 't' / 'true' / '1') | falsy | 빈 rows 또는 null |
+| scalar_count | 양수 | 0 | 빈 rows 또는 null |
+| ratio | 양수 | 0 | 빈 rows 또는 null |
+
+#### 점진적 노출 (progressive disclosure)
+
+신뢰 확보 전에는 LLM이 "그럴듯한 헛소리"를 할 수 있으므로 메시지를 보수적으로 노출:
+
+- **누적 검증 < 10건**: finding 본문만 발송 (히트율 미공개)
+- **누적 검증 ≥ 10건**: "지난 검증 N건 중 M건 적중 (X%)" 한 줄 추가 — 사용자가 신호를 채점하면서 보기
+
+`tryLlmInsightFastPath` (정규식: `발견.*검증 | 정확도 | LLM.*어땠`) 로 누적 hit/miss/inconclusive + 최근 5건 조회 가능.
+
+#### 데이터 모델
+
+`llm_insights` 테이블 (마이그레이션 048):
+- 발견: signal_text / hypothesis_text / domains[] / confidence(high·medium)
+- 검증 계약: verification_sql / verification_result_type / verify_at
+- 검증 결과: outcome / verified_at / verification_result_json / verification_error
+- 노출 추적: shown_in_slot_at
+
+설계 배경 및 대안 비교는 [ADR 0016](../adr/0016-llm-autonomous-slot-outcome-verification.md) 참조.
+
 ## 파일 구조
 
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,11 +48,23 @@
 - 설계 흐름: [docs/design-notebook/insight-engine-v2.md](./design-notebook/insight-engine-v2.md)
 - 결정 기록: [ADR-0014](./adr/0014-insight-engine-unification.md)
 
+### LLM 자율 발견 슬롯 (Phase 2)
+
+- 주간(월요일 09:30) / 월간(매월 1일 09:30) — 정량 데이터 컨텍스트만으로 "신호 → 가설 → 검증 SQL" 자동 작성
+- N일 뒤 검증 cron(매일 09:10)이 SELECT-only SQL 실행 → outcome(hit/miss/inconclusive) 자동 채점
+- 4중 안전장치: JSON 파싱 폴백 / SELECT-only 정규식 / result_type 화이트리스트 / verify_after_days clamp 1\~28
+- 점진적 노출: 누적 검증 ≥ 10건부터 히트율 공개
+- 슬랙 조회: "발견 검증 어떻게 됐어" / "정확도 알려줘" / "LLM 어땠어"
+- 결정 기록: [ADR-0016](./adr/0016-llm-autonomous-slot-outcome-verification.md)
+
 ### 크론 시스템
 
 | 시간 | 내용 |
 |------|------|
 | 09:05 | 오늘 일정 + 낮 루틴 체크리스트 + 어제 리뷰 + morning 인사이트 |
+| 09:10 | LLM 자율 발견 outcome 검증 (대기열 50건) |
+| 월요일 09:30 | 주간 LLM 자율 발견 슬롯 (Block Kit) |
+| 매월 1일 09:30 | 월간 LLM 자율 발견 슬롯 (Block Kit) |
 | 23:55 | 하루 종합 리뷰 + 밤 루틴 + 마무리 잔소리 + night 인사이트 |
 | 월요일 09:00 | 주간 인사이트 리포트 (Block Kit) |
 | 매일 22:00 | 개발 리포트 분석 (Opus) |

--- a/src/agents/insight/__tests__/llm-insight-fast-path.test.ts
+++ b/src/agents/insight/__tests__/llm-insight-fast-path.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+
+vi.mock('pg', () => {
+  const MockPool = vi.fn(function (this: Record<string, unknown>) {
+    this.query = mockQuery;
+    this.connect = mockConnect;
+    this.end = vi.fn();
+  });
+  return { default: { Pool: MockPool, types: { setTypeParser: vi.fn() } } };
+});
+
+import { connectDB } from '../../../shared/db.js';
+import { tryLlmInsightFastPath, buildLlmInsightSlackMessage } from '../llm-insight-fast-path.js';
+import type { LlmInsightDraft } from '../../../shared/llm-insight-prompts.js';
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockConnect.mockResolvedValue({ release: vi.fn() });
+  await connectDB('postgresql://test@localhost/test');
+});
+
+const sayMock = (): { say: ReturnType<typeof vi.fn>; calls: unknown[] } => {
+  const calls: unknown[] = [];
+  const say = vi.fn(async (arg: unknown) => {
+    calls.push(arg);
+  });
+  return { say: say as unknown as ReturnType<typeof vi.fn>, calls };
+};
+
+describe('tryLlmInsightFastPath', () => {
+  it('매칭되지 않는 문장은 false 반환', async () => {
+    const { say } = sayMock();
+    const result = await tryLlmInsightFastPath('오늘 일정 뭐 있어', say as never, 1);
+    expect(result).toBe(false);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('"발견 검증" 매칭 → true + say 호출 (0건 시 안내)', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const { say, calls } = sayMock();
+    const result = await tryLlmInsightFastPath('발견 검증 어떻게 됐어', say as never, 1);
+    expect(result).toBe(true);
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    const blockArg = calls[0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(blockArg.blocks);
+    expect(blocksStr).toContain('아직 발견된 패턴이 없어');
+    expect(blocksStr).toContain('누적 검증: 0건');
+  });
+
+  it('"정확도" 매칭 → true', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const { say } = sayMock();
+    const result = await tryLlmInsightFastPath('LLM 정확도 알려줘', say as never, 1);
+    expect(result).toBe(true);
+  });
+
+  it('"LLM 어땠어" 매칭 → true', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const { say } = sayMock();
+    const result = await tryLlmInsightFastPath('이번 LLM 어땠어', say as never, 1);
+    expect(result).toBe(true);
+  });
+
+  it('누적 hit/miss 있으면 hitRate 표시', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('GROUP BY outcome')) {
+        return Promise.resolve({
+          rows: [
+            { outcome: 'hit', cnt: '6' },
+            { outcome: 'miss', cnt: '4' },
+            { outcome: 'pending', cnt: '2' },
+          ],
+        });
+      }
+      if (sql.includes('ORDER BY discovered_at DESC')) {
+        return Promise.resolve({
+          rows: [
+            {
+              discovered_at: '2026-05-10 09:30:00+09',
+              slot: 'weekly',
+              signal_text: 'sig',
+              hypothesis_text: 'hyp',
+              confidence: 'medium',
+              outcome: 'hit',
+              verified_at: '2026-05-17 09:10:00+09',
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const { calls } = sayMock();
+    const say = vi.fn(async (arg: unknown) => {
+      calls.push(arg);
+    });
+    const result = await tryLlmInsightFastPath('정확도 알려줘', say as never, 1);
+    expect(result).toBe(true);
+    const blocksStr = JSON.stringify(calls[0]);
+    expect(blocksStr).toContain('누적 검증 10건');
+    expect(blocksStr).toContain('60%');
+  });
+});
+
+describe('buildLlmInsightSlackMessage', () => {
+  const draft: LlmInsightDraft = {
+    signal: 'sig',
+    hypothesis: 'hyp',
+    domains: ['sleep', 'routine'],
+    confidence: 'medium',
+    verification: { sql: 'SELECT 1', resultType: 'boolean', verifyAfterDays: 7 },
+  };
+
+  it('totalVerified < 10 → 점진적 노출 줄 없음', async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        { outcome: 'hit', cnt: '3' },
+        { outcome: 'miss', cnt: '2' },
+      ],
+    });
+    const { headerText, blocks } = await buildLlmInsightSlackMessage(1, 'weekly', [draft]);
+    expect(headerText).toContain('주간 LLM 자율 발견 1건');
+    expect(JSON.stringify(blocks)).not.toContain('지난 검증');
+  });
+
+  it('totalVerified ≥ 10 → 점진적 노출 줄 포함', async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        { outcome: 'hit', cnt: '7' },
+        { outcome: 'miss', cnt: '3' },
+      ],
+    });
+    const { blocks } = await buildLlmInsightSlackMessage(1, 'monthly', [draft]);
+    expect(JSON.stringify(blocks)).toContain('지난 검증 10건 중 7건 적중 (70%)');
+  });
+});

--- a/src/agents/insight/index.ts
+++ b/src/agents/insight/index.ts
@@ -5,6 +5,7 @@ import { queryOne } from '../../shared/db.js';
 import { getTodayISO, getEffectiveTodayISO, addDays } from '../../shared/kst.js';
 import { resolveUserId, DEFAULT_USER_ID } from '../../shared/user-resolver.js';
 import { saveDiaryEntry, pickDiaryConfirmation, naturalDelay } from './diary-fast-path.js';
+import { tryLlmInsightFastPath } from './llm-insight-fast-path.js';
 import { formatFortuneText } from '../../shared/fortune-format.js';
 
 // ─── fast path 패턴 ──────────────────────────────────
@@ -139,6 +140,9 @@ export const createInsightAgent = (_llmClient: LLMClient): AgentHandler => {
 
     // ── fast path: 운세 조회 ──
     if (await tryFortuneFastPath(trimmed, say, userId)) return;
+
+    // ── fast path: LLM 자율 발견 조회 ──
+    if (await tryLlmInsightFastPath(trimmed, say, userId)) return;
 
     // ── fast path: 오늘 일기 조회 ──
     if (TODAY_DIARY_RE.test(trimmed)) {

--- a/src/agents/insight/llm-insight-fast-path.ts
+++ b/src/agents/insight/llm-insight-fast-path.ts
@@ -1,0 +1,191 @@
+/**
+ * 프로액티브 인사이트 v2 Phase 2 — LLM 자율 발견 조회 fast path + Slack 메시지 빌더.
+ *
+ * 사용자 자연어 ("발견 검증", "정확도", "LLM 어땠어") → 누적 통계 + 최근 발견 N개.
+ * Cron이 신규 발견을 발송할 때도 동일 모듈의 빌더 사용 (점진적 노출 로직 포함).
+ */
+
+import type { AgentHandler } from '../../router.js';
+import type { KnownBlock } from '@slack/types';
+import { query } from '../../shared/db.js';
+import { sendMessage } from '../../shared/slack.js';
+import type { InsightSlot } from '../../shared/llm-insights.js';
+import type { LlmInsightDraft } from '../../shared/llm-insight-prompts.js';
+
+const LLM_INSIGHT_FAST_PATH_RE = /(발견.*검증|정확도|LLM.*(어땠|어때|어떻게))/i;
+const VERIFIED_THRESHOLD_FOR_DISCLOSURE = 10;
+const RECENT_INSIGHTS_LIMIT = 5;
+
+interface OutcomeCountRow {
+  outcome: string;
+  cnt: string;
+}
+
+interface RecentInsightRow {
+  discovered_at: string;
+  slot: string;
+  signal_text: string;
+  hypothesis_text: string;
+  confidence: string;
+  outcome: string;
+  verified_at: string | null;
+}
+
+interface AccuracyStats {
+  totalVerified: number;
+  hit: number;
+  miss: number;
+  inconclusive: number;
+  pending: number;
+  hitRate: number | null;
+}
+
+const queryAccuracyStats = async (userId: number): Promise<AccuracyStats> => {
+  const result = await query<OutcomeCountRow>(
+    `SELECT outcome, COUNT(*)::text AS cnt
+     FROM llm_insights
+     WHERE user_id = $1
+     GROUP BY outcome`,
+    [userId],
+  );
+
+  const counts = { hit: 0, miss: 0, inconclusive: 0, pending: 0 };
+  for (const row of result.rows) {
+    const n = Number(row.cnt);
+    if (row.outcome === 'hit') counts.hit = n;
+    else if (row.outcome === 'miss') counts.miss = n;
+    else if (row.outcome === 'inconclusive') counts.inconclusive = n;
+    else if (row.outcome === 'pending') counts.pending = n;
+  }
+  const totalVerified = counts.hit + counts.miss;
+  const hitRate = totalVerified > 0 ? Math.round((counts.hit / totalVerified) * 100) : null;
+  return { ...counts, totalVerified, hitRate };
+};
+
+const queryRecentInsights = async (userId: number, limit: number): Promise<RecentInsightRow[]> => {
+  const result = await query<RecentInsightRow>(
+    `SELECT discovered_at::text, slot, signal_text, hypothesis_text, confidence, outcome,
+            verified_at::text
+     FROM llm_insights
+     WHERE user_id = $1
+     ORDER BY discovered_at DESC
+     LIMIT $2`,
+    [userId, limit],
+  );
+  return result.rows;
+};
+
+const formatOutcomeLabel = (outcome: string): string => {
+  if (outcome === 'hit') return '적중';
+  if (outcome === 'miss') return '빗나감';
+  if (outcome === 'inconclusive') return '판정 불가';
+  return '검증 대기';
+};
+
+const buildAccuracyLine = (stats: AccuracyStats): string => {
+  if (stats.totalVerified === 0) {
+    return `누적 검증: 0건 (대기 ${stats.pending}건)`;
+  }
+  return `누적 검증 ${stats.totalVerified}건 중 ${stats.hit}건 적중 (${stats.hitRate ?? 0}%) — 대기 ${stats.pending}건, 판정불가 ${stats.inconclusive}건`;
+};
+
+const buildRecentBlock = (rows: RecentInsightRow[]): KnownBlock => {
+  if (rows.length === 0) {
+    return {
+      type: 'section',
+      text: { type: 'mrkdwn', text: '아직 발견된 패턴이 없어. 다음 슬롯을 기다려보자.' },
+    };
+  }
+  const lines = rows.map((r) => {
+    const date = r.discovered_at.slice(0, 10);
+    const outcomeLabel = formatOutcomeLabel(r.outcome);
+    return `• \`${date}\` ${outcomeLabel} (${r.slot})\n  시그널: ${r.signal_text}\n  가설: ${r.hypothesis_text}`;
+  });
+  return {
+    type: 'section',
+    text: { type: 'mrkdwn', text: `*최근 발견 ${rows.length}건*\n${lines.join('\n\n')}` },
+  };
+};
+
+/** fast path 매칭. 매칭되면 응답 후 true. */
+export const tryLlmInsightFastPath = async (
+  trimmed: string,
+  say: Parameters<AgentHandler>[1],
+  userId: number,
+): Promise<boolean> => {
+  if (!LLM_INSIGHT_FAST_PATH_RE.test(trimmed)) return false;
+
+  try {
+    const [stats, recent] = await Promise.all([
+      queryAccuracyStats(userId),
+      queryRecentInsights(userId, RECENT_INSIGHTS_LIMIT),
+    ]);
+
+    const blocks: KnownBlock[] = [
+      { type: 'header', text: { type: 'plain_text', text: 'LLM 자율 발견 현황', emoji: false } },
+      { type: 'section', text: { type: 'mrkdwn', text: buildAccuracyLine(stats) } },
+      { type: 'divider' },
+      buildRecentBlock(recent),
+    ];
+
+    await say({ text: 'LLM 자율 발견 현황', blocks });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error('[Insight Agent] LLM 발견 조회 fast path 오류:', msg);
+    await sendMessage(say, 'LLM 자율 발견 조회 중 오류가 발생했어.');
+  }
+  return true;
+};
+
+// ─── Cron용 빌더 ───────────────────────────────────────
+
+export interface LlmInsightSlackMessage {
+  headerText: string;
+  blocks: KnownBlock[];
+}
+
+const formatSlotLabel = (slot: InsightSlot): string => (slot === 'weekly' ? '주간' : '월간');
+
+/**
+ * 누적 검증 10건 도달 후 첫 줄에 정확도 표시 (점진적 노출).
+ * 임계 미달이면 신규 발견만 표시.
+ */
+export const buildLlmInsightSlackMessage = async (
+  userId: number,
+  slot: InsightSlot,
+  drafts: LlmInsightDraft[],
+): Promise<LlmInsightSlackMessage> => {
+  const slotLabel = formatSlotLabel(slot);
+  const headerText = `${slotLabel} LLM 자율 발견 ${drafts.length}건`;
+
+  const stats = await queryAccuracyStats(userId);
+
+  const blocks: KnownBlock[] = [
+    { type: 'header', text: { type: 'plain_text', text: headerText, emoji: false } },
+  ];
+
+  if (stats.totalVerified >= VERIFIED_THRESHOLD_FOR_DISCLOSURE) {
+    blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `지난 검증 ${stats.totalVerified}건 중 ${stats.hit}건 적중 (${stats.hitRate ?? 0}%)`,
+        },
+      ],
+    });
+  }
+
+  blocks.push({ type: 'divider' });
+
+  const findingsLines = drafts.map((d, i) => {
+    const verifyDays = d.verification.verifyAfterDays;
+    return `*${i + 1}. ${d.signal}*\n_가설_: ${d.hypothesis}\n_도메인_: ${d.domains.join(', ')} · ${verifyDays}일 후 자동 검증`;
+  });
+  blocks.push({
+    type: 'section',
+    text: { type: 'mrkdwn', text: findingsLines.join('\n\n') },
+  });
+
+  return { headerText, blocks };
+};

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -47,6 +47,9 @@ import {
 } from '../agents/life/blocks.js';
 import { pickMorningNudges, pickNightNudges } from '../shared/insights.js';
 import { weeklyReportTask } from './weekly-report.js';
+import { weeklyLlmInsightTask } from './weekly-llm-insight.js';
+import { monthlyLlmInsightTask } from './monthly-llm-insight.js';
+import { verifyLlmInsightsTask } from './verify-llm-insights.js';
 import { buildLifeContext } from '../shared/life-context.js';
 import { publishHomeView } from '../agents/life/home.js';
 
@@ -646,6 +649,11 @@ const SLOT_TASKS: Record<string, CronTaskFn> = {
   weeklyReport: weeklyReportTask,
   insightMorning: insightMorningTask,
   insightNight: insightNightTask,
+  weeklyLlmInsight: weeklyLlmInsightTask,
+  monthlyLlmInsight: monthlyLlmInsightTask,
+  verifyLlmInsights: async () => {
+    await verifyLlmInsightsTask();
+  },
 };
 
 // ─── CronScheduler 클래스 ───────────────────────────────

--- a/src/cron/monthly-llm-insight.ts
+++ b/src/cron/monthly-llm-insight.ts
@@ -1,0 +1,47 @@
+/**
+ * 프로액티브 인사이트 v2 Phase 2 — 월간 LLM 자율 발견 슬롯.
+ * 매월 1일 09:30 실행. 1일 아닌 날은 early return.
+ */
+
+import type { App } from '@slack/bolt';
+import type { LifeCronConfig } from './life-cron.js';
+import { runAutonomousAnalysis, persistLlmInsights } from '../shared/llm-insights.js';
+import { buildLlmInsightSlackMessage } from '../agents/insight/llm-insight-fast-path.js';
+import { postBlockMessage } from '../shared/slack.js';
+import { getKSTDayOfMonth } from '../shared/kst.js';
+import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
+
+export const monthlyLlmInsightTask = async (app: App, config: LifeCronConfig): Promise<void> => {
+  if (getKSTDayOfMonth() !== 1) return;
+
+  const mappings = await queryAllUserMappings();
+  const targets =
+    mappings.length > 0
+      ? mappings.map((m) => ({
+          userId: m.userId,
+          channelId: m.insightChannelId ?? m.slackUserId,
+        }))
+      : [{ userId: DEFAULT_USER_ID, channelId: process.env['INSIGHT_CHANNEL_ID'] ?? '' }];
+
+  for (const target of targets) {
+    if (!target.channelId) continue;
+    try {
+      const drafts = await runAutonomousAnalysis(config.llmClient, target.userId, 'monthly');
+      if (drafts.length === 0) {
+        console.warn(`[LLM Insight] 월간 발견 0건 (유저=${target.userId}) — 메시지 스킵`);
+        continue;
+      }
+      await persistLlmInsights(target.userId, 'monthly', drafts);
+      const { headerText, blocks } = await buildLlmInsightSlackMessage(
+        target.userId,
+        'monthly',
+        drafts,
+      );
+      await postBlockMessage(app.client, target.channelId, headerText, blocks);
+      console.warn(`[LLM Insight] 월간 발견 ${drafts.length}건 전송 (유저=${target.userId})`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[LLM Insight] 월간 실패 (유저=${target.userId}): ${msg}`);
+    }
+  }
+};

--- a/src/cron/verify-llm-insights.ts
+++ b/src/cron/verify-llm-insights.ts
@@ -1,0 +1,59 @@
+/**
+ * 프로액티브 인사이트 v2 Phase 2 — pending llm_insights를 후행 검증.
+ * 매일 09:10 실행. verify_at <= NOW()인 row 50건씩 처리.
+ */
+
+import { query } from '../shared/db.js';
+import { executeVerificationSql } from '../shared/llm-insight-verify.js';
+import type { InsightVerificationType } from '../shared/llm-insights.js';
+
+interface PendingRow {
+  id: number;
+  verification_sql: string;
+  verification_result_type: InsightVerificationType;
+}
+
+const BATCH_LIMIT = 50;
+
+export const verifyLlmInsightsTask = async (): Promise<void> => {
+  const result = await query<PendingRow>(
+    `SELECT id, verification_sql, verification_result_type
+     FROM llm_insights
+     WHERE outcome = 'pending' AND verify_at <= NOW()
+     ORDER BY verify_at ASC
+     LIMIT $1`,
+    [BATCH_LIMIT],
+  );
+
+  if (result.rows.length === 0) {
+    console.warn('[LLM Insight] 검증 대기 0건');
+    return;
+  }
+
+  let hitCount = 0;
+  let missCount = 0;
+  let inconclusiveCount = 0;
+
+  for (const row of result.rows) {
+    const { outcome, resultJson, errorText } = await executeVerificationSql(
+      row.verification_sql,
+      row.verification_result_type,
+    );
+    await query(
+      `UPDATE llm_insights
+         SET outcome = $1,
+             verified_at = NOW(),
+             verification_result_json = $2::jsonb,
+             verification_error = $3
+       WHERE id = $4`,
+      [outcome, resultJson ? JSON.stringify(resultJson) : null, errorText, row.id],
+    );
+    if (outcome === 'hit') hitCount++;
+    else if (outcome === 'miss') missCount++;
+    else inconclusiveCount++;
+  }
+
+  console.warn(
+    `[LLM Insight] 검증 완료: ${result.rows.length}건 (hit=${hitCount}, miss=${missCount}, inconclusive=${inconclusiveCount})`,
+  );
+};

--- a/src/cron/weekly-llm-insight.ts
+++ b/src/cron/weekly-llm-insight.ts
@@ -1,0 +1,47 @@
+/**
+ * 프로액티브 인사이트 v2 Phase 2 — 주간 LLM 자율 발견 슬롯.
+ * 매주 월요일 09:30 실행. 월요일 아닌 날은 early return.
+ */
+
+import type { App } from '@slack/bolt';
+import type { LifeCronConfig } from './life-cron.js';
+import { runAutonomousAnalysis, persistLlmInsights } from '../shared/llm-insights.js';
+import { buildLlmInsightSlackMessage } from '../agents/insight/llm-insight-fast-path.js';
+import { postBlockMessage } from '../shared/slack.js';
+import { getKSTDayOfWeek } from '../shared/kst.js';
+import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
+
+export const weeklyLlmInsightTask = async (app: App, config: LifeCronConfig): Promise<void> => {
+  if (getKSTDayOfWeek() !== 1) return;
+
+  const mappings = await queryAllUserMappings();
+  const targets =
+    mappings.length > 0
+      ? mappings.map((m) => ({
+          userId: m.userId,
+          channelId: m.insightChannelId ?? m.slackUserId,
+        }))
+      : [{ userId: DEFAULT_USER_ID, channelId: process.env['INSIGHT_CHANNEL_ID'] ?? '' }];
+
+  for (const target of targets) {
+    if (!target.channelId) continue;
+    try {
+      const drafts = await runAutonomousAnalysis(config.llmClient, target.userId, 'weekly');
+      if (drafts.length === 0) {
+        console.warn(`[LLM Insight] 주간 발견 0건 (유저=${target.userId}) — 메시지 스킵`);
+        continue;
+      }
+      await persistLlmInsights(target.userId, 'weekly', drafts);
+      const { headerText, blocks } = await buildLlmInsightSlackMessage(
+        target.userId,
+        'weekly',
+        drafts,
+      );
+      await postBlockMessage(app.client, target.channelId, headerText, blocks);
+      console.warn(`[LLM Insight] 주간 발견 ${drafts.length}건 전송 (유저=${target.userId})`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[LLM Insight] 주간 실패 (유저=${target.userId}): ${msg}`);
+    }
+  }
+};

--- a/src/shared/__tests__/llm-insight-verify.test.ts
+++ b/src/shared/__tests__/llm-insight-verify.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+
+vi.mock('pg', () => {
+  const MockPool = vi.fn(function (this: Record<string, unknown>) {
+    this.query = mockQuery;
+    this.connect = mockConnect;
+    this.end = vi.fn();
+  });
+  return { default: { Pool: MockPool, types: { setTypeParser: vi.fn() } } };
+});
+
+import { connectDB } from '../db.js';
+import { classifyOutcome, executeVerificationSql } from '../llm-insight-verify.js';
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockConnect.mockResolvedValue({
+    query: mockQuery,
+    release: vi.fn(),
+  });
+  await connectDB('postgresql://test@localhost/test');
+});
+
+describe('classifyOutcome', () => {
+  it('빈 결과는 inconclusive', () => {
+    expect(classifyOutcome([], 'boolean')).toBe('inconclusive');
+    expect(classifyOutcome([], 'scalar_count')).toBe('inconclusive');
+  });
+
+  it('첫 값이 null/undefined면 inconclusive', () => {
+    expect(classifyOutcome([{ pass: null }], 'boolean')).toBe('inconclusive');
+  });
+
+  describe('boolean', () => {
+    it('true → hit', () => {
+      expect(classifyOutcome([{ pass: true }], 'boolean')).toBe('hit');
+    });
+    it('false → miss', () => {
+      expect(classifyOutcome([{ pass: false }], 'boolean')).toBe('miss');
+    });
+    it('"t" 문자열 → hit (pg boolean serialization)', () => {
+      expect(classifyOutcome([{ pass: 't' }], 'boolean')).toBe('hit');
+    });
+    it('"true" 문자열 → hit', () => {
+      expect(classifyOutcome([{ pass: 'true' }], 'boolean')).toBe('hit');
+    });
+  });
+
+  describe('scalar_count', () => {
+    it('양수 → hit', () => {
+      expect(classifyOutcome([{ count: 5 }], 'scalar_count')).toBe('hit');
+      expect(classifyOutcome([{ count: '3' }], 'scalar_count')).toBe('hit');
+    });
+    it('0 → miss', () => {
+      expect(classifyOutcome([{ count: 0 }], 'scalar_count')).toBe('miss');
+      expect(classifyOutcome([{ count: '0' }], 'scalar_count')).toBe('miss');
+    });
+  });
+
+  describe('ratio', () => {
+    it('양수 → hit', () => {
+      expect(classifyOutcome([{ r: 0.5 }], 'ratio')).toBe('hit');
+    });
+    it('0 → miss', () => {
+      expect(classifyOutcome([{ r: 0 }], 'ratio')).toBe('miss');
+    });
+  });
+});
+
+describe('executeVerificationSql', () => {
+  it('SQL 에러 시 inconclusive + errorText', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.startsWith('SET statement_timeout')) return Promise.resolve({});
+      throw new Error('syntax error at or near "FRO"');
+    });
+
+    const result = await executeVerificationSql('SELECT FRO bad', 'boolean');
+    expect(result.outcome).toBe('inconclusive');
+    expect(result.errorText).toContain('syntax error');
+    expect(result.resultJson).toBeNull();
+  });
+
+  it('정상 boolean true → hit', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.startsWith('SET statement_timeout')) return Promise.resolve({});
+      return Promise.resolve({ rows: [{ pass: true }], rowCount: 1 });
+    });
+
+    const result = await executeVerificationSql('SELECT true AS pass', 'boolean');
+    expect(result.outcome).toBe('hit');
+    expect(result.errorText).toBeNull();
+  });
+
+  it('빈 row → inconclusive', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.startsWith('SET statement_timeout')) return Promise.resolve({});
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+
+    const result = await executeVerificationSql('SELECT 1 WHERE false', 'scalar_count');
+    expect(result.outcome).toBe('inconclusive');
+  });
+});

--- a/src/shared/__tests__/llm-insights.test.ts
+++ b/src/shared/__tests__/llm-insights.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { validateLlmInsightResponse } from '../llm-insight-prompts.js';
+
+const validResponse = JSON.stringify({
+  findings: [
+    {
+      signal: '지난 28일 평균 취침 1.2시',
+      hypothesis: '다음 7일 아침 루틴 달성률 10%p 이상 감소',
+      domains: ['sleep', 'routine'],
+      confidence: 'medium',
+      verification: {
+        sql: 'SELECT COUNT(*) FROM routine_records WHERE user_id = 1',
+        result_type: 'scalar_count',
+        verify_after_days: 7,
+      },
+    },
+  ],
+});
+
+describe('validateLlmInsightResponse', () => {
+  it('정상 응답을 파싱한다', () => {
+    const drafts = validateLlmInsightResponse(validResponse);
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]).toMatchObject({
+      signal: '지난 28일 평균 취침 1.2시',
+      hypothesis: '다음 7일 아침 루틴 달성률 10%p 이상 감소',
+      domains: ['sleep', 'routine'],
+      confidence: 'medium',
+    });
+    expect(drafts[0]?.verification.resultType).toBe('scalar_count');
+    expect(drafts[0]?.verification.verifyAfterDays).toBe(7);
+  });
+
+  it('빈 문자열은 빈 배열', () => {
+    expect(validateLlmInsightResponse('')).toEqual([]);
+  });
+
+  it('JSON 파싱 실패 시 빈 배열', () => {
+    expect(validateLlmInsightResponse('not json')).toEqual([]);
+    expect(validateLlmInsightResponse('{malformed')).toEqual([]);
+  });
+
+  it('findings가 배열 아니면 빈 배열', () => {
+    expect(validateLlmInsightResponse('{"findings": "x"}')).toEqual([]);
+    expect(validateLlmInsightResponse('{}')).toEqual([]);
+  });
+
+  it('SQL에 DELETE 포함 시 해당 finding 제외', () => {
+    const payload = JSON.stringify({
+      findings: [
+        {
+          signal: 'x',
+          hypothesis: 'y',
+          domains: ['sleep'],
+          confidence: 'high',
+          verification: {
+            sql: 'DELETE FROM users; SELECT 1',
+            result_type: 'boolean',
+            verify_after_days: 5,
+          },
+        },
+      ],
+    });
+    expect(validateLlmInsightResponse(payload)).toEqual([]);
+  });
+
+  it('SQL에 DROP/TRUNCATE/ALTER 포함 시 제외', () => {
+    const cases = ['DROP TABLE x', 'TRUNCATE x', 'ALTER TABLE x', 'INSERT INTO x VALUES(1)'];
+    for (const sql of cases) {
+      const payload = JSON.stringify({
+        findings: [
+          {
+            signal: 'x',
+            hypothesis: 'y',
+            domains: ['sleep'],
+            confidence: 'medium',
+            verification: { sql, result_type: 'scalar_count', verify_after_days: 7 },
+          },
+        ],
+      });
+      expect(validateLlmInsightResponse(payload), sql).toEqual([]);
+    }
+  });
+
+  it('result_type 화이트리스트 외 값은 제외', () => {
+    const payload = JSON.stringify({
+      findings: [
+        {
+          signal: 'x',
+          hypothesis: 'y',
+          domains: ['sleep'],
+          confidence: 'medium',
+          verification: { sql: 'SELECT 1', result_type: 'text', verify_after_days: 7 },
+        },
+      ],
+    });
+    expect(validateLlmInsightResponse(payload)).toEqual([]);
+  });
+
+  it('verify_after_days 범위 외 값은 1~28로 클램프', () => {
+    const buildPayload = (days: number): string =>
+      JSON.stringify({
+        findings: [
+          {
+            signal: 'x',
+            hypothesis: 'y',
+            domains: ['sleep'],
+            confidence: 'medium',
+            verification: { sql: 'SELECT 1', result_type: 'boolean', verify_after_days: days },
+          },
+        ],
+      });
+
+    expect(validateLlmInsightResponse(buildPayload(0))[0]?.verification.verifyAfterDays).toBe(1);
+    expect(validateLlmInsightResponse(buildPayload(-5))[0]?.verification.verifyAfterDays).toBe(1);
+    expect(validateLlmInsightResponse(buildPayload(100))[0]?.verification.verifyAfterDays).toBe(28);
+    expect(validateLlmInsightResponse(buildPayload(14))[0]?.verification.verifyAfterDays).toBe(14);
+  });
+
+  it('confidence가 low면 제외 (medium/high만 허용)', () => {
+    const payload = JSON.stringify({
+      findings: [
+        {
+          signal: 'x',
+          hypothesis: 'y',
+          domains: ['sleep'],
+          confidence: 'low',
+          verification: { sql: 'SELECT 1', result_type: 'boolean', verify_after_days: 7 },
+        },
+      ],
+    });
+    expect(validateLlmInsightResponse(payload)).toEqual([]);
+  });
+
+  it('signal/hypothesis/domains 누락 시 제외', () => {
+    const base = {
+      signal: 'x',
+      hypothesis: 'y',
+      domains: ['sleep'],
+      confidence: 'medium',
+      verification: { sql: 'SELECT 1', result_type: 'boolean', verify_after_days: 7 },
+    };
+    const missingSignal = { ...base, signal: '' };
+    const missingDomains = { ...base, domains: [] };
+    expect(validateLlmInsightResponse(JSON.stringify({ findings: [missingSignal] }))).toEqual([]);
+    expect(validateLlmInsightResponse(JSON.stringify({ findings: [missingDomains] }))).toEqual([]);
+  });
+
+  it('JSON 앞뒤에 부가 텍스트가 있어도 추출', () => {
+    const wrapped = `여기 분석 결과야:\n${validResponse}\n끝.`;
+    const drafts = validateLlmInsightResponse(wrapped);
+    expect(drafts).toHaveLength(1);
+  });
+});

--- a/src/shared/kst.ts
+++ b/src/shared/kst.ts
@@ -60,6 +60,9 @@ export const getKSTTimeString = (): string => {
 /** KST 기준 요일 번호 (0=일 ~ 6=토) */
 export const getKSTDayOfWeek = (): number => getKSTDate().getDay();
 
+/** KST 기준 일자 (1~31) */
+export const getKSTDayOfMonth = (): number => getKSTDate().getDate();
+
 /**
  * 생활 기준 "오늘" 날짜 (YYYY-MM-DD).
  * 새벽 5시 이전이면 아직 전날로 취급 — 올빼미형 사용자 대응.
@@ -84,8 +87,13 @@ export const getEffectiveTodayISO = (): string => {
  * YYYY-MM-DD 문자열 → KST 기준 날짜 컴포넌트.
  * 정오 KST(= 03:00 UTC)로 파싱해 UTC 메서드 사용 시 날짜 경계 문제 방지.
  */
-const parseKSTDateStr = (dateStr: string): {
-  year: number; month: number; day: number; dow: number;
+const parseKSTDateStr = (
+  dateStr: string,
+): {
+  year: number;
+  month: number;
+  day: number;
+  dow: number;
 } => {
   const parts = dateStr.split('-');
   const year = Number(parts[0]);

--- a/src/shared/llm-insight-prompts.ts
+++ b/src/shared/llm-insight-prompts.ts
@@ -1,0 +1,401 @@
+/**
+ * 프로액티브 인사이트 v2 Phase 2 — LLM 자율 분석 prompt + 컨텍스트 빌더 + 응답 검증.
+ *
+ * 컨텍스트는 schedule/sleep/routine/expense 4개 도메인으로 제한.
+ * 텍스트(일정 제목·일기·메모)와 금액은 포함하지 않는다 — 노출 표면 최소화.
+ *
+ * ADR-0016 안전장치 4종:
+ * 1) JSON 파싱 실패 → 빈 배열 (cron 메시지 스킵)
+ * 2) verification.sql에 DDL/DML 키워드 → 해당 finding 제외
+ * 3) result_type 화이트리스트
+ * 4) verify_after_days 1~28 클램프
+ */
+
+import { query } from './db.js';
+import { getTodayISO, addDays } from './kst.js';
+import type { InsightSlot, InsightConfidence, InsightVerificationType } from './llm-insights.js';
+
+export interface LlmInsightDraft {
+  signal: string;
+  hypothesis: string;
+  domains: string[];
+  confidence: InsightConfidence;
+  verification: {
+    sql: string;
+    resultType: InsightVerificationType;
+    verifyAfterDays: number;
+  };
+}
+
+export interface LlmInsightContext {
+  text: string;
+  windowDays: number;
+}
+
+const WEEKLY_WINDOW_DAYS = 28;
+const MONTHLY_WINDOW_DAYS = 90;
+
+// ─── 컨텍스트: 수면 ────────────────────────────────────
+
+interface SleepAggRow {
+  avg_duration: string | null;
+  avg_bedtime_hour: string | null;
+  avg_wake_hour: string | null;
+  night_count: string;
+  late_night_count: string;
+  short_sleep_count: string;
+}
+
+const buildSleepContext = async (
+  userId: number,
+  windowStart: string,
+  windowEnd: string,
+): Promise<string> => {
+  const result = await query<SleepAggRow>(
+    `SELECT
+       ROUND(AVG(duration_minutes))::text AS avg_duration,
+       ROUND(AVG(
+         CASE WHEN bedtime::time < '06:00'
+              THEN EXTRACT(HOUR FROM bedtime::time) + 24 + EXTRACT(MINUTE FROM bedtime::time) / 60.0
+              ELSE EXTRACT(HOUR FROM bedtime::time) + EXTRACT(MINUTE FROM bedtime::time) / 60.0
+         END
+       ), 1)::text AS avg_bedtime_hour,
+       ROUND(AVG(EXTRACT(HOUR FROM wake_time::time) + EXTRACT(MINUTE FROM wake_time::time) / 60.0), 1)::text AS avg_wake_hour,
+       COUNT(*)::text AS night_count,
+       COUNT(*) FILTER (WHERE bedtime::time >= '00:00' AND bedtime::time < '06:00')::text AS late_night_count,
+       COUNT(*) FILTER (WHERE duration_minutes < 360)::text AS short_sleep_count
+     FROM sleep_records
+     WHERE sleep_type = 'night' AND user_id = $1
+       AND date BETWEEN $2 AND $3
+       AND duration_minutes IS NOT NULL
+       AND bedtime IS NOT NULL`,
+    [userId, windowStart, windowEnd],
+  );
+
+  const row = result.rows[0];
+  if (!row || Number(row.night_count) === 0) return '- 수면: 기록 없음';
+
+  const parts: string[] = [];
+  parts.push(`평균 ${Math.round(Number(row.avg_duration ?? 0))}분`);
+  if (row.avg_bedtime_hour) parts.push(`평균 취침 ${row.avg_bedtime_hour}시`);
+  if (row.avg_wake_hour) parts.push(`평균 기상 ${row.avg_wake_hour}시`);
+  parts.push(`기록 ${row.night_count}일`);
+  parts.push(`자정 이후 취침 ${row.late_night_count}일`);
+  parts.push(`6시간 미만 ${row.short_sleep_count}일`);
+  return `- 수면: ${parts.join(', ')}`;
+};
+
+// ─── 컨텍스트: 루틴 ────────────────────────────────────
+
+interface RoutineAggRow {
+  total: string;
+  completed: string;
+  morning_total: string;
+  morning_done: string;
+  day_total: string;
+  day_done: string;
+  night_total: string;
+  night_done: string;
+  spotty_days: string;
+}
+
+const buildRoutineContext = async (
+  userId: number,
+  windowStart: string,
+  windowEnd: string,
+): Promise<string> => {
+  const result = await query<RoutineAggRow>(
+    `WITH base AS (
+       SELECT r.date, r.completed, t.time_slot
+       FROM routine_records r
+       JOIN routine_templates t ON r.template_id = t.id
+       WHERE r.user_id = $1 AND r.date BETWEEN $2 AND $3
+     ),
+     daily AS (
+       SELECT date,
+              COUNT(*) FILTER (WHERE completed)::numeric / NULLIF(COUNT(*), 0) AS rate
+       FROM base GROUP BY date
+     )
+     SELECT
+       COUNT(*)::text AS total,
+       COUNT(*) FILTER (WHERE completed)::text AS completed,
+       COUNT(*) FILTER (WHERE time_slot = '아침')::text AS morning_total,
+       COUNT(*) FILTER (WHERE time_slot = '아침' AND completed)::text AS morning_done,
+       COUNT(*) FILTER (WHERE time_slot = '낮')::text AS day_total,
+       COUNT(*) FILTER (WHERE time_slot = '낮' AND completed)::text AS day_done,
+       COUNT(*) FILTER (WHERE time_slot = '밤')::text AS night_total,
+       COUNT(*) FILTER (WHERE time_slot = '밤' AND completed)::text AS night_done,
+       (SELECT COUNT(*)::text FROM daily WHERE rate > 0 AND rate < 1) AS spotty_days
+     FROM base`,
+    [userId, windowStart, windowEnd],
+  );
+
+  const row = result.rows[0];
+  if (!row || Number(row.total) === 0) return '- 루틴: 기록 없음';
+
+  const rate = (done: number, total: number): string =>
+    total === 0 ? 'N/A' : `${Math.round((done / total) * 100)}%`;
+
+  const total = Number(row.total);
+  const completed = Number(row.completed);
+  const parts: string[] = [];
+  parts.push(`전체 ${rate(completed, total)} (${completed}/${total})`);
+  parts.push(`아침 ${rate(Number(row.morning_done), Number(row.morning_total))}`);
+  parts.push(`낮 ${rate(Number(row.day_done), Number(row.day_total))}`);
+  parts.push(`밤 ${rate(Number(row.night_done), Number(row.night_total))}`);
+  parts.push(`산발 빠짐 ${row.spotty_days}일`);
+  return `- 루틴: ${parts.join(', ')}`;
+};
+
+// ─── 컨텍스트: 일정 ────────────────────────────────────
+
+interface ScheduleCatRow {
+  category: string;
+  total: string;
+  done: string;
+  cancelled: string;
+}
+
+const buildScheduleContext = async (
+  userId: number,
+  windowStart: string,
+  windowEnd: string,
+): Promise<string> => {
+  const result = await query<ScheduleCatRow>(
+    `SELECT
+       COALESCE(p.name, c.name, '미분류') AS category,
+       COUNT(*)::text AS total,
+       COUNT(*) FILTER (WHERE s.status = 'done')::text AS done,
+       COUNT(*) FILTER (WHERE s.status = 'cancelled')::text AS cancelled
+     FROM schedules s
+     LEFT JOIN categories c ON c.id = s.category_id
+     LEFT JOIN categories p ON p.id = c.parent_id
+     WHERE s.user_id = $1 AND s.date BETWEEN $2 AND $3
+       AND COALESCE(c.type, p.type, 'task') = 'task'
+     GROUP BY COALESCE(p.name, c.name)
+     ORDER BY COUNT(*) DESC
+     LIMIT 8`,
+    [userId, windowStart, windowEnd],
+  );
+
+  if (result.rows.length === 0) return '- 일정: 기록 없음';
+
+  const lines = result.rows.map((r) => {
+    const total = Number(r.total);
+    const done = Number(r.done);
+    const cancelled = Number(r.cancelled);
+    const rate = total > 0 ? Math.round((done / total) * 100) : 0;
+    return `  · ${r.category}: ${total}건 (완료 ${rate}%, 취소 ${cancelled})`;
+  });
+  return `- 일정 카테고리 분포:\n${lines.join('\n')}`;
+};
+
+// ─── 컨텍스트: 지출 ────────────────────────────────────
+
+interface ExpenseCatRow {
+  category: string;
+  count: string;
+  active_days: string;
+}
+
+const buildExpenseContext = async (
+  userId: number,
+  windowStart: string,
+  windowEnd: string,
+): Promise<string> => {
+  const result = await query<ExpenseCatRow>(
+    `SELECT
+       COALESCE(p.name, c.name, '미분류') AS category,
+       COUNT(*)::text AS count,
+       COUNT(DISTINCT e.date)::text AS active_days
+     FROM expenses e
+     LEFT JOIN categories c ON c.id = e.category_id
+     LEFT JOIN categories p ON p.id = c.parent_id
+     WHERE e.user_id = $1 AND e.date BETWEEN $2 AND $3
+       AND COALESCE(e.type, 'expense') = 'expense'
+       AND e.exclude_from_budget = false
+     GROUP BY COALESCE(p.name, c.name)
+     ORDER BY COUNT(*) DESC
+     LIMIT 8`,
+    [userId, windowStart, windowEnd],
+  );
+
+  if (result.rows.length === 0) return '- 지출: 기록 없음';
+
+  const lines = result.rows.map((r) => `  · ${r.category}: ${r.count}회 (${r.active_days}일 발생)`);
+  return `- 지출 카테고리 빈도 (금액 제외):\n${lines.join('\n')}`;
+};
+
+// ─── 컨텍스트 통합 빌더 ────────────────────────────────
+
+export const buildLlmInsightContext = async (
+  userId: number,
+  slot: InsightSlot,
+): Promise<LlmInsightContext> => {
+  const windowDays = slot === 'weekly' ? WEEKLY_WINDOW_DAYS : MONTHLY_WINDOW_DAYS;
+  const today = getTodayISO();
+  const windowStart = addDays(today, -windowDays);
+  const windowEnd = addDays(today, -1);
+
+  const [sleep, routine, schedule, expense] = await Promise.all([
+    buildSleepContext(userId, windowStart, windowEnd),
+    buildRoutineContext(userId, windowStart, windowEnd),
+    buildScheduleContext(userId, windowStart, windowEnd),
+    buildExpenseContext(userId, windowStart, windowEnd),
+  ]);
+
+  const text = [
+    `## 분석 기간`,
+    `${windowStart} ~ ${windowEnd} (${windowDays}일)`,
+    ``,
+    `## 도메인 컨텍스트`,
+    sleep,
+    routine,
+    schedule,
+    expense,
+    ``,
+    `## 작업`,
+    `위 데이터에서 cross-domain 패턴이나 잠재 변화를 발견하면 출력 형식대로 JSON을 반환해.`,
+    `잡음이거나 확신이 약하면 findings 배열을 비우거나 high/medium 확신 발견만 골라.`,
+  ].join('\n');
+
+  return { text, windowDays };
+};
+
+// ─── 시스템 프롬프트 ───────────────────────────────────
+
+export const systemPromptForAutonomousAnalysis = (slot: InsightSlot): string => {
+  const windowDesc = slot === 'weekly' ? '지난 28일' : '지난 90일';
+  return `너는 한 사용자의 ${windowDesc} 생활 데이터(수면·루틴·일정·지출)를 보고 cross-domain 패턴이나 잠재 변화를 발견하는 분석가야.
+
+발견은 반드시 다음 두 조건을 만족해야 한다:
+1) 단순 집계 요약이 아닌, 한 도메인의 변화가 다른 도메인에 미치는 영향에 대한 가설
+2) SELECT 한 줄로 hit/miss를 자동 판정할 수 있는 검증 가능한 가설
+
+출력은 반드시 아래 JSON 형식 (다른 텍스트 금지):
+{
+  "findings": [
+    {
+      "signal": "관측된 현상 (예: '지난 28일 평균 취침 1.2시(직전 28일 0.5시 대비 +42분)')",
+      "hypothesis": "검증 가능한 가설 (예: '다음 7일 아침 루틴 달성률이 직전 28일 평균 대비 10%p 이상 낮을 것')",
+      "domains": ["sleep", "routine"],
+      "confidence": "high|medium",
+      "verification": {
+        "sql": "SELECT (검증식) FROM ... WHERE user_id = 1 AND ...",
+        "result_type": "boolean|scalar_count|ratio",
+        "verify_after_days": 7
+      }
+    }
+  ]
+}
+
+## 검증 SQL 규칙
+- 반드시 SELECT 하나 (DDL/DML 금지 — INSERT/UPDATE/DELETE/DROP/TRUNCATE/ALTER/CREATE 사용 불가)
+- 결과는 한 줄, 한 값으로 떨어져야 함
+  - boolean: SELECT (expr) AS pass — true면 hit
+  - scalar_count: SELECT COUNT(*) — 0보다 크면 hit (가설 임계를 SQL의 WHERE 안에 포함)
+  - ratio: SELECT (수/분모) — 0보다 크면 hit (가설 임계는 SQL의 HAVING/WHERE 안에 포함)
+- verify_after_days는 1~28 사이, 가설 성격에 맞게 결정 (단기 동조 = 7, 누적 패턴 = 28)
+- user_id는 컨텍스트에서 받은 값을 그대로 하드코딩 (질문에 user_id가 주어짐)
+
+## 도메인 컨텍스트 한계
+- 일정 제목·일기 내용·사주·금액은 컨텍스트에 없다 — 추측 금지
+- 사용 가능 컬럼: schedules(category_id, status, date, time), sleep_records(bedtime, wake_time, duration_minutes, date), routine_records(template_id, completed, date) + routine_templates(time_slot), expenses(category_id, date) — expenses.amount 사용 금지
+
+## 출력 톤
+- findings는 0~3개 (너무 많으면 잡음). 확신 없으면 비워라
+- low 확신은 출력 자체에서 제외 (medium 이상만)`;
+};
+
+// ─── 응답 검증 (안전장치 4종) ──────────────────────────
+
+interface RawFinding {
+  signal?: unknown;
+  hypothesis?: unknown;
+  domains?: unknown;
+  confidence?: unknown;
+  verification?: {
+    sql?: unknown;
+    result_type?: unknown;
+    verify_after_days?: unknown;
+  };
+}
+
+const FORBIDDEN_SQL = /\b(insert|update|delete|drop|truncate|alter|create|grant|revoke)\b/i;
+const ALLOWED_RESULT_TYPES: ReadonlySet<InsightVerificationType> = new Set([
+  'boolean',
+  'scalar_count',
+  'ratio',
+]);
+const ALLOWED_CONFIDENCE: ReadonlySet<InsightConfidence> = new Set(['high', 'medium']);
+
+const clampVerifyDays = (raw: number): number => {
+  const rounded = Math.round(raw);
+  if (rounded < 1) return 1;
+  if (rounded > 28) return 28;
+  return rounded;
+};
+
+const extractJsonObject = (text: string): string | null => {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) return trimmed;
+  const start = trimmed.indexOf('{');
+  const end = trimmed.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) return null;
+  return trimmed.slice(start, end + 1);
+};
+
+export const validateLlmInsightResponse = (text: string): LlmInsightDraft[] => {
+  const jsonStr = extractJsonObject(text);
+  if (!jsonStr) return [];
+
+  let parsed: { findings?: unknown };
+  try {
+    parsed = JSON.parse(jsonStr) as { findings?: unknown };
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(parsed.findings)) return [];
+
+  const drafts: LlmInsightDraft[] = [];
+  for (const raw of parsed.findings as RawFinding[]) {
+    if (typeof raw !== 'object' || raw === null) continue;
+
+    const signal = typeof raw.signal === 'string' ? raw.signal.trim() : '';
+    const hypothesis = typeof raw.hypothesis === 'string' ? raw.hypothesis.trim() : '';
+    const confidenceVal = typeof raw.confidence === 'string' ? raw.confidence : '';
+    if (!signal || !hypothesis) continue;
+    if (!ALLOWED_CONFIDENCE.has(confidenceVal as InsightConfidence)) continue;
+
+    const domains = Array.isArray(raw.domains)
+      ? raw.domains.filter((d): d is string => typeof d === 'string' && d.length > 0)
+      : [];
+    if (domains.length === 0) continue;
+
+    const v = raw.verification;
+    if (!v || typeof v !== 'object') continue;
+    const sql = typeof v.sql === 'string' ? v.sql.trim() : '';
+    const resultType = typeof v.result_type === 'string' ? v.result_type : '';
+    const verifyDaysRaw = typeof v.verify_after_days === 'number' ? v.verify_after_days : NaN;
+
+    if (!sql) continue;
+    if (FORBIDDEN_SQL.test(sql)) continue;
+    if (!ALLOWED_RESULT_TYPES.has(resultType as InsightVerificationType)) continue;
+    if (!Number.isFinite(verifyDaysRaw)) continue;
+
+    drafts.push({
+      signal,
+      hypothesis,
+      domains,
+      confidence: confidenceVal as InsightConfidence,
+      verification: {
+        sql,
+        resultType: resultType as InsightVerificationType,
+        verifyAfterDays: clampVerifyDays(verifyDaysRaw),
+      },
+    });
+  }
+
+  return drafts;
+};

--- a/src/shared/llm-insight-verify.ts
+++ b/src/shared/llm-insight-verify.ts
@@ -1,0 +1,73 @@
+/**
+ * 프로액티브 인사이트 v2 Phase 2 — LLM 자율 발견의 검증 SQL을 실행해 hit/miss/inconclusive 판정.
+ *
+ * 안전장치: 검증 SQL은 영속 시점에서 이미 SELECT-only로 검증됨 (llm-insight-prompts.ts).
+ * 여기서는 statement_timeout 적용 + 결과 형식별 분류만 수행.
+ */
+
+import { queryWithClient } from './db.js';
+import type { InsightVerificationType } from './llm-insights.js';
+
+export type InsightOutcome = 'hit' | 'miss' | 'inconclusive';
+
+export interface VerifyResult {
+  outcome: InsightOutcome;
+  resultJson: unknown;
+  errorText: string | null;
+}
+
+const VERIFY_TIMEOUT_MS = 5_000;
+
+const isTruthy = (val: unknown): boolean => {
+  if (typeof val === 'boolean') return val;
+  if (typeof val === 'number') return val > 0;
+  if (typeof val === 'string') return val === 't' || val === 'true' || val === '1';
+  return false;
+};
+
+const isPositiveNumber = (val: unknown): boolean => {
+  if (typeof val === 'number') return val > 0;
+  if (typeof val === 'string') {
+    const n = Number(val);
+    return Number.isFinite(n) && n > 0;
+  }
+  return false;
+};
+
+export const classifyOutcome = (
+  rows: Record<string, unknown>[],
+  resultType: InsightVerificationType,
+): InsightOutcome => {
+  if (rows.length === 0) return 'inconclusive';
+  const firstRow = rows[0];
+  if (!firstRow) return 'inconclusive';
+  const firstValue = Object.values(firstRow)[0];
+  if (firstValue === undefined || firstValue === null) return 'inconclusive';
+
+  if (resultType === 'boolean') {
+    return isTruthy(firstValue) ? 'hit' : 'miss';
+  }
+  return isPositiveNumber(firstValue) ? 'hit' : 'miss';
+};
+
+export const executeVerificationSql = async (
+  sql: string,
+  resultType: InsightVerificationType,
+): Promise<VerifyResult> => {
+  try {
+    const result = await queryWithClient<Record<string, unknown>>(sql, VERIFY_TIMEOUT_MS);
+    const outcome = classifyOutcome(result.rows, resultType);
+    return {
+      outcome,
+      resultJson: result.rows,
+      errorText: null,
+    };
+  } catch (err) {
+    const errorText = err instanceof Error ? err.message : String(err);
+    return {
+      outcome: 'inconclusive',
+      resultJson: null,
+      errorText,
+    };
+  }
+};

--- a/src/shared/llm-insights.ts
+++ b/src/shared/llm-insights.ts
@@ -1,0 +1,60 @@
+/**
+ * 프로액티브 인사이트 v2 Phase 2 — LLM 자율 분석 코어.
+ *
+ * 컨텍스트 빌드 → LLM 호출 → 응답 검증 → llm_insights 영속.
+ * 안전장치 + 컨텍스트 빌더는 llm-insight-prompts.ts에 격리.
+ */
+
+import type { LLMClient, LLMMessage } from './llm.js';
+import { query } from './db.js';
+import {
+  buildLlmInsightContext,
+  systemPromptForAutonomousAnalysis,
+  validateLlmInsightResponse,
+  type LlmInsightDraft,
+} from './llm-insight-prompts.js';
+
+export type InsightSlot = 'weekly' | 'monthly';
+export type InsightConfidence = 'high' | 'medium';
+export type InsightVerificationType = 'boolean' | 'scalar_count' | 'ratio';
+
+export const runAutonomousAnalysis = async (
+  llm: LLMClient,
+  userId: number,
+  slot: InsightSlot,
+): Promise<LlmInsightDraft[]> => {
+  const context = await buildLlmInsightContext(userId, slot);
+  const messages: LLMMessage[] = [
+    { role: 'system', content: systemPromptForAutonomousAnalysis(slot) },
+    { role: 'user', content: `user_id = ${userId}\n\n${context.text}` },
+  ];
+  const response = await llm.chat(messages);
+  return validateLlmInsightResponse(response.text ?? '');
+};
+
+export const persistLlmInsights = async (
+  userId: number,
+  slot: InsightSlot,
+  drafts: LlmInsightDraft[],
+): Promise<void> => {
+  for (const d of drafts) {
+    const verifyAt = new Date(Date.now() + d.verification.verifyAfterDays * 86_400_000);
+    await query(
+      `INSERT INTO llm_insights (
+         user_id, slot, signal_text, hypothesis_text, domains, confidence,
+         verification_sql, verification_result_type, verify_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+      [
+        userId,
+        slot,
+        d.signal,
+        d.hypothesis,
+        d.domains,
+        d.confidence,
+        d.verification.sql,
+        d.verification.resultType,
+        verifyAt,
+      ],
+    );
+  }
+};


### PR DESCRIPTION
## 관련 이슈

Closes #390
Closes #354 (LLM 트렌드 인사이트 — Phase 2 자율 슬롯으로 superseded)

마스터: #393 프로액티브 인사이트 v2 Phase 2

## 변경 내용

Phase 1(결정론적 SQL 패턴 11종) 위에 LLM 자율 발견 슬롯을 한 줄 추가. LLM이 수면·루틴·일정·지출 정량 컨텍스트만 보고 "신호 → 가설 → 검증 SQL"을 스스로 작성하면, N일 뒤 cron이 SQL을 실행해 outcome(hit/miss/inconclusive)을 자동 채점.

### 데이터 모델
- 마이그레이션 048: `llm_insights` 테이블 + 인덱스 2종 + `notification_settings` 3행 시드

### 코어 모듈 (src/shared)
- `llm-insight-prompts.ts` — 4 도메인 컨텍스트 빌더 (텍스트·금액 제외) + 시스템 프롬프트 + `validateLlmInsightResponse` (4중 안전장치)
- `llm-insights.ts` — `runAutonomousAnalysis` + `persistLlmInsights`
- `llm-insight-verify.ts` — `classifyOutcome` + `executeVerificationSql` (statement_timeout 5초)

### Cron (src/cron)
- `weekly-llm-insight.ts` — 월요일 09:30 슬롯 (주간 28일 윈도우)
- `monthly-llm-insight.ts` — 매월 1일 09:30 슬롯 (월간 90일 윈도우)
- `verify-llm-insights.ts` — 매일 09:10 pending 50건 검증 배치
- `life-cron.ts` SLOT_TASKS 3개 신규 등록

### 에이전트 fast path (src/agents/insight)
- `llm-insight-fast-path.ts` — "발견 검증"·"정확도"·"LLM 어땠/어때/어떻게" 매칭 → 누적 정확도 + 최근 5건 조회
- 같은 모듈의 `buildLlmInsightSlackMessage`를 cron에서도 재사용 → 점진적 노출(누적 검증 ≥ 10건 시 hitRate 공개) 로직 일원화

### 4중 안전장치 (ADR-0016)
1. JSON 파싱 폴백 → 실패 시 빈 배열
2. SELECT-only 정규식 — `insert|update|delete|drop|truncate|alter|create|grant|revoke` 포함 시 finding 제외
3. result_type 화이트리스트 (`boolean | scalar_count | ratio`)
4. verify_after_days 1~28 클램프

### 문서
- `docs/domains/insight.md` 섹션 9 추가
- `docs/features.md` LLM 자율 발견 슬롯 + 크론 행 3개 추가
- ADR-0016 / design-notebook Phase 2 섹션은 PR #403에서 선반영

## 코드 리뷰 결과

- [x] 보안: SELECT-only 강제, result_type/confidence 화이트리스트, verify_after_days 1\~28 클램프, statement_timeout 5초
- [x] 컨텍스트 노출 최소: 일기·사주·일정 제목·금액 모두 제외, 정량 집계만
- [x] 타입 안전성: any 없음, unknown + 타입 가드, named export
- [x] 에러 핸들링: LLM·SQL 경계에서만 try-catch, 유저별 격리
- [x] 발견 0건 시 메시지 스킵 (no-news is good news)
- [x] 한글 커밋 + Conventional Commits + Issue 번호

## 테스트

- [x] `llm-insights.test.ts` — JSON 파싱·DELETE/DROP 등 제외·verify_after_days 클램프·confidence low 제외·JSON wrap 추출 (11 케이스)
- [x] `llm-insight-verify.test.ts` — boolean/scalar_count/ratio outcome 분류 + SQL 에러 시 inconclusive
- [x] `llm-insight-fast-path.test.ts` — 매칭 정규식·0건 안내·누적 hitRate 표시·점진적 노출 임계 전/후
- [x] 전체 432 테스트 통과 / build (tsc) 통과

## 운영 적용 (참고)

1. PR 머지 → GitHub Actions 자동 배포 → 마이그레이션 048 적용
2. CronScheduler reload 후 신규 슬롯 3개 등록 확인
3. 1\~2주 운영 후 발견 빈도 + outcome 분포 점검
4. 누적 검증 10건 도달 시 점진적 노출(hitRate 공개) 자동 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)