### PR TITLE
fix(budget): 현대카드 대금기간 시작일 14일 → 15일로 보정

### DIFF
--- a/db/migrations/056_billing_month_hyundai_shift.sql
+++ b/db/migrations/056_billing_month_hyundai_shift.sql
@@ -1,0 +1,17 @@
+-- 현대카드 대금기간 14일 → 15일 변경에 따른 expenses.billing_month 재계산
+-- (시스템 기본/현금/미등록 결제수단도 현대카드 기준이라 같이 적용)
+--
+-- 변경 전: 14일 이상이면 다음 달 대금
+-- 변경 후: 15일 이상이면 다음 달 대금
+--
+-- 대상: 5월달 대금까지(date <= 2026-05-14)의 매월 14일 지출 중 결제수단이 '국민카드'가 아닌 것
+-- 동작: 다음 달로 잘못 저장된 billing_month를 현재 달로 이동
+-- 비대상: monthly_budget_snapshots (지난 사이클 정산은 종료, 재계산 안 함)
+-- 안전장치: billing_month가 이미 현재 달인 경우(수동 입력 등)는 건드리지 않음
+
+UPDATE expenses
+SET billing_month = TO_CHAR(date, 'YYYY-MM')
+WHERE EXTRACT(DAY FROM date) = 14
+  AND date <= DATE '2026-05-14'
+  AND (payment_method IS NULL OR payment_method <> '국민카드')
+  AND billing_month = TO_CHAR(date + INTERVAL '1 month', 'YYYY-MM');

--- a/docs/domains/budget.md
+++ b/docs/domains/budget.md
@@ -12,8 +12,8 @@
 ## 핵심 개념
 
 ### 결제주기 (Billing Cycle)
-- 1개 결제월 = **전월 14일 \~ 당월 13일**
-- 예: `2026-04` → `2026-03-14 \~ 2026-04-13`
+- 1개 결제월 = **전월 15일 \~ 당월 14일**
+- 예: `2026-04` → `2026-03-15 \~ 2026-04-14`
 - 모든 예산/정산/고정비 계산의 기준 단위
 - 구현: [billing/cycle.ts](../../web/src/features/budget/lib/billing/cycle.ts)
 
@@ -208,8 +208,8 @@ features/budget/
 | 9 | 일 예산 배분 | month-summary 오늘 예산 | `/api/budget/today` | day-allocator.ts | 초과 클램프 |
 | 10 | 장기 예산 시뮬레이션 | runway-card | `/api/budget/runway` | runway-projection.ts | 월별 burn 시뮬 |
 | 11 | 일별 예산 로그 | daily-budget-log | `/api/budget/daily-logs` + cron | `saveDailyBudgetLog` | UNIQUE(user, date) |
-| 12 | 월별 예산 스냅샷 | — (내부) | 정산 cron 진입점 | `buildSettlementSnapshot` | 13일 종료 → 14일 새벽 cron, idempotent |
-| 13 | 결제주기 유틸 | — | — | billing/cycle.ts | 전월 14일\~당월 13일 |
+| 12 | 월별 예산 스냅샷 | — (내부) | 정산 cron 진입점 | `buildSettlementSnapshot` | 14일 종료 → 15일 새벽 cron, idempotent |
+| 13 | 결제주기 유틸 | — | — | billing/cycle.ts | 전월 15일\~당월 14일 |
 
 ### 🟡 부분 구현 (4)
 
@@ -225,7 +225,7 @@ features/budget/
 | # | 항목 | 설명 |
 |---|------|------|
 | A | 수입 "이번 달" 옵션 | `distribute_to_budget=false` 시 예산 계산에 미반영. UI 레이블과 동작 불일치 — 의도 확인 + 구현 필요 |
-| B | 할부 `isNew` 경계 판정 | 빌링 시작일(당월 14일) 전후로 선택된 할부의 신규 여부 판정이 의도대로 동작하는지 경계 테스트 필요 |
+| B | 할부 `isNew` 경계 판정 | 빌링 시작일(당월 15일) 전후로 선택된 할부의 신규 여부 판정이 의도대로 동작하는지 경계 테스트 필요 |
 | C | 고정비 자동 기록 강제 `exclude_from_budget=true` | [queries.ts `ensureFixedCostExpenses`](../../web/src/features/budget/lib/queries.ts)에서 강제. 사용자 정책 재검토 필요 |
 
 ## 데이터 흐름
@@ -253,9 +253,9 @@ expense-form (type=expense)
   → allocateTodayBudget() 의 todayRemaining 감소
 ```
 
-### 월 경계 정산 (13일 종료 → 14일 새벽 cron)
+### 월 경계 정산 (14일 종료 → 15일 새벽 cron)
 ```
-detectSettlementTrigger() → 어제가 13일(주기 마지막)인지 판정
+detectSettlementTrigger() → 어제가 14일(주기 마지막)인지 판정
   → getMonthlyAllocation() 재실행
   → readFlexibleSpent/Excluded/Income (범위: 정산 대상 월)
   → buildSettlementSnapshot() 로 monthly_budget_snapshots 저장 (idempotent)

--- a/web/src/features/budget/lib/allocator/__tests__/month-allocator.test.ts
+++ b/web/src/features/budget/lib/allocator/__tests__/month-allocator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { allocateMonthlyBudgets } from '../month-allocator';
 import type { MonthAllocatorInput } from '../../types-v2';
 
-// today: 2026-04-11 → 현재 주기 03-14~04-13 (31일)
+// today: 2026-04-11 → 현재 주기 03-15~04-14 (31일)
 const BASE: MonthAllocatorInput = {
   totalAvailable: 36000,
   fixedMonthly: 0,

--- a/web/src/features/budget/lib/billing/__tests__/card-billing.test.ts
+++ b/web/src/features/budget/lib/billing/__tests__/card-billing.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { getBillingMonthForExpense } from '../card-billing';
 
 describe('getBillingMonthForExpense — 카드별 귀속 월 판별', () => {
-  describe('현대카드 (startDay=14)', () => {
-    it('13일 → 현재 달 귀속 (13 < 14)', () => {
-      expect(getBillingMonthForExpense('2026-04-13', '현대카드')).toBe('2026-04');
+  describe('현대카드 (startDay=15)', () => {
+    it('14일 → 현재 달 귀속 (14 < 15)', () => {
+      expect(getBillingMonthForExpense('2026-04-14', '현대카드')).toBe('2026-04');
     });
 
-    it('14일 → 다음 달 귀속 (14 >= 14)', () => {
-      expect(getBillingMonthForExpense('2026-04-14', '현대카드')).toBe('2026-05');
+    it('15일 → 다음 달 귀속 (15 >= 15)', () => {
+      expect(getBillingMonthForExpense('2026-04-15', '현대카드')).toBe('2026-05');
     });
 
     it('1일 → 현재 달 귀속', () => {
@@ -30,37 +30,37 @@ describe('getBillingMonthForExpense — 카드별 귀속 월 판별', () => {
     });
   });
 
-  describe('현금 (시스템 기본 startDay=14 적용)', () => {
-    it('13일 → 현재 달 귀속', () => {
-      expect(getBillingMonthForExpense('2026-04-13', '현금')).toBe('2026-04');
+  describe('현금 (시스템 기본 startDay=15 적용)', () => {
+    it('14일 → 현재 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-04-14', '현금')).toBe('2026-04');
     });
 
-    it('14일 → 다음 달 귀속', () => {
-      expect(getBillingMonthForExpense('2026-04-14', '현금')).toBe('2026-05');
+    it('15일 → 다음 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-04-15', '현금')).toBe('2026-05');
     });
   });
 
   describe('미등록 결제수단 → 시스템 기본 적용', () => {
-    it('13일 → 현재 달 귀속', () => {
-      expect(getBillingMonthForExpense('2026-04-13', '알수없는카드')).toBe('2026-04');
+    it('14일 → 현재 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-04-14', '알수없는카드')).toBe('2026-04');
     });
 
-    it('14일 → 다음 달 귀속', () => {
-      expect(getBillingMonthForExpense('2026-04-14', '알수없는카드')).toBe('2026-05');
+    it('15일 → 다음 달 귀속', () => {
+      expect(getBillingMonthForExpense('2026-04-15', '알수없는카드')).toBe('2026-05');
     });
   });
 
   describe('12월 → 연도 넘김 처리', () => {
-    it('현대카드 12월 14일 → 2027-01', () => {
-      expect(getBillingMonthForExpense('2026-12-14', '현대카드')).toBe('2027-01');
+    it('현대카드 12월 15일 → 2027-01', () => {
+      expect(getBillingMonthForExpense('2026-12-15', '현대카드')).toBe('2027-01');
     });
 
     it('국민카드 12월 13일 → 2027-01', () => {
       expect(getBillingMonthForExpense('2026-12-13', '국민카드')).toBe('2027-01');
     });
 
-    it('현대카드 12월 13일 → 2026-12 (현재 달)', () => {
-      expect(getBillingMonthForExpense('2026-12-13', '현대카드')).toBe('2026-12');
+    it('현대카드 12월 14일 → 2026-12 (현재 달)', () => {
+      expect(getBillingMonthForExpense('2026-12-14', '현대카드')).toBe('2026-12');
     });
   });
 });

--- a/web/src/features/budget/lib/billing/__tests__/cycle.test.ts
+++ b/web/src/features/budget/lib/billing/__tests__/cycle.test.ts
@@ -9,54 +9,54 @@ import {
 } from '../cycle';
 
 describe('A. 빌링 주기', () => {
-  describe('A-1. getCurrentBillingMonth — 13일/14일 경계', () => {
-    it('13일 23:59 KST는 당월', () => {
-      // 2026-04-13 23:59 KST = 2026-04-13 14:59 UTC
-      const now = new Date('2026-04-13T14:59:00Z');
+  describe('A-1. getCurrentBillingMonth — 14일/15일 경계', () => {
+    it('14일 23:59 KST는 당월', () => {
+      // 2026-04-14 23:59 KST = 2026-04-14 14:59 UTC
+      const now = new Date('2026-04-14T14:59:00Z');
       expect(getCurrentBillingMonth(now)).toBe('2026-04');
     });
 
-    it('14일 00:00 KST는 다음 월', () => {
-      // 2026-04-14 00:00 KST = 2026-04-13 15:00 UTC
-      const now = new Date('2026-04-13T15:00:00Z');
+    it('15일 00:00 KST는 다음 월', () => {
+      // 2026-04-15 00:00 KST = 2026-04-14 15:00 UTC
+      const now = new Date('2026-04-14T15:00:00Z');
       expect(getCurrentBillingMonth(now)).toBe('2026-05');
     });
 
     it('월말(31일) → 다음 월로 올바르게 넘어감', () => {
-      // 2026-03-14 → 2026-04
-      const now = new Date('2026-03-14T00:00:00+09:00');
+      // 2026-03-15 → 2026-04
+      const now = new Date('2026-03-15T00:00:00+09:00');
       expect(getCurrentBillingMonth(now)).toBe('2026-04');
     });
 
-    it('12월 14일 → 다음 해 1월', () => {
-      const now = new Date('2025-12-14T00:00:00+09:00');
+    it('12월 15일 → 다음 해 1월', () => {
+      const now = new Date('2025-12-15T00:00:00+09:00');
       expect(getCurrentBillingMonth(now)).toBe('2026-01');
     });
   });
 
   describe('A-2. getBillingRange', () => {
-    it("'2026-04' → { from: '2026-03-14', to: '2026-04-13' }", () => {
+    it("'2026-04' → { from: '2026-03-15', to: '2026-04-14' }", () => {
       expect(getBillingRange('2026-04')).toEqual({
-        from: '2026-03-14',
-        to: '2026-04-13',
+        from: '2026-03-15',
+        to: '2026-04-14',
       });
     });
 
-    it('1월인 경우 전년 12월 14일', () => {
+    it('1월인 경우 전년 12월 15일', () => {
       expect(getBillingRange('2026-01')).toEqual({
-        from: '2025-12-14',
-        to: '2026-01-13',
+        from: '2025-12-15',
+        to: '2026-01-14',
       });
     });
   });
 
   describe('A-3. calcCycleDays', () => {
-    it("'2026-03-14' ~ '2026-04-13' = 31일", () => {
-      expect(calcCycleDays('2026-03-14', '2026-04-13')).toBe(31);
+    it("'2026-03-15' ~ '2026-04-14' = 31일", () => {
+      expect(calcCycleDays('2026-03-15', '2026-04-14')).toBe(31);
     });
 
-    it('2월 포함 주기 (2025-01-14 ~ 2025-02-13) = 31일', () => {
-      expect(calcCycleDays('2025-01-14', '2025-02-13')).toBe(31);
+    it('2월 포함 주기 (2025-01-15 ~ 2025-02-14) = 31일', () => {
+      expect(calcCycleDays('2025-01-15', '2025-02-14')).toBe(31);
     });
 
     it('같은 날 = 1일', () => {
@@ -83,23 +83,23 @@ describe('A. 빌링 주기', () => {
       const now = new Date('2026-04-10T10:00:00+09:00');
       const cycle = getBillingCycle(now);
       expect(cycle.yearMonth).toBe('2026-04');
-      expect(cycle.from).toBe('2026-03-14');
-      expect(cycle.to).toBe('2026-04-13');
+      expect(cycle.from).toBe('2026-03-15');
+      expect(cycle.to).toBe('2026-04-14');
       expect(cycle.totalDays).toBe(31);
     });
   });
 
   describe('isLastDayOfCycle', () => {
-    it('13일 = true', () => {
-      expect(isLastDayOfCycle('2026-04-13')).toBe(true);
+    it('14일 = true', () => {
+      expect(isLastDayOfCycle('2026-04-14')).toBe(true);
     });
 
-    it('12일 = false', () => {
-      expect(isLastDayOfCycle('2026-04-12')).toBe(false);
+    it('13일 = false', () => {
+      expect(isLastDayOfCycle('2026-04-13')).toBe(false);
     });
 
-    it('1월 13일 = true', () => {
-      expect(isLastDayOfCycle('2026-01-13')).toBe(true);
+    it('1월 14일 = true', () => {
+      expect(isLastDayOfCycle('2026-01-14')).toBe(true);
     });
   });
 });

--- a/web/src/features/budget/lib/billing/__tests__/fixed-cost-date.test.ts
+++ b/web/src/features/budget/lib/billing/__tests__/fixed-cost-date.test.ts
@@ -7,12 +7,12 @@ describe('resolveFixedCostExpenseDate', () => {
       expect(resolveFixedCostExpenseDate('2026-04', 1)).toBe('2026-04-01');
     });
 
-    it('결제일 13일 (결제주기 말일) → 당월', () => {
-      expect(resolveFixedCostExpenseDate('2026-04', 13)).toBe('2026-04-13');
+    it('결제일 14일 (결제주기 말일) → 당월', () => {
+      expect(resolveFixedCostExpenseDate('2026-04', 14)).toBe('2026-04-14');
     });
 
-    it('결제일 14일 (결제주기 시작일) → 전월', () => {
-      expect(resolveFixedCostExpenseDate('2026-04', 14)).toBe('2026-03-14');
+    it('결제일 15일 (결제주기 시작일) → 전월', () => {
+      expect(resolveFixedCostExpenseDate('2026-04', 15)).toBe('2026-03-15');
     });
 
     it('결제일 31일 → 전월 말일', () => {
@@ -20,10 +20,10 @@ describe('resolveFixedCostExpenseDate', () => {
     });
   });
 
-  describe('월 경계 — 13일/14일 boundary', () => {
-    it('13일 ↔ 14일 경계에서 월이 바뀐다', () => {
-      expect(resolveFixedCostExpenseDate('2026-04', 13)).toBe('2026-04-13');
-      expect(resolveFixedCostExpenseDate('2026-04', 14)).toBe('2026-03-14');
+  describe('월 경계 — 14일/15일 boundary', () => {
+    it('14일 ↔ 15일 경계에서 월이 바뀐다', () => {
+      expect(resolveFixedCostExpenseDate('2026-04', 14)).toBe('2026-04-14');
+      expect(resolveFixedCostExpenseDate('2026-04', 15)).toBe('2026-03-15');
     });
   });
 
@@ -32,8 +32,8 @@ describe('resolveFixedCostExpenseDate', () => {
       expect(resolveFixedCostExpenseDate('2026-01', 16)).toBe('2025-12-16');
     });
 
-    it('1월 + 결제일 13일 → 당월 1월', () => {
-      expect(resolveFixedCostExpenseDate('2026-01', 13)).toBe('2026-01-13');
+    it('1월 + 결제일 14일 → 당월 1월', () => {
+      expect(resolveFixedCostExpenseDate('2026-01', 14)).toBe('2026-01-14');
     });
 
     it('12월 + 결제일 16일 → 당년 11월', () => {

--- a/web/src/features/budget/lib/billing/card-billing.ts
+++ b/web/src/features/budget/lib/billing/card-billing.ts
@@ -1,18 +1,18 @@
 /** 카드별 대금기간 상수 (startDay: 해당 일 이상이면 다음 달 대금) */
 export const CARD_BILLING_CYCLES: Record<string, { startDay: number }> = {
-  '현대카드': { startDay: 14 },
-  '국민카드': { startDay: 13 },
+  현대카드: { startDay: 15 },
+  국민카드: { startDay: 13 },
 };
 
 /** 시스템 기본 대금기간 시작일 (현대카드 기준) */
-const DEFAULT_START_DAY = 14;
+const DEFAULT_START_DAY = 15;
 
 /**
  * 결제수단 + 결제일 → 귀속 billing month 반환
  *
- * - 현대카드: 14일 이상 → 다음 달 대금
+ * - 현대카드: 15일 이상 → 다음 달 대금
  * - 국민카드: 13일 이상 → 다음 달 대금
- * - 현금 / 미등록 결제수단: 시스템 기본(14일 기준) 적용
+ * - 현금 / 미등록 결제수단: 시스템 기본(15일 기준) 적용
  *
  * @param date 'YYYY-MM-DD'
  * @param paymentMethod 결제수단 문자열

--- a/web/src/features/budget/lib/billing/cycle.ts
+++ b/web/src/features/budget/lib/billing/cycle.ts
@@ -11,10 +11,10 @@ function pad2(n: number): string {
   return String(n).padStart(2, '0');
 }
 
-/** 현재 결제 주기의 billing month (14일 이후면 다음 달) */
+/** 현재 결제 주기의 billing month (15일 이후면 다음 달) */
 export function getCurrentBillingMonth(now: Date): string {
   const { year, month, day } = toKST(now);
-  if (day >= 14) {
+  if (day >= 15) {
     const nextMonth = month === 12 ? 1 : month + 1;
     const nextYear = month === 12 ? year + 1 : year;
     return `${nextYear}-${pad2(nextMonth)}`;
@@ -22,14 +22,14 @@ export function getCurrentBillingMonth(now: Date): string {
   return `${year}-${pad2(month)}`;
 }
 
-/** 결제 주기 날짜 범위 (전월 14일 ~ 당월 13일) */
+/** 결제 주기 날짜 범위 (전월 15일 ~ 당월 14일) */
 export function getBillingRange(yearMonth: string): { from: string; to: string } {
   const [y, m] = yearMonth.split('-').map(Number);
   const prevMonth = m === 1 ? 12 : m - 1;
   const prevYear = m === 1 ? y - 1 : y;
   return {
-    from: `${prevYear}-${pad2(prevMonth)}-14`,
-    to: `${y}-${pad2(m)}-13`,
+    from: `${prevYear}-${pad2(prevMonth)}-15`,
+    to: `${y}-${pad2(m)}-14`,
   };
 }
 
@@ -53,7 +53,7 @@ export function getBillingCycle(now: Date): BillingCycle {
   return { yearMonth, from, to, totalDays: calcCycleDays(from, to) };
 }
 
-/** 날짜(YYYY-MM-DD)가 결제 주기 마지막 날(13일)인지 */
+/** 날짜(YYYY-MM-DD)가 결제 주기 마지막 날(14일)인지 */
 export function isLastDayOfCycle(date: string): boolean {
-  return date.endsWith('-13');
+  return date.endsWith('-14');
 }

--- a/web/src/features/budget/lib/billing/fixed-cost-date.ts
+++ b/web/src/features/budget/lib/billing/fixed-cost-date.ts
@@ -1,16 +1,13 @@
 /**
  * 결제주기 기반 고정비 기록 날짜 결정 (순수 함수).
- * 결제주기는 전월 14일 ~ 당월 13일이므로, day_of_month >= 14 이면 전월에 기록된다.
+ * 결제주기는 전월 15일 ~ 당월 14일이므로, day_of_month >= 15 이면 전월에 기록된다.
  * 해당 월에 day_of_month 가 없는 경우(예: 2월 31일)는 그 달의 말일로 보정한다.
  *
  * @param yearMonth 'YYYY-MM' — 결제주기 기준 월
  * @param dayOfMonth 1~31 — 고정비 결제일
  * @returns 'YYYY-MM-DD'
  */
-export function resolveFixedCostExpenseDate(
-  yearMonth: string,
-  dayOfMonth: number,
-): string {
+export function resolveFixedCostExpenseDate(yearMonth: string, dayOfMonth: number): string {
   if (!/^\d{4}-\d{2}$/.test(yearMonth)) {
     throw new Error(`invalid yearMonth: ${yearMonth}`);
   }
@@ -22,8 +19,8 @@ export function resolveFixedCostExpenseDate(
   const prevMonth = month === 1 ? 12 : month - 1;
   const prevYear = month === 1 ? year - 1 : year;
 
-  const expenseYear = dayOfMonth >= 14 ? prevYear : year;
-  const expenseMonth = dayOfMonth >= 14 ? prevMonth : month;
+  const expenseYear = dayOfMonth >= 15 ? prevYear : year;
+  const expenseMonth = dayOfMonth >= 15 ? prevMonth : month;
 
   const lastDay = new Date(expenseYear, expenseMonth, 0).getDate();
   const actualDay = Math.min(dayOfMonth, lastDay);

--- a/web/src/features/budget/lib/settlement/__tests__/settle.test.ts
+++ b/web/src/features/budget/lib/settlement/__tests__/settle.test.ts
@@ -4,25 +4,25 @@ import type { MonthlyBudget, SettlementInput } from '../../types-v2';
 
 describe('E. 월 경계 정산', () => {
   describe('E-1. detectSettlementTrigger', () => {
-    it('KST 00:30 on 14일 → 어제(13일) = 주기 끝 → shouldSettle:true', () => {
-      // 2026-04-14 00:30 KST = 2026-04-13 15:30 UTC
-      const today = new Date('2026-04-13T15:30:00Z');
+    it('KST 00:30 on 15일 → 어제(14일) = 주기 끝 → shouldSettle:true', () => {
+      // 2026-04-15 00:30 KST = 2026-04-14 15:30 UTC
+      const today = new Date('2026-04-14T15:30:00Z');
       const result = detectSettlementTrigger(today);
       expect(result.shouldSettle).toBe(true);
       expect(result.targetMonth).toBe('2026-04');
     });
 
-    it('KST 00:30 on 15일 → 어제(14일) = 주기 시작일 → shouldSettle:false', () => {
-      // 2026-04-15 00:30 KST = 2026-04-14 15:30 UTC
-      const today = new Date('2026-04-14T15:30:00Z');
+    it('KST 00:30 on 16일 → 어제(15일) = 주기 시작일 → shouldSettle:false', () => {
+      // 2026-04-16 00:30 KST = 2026-04-15 15:30 UTC
+      const today = new Date('2026-04-15T15:30:00Z');
       const result = detectSettlementTrigger(today);
       expect(result.shouldSettle).toBe(false);
       expect(result.targetMonth).toBeNull();
     });
 
-    it('1월 14일 KST → 어제(1월 13일) = 주기 끝 → targetMonth=\'2026-01\'', () => {
-      // 2026-01-14 00:30 KST = 2026-01-13 15:30 UTC
-      const today = new Date('2026-01-13T15:30:00Z');
+    it("1월 15일 KST → 어제(1월 14일) = 주기 끝 → targetMonth='2026-01'", () => {
+      // 2026-01-15 00:30 KST = 2026-01-14 15:30 UTC
+      const today = new Date('2026-01-14T15:30:00Z');
       const result = detectSettlementTrigger(today);
       expect(result.shouldSettle).toBe(true);
       expect(result.targetMonth).toBe('2026-01');

--- a/web/src/features/budget/lib/settlement/settle.ts
+++ b/web/src/features/budget/lib/settlement/settle.ts
@@ -18,15 +18,16 @@ function subtractOneDay(dateStr: string): string {
   return `${y}-${m}-${day}`;
 }
 
-/** 어제 날짜가 주기 마지막 날(13일)인지 확인 */
-export function detectSettlementTrigger(
-  today: Date,
-): { shouldSettle: boolean; targetMonth: string | null } {
+/** 어제 날짜가 주기 마지막 날(14일)인지 확인 */
+export function detectSettlementTrigger(today: Date): {
+  shouldSettle: boolean;
+  targetMonth: string | null;
+} {
   const todayKST = toKSTDateStr(today);
   const yesterday = subtractOneDay(todayKST);
   const day = parseInt(yesterday.slice(8, 10), 10);
 
-  if (day !== 13) return { shouldSettle: false, targetMonth: null };
+  if (day !== 14) return { shouldSettle: false, targetMonth: null };
 
   const targetMonth = yesterday.slice(0, 7); // YYYY-MM
   return { shouldSettle: true, targetMonth };
@@ -34,8 +35,15 @@ export function detectSettlementTrigger(
 
 /** 월 경계 시점에 스냅샷 구조 생성 (DB 저장은 호출자가 담당) */
 export function buildSettlementSnapshot(input: SettlementInput): SettlementSnapshot {
-  const { yearMonth, monthlyBudget, actualFlexibleSpent, actualExcludedSpent,
-    actualIncome, availableAtStart, availableAtEnd } = input;
+  const {
+    yearMonth,
+    monthlyBudget,
+    actualFlexibleSpent,
+    actualExcludedSpent,
+    actualIncome,
+    availableAtStart,
+    availableAtEnd,
+  } = input;
 
   return {
     year_month: yearMonth,


### PR DESCRIPTION
## Summary

- 실제 카드사 대금기간 관찰 결과(14일 기록까지 이전 대금에 포함)에 맞춰 결제주기 경계 조정
- 시스템 기본/현금/미등록 결제수단도 현대카드 기준이므로 같이 반영
- 결제주기: **전월 14일 \~ 당월 13일** → **전월 15일 \~ 당월 14일**
- 정산 cron 트리거: 어제가 13일 → 어제가 14일

## 변경 범위

- `card-billing.ts`: 현대카드 `startDay: 15`, `DEFAULT_START_DAY = 15`
- `cycle.ts`: `getCurrentBillingMonth`(`day >= 15`), `getBillingRange`(전월 15일 \~ 당월 14일), `isLastDayOfCycle`(14일)
- `fixed-cost-date.ts`: `dayOfMonth >= 15`이면 전월에 기록
- `settle.ts`: 정산 트리거 `day !== 14`
- 테스트 4개 + month-allocator 주석 일치
- `docs/domains/budget.md` 결제주기 설명 갱신
- 마이그레이션 `056_billing_month_hyundai_shift.sql`: 기존 데이터의 매월 14일 지출(국민카드 제외) `billing_month`를 한 달 앞으로 이동

## 데이터 마이그레이션 적용

- 대상: 1\~5월 매월 14일 지출 20건 (국민카드 제외)
- 결과: `billing_month` 한 달 앞으로 이동 완료 (`UPDATE 20`)
- `monthly_budget_snapshots`는 비대상 (지난 사이클 정산은 종료)

## Test plan

- [x] 단위 테스트 127개 통과 (budget billing/settlement/allocator 영역)
- [ ] 머지 후 지출 페이지 월별 분류 확인
- [ ] 다음 정산 cron 트리거 시점 확인 (매월 15일 새벽)

🤖 Generated with [Claude Code](https://claude.com/claude-code)