### PR TITLE
feat(budget): 할부 자산 차감 범위 토글 + 세금 카테고리 추가

### DIFF
--- a/db/migrations/057_expenses_distribute_to_runway.sql
+++ b/db/migrations/057_expenses_distribute_to_runway.sql
@@ -1,0 +1,9 @@
+-- 할부 자산 차감 범위 토글 — distribute_to_runway 컬럼 추가
+--
+-- ADR 0018: 사용자가 명시적으로 OFF한 할부는 target_date 이내 회차만 INSERT 시 자산 차감.
+-- target_date 이후 회차는 자산 무영향 → 결제주기 종료 cron에서 자유지출로 처리.
+--
+-- 기본값 true로 backfill되어 ADR 0015 동작은 그대로 유지 (default = 즉시 전체 차감).
+
+ALTER TABLE expenses
+  ADD COLUMN IF NOT EXISTS distribute_to_runway BOOLEAN NOT NULL DEFAULT true;

--- a/docs/adr/0018-installment-runway-scope-toggle.md
+++ b/docs/adr/0018-installment-runway-scope-toggle.md
@@ -1,0 +1,121 @@
+# 0018. 할부 자산 차감 범위 토글 — `distribute_to_runway` 분기
+
+- Status: Accepted
+- Date: 2026-05-20
+- Related: #411
+- Tags: data, budget
+
+## Context
+
+ADR 0015는 "자산 표시값 = 즉시 쓸 수 있는 돈" 직관을 우선해 할부 2+회차를 INSERT 즉시 자산에서 차감하는 정책을 채택했다. 이 정책은 대부분의 할부(카드 3~6개월 등)에서 잘 작동하지만, **목표 기간(target_date)을 넘어가는 할부**에서는 사용자 의도와 충돌한다.
+
+구체 케이스 (예시):
+- 목표 기간이 N개월 후로 설정된 상태
+- 12개월 분할 할부 입력 — 사용자 의도: "분산 = 월 자금 부담 완화"
+- 현재 동작: INSERT 시 2~12회차 전부 즉시 자산 차감 → 목표 기간까지의 자유 예산이 11개월치 회차분만큼 줄어든 상태로 분배 → 사용자 의도("목표 기간 이후 회차는 그때 갚을 자금")와 정반대
+
+목표 기간 이후로 결제가 이어지는 할부에서 "사용자 의도(미래 자금으로 갚을 예정)"와 "기본 정책(즉시 전체 차감)" 사이 분기가 필요하다.
+
+## Decision
+
+ADR 0015 정책은 **default로 유지**하고, 할부 입력 시 사용자가 명시적으로 OFF할 수 있는 `distribute_to_runway` 토글을 추가한다.
+
+### 토글 의미
+
+| 값 | 동작 |
+|----|------|
+| `true` (default) | 2~마지막 회차 전부 INSERT 즉시 자산 차감 (= ADR 0015 그대로) |
+| `false` | 2회차부터 target_date 이내 회차만 자산 차감. target_date 이후 회차는 자산 무영향 — 각 결제주기 종료 cron에서 자유지출로 처리 |
+
+> 1회차는 토글과 무관 — 항상 현재 결제주기의 자유지출로 잡혀 결제주기 종료 cron에서 정산.
+
+### 토글 노출 조건 — 조건부
+
+할부 입력 폼에서 토글은 **마지막 회차의 결제월(billing_month)이 target_date보다 큰 경우에만** 노출. 같거나 작으면 ON/OFF 동작 동일이라 사용자에게 의미 없는 선택 강요 X.
+
+```ts
+// 노출 조건 (pseudocode)
+const lastInstallmentBillingMonth = computeLastInstallmentBillingMonth(date, months, paymentMethod);
+const showToggle = lastInstallmentBillingMonth > targetDate;
+```
+
+### target_date 변경 시 — 자동 재계산 + 변경 직전 안내
+
+사용자가 budget settings에서 target_date를 변경하면:
+1. 변경 직전 모달 — 영향받는 OFF 할부 X개, 자산 차감 변화 ±Y원 안내
+2. 사용자 확인 시 OFF 할부 전부 순회하며 자산 보정
+   - target 늘어남 → 새 범위 안에 들어온 회차분 추가 차감
+   - target 줄어듦 → 새 범위 밖으로 나간 회차분 환원
+
+### 회차별 settled 상태 — 새 컬럼 없이 결제주기 기반 계산
+
+토글 사후 변경 / target_date 변경 시 보정 대상은 **"현재 결제주기 시점에서 아직 정산 안 된 미래 회차"** = `installment_num >= 2 AND billing_month > 현재_billing_month`. 추가 컬럼 없이 기존 `isFutureInstallment` 로직 + `billing_month > target_date` 조건만으로 식별.
+
+### 사용자 의도 기록
+
+`expenses.distribute_to_runway` 컬럼은 사용자가 명시적으로 OFF한 케이스만 false. INSERT 시점에 토글이 노출되지 않은 경우(=마지막 회차 ≤ target_date) default true로 저장. 향후 사용자가 의도 분석 / 회고할 때 "이 할부는 분산 의도였는지" 명확히 기록됨.
+
+## Alternatives considered
+
+### A. 자동 보정 (옵션 A) — target 이후 회차분을 allocator 입력 단계에서 환원
+
+- 장점: 사용자 액션 0. 모든 할부에 일괄 적용. ADR 0015 자산 차감 정책 그대로
+- 단점: 사용자 의도가 케이스마다 다를 수 있음 ("이 큰 할부는 그냥 미리 다 빼놓을게" vs "이건 분산 부담 완화") — 자동 보정은 이 차이를 표현 못 함. 자산 카드 값과 allocator 계산값 사이 의미 분기 발생 → 사용자에게 매번 설명 필요
+- 기각 이유: 사용자가 의식적으로 할부 분산 의도를 결정한 케이스가 있는 만큼, 시스템이 자동 판정하기보다 명시적 선택을 받는 게 의도 기록과 시스템 일관성에 유리
+
+### B. 자산 차감 정책 자체를 결제주기 cron 시점으로 변경
+
+- 장점: 자연스러운 회계 모델 — 매 결제주기마다 그 회차분이 자산에서 차감
+- 단점: ADR 0015 핵심 결정("자산 = 즉시 쓸 수 있는 돈" 직관) 정면 뒤집기. "큰 할부를 걸었는데 자산은 1회차분만 빠짐" 사용자 멘탈 모델 충돌. 결제주기 cron 누락 시 사용자가 갑자기 자산이 안 맞는다고 느낌
+- 기각 이유: ADR 0015의 직관을 약화시키는 변경. 케이스마다 의도가 다른 문제를 더 큰 정책 변경으로 푸는 건 비례 안 맞음
+
+### C. (선택) `distribute_to_runway` 토글 + default true (현재 동작 유지)
+
+- 장점:
+  - ADR 0015 정책 약화 없음 — 보완 ADR이 정책을 **그대로 두고** 분기만 추가
+  - OFF가 100% 명시 의도 → DB에 사용자 결정 기록
+  - target 변경 시 자동 재계산 정책이 "내가 OFF했으니까"로 자연스럽게 납득
+- 단점:
+  - 사용자가 큰 할부마다 OFF 선택 (액션 1회 추가)
+  - 자산 보정 로직이 분산되는 ADR 0015 단점이 약간 더 늘어남 (createInstallment / updateExpense / deleteExpense + target_date 변경 보정)
+
+### D. 자동 판정 (마지막 회차가 target 넘으면 자동 OFF)
+
+- 장점: 사용자 선택 0
+- 단점: "큰 할부도 전부 미리 차감하고 싶다"는 의도일 때 우회 불가. 자동 판정 결과를 사용자가 인지하지 못함 → "왜 자산이 다르게 빠졌지?" 혼란
+- 기각 이유: 의도 분기를 시스템이 강제하는 건 사용자 결정권 침해
+
+### E. 사후 PATCH 불가 — 토글은 INSERT 시점에만 결정
+
+- 장점: 자산 보정 로직 단순화 (생성/삭제만 보정)
+- 단점: 사용자가 잘못 입력 시 DELETE → 재INSERT 부담
+- 기각 이유: 12개월 할부 같은 큰 거래를 잘못 입력하면 사용자 부담 큼. 보정 로직 복잡도는 결제주기 기반 계산으로 흡수 가능
+
+## Consequences
+
+### 장점
+
+- 사용자 의도가 시스템에 명시적으로 기록됨 (`distribute_to_runway` 컬럼)
+- ADR 0015 핵심 원칙("자산 = 즉시 쓸 수 있는 돈") 유지 — default 동작 그대로
+- target_date 변경 시 자동 재계산이 사용자 명시 OFF에만 적용되어 의도 일관성
+- 조건부 노출로 의미 없는 선택 강요 X (마지막 회차 ≤ target_date면 토글 숨김)
+
+### 단점 / 제약
+
+- 자산 보정 로직 분산이 3곳(create/update/delete) → 4곳(+ target_date 변경 보정)으로 늘어남
+- 토글 사후 변경 시 결제주기 경계 타이밍 이슈 가능 — 결제주기 종료 cron 직전/직후 PATCH 시 미세한 회차 분류 차이 발생 가능 (월 단위 비교라 영향 작음)
+- 마이그레이션 1번 (`distribute_to_runway` 컬럼 추가, default true)
+
+### 후속 작업
+
+- [ ] DB 마이그레이션 작성 (`distribute_to_runway BOOLEAN DEFAULT true`)
+- [ ] 자산 보정 로직 단위 테스트 (toggle ON→OFF, OFF→ON, target_date 변경)
+- [ ] expense-form 조건부 노출 경계 테스트 (마지막 회차 = target_date 인 경우)
+- [ ] budget settings의 target_date 변경 모달 UX 검증 (영향 범위 안내 정확도)
+
+---
+
+**참고 자료**
+
+- ADR 0007 — 자유지출 정의 통일
+- ADR 0015 — 자산 자동 차감 정책 (본 ADR의 보완 대상)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,6 +124,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0015](0015-asset-auto-deduction-policy.md) | 자산 자동 차감 정책 — 결제주기 종료 cron + 할부 미래 회차 즉시 반영 | Accepted | 2026-05-14 | data, budget |
 | [0016](0016-llm-autonomous-slot-outcome-verification.md) | LLM 자율 발견 슬롯 + Outcome-based 검증 | Accepted | 2026-05-16 | data, insight, llm |
 | [0017](0017-saju-ganji-master-normalization.md) | 사주 60갑자 마스터 정규화 + 카탈로그 기반 일일 매칭 | Accepted | 2026-05-17 | data, architecture |
+| [0018](0018-installment-runway-scope-toggle.md) | 할부 자산 차감 범위 토글 — `distribute_to_runway` 분기 | Accepted | 2026-05-20 | data, budget |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/domains/budget.md
+++ b/docs/domains/budget.md
@@ -20,9 +20,9 @@
 ### 가용자금 (Total Available)
 - `assets.available_amount` 합계 (`is_emergency=false`)
 - 결제주기 종료 cron이 이전 사이클의 자유+제외 지출을 default 자산에서 자동 차감하고 수입을 default 자산에 증액 — 자산 테이블이 곧 가용자금이 되도록 유지
-- 할부 2+회차는 INSERT 즉시 자산에서 차감 (allocator의 monthBudget 락에서는 제외해 수학적 동등)
+- 할부 2+회차는 INSERT 즉시 자산에서 차감 (allocator의 monthBudget 락에서는 제외해 수학적 동등). 단, `distribute_to_runway=false`면 target_date 이후 회차는 자산 무영향 — 결제주기 cron에서 자유지출로 정산
 - 구현: [facade.ts `runSettlementIfDue`](../../web/src/features/budget/lib/facade.ts), [assets-repo.ts](../../web/src/features/budget/lib/repository/assets-repo.ts)
-- 판단 근거: [ADR 0015](../adr/0015-asset-auto-deduction-policy.md)
+- 판단 근거: [ADR 0015](../adr/0015-asset-auto-deduction-policy.md) — 즉시 차감 default 정책 / [ADR 0018](../adr/0018-installment-runway-scope-toggle.md) — 사용자 명시 OFF 분기
 
 ### 자유 예산 (Free Budget)
 - 월 자유 예산 = 월 가용자금 − (월 고정비 + 할부 월분 + 예정 지출)
@@ -54,6 +54,7 @@ ADR 0008 도입 후 일 예산은 두 값으로 분리된다:
 |------|--------|------|
 | `exclude_from_budget` | expenses | 지출을 자유 예산 계산에서 제외 |
 | `distribute_to_budget` | expenses | 수입을 목표 기간 전체에 분배 |
+| `distribute_to_runway` | expenses | 할부 미래 회차를 INSERT 즉시 자산 차감(true, default) vs target_date 이내만 차감(false). ADR 0018 |
 | `is_emergency` | assets | 비상금을 가용자금에서 제외 |
 | `is_variable` | fixed_costs | 변동 고정비 표시 |
 
@@ -79,6 +80,8 @@ expenses:
   planned_expense_id INTEGER FK,
   exclude_from_budget BOOLEAN,
   distribute_to_budget BOOLEAN,
+  distribute_to_runway BOOLEAN DEFAULT true,  -- ADR 0018: false면 target_date 이후 할부 회차는 자산 무영향
+  billing_month VARCHAR(7),            -- 카드별 결제주기 귀속 (전월 15일~당월 14일)
   created_at TIMESTAMPTZ
 
 -- 고정비 템플릿
@@ -193,23 +196,24 @@ features/budget/
 
 ## 기능 구현 상태
 
-### ✅ 완전 구현 (13)
+### ✅ 완전 구현 (14)
 
 | # | 기능 | UI | API | 계산/쿼리 | 비고 |
 |---|------|----|----|---------|------|
-| 1 | 지출 CRUD | [expense-form.tsx](../../web/src/features/budget/components/expense-form.tsx), expense-edit-modal | `/api/expenses` + `/[id]` | queries.ts | 카테고리/결제수단/메모 |
+| 1 | 지출 CRUD | [expense-form.tsx](../../web/src/features/budget/components/expense-form.tsx), expense-edit-modal | `/api/expenses` + `/[id]` | queries.ts | 카테고리/결제수단/메모. 세금 카테고리 포함(예산 제외 default) |
 | 2 | 수입 기록 (전체 분배) | [expense-form.tsx:275](../../web/src/features/budget/components/expense-form.tsx#L275) | `/api/expenses` POST | incomes-repo.ts | `type='income'` + `distribute_to_budget=true` |
 | 3 | 할부 처리 (2\~12개월) | expense-form 할부 옵션 | POST `installment_months` | createInstallmentExpenses | 그룹 UUID, 끝전 보정 |
 | 4 | 예정 지출 | planned-expense-list | `/api/budget/planned-expenses` | planned-repo.ts | 지출 시 `planned_expense_id` 연결 |
 | 5 | 고정비 템플릿 | 고정비 UI + 자동 기록 | `/api/budget/fixed-costs` | `ensureFixedCostExpenses` | 결제일 기준 자동 생성 |
 | 6 | 자산 관리 | 자산 목록/수정 | `/api/budget/assets` + `/[id]` | assets-repo.ts | 비상금 분리 |
-| 7 | 예산 설정 (목표 기간) | budget-settings-page | `/api/budget/settings` | settings-repo.ts | `target_date` 변경 프리뷰 지원 |
+| 7 | 예산 설정 (목표 기간) | budget-settings-page | `/api/budget/settings` | settings-repo.ts | `target_date` 변경 시 OFF 할부 영향 분석 모달 (ADR 0018) |
 | 8 | 월 예산 배분 | month-summary | `/api/budget/monthly` | month-allocator.ts | 일수 비례 균등 분배 |
 | 9 | 일 예산 배분 | month-summary 오늘 예산 | `/api/budget/today` | day-allocator.ts | 초과 클램프 |
 | 10 | 장기 예산 시뮬레이션 | runway-card | `/api/budget/runway` | runway-projection.ts | 월별 burn 시뮬 |
 | 11 | 일별 예산 로그 | daily-budget-log | `/api/budget/daily-logs` + cron | `saveDailyBudgetLog` | UNIQUE(user, date) |
 | 12 | 월별 예산 스냅샷 | — (내부) | 정산 cron 진입점 | `buildSettlementSnapshot` | 14일 종료 → 15일 새벽 cron, idempotent |
-| 13 | 결제주기 유틸 | — | — | billing/cycle.ts | 전월 15일\~당월 14일 |
+| 13 | 결제주기 유틸 | — | — | billing/cycle.ts, billing/card-billing.ts | 전월 15일\~당월 14일, 카드별 startDay |
+| 14 | 할부 자산 차감 범위 토글 | expense-form / expense-edit-modal 조건부 라디오 | `/api/expenses` POST/PATCH + `/api/budget/settings` `?preview=true` | createInstallmentExpenses, updateExpense, settings-repo (analyzeTargetDateChange / applyTargetDateChange / computeInstallmentToggleAdjustment) | ADR 0018. 마지막 회차 > target_date 일 때만 노출. 그룹 단위 적용 |
 
 ### 🟡 부분 구현 (4)
 
@@ -269,6 +273,32 @@ detectSettlementTrigger() → 어제가 14일(주기 마지막)인지 판정
   → getTodayAllocation() (정산된 시각 기준)
   → saveDailyBudgetLog() (UNIQUE(user, date))
   → daily-budget-log 컴포넌트가 차트로 렌더
+```
+
+### 할부 자산 차감 범위 토글 (ADR 0018)
+```
+[INSERT] expense-form 할부 옵션 + (마지막 회차 billing_month > target_date 일 때만) 라디오
+  → POST /api/expenses { installment_months, distribute_to_runway }
+  → createInstallmentExpenses
+     ├─ distribute_to_runway=true (default): 2~N회차 amount 합 = futureSum
+     └─ distribute_to_runway=false: 2~N회차 중 billing_month ≤ target_date 만 futureSum
+  → applyAssetDeduction(futureSum) — wasDeductedFromAssetAtInsert 기준 idempotent
+
+[사후 토글] expense-edit-modal 라디오 변경
+  → PATCH /api/expenses/[id] { distribute_to_runway }
+  → updateExpense 토글 분기
+     ├─ computeInstallmentToggleAdjustment(group, newValue): 그룹 미래 회차 중 billing_month > target_date 인 amount 합 = boundarySum
+     │  ├─ true (OFF→ON): +boundarySum → applyAssetDeduction
+     │  └─ false (ON→OFF): -boundarySum → applyAssetIncrease
+     └─ UPDATE expenses SET distribute_to_runway WHERE installment_group = ? (그룹 전체 동기화)
+
+[target_date 변경] budget-settings-page 목표 기간 변경 → 영향 분석 모달
+  → PUT /api/budget/settings?preview=true { target_date }
+  → analyzeTargetDateChange: OFF 할부의 미래 회차를 old/new boundary 로 비교, 그룹별 deltaAmount 산출
+  → 모달에서 사용자가 확인 → PUT (preview 없이) → applyTargetDateChange
+     ├─ totalDelta > 0: applyAssetDeduction
+     ├─ totalDelta < 0: applyAssetIncrease
+     └─ upsertTargetDate
 ```
 
 ## 주요 계산 규칙
@@ -335,4 +365,4 @@ detectSettlementTrigger() → 어제가 14일(주기 마지막)인지 판정
 
 ## 주요 PR
 
-- #292 (v2 전환), #293 (정합성 수정), #295 (projectFromAllocator 도입)
+- #292 (v2 전환), #293 (정합성 수정), #295 (projectFromAllocator 도입), #411 (할부 자산 차감 범위 토글 + 세금 카테고리)

--- a/web/src/app/api/budget/settings/route.ts
+++ b/web/src/app/api/budget/settings/route.ts
@@ -3,10 +3,15 @@ import { requireAuth } from '@/lib/auth';
 import { getBudgetPreview } from '@/features/budget/lib/facade';
 import {
   readTargetMonth,
-  upsertTargetDate,
+  analyzeTargetDateChange,
+  applyTargetDateChange,
 } from '@/features/budget/lib/repository/settings-repo';
 
 export const dynamic = 'force-dynamic';
+
+function isValidTargetDate(td: string | null | undefined): td is string | null {
+  return td === null || td === undefined || /^\d{4}-\d{2}$/.test(td);
+}
 
 export async function GET(request: Request) {
   const userId = await requireAuth();
@@ -30,18 +35,32 @@ export async function GET(request: Request) {
   }
 }
 
+/**
+ * target_date 변경 — preview/apply 분기 (ADR 0018).
+ *
+ * ?preview=true: 영향 분석만 반환 (DB 미변경)
+ * (없음): OFF 할부 자산 보정 + budget_settings UPDATE
+ *
+ * 응답: TargetDateChangePreview { oldTargetDate, newTargetDate, affectedGroups, totalDelta }
+ */
 export async function PUT(request: Request) {
   const userId = await requireAuth();
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   try {
+    const { searchParams } = new URL(request.url);
+    const previewMode = searchParams.get('preview') === 'true';
+
     const body = (await request.json()) as { target_date?: string | null };
-    const td = body.target_date;
-    if (td !== null && td !== undefined && !/^\d{4}-\d{2}$/.test(td)) {
+    const td = body.target_date ?? null;
+    if (!isValidTargetDate(td)) {
       return NextResponse.json({ error: 'target_date 형식: YYYY-MM' }, { status: 400 });
     }
-    await upsertTargetDate(userId, td ?? null);
-    return NextResponse.json({ data: { target_date: td ?? null } });
+
+    const result = previewMode
+      ? await analyzeTargetDateChange(userId, td)
+      : await applyTargetDateChange(userId, td);
+    return NextResponse.json({ data: result });
   } catch (err) {
     console.error('[Budget API] settings PUT', err);
     return NextResponse.json({ error: '설정 저장 실패' }, { status: 500 });

--- a/web/src/app/api/expenses/[id]/route.ts
+++ b/web/src/app/api/expenses/[id]/route.ts
@@ -41,6 +41,12 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         { status: 400 },
       );
     }
+    if ('distribute_to_runway' in body && typeof body.distribute_to_runway !== 'boolean') {
+      return NextResponse.json(
+        { error: 'distribute_to_runway는 boolean이어야 합니다' },
+        { status: 400 },
+      );
+    }
 
     const lengthError = validateFields([
       [body.description, 'description'],

--- a/web/src/app/api/expenses/route.ts
+++ b/web/src/app/api/expenses/route.ts
@@ -83,6 +83,8 @@ export async function POST(request: Request) {
       installment_months?: number;
       exclude_from_budget?: boolean;
       distribute_to_budget?: boolean;
+      /** 할부 자산 차감 범위 토글 (ADR 0018). 기본 true=전체 회차 즉시 차감 / false=target_date 이내만 */
+      distribute_to_runway?: boolean;
     };
 
     if (!body.date || !/^\d{4}-\d{2}-\d{2}$/.test(body.date)) {
@@ -131,6 +133,7 @@ export async function POST(request: Request) {
         memo: body.memo,
         type: entryType,
         exclude_from_budget: excludeFromBudget,
+        distribute_to_runway: body.distribute_to_runway,
       });
       return NextResponse.json({ data }, { status: 201 });
     }

--- a/web/src/features/budget/components/budget-settings-page.tsx
+++ b/web/src/features/budget/components/budget-settings-page.tsx
@@ -583,6 +583,21 @@ interface BudgetPreviewData {
   month_breakdown: MonthBreakdownItem[];
 }
 
+// ADR 0018: target_date 변경 영향 — OFF 할부 자산 보정 미리보기
+interface TargetDateChangeGroup {
+  groupId: string;
+  description: string | null;
+  /** 자산 변화량. 양수=추가 차감, 음수=환원 */
+  deltaAmount: number;
+}
+
+interface TargetDateChangePreview {
+  oldTargetDate: string | null;
+  newTargetDate: string | null;
+  affectedGroups: TargetDateChangeGroup[];
+  totalDelta: number;
+}
+
 function TargetDateCard({
   savedTarget,
   onSaved,
@@ -595,6 +610,7 @@ function TargetDateCard({
   const [loadingPreview, setLoadingPreview] = useState(false);
   const [saving, setSaving] = useState(false);
   const [showAllMonths, setShowAllMonths] = useState(false);
+  const [changePreview, setChangePreview] = useState<TargetDateChangePreview | null>(null);
 
   // 초기 프리뷰 로드 (저장된 목표가 있으면)
   useEffect(() => {
@@ -627,18 +643,40 @@ function TargetDateCard({
     }
   };
 
+  /** target_date 실제 저장 (확정 단계 — DB 변경) */
+  const applyTargetDate = async (target: string) => {
+    const res = await fetch('/api/budget/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target_date: target }),
+    });
+    if (res.ok) {
+      onSaved(target);
+      setChangePreview(null);
+    }
+  };
+
   const handleSave = async () => {
     if (!inputValue || !/^\d{4}-\d{2}$/.test(inputValue)) return;
     setSaving(true);
     try {
-      const res = await fetch('/api/budget/settings', {
+      // 1단계: 영향 분석 (DB 미변경)
+      const previewRes = await fetch('/api/budget/settings?preview=true', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ target_date: inputValue }),
       });
-      if (res.ok) {
-        onSaved(inputValue);
+      if (!previewRes.ok) return;
+      const { data } = (await previewRes.json()) as { data: TargetDateChangePreview };
+
+      // 영향 받는 OFF 할부 그룹이 없으면 즉시 적용
+      if (data.affectedGroups.length === 0) {
+        await applyTargetDate(inputValue);
+        return;
       }
+
+      // 영향이 있으면 확인 모달 표시
+      setChangePreview(data);
     } finally {
       setSaving(false);
     }
@@ -737,6 +775,81 @@ function TargetDateCard({
         <p className="text-xs text-gray-400">
           목표 기간을 설정하면 월별 예산과 일일 자유 예산을 미리 확인할 수 있습니다.
         </p>
+      )}
+
+      {/* 목표 기간 변경 영향 모달 (ADR 0018) */}
+      {changePreview && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setChangePreview(null);
+          }}
+        >
+          <div className="w-full max-w-md rounded-xl bg-white p-5 shadow-lg">
+            <h3 className="mb-2 text-sm font-semibold text-gray-800">목표 기간 변경 영향</h3>
+            <p className="mb-3 text-xs text-gray-500">
+              {changePreview.oldTargetDate ?? '미설정'} →{' '}
+              <span className="font-medium text-gray-700">
+                {changePreview.newTargetDate ?? '미설정'}
+              </span>
+            </p>
+
+            <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 p-3">
+              <p className="mb-2 text-xs text-amber-700">
+                "목표 기간 이내만" 모드로 등록된 할부 그룹의 자산 차감이 다음과 같이 조정됩니다:
+              </p>
+              <div className="max-h-40 overflow-y-auto divide-y divide-amber-100">
+                {changePreview.affectedGroups.map((g) => (
+                  <div key={g.groupId} className="flex items-center justify-between py-1.5 text-xs">
+                    <span className="truncate text-gray-700">{g.description ?? '내역 없음'}</span>
+                    <span
+                      className={`ml-2 whitespace-nowrap font-medium ${g.deltaAmount > 0 ? 'text-red-600' : 'text-blue-600'}`}
+                    >
+                      {g.deltaAmount > 0 ? '추가 차감' : '환원'}{' '}
+                      {formatAmount(Math.abs(g.deltaAmount))}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-2 flex items-center justify-between border-t border-amber-200 pt-2 text-xs">
+                <span className="font-medium text-gray-700">총 자산 변화</span>
+                <span
+                  className={`font-bold ${changePreview.totalDelta > 0 ? 'text-red-600' : changePreview.totalDelta < 0 ? 'text-blue-600' : 'text-gray-500'}`}
+                >
+                  {changePreview.totalDelta > 0
+                    ? `-${formatAmount(changePreview.totalDelta)} (차감)`
+                    : changePreview.totalDelta < 0
+                      ? `+${formatAmount(-changePreview.totalDelta)} (환원)`
+                      : '변화 없음'}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setChangePreview(null)}
+                disabled={saving}
+                className="rounded-lg px-3 py-1.5 text-xs text-gray-500 hover:bg-gray-100"
+              >
+                취소
+              </button>
+              <button
+                onClick={() => {
+                  if (changePreview.newTargetDate) {
+                    setSaving(true);
+                    void applyTargetDate(changePreview.newTargetDate).finally(() =>
+                      setSaving(false),
+                    );
+                  }
+                }}
+                disabled={saving}
+                className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white disabled:opacity-40 hover:bg-blue-700"
+              >
+                {saving ? '적용 중...' : '확인하고 적용'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/web/src/features/budget/components/expense-edit-modal.tsx
+++ b/web/src/features/budget/components/expense-edit-modal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import type { ExpenseRow, PlannedExpenseRow } from '@/features/budget/lib/types';
 import { ALL_EXPENSE_CATEGORIES, BUDGET_EXCLUDED_CATEGORIES } from '@/features/budget/lib/types';
+import { computeLastInstallmentBillingMonth } from '@/features/budget/lib/billing/card-billing';
 import { formatAmount } from '@/lib/types';
 import { XMarkIcon } from '@/components/ui/icons';
 import { Button } from '@/components/ui/button';
@@ -21,6 +22,7 @@ interface ExpenseEditModalProps {
       description: string | null;
       exclude_from_budget: boolean;
       planned_expense_id: number | null;
+      distribute_to_runway?: boolean;
     },
   ) => Promise<void>;
   onDelete: (id: number) => Promise<void>;
@@ -44,8 +46,48 @@ export function ExpenseEditModal({
   const [plannedExpenses, setPlannedExpenses] = useState<PlannedExpenseRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // ADR 0018: 할부 자산 차감 범위 토글 (그룹 전체에 적용)
+  const [distributeToRunway, setDistributeToRunway] = useState(expense.distribute_to_runway);
+  const [targetDate, setTargetDate] = useState<string | null>(null);
 
   const showPlannedSelect = yearMonth && !expense.is_installment && expense.type !== 'income';
+
+  // target_date 로드 — 할부 토글 조건부 노출 판단용
+  useEffect(() => {
+    if (!expense.is_installment) return;
+    void fetch('/api/budget/settings')
+      .then((r) => r.json())
+      .then((d: { data?: { target_date: string | null } }) =>
+        setTargetDate(d.data?.target_date ?? null),
+      )
+      .catch(() => setTargetDate(null));
+  }, [expense.is_installment]);
+
+  // 이 회차로부터 첫 회차 date 역산 후 마지막 회차 billing_month 계산
+  const lastInstallmentBillingMonth =
+    expense.is_installment &&
+    expense.installment_num != null &&
+    expense.installment_total != null &&
+    expense.payment_method
+      ? (() => {
+          const baseDate = new Date(`${expense.date}T00:00:00`);
+          baseDate.setMonth(baseDate.getMonth() - (expense.installment_num - 1));
+          const firstDate = `${baseDate.getFullYear()}-${String(baseDate.getMonth() + 1).padStart(2, '0')}-${String(baseDate.getDate()).padStart(2, '0')}`;
+          return computeLastInstallmentBillingMonth(
+            firstDate,
+            expense.installment_total,
+            expense.payment_method,
+          );
+        })()
+      : null;
+
+  const showRunwayToggle =
+    expense.is_installment &&
+    expense.type !== 'income' &&
+    !expense.exclude_from_budget &&
+    targetDate !== null &&
+    lastInstallmentBillingMonth !== null &&
+    lastInstallmentBillingMonth > targetDate;
 
   useEffect(() => {
     if (!showPlannedSelect) return;
@@ -74,6 +116,16 @@ export function ExpenseEditModal({
       setError('금액을 올바르게 입력해주세요');
       return;
     }
+
+    // 할부 자산 차감 범위 변경은 그룹 전체에 적용 — 사용자 확인
+    const runwayChanged = showRunwayToggle && distributeToRunway !== expense.distribute_to_runway;
+    if (runwayChanged) {
+      const msg = distributeToRunway
+        ? '자산 차감 범위를 "전체 회차 즉시 차감"으로 변경합니다.\n같은 할부 그룹의 모든 회차에 적용되며, 자산이 추가로 차감됩니다.\n계속할까요?'
+        : '자산 차감 범위를 "목표 기간 이내만"으로 변경합니다.\n같은 할부 그룹의 모든 회차에 적용되며, 목표 기간 이후 회차분이 자산에 환원됩니다.\n계속할까요?';
+      if (!confirm(msg)) return;
+    }
+
     setLoading(true);
     try {
       await onSave(expense.id, {
@@ -83,6 +135,7 @@ export function ExpenseEditModal({
         description: description || null,
         exclude_from_budget: excludeFromBudget,
         planned_expense_id: selectedPlanned,
+        ...(runwayChanged ? { distribute_to_runway: distributeToRunway } : {}),
       });
       onClose();
     } catch (err) {
@@ -194,6 +247,50 @@ export function ExpenseEditModal({
               </button>
             </div>
           </div>
+
+          {/* 할부 자산 차감 범위 토글 (ADR 0018) — 마지막 회차가 target_date 이후일 때만 노출 */}
+          {showRunwayToggle && (
+            <fieldset className="rounded-lg border border-amber-300 bg-amber-50 p-3">
+              <legend className="px-1 text-[11px] font-medium text-amber-700">
+                자산 차감 범위 (할부 그룹 전체에 적용)
+              </legend>
+              <p className="mb-2 text-[10px] text-amber-700">
+                마지막 회차({lastInstallmentBillingMonth})는 목표 기간({targetDate}) 이후입니다.
+              </p>
+              <label className="mb-1 flex cursor-pointer items-start gap-2 text-xs text-gray-700">
+                <input
+                  type="radio"
+                  name="distribute_to_runway"
+                  checked={distributeToRunway}
+                  onChange={() => setDistributeToRunway(true)}
+                  className="mt-0.5"
+                />
+                <span>
+                  <strong>지금 자산에서 전부 미리 차감</strong>
+                  <br />
+                  <span className="text-[10px] text-gray-500">
+                    모든 회차 금액을 즉시 자산에서 빼고 매달 잊는다
+                  </span>
+                </span>
+              </label>
+              <label className="flex cursor-pointer items-start gap-2 text-xs text-gray-700">
+                <input
+                  type="radio"
+                  name="distribute_to_runway"
+                  checked={!distributeToRunway}
+                  onChange={() => setDistributeToRunway(false)}
+                  className="mt-0.5"
+                />
+                <span>
+                  <strong>목표 기간 이후 회차는 그때의 자금으로</strong>
+                  <br />
+                  <span className="text-[10px] text-gray-500">
+                    목표 기간 이내 회차만 자산에서 차감, 이후는 매달 예산에서 분배
+                  </span>
+                </span>
+              </label>
+            </fieldset>
+          )}
 
           {/* 예정 지출 연결 (일시불 지출만, 할부/수입 제외) */}
           {showPlannedSelect && plannedExpenses.length > 0 && (

--- a/web/src/features/budget/components/expense-form.tsx
+++ b/web/src/features/budget/components/expense-form.tsx
@@ -12,7 +12,10 @@ import { PlusIcon, XMarkIcon } from '@/components/ui/icons';
 import { formatAmount } from '@/lib/types';
 import { Input, Select } from '@/components/ui/input';
 import { getTodayISO } from '@/lib/kst';
-import { getBillingMonthForExpense } from '@/features/budget/lib/billing/card-billing';
+import {
+  getBillingMonthForExpense,
+  computeLastInstallmentBillingMonth,
+} from '@/features/budget/lib/billing/card-billing';
 
 interface ExpenseFormProps {
   onAdd: (data: {
@@ -26,6 +29,7 @@ interface ExpenseFormProps {
     installment_months?: number;
     exclude_from_budget?: boolean;
     distribute_to_budget?: boolean;
+    distribute_to_runway?: boolean;
   }) => Promise<ExpenseRow>;
   /** 현재 보고 있는 결제주기 월 (예정 지출 목록용) */
   yearMonth?: string;
@@ -48,6 +52,8 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
   const [installmentMonths, setInstallmentMonths] = useState<number>(1);
   const [excludeFromBudget, setExcludeFromBudget] = useState(false);
   const [distributeToBudget, setDistributeToBudget] = useState(false);
+  const [distributeToRunway, setDistributeToRunway] = useState(true);
+  const [targetDate, setTargetDate] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,6 +65,16 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
       .then((d: { data?: PlannedExpenseRow[] }) => setPlannedExpenses(d.data ?? []))
       .catch(() => setPlannedExpenses([]));
   }, [yearMonth]);
+
+  // target_date 로드 — 할부 토글 조건부 노출 판단용
+  useEffect(() => {
+    void fetch('/api/budget/settings')
+      .then((r) => r.json())
+      .then((d: { data?: { target_date: string | null } }) => {
+        setTargetDate(d.data?.target_date ?? null);
+      })
+      .catch(() => setTargetDate(null));
+  }, []);
 
   const handleTypeChange = (type: 'expense' | 'income') => {
     setEntryType(type);
@@ -103,6 +119,10 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
           entryType === 'expense' && paymentMethod !== '현금' ? installmentMonths : undefined,
         exclude_from_budget: entryType === 'expense' ? excludeFromBudget : false,
         distribute_to_budget: entryType === 'income' ? distributeToBudget : false,
+        distribute_to_runway:
+          entryType === 'expense' && paymentMethod !== '현금' && installmentMonths > 1
+            ? distributeToRunway
+            : undefined,
       });
       setAmountStr('');
       setDescription('');
@@ -111,6 +131,7 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
       setInstallmentMonths(1);
       setExcludeFromBudget(BUDGET_EXCLUDED_CATEGORIES.has(EXPENSE_CATEGORIES[0]));
       setDistributeToBudget(false);
+      setDistributeToRunway(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : '추가 실패');
     } finally {
@@ -136,6 +157,17 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
 
   // 귀속 월 계산 (지출 모드에서 실시간 표시)
   const billingMonthNum = parseInt(getBillingMonthForExpense(date, paymentMethod).slice(5), 10);
+
+  // 할부 자산 차감 범위 토글 노출 조건 (ADR 0018):
+  // 마지막 회차 billing_month > target_date 일 때만 의미 있는 분기.
+  const lastInstallmentBillingMonth =
+    entryType === 'expense' && paymentMethod !== '현금' && installmentMonths >= 2
+      ? computeLastInstallmentBillingMonth(date, installmentMonths, paymentMethod)
+      : null;
+  const showRunwayToggle =
+    lastInstallmentBillingMonth !== null &&
+    targetDate !== null &&
+    lastInstallmentBillingMonth > targetDate;
 
   return (
     <form
@@ -305,6 +337,45 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
             </div>
           </div>
         </div>
+      )}
+
+      {/* 할부 자산 차감 범위 토글 (ADR 0018) — 마지막 회차가 target_date를 넘을 때만 노출 */}
+      {showRunwayToggle && (
+        <fieldset className="mt-3 rounded-lg border border-amber-300 bg-amber-50 p-3">
+          <legend className="px-1 text-xs text-amber-700">
+            마지막 회차({lastInstallmentBillingMonth})는 목표 기간({targetDate}) 이후입니다
+          </legend>
+          <label className="flex cursor-pointer items-start gap-2 py-1 text-xs text-gray-700">
+            <input
+              type="radio"
+              name="distribute-to-runway"
+              checked={distributeToRunway}
+              onChange={() => setDistributeToRunway(true)}
+              className="mt-0.5"
+            />
+            <span>
+              <strong>지금 자산에서 전부 미리 차감</strong>
+              <span className="block text-[10px] text-gray-500">
+                목표 기간 이후 회차도 즉시 자산에서 빠집니다. 확실하게 잡고 가고 싶을 때.
+              </span>
+            </span>
+          </label>
+          <label className="flex cursor-pointer items-start gap-2 py-1 text-xs text-gray-700">
+            <input
+              type="radio"
+              name="distribute-to-runway"
+              checked={!distributeToRunway}
+              onChange={() => setDistributeToRunway(false)}
+              className="mt-0.5"
+            />
+            <span>
+              <strong>목표 기간 이후 회차는 그때의 자금으로 갚을 예정</strong>
+              <span className="block text-[10px] text-gray-500">
+                목표 기간 안의 회차만 지금 자산에서 빠지고, 이후 회차는 결제될 때 처리합니다.
+              </span>
+            </span>
+          </label>
+        </fieldset>
       )}
 
       {/* 수입 전체 분배 토글 (수입 모드 전용) */}

--- a/web/src/features/budget/hooks/use-budget.ts
+++ b/web/src/features/budget/hooks/use-budget.ts
@@ -203,6 +203,8 @@ export function useBudget() {
       planned_expense_id?: number | null;
       installment_months?: number;
       exclude_from_budget?: boolean;
+      /** 할부 자산 차감 범위 토글 (ADR 0018). 기본 true=전체 회차 즉시 차감 / false=target_date 이내만 */
+      distribute_to_runway?: boolean;
     }): Promise<ExpenseRow> => {
       const res = await fetch('/api/expenses', {
         method: 'POST',
@@ -253,6 +255,8 @@ export function useBudget() {
         description: string | null;
         exclude_from_budget?: boolean;
         planned_expense_id?: number | null;
+        /** 할부 자산 차감 범위 토글 (ADR 0018). 변경 시 그룹 전체에 적용 */
+        distribute_to_runway?: boolean;
       },
     ): Promise<void> => {
       const res = await fetch(`/api/expenses/${id}`, {
@@ -265,11 +269,16 @@ export function useBudget() {
         throw new Error(err.error ?? '지출 수정 실패');
       }
       const { data } = (await res.json()) as { data: ExpenseRow };
-      setExpenses((prev) => prev.map((e) => (e.id === id ? data : e)));
+      // distribute_to_runway 변경은 그룹 전체에 적용되므로 목록 전체 재조회
+      if ('distribute_to_runway' in updates) {
+        void fetchAll(selectedMonth);
+      } else {
+        setExpenses((prev) => prev.map((e) => (e.id === id ? data : e)));
+      }
       setExpenseVersion((v) => v + 1);
       void refreshBudget(selectedMonth).catch(() => {});
     },
-    [selectedMonth, refreshBudget],
+    [selectedMonth, refreshBudget, fetchAll],
   );
 
   const updateAssetBalance = useCallback(

--- a/web/src/features/budget/lib/billing/__tests__/card-billing.test.ts
+++ b/web/src/features/budget/lib/billing/__tests__/card-billing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getBillingMonthForExpense } from '../card-billing';
+import { getBillingMonthForExpense, computeLastInstallmentBillingMonth } from '../card-billing';
 
 describe('getBillingMonthForExpense — 카드별 귀속 월 판별', () => {
   describe('현대카드 (startDay=15)', () => {
@@ -62,5 +62,31 @@ describe('getBillingMonthForExpense — 카드별 귀속 월 판별', () => {
     it('현대카드 12월 14일 → 2026-12 (현재 달)', () => {
       expect(getBillingMonthForExpense('2026-12-14', '현대카드')).toBe('2026-12');
     });
+  });
+});
+
+describe('computeLastInstallmentBillingMonth — 할부 마지막 회차 billing_month (ADR 0018)', () => {
+  it('현대카드 1회차 5월 14일 + 12개월 → 2027-04 (마지막 회차 4월 14일)', () => {
+    expect(computeLastInstallmentBillingMonth('2026-05-14', 12, '현대카드')).toBe('2027-04');
+  });
+
+  it('현대카드 1회차 5월 15일 + 12개월 → 2027-05 (5월 15일 시작 → 다음달 귀속, 마지막은 2027-04-15 → 2027-05)', () => {
+    expect(computeLastInstallmentBillingMonth('2026-05-15', 12, '현대카드')).toBe('2027-05');
+  });
+
+  it('국민카드 1회차 5월 13일 + 6개월 → 2026-11 (마지막 회차 10월 13일 → 11월 귀속)', () => {
+    expect(computeLastInstallmentBillingMonth('2026-05-13', 6, '국민카드')).toBe('2026-11');
+  });
+
+  it('months=2 → 첫 회차 +1개월', () => {
+    expect(computeLastInstallmentBillingMonth('2026-05-10', 2, '현대카드')).toBe('2026-06');
+  });
+
+  it('months=1 (할부 아님, 토글 안 노출되는 케이스라 의미 X) → 첫 회차 billing_month 그대로', () => {
+    expect(computeLastInstallmentBillingMonth('2026-05-10', 1, '현대카드')).toBe('2026-05');
+  });
+
+  it('연도 넘김 — 1회차 11월 1일 + 6개월 → 2027-04', () => {
+    expect(computeLastInstallmentBillingMonth('2026-11-01', 6, '현대카드')).toBe('2027-04');
   });
 });

--- a/web/src/features/budget/lib/billing/card-billing.ts
+++ b/web/src/features/budget/lib/billing/card-billing.ts
@@ -29,3 +29,24 @@ export function getBillingMonthForExpense(date: string, paymentMethod: string): 
   }
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
 }
+
+/**
+ * 할부 마지막 회차의 billing_month 계산 (할부 토글 조건부 노출 판단용).
+ *
+ * createInstallmentExpenses와 동일한 분할 로직: 첫 회차 date 기준 (months - 1)개월 후의 billing_month.
+ *
+ * @param firstDate 첫 회차 date 'YYYY-MM-DD'
+ * @param months 총 할부 개월 수 (>= 1)
+ * @param paymentMethod 결제수단 문자열
+ * @returns 'YYYY-MM' 마지막 회차 billing_month
+ */
+export function computeLastInstallmentBillingMonth(
+  firstDate: string,
+  months: number,
+  paymentMethod: string,
+): string {
+  const baseDate = new Date(`${firstDate}T00:00:00`);
+  baseDate.setMonth(baseDate.getMonth() + (months - 1));
+  const expDate = `${baseDate.getFullYear()}-${String(baseDate.getMonth() + 1).padStart(2, '0')}-${String(baseDate.getDate()).padStart(2, '0')}`;
+  return getBillingMonthForExpense(expDate, paymentMethod);
+}

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -156,10 +156,10 @@ describe('runSettlementIfDue', () => {
   });
 
   it('정산일(14일)이고 스냅샷 신규 → settled=true + 스냅샷 반환', async () => {
-    // April 14 12:00 UTC = April 14 21:00 KST → yesterday=April 13 → shouldSettle=true, targetMonth='2026-04'
-    // targetMonth = '2026-04-13'.slice(0,7) = '2026-04', range.to = '2026-04-13'
-    // targetEnd = new Date('2026-04-13T12:00:00Z') = Apr 13 21:00 KST → billing cycle '2026-04' ✓
-    const settlementNow = new Date('2026-04-14T12:00:00Z');
+    // April 15 12:00 UTC = April 15 21:00 KST → yesterday=April 14 → shouldSettle=true, targetMonth='2026-04'
+    // range.to = '2026-04-14' (cycle 15→14 boundary)
+    // targetEnd = new Date('2026-04-14T12:00:00Z') = Apr 14 21:00 KST → billing cycle '2026-04' ✓
+    const settlementNow = new Date('2026-04-15T12:00:00Z');
 
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
@@ -176,7 +176,7 @@ describe('runSettlementIfDue', () => {
   });
 
   it('available_at_end = availableAtStart + income - flex - excluded (자산 미참조)', async () => {
-    const settlementNow = new Date('2026-04-14T12:00:00Z');
+    const settlementNow = new Date('2026-04-15T12:00:00Z');
 
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
@@ -194,7 +194,7 @@ describe('runSettlementIfDue', () => {
   });
 
   it('snapshot 신규 저장 시 자산 자동 차감/증액 호출 (flex + excluded, income 분리)', async () => {
-    const settlementNow = new Date('2026-04-14T12:00:00Z');
+    const settlementNow = new Date('2026-04-15T12:00:00Z');
 
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
@@ -210,7 +210,7 @@ describe('runSettlementIfDue', () => {
   });
 
   it('snapshot 재실행(saved=false) 시 자산 변동 호출 없음 — idempotency', async () => {
-    const settlementNow = new Date('2026-04-14T12:00:00Z');
+    const settlementNow = new Date('2026-04-15T12:00:00Z');
 
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -6,6 +6,11 @@ import { resolveFixedCostExpenseDate } from './billing/fixed-cost-date';
 import { getBillingMonthForExpense } from './billing/card-billing';
 import { readFlexibleSpent, readTodayFlexSpent } from './repository/expenses-repo';
 import { applyAssetDeduction, applyAssetIncrease } from './repository/assets-repo';
+import {
+  readTargetMonth,
+  computeInstallmentToggleAdjustment,
+  applyInstallmentToggleAdjustment,
+} from './repository/settings-repo';
 import type {
   ExpenseRow,
   FixedCostRow,
@@ -150,6 +155,8 @@ export async function createInstallmentExpenses(
     memo?: string | null;
     type?: 'expense' | 'income';
     exclude_from_budget?: boolean;
+    /** 할부 자산 차감 범위 토글 (ADR 0018). default true = 즉시 전체 차감 (ADR 0015 그대로) */
+    distribute_to_runway?: boolean;
   },
 ): Promise<ExpenseRow> {
   const monthlyAmount = Math.round(data.totalAmount / data.months);
@@ -157,6 +164,10 @@ export async function createInstallmentExpenses(
   const lastMonthAmount = data.totalAmount - monthlyAmount * (data.months - 1);
   const groupId = crypto.randomUUID();
   const excludeFromBudget = data.exclude_from_budget ?? false;
+  const distributeToRunway = data.distribute_to_runway ?? true;
+
+  // OFF 모드일 때만 target_date 조회. ON 모드(default)는 ADR 0015 그대로 동작.
+  const targetDate = !distributeToRunway ? await readTargetMonth(userId) : null;
 
   let firstRow: ExpenseRow | null = null;
   let futureSum = 0;
@@ -173,12 +184,14 @@ export async function createInstallmentExpenses(
     const row = await queryOne<ExpenseRow>(
       `INSERT INTO expenses (user_id, date, amount, category, description, payment_method,
                              is_installment, installment_num, installment_total, installment_group,
-                             memo, source, type, exclude_from_budget, billing_month)
-       VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8, $9, $10, 'manual', $11, $12, $13)
+                             memo, source, type, exclude_from_budget, distribute_to_runway, billing_month)
+       VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8, $9, $10, 'manual', $11, $12, $13, $14)
        RETURNING id, date::text, amount, category, description, payment_method,
                  is_installment, installment_num, installment_total, installment_group,
                  source, memo, COALESCE(type, 'expense') as type, planned_expense_id, created_at::text,
-                 COALESCE(exclude_from_budget, false) as exclude_from_budget`,
+                 COALESCE(exclude_from_budget, false) as exclude_from_budget,
+                 COALESCE(distribute_to_budget, false) as distribute_to_budget,
+                 COALESCE(distribute_to_runway, true) as distribute_to_runway`,
       [
         userId,
         expDate,
@@ -192,11 +205,23 @@ export async function createInstallmentExpenses(
         data.memo ?? null,
         data.type ?? 'expense',
         excludeFromBudget,
+        distributeToRunway,
         billingMonth,
       ],
     );
-    if (i === 0) firstRow = row ?? null;
-    else futureSum += amount;
+    if (i === 0) {
+      firstRow = row ?? null;
+    } else {
+      // 2+회차 자산 차감 범위:
+      // - distribute_to_runway=true: 전부 차감 (ADR 0015 그대로)
+      // - distribute_to_runway=false + target_date 안: 차감
+      // - distribute_to_runway=false + target_date 밖: 무영향 (결제주기 cron이 자유지출로 처리)
+      const beyondTarget = !distributeToRunway && targetDate !== null && billingMonth > targetDate;
+      const beyondWithNoTarget = !distributeToRunway && targetDate === null;
+      if (!beyondTarget && !beyondWithNoTarget) {
+        futureSum += amount;
+      }
+    }
   }
 
   if (!firstRow) throw new Error('createInstallmentExpenses: INSERT returned no rows');
@@ -224,6 +249,7 @@ const EXPENSE_COLUMNS = new Set([
   'planned_expense_id',
   'exclude_from_budget',
   'distribute_to_budget',
+  'distribute_to_runway',
 ]);
 
 /** source='fixed' 행의 exclude_from_budget 변경 시도 시 throw되는 sentinel error */
@@ -235,6 +261,9 @@ interface ExistingForAsset {
   installment_num: number | null;
   type: string;
   exclude_from_budget: boolean;
+  distribute_to_runway: boolean;
+  billing_month: string | null;
+  installment_group: string | null;
 }
 
 function isFutureInstallment(row: ExistingForAsset): boolean {
@@ -245,6 +274,30 @@ function isFutureInstallment(row: ExistingForAsset): boolean {
     !row.exclude_from_budget
   );
 }
+
+/**
+ * INSERT 시점에 자산에서 차감된 회차인지 — OFF + target 밖 회차는 자산 차감되지 않았으므로 false.
+ * amount 변경 / 삭제 시 자산 보정 여부 판단에 사용.
+ */
+async function wasDeductedFromAssetAtInsert(
+  userId: number,
+  row: ExistingForAsset,
+): Promise<boolean> {
+  if (!isFutureInstallment(row)) return false;
+  if (row.distribute_to_runway) return true; // ON이면 모든 2+회차가 차감됐었음
+  // OFF: billing_month <= target_date 인 회차만 차감됐었음
+  if (row.billing_month === null) return false;
+  const targetDate = await readTargetMonth(userId);
+  if (targetDate === null) return false; // target 없으면 OFF는 모든 회차가 무영향
+  return row.billing_month <= targetDate;
+}
+
+const EXISTING_FOR_ASSET_SELECT = `SELECT amount, is_installment, installment_num,
+            COALESCE(type, 'expense') as type,
+            COALESCE(exclude_from_budget, false) as exclude_from_budget,
+            COALESCE(distribute_to_runway, true) as distribute_to_runway,
+            billing_month,
+            installment_group`;
 
 export async function updateExpense(
   userId: number,
@@ -266,35 +319,67 @@ export async function updateExpense(
     }
   }
 
-  // 할부 미래 회차 amount 변경 시 자산 보정용 사전 조회
+  // 할부 미래 회차 amount/distribute_to_runway 변경 시 자산 보정용 사전 조회
   const amountChanging = keys.includes('amount');
-  const existingForAsset = amountChanging
-    ? await queryOne<ExistingForAsset>(
-        `SELECT amount, is_installment, installment_num,
-                COALESCE(type, 'expense') as type,
-                COALESCE(exclude_from_budget, false) as exclude_from_budget
-         FROM expenses WHERE id = $1 AND user_id = $2`,
-        [id, userId],
-      )
-    : null;
+  const toggleChanging = keys.includes('distribute_to_runway');
+  const existingForAsset =
+    amountChanging || toggleChanging
+      ? await queryOne<ExistingForAsset>(
+          `${EXISTING_FOR_ASSET_SELECT}
+           FROM expenses WHERE id = $1 AND user_id = $2`,
+          [id, userId],
+        )
+      : null;
 
-  const setClauses = keys.map((k, i) => `${k} = $${i + 3}`);
-  const values = keys.map((k) => updates[k]);
+  // distribute_to_runway 변경: 그룹 전체 동기화 + 자산 보정 (ADR 0018).
+  // 같은 할부의 다른 회차도 함께 변경되어야 정책 일관성 유지.
+  if (toggleChanging && existingForAsset?.installment_group) {
+    const newValue = Boolean(updates['distribute_to_runway']);
+    const adjustment = await computeInstallmentToggleAdjustment(
+      userId,
+      existingForAsset.installment_group,
+      newValue,
+    );
+    if (adjustment) {
+      await applyInstallmentToggleAdjustment(userId, adjustment);
+    }
+    // 그룹 전체 UPDATE — 단일 행 UPDATE 대신 group 동기화
+    await query(
+      `UPDATE expenses SET distribute_to_runway = $1
+       WHERE user_id = $2 AND installment_group = $3`,
+      [newValue, userId, existingForAsset.installment_group],
+    );
+  }
+
+  // distribute_to_runway는 그룹 UPDATE에서 이미 처리 → 단일행 SET clause에서 제외
+  const setKeys = toggleChanging ? keys.filter((k) => k !== 'distribute_to_runway') : keys;
+  if (setKeys.length === 0) {
+    return queryExpense(userId, id);
+  }
+
+  const setClauses = setKeys.map((k, i) => `${k} = $${i + 3}`);
+  const values = setKeys.map((k) => updates[k]);
   const row = await queryOne<ExpenseRow>(
     `UPDATE expenses SET ${setClauses.join(', ')}
      WHERE id = $1 AND user_id = $2
      RETURNING id, date::text, amount, category, description, payment_method,
                is_installment, installment_num, installment_total, installment_group,
                source, memo, COALESCE(type, 'expense') as type, planned_expense_id, created_at::text,
-            COALESCE(exclude_from_budget, false) as exclude_from_budget,
-            COALESCE(distribute_to_budget, false) as distribute_to_budget`,
+               COALESCE(exclude_from_budget, false) as exclude_from_budget,
+               COALESCE(distribute_to_budget, false) as distribute_to_budget,
+               COALESCE(distribute_to_runway, true) as distribute_to_runway`,
     [id, userId, ...values],
   );
 
-  if (row && existingForAsset && isFutureInstallment(existingForAsset)) {
-    const diff = Number(updates['amount']) - existingForAsset.amount;
-    if (diff > 0) await applyAssetDeduction(userId, diff);
-    else if (diff < 0) await applyAssetIncrease(userId, -diff);
+  // amount 변경 시 자산 보정 — 단, INSERT 시점에 자산에서 차감됐던 회차에 대해서만.
+  // OFF + target 밖 회차는 자산에 영향 없었으므로 amount 변경도 자산 무영향.
+  if (row && amountChanging && existingForAsset) {
+    const deducted = await wasDeductedFromAssetAtInsert(userId, existingForAsset);
+    if (deducted) {
+      const diff = Number(updates['amount']) - existingForAsset.amount;
+      if (diff > 0) await applyAssetDeduction(userId, diff);
+      else if (diff < 0) await applyAssetIncrease(userId, -diff);
+    }
   }
 
   return row;
@@ -303,16 +388,18 @@ export async function updateExpense(
 /** 지출 삭제 — 할부 미래 회차 삭제 시 자산 복원 */
 export async function deleteExpense(userId: number, id: number): Promise<boolean> {
   const existing = await queryOne<ExistingForAsset>(
-    `SELECT amount, is_installment, installment_num,
-            COALESCE(type, 'expense') as type,
-            COALESCE(exclude_from_budget, false) as exclude_from_budget
+    `${EXISTING_FOR_ASSET_SELECT}
      FROM expenses WHERE id = $1 AND user_id = $2`,
     [id, userId],
   );
   const result = await query('DELETE FROM expenses WHERE id = $1 AND user_id = $2', [id, userId]);
   const deleted = (result.rowCount ?? 0) > 0;
-  if (deleted && existing && isFutureInstallment(existing)) {
-    await applyAssetIncrease(userId, existing.amount);
+  if (deleted && existing) {
+    // INSERT 시점에 자산에서 차감됐던 회차만 환원. OFF + target 밖 회차는 자산 무영향이었으므로 환원 X.
+    const wasDeducted = await wasDeductedFromAssetAtInsert(userId, existing);
+    if (wasDeducted) {
+      await applyAssetIncrease(userId, existing.amount);
+    }
   }
   return deleted;
 }

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -41,7 +41,8 @@ export async function queryExpenses(
             is_installment, installment_num, installment_total, installment_group,
             source, memo, COALESCE(type, 'expense') as type, planned_expense_id, created_at::text,
             COALESCE(exclude_from_budget, false) as exclude_from_budget,
-            COALESCE(distribute_to_budget, false) as distribute_to_budget
+            COALESCE(distribute_to_budget, false) as distribute_to_budget,
+            COALESCE(distribute_to_runway, true) as distribute_to_runway
      FROM expenses
      WHERE ${conditions.join(' AND ')}
      ORDER BY date DESC, created_at DESC`,
@@ -67,7 +68,8 @@ export async function queryExpensesByBillingMonth(
             is_installment, installment_num, installment_total, installment_group,
             source, memo, COALESCE(type, 'expense') as type, planned_expense_id, created_at::text,
             COALESCE(exclude_from_budget, false) as exclude_from_budget,
-            COALESCE(distribute_to_budget, false) as distribute_to_budget
+            COALESCE(distribute_to_budget, false) as distribute_to_budget,
+            COALESCE(distribute_to_runway, true) as distribute_to_runway
      FROM expenses
      WHERE ${conditions.join(' AND ')}
      ORDER BY date DESC, created_at DESC`,
@@ -83,7 +85,8 @@ export async function queryExpense(userId: number, id: number): Promise<ExpenseR
             is_installment, installment_num, installment_total, installment_group,
             source, memo, COALESCE(type, 'expense') as type, planned_expense_id, created_at::text,
             COALESCE(exclude_from_budget, false) as exclude_from_budget,
-            COALESCE(distribute_to_budget, false) as distribute_to_budget
+            COALESCE(distribute_to_budget, false) as distribute_to_budget,
+            COALESCE(distribute_to_runway, true) as distribute_to_runway
      FROM expenses WHERE id = $1 AND user_id = $2`,
     [id, userId],
   );
@@ -113,7 +116,8 @@ export async function createExpense(
                is_installment, installment_num, installment_total, installment_group,
                source, memo, COALESCE(type, 'expense') as type, planned_expense_id, created_at::text,
                COALESCE(exclude_from_budget, false) as exclude_from_budget,
-               COALESCE(distribute_to_budget, false) as distribute_to_budget`,
+               COALESCE(distribute_to_budget, false) as distribute_to_budget,
+               COALESCE(distribute_to_runway, true) as distribute_to_runway`,
     [
       userId,
       data.date,

--- a/web/src/features/budget/lib/repository/__tests__/settings-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/settings-repo.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// getCurrentBillingMonth 결정론화 — 모든 테스트가 같은 billing month를 보도록 고정
+vi.mock('../../billing/cycle', () => ({
+  getCurrentBillingMonth: () => '2026-05',
+}));
+
+vi.mock('@/lib/db', () => ({
+  query: vi.fn(),
+  queryOne: vi.fn(),
+}));
+
+vi.mock('../assets-repo', () => ({
+  applyAssetDeduction: vi.fn(),
+  applyAssetIncrease: vi.fn(),
+}));
+
+import { query, queryOne } from '@/lib/db';
+import { applyAssetDeduction, applyAssetIncrease } from '../assets-repo';
+import {
+  analyzeTargetDateChange,
+  applyTargetDateChange,
+  computeInstallmentToggleAdjustment,
+  applyInstallmentToggleAdjustment,
+} from '../settings-repo';
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
+type Any = any;
+
+const USER = 1;
+
+function mockTargetDate(td: string | null) {
+  vi.mocked(query).mockResolvedValueOnce({ rows: [{ target_date: td }] } as Any);
+}
+
+describe('analyzeTargetDateChange — ADR 0018 target_date 변경 영향 분석', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('oldTargetDate === newTargetDate → affectedGroups 빈 배열', async () => {
+    mockTargetDate('2026-08');
+
+    const result = await analyzeTargetDateChange(USER, '2026-08');
+
+    expect(result.affectedGroups).toEqual([]);
+    expect(result.totalDelta).toBe(0);
+    // SELECT(readTargetMonth)만 1회, 미래 회차 SELECT는 호출 안 됨
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('target 늘어남 (2026-08 → 2026-10) — 새 범위 안의 회차분만큼 추가 차감', async () => {
+    mockTargetDate('2026-08'); // old
+    // OFF 할부 미래 회차들 — 9월/10월/11월 회차 (groupA), 12월 회차 (groupB)
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { installment_group: 'A', description: 'foo', amount: 100_000, billing_month: '2026-09' },
+        { installment_group: 'A', description: 'foo', amount: 100_000, billing_month: '2026-10' },
+        { installment_group: 'A', description: 'foo', amount: 100_000, billing_month: '2026-11' },
+        { installment_group: 'B', description: 'bar', amount: 200_000, billing_month: '2026-12' },
+      ],
+    } as Any);
+
+    const result = await analyzeTargetDateChange(USER, '2026-10');
+
+    // old=2026-08: 9월/10월/11월 모두 boundary 밖 (차감 안 됨)
+    // new=2026-10: 9월/10월이 boundary 안으로 들어옴 → +100k씩 추가 차감
+    // A: 9월(+100k) + 10월(+100k) + 11월(변화없음) → delta = +200_000
+    // B: 12월(여전히 밖) → 변화 없음 → 그룹 자체 제외
+    expect(result.affectedGroups).toEqual([
+      { groupId: 'A', description: 'foo', deltaAmount: 200_000 },
+    ]);
+    expect(result.totalDelta).toBe(200_000);
+  });
+
+  it('target 줄어듦 (2026-12 → 2026-09) — 새 범위 밖으로 나간 회차분 환원', async () => {
+    mockTargetDate('2026-12');
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { installment_group: 'A', description: 'foo', amount: 100_000, billing_month: '2026-10' },
+        { installment_group: 'A', description: 'foo', amount: 100_000, billing_month: '2026-11' },
+      ],
+    } as Any);
+
+    const result = await analyzeTargetDateChange(USER, '2026-09');
+
+    // 10월: was in target(was차감) → not in target(이제 무영향) → -100k
+    // 11월: 동일 → -100k
+    expect(result.affectedGroups).toEqual([
+      { groupId: 'A', description: 'foo', deltaAmount: -200_000 },
+    ]);
+    expect(result.totalDelta).toBe(-200_000);
+  });
+
+  it('target=null → 모든 OFF 할부 회차 환원', async () => {
+    mockTargetDate('2026-10');
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { installment_group: 'A', description: null, amount: 100_000, billing_month: '2026-09' },
+        { installment_group: 'A', description: null, amount: 100_000, billing_month: '2026-10' },
+      ],
+    } as Any);
+
+    const result = await analyzeTargetDateChange(USER, null);
+
+    // 9월: was in target → now not in target (null=target 없음) → -100k
+    // 10월: was in target → now not in target → -100k
+    expect(result.totalDelta).toBe(-200_000);
+    expect(result.affectedGroups[0]?.deltaAmount).toBe(-200_000);
+  });
+
+  it('null → target 설정 — 새 범위 안 회차분만큼 추가 차감', async () => {
+    mockTargetDate(null);
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { installment_group: 'A', description: 'x', amount: 100_000, billing_month: '2026-08' },
+        { installment_group: 'A', description: 'x', amount: 100_000, billing_month: '2026-12' },
+      ],
+    } as Any);
+
+    const result = await analyzeTargetDateChange(USER, '2026-10');
+
+    // 8월: was not in target → now in target → +100k
+    // 12월: was not in target → still not in target → 변화 없음
+    expect(result.totalDelta).toBe(100_000);
+  });
+
+  it('경계 — billing_month === targetDate는 target "이내" (<=)', async () => {
+    mockTargetDate('2026-08');
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { installment_group: 'A', description: null, amount: 100_000, billing_month: '2026-10' },
+      ],
+    } as Any);
+
+    // target 2026-08 → 2026-10 (확장)
+    const result = await analyzeTargetDateChange(USER, '2026-10');
+
+    // 10월 회차: was billing(10) > old target(8) → 밖, will billing(10) <= new target(10) → 이내 → +100k
+    expect(result.totalDelta).toBe(100_000);
+  });
+});
+
+describe('applyTargetDateChange — 영향 분석 + 자산 보정 + UPSERT', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('totalDelta > 0 → applyAssetDeduction 호출', async () => {
+    mockTargetDate('2026-08'); // analyze 내부 readTargetMonth
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { installment_group: 'A', description: null, amount: 100_000, billing_month: '2026-10' },
+      ],
+    } as Any);
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // upsertTargetDate
+
+    await applyTargetDateChange(USER, '2026-10');
+
+    expect(applyAssetDeduction).toHaveBeenCalledWith(USER, 100_000);
+    expect(applyAssetIncrease).not.toHaveBeenCalled();
+  });
+
+  it('totalDelta < 0 → applyAssetIncrease 호출 (절대값)', async () => {
+    mockTargetDate('2026-10');
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [
+        { installment_group: 'A', description: null, amount: 100_000, billing_month: '2026-10' },
+      ],
+    } as Any);
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // upsertTargetDate
+
+    await applyTargetDateChange(USER, '2026-09');
+
+    expect(applyAssetIncrease).toHaveBeenCalledWith(USER, 100_000);
+    expect(applyAssetDeduction).not.toHaveBeenCalled();
+  });
+
+  it('totalDelta === 0 → 자산 변동 없음, UPSERT만', async () => {
+    mockTargetDate('2026-10');
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // 미래 회차 없음
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // upsertTargetDate
+
+    await applyTargetDateChange(USER, '2026-12');
+
+    expect(applyAssetDeduction).not.toHaveBeenCalled();
+    expect(applyAssetIncrease).not.toHaveBeenCalled();
+  });
+});
+
+describe('computeInstallmentToggleAdjustment — ADR 0018 토글 사후 변경 자산 보정', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  function mockMeta(meta: { exclude_from_budget: boolean; type: string } | null) {
+    vi.mocked(queryOne).mockResolvedValueOnce(meta as Any);
+  }
+
+  function mockTargetDate2(td: string | null) {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ target_date: td }] } as Any);
+  }
+
+  function mockGroupRows(rows: Array<{ amount: number; billing_month: string }>) {
+    vi.mocked(query).mockResolvedValueOnce({ rows } as Any);
+  }
+
+  it('그룹 없음 → null 반환', async () => {
+    mockTargetDate2('2026-08');
+    mockMeta(null);
+
+    const result = await computeInstallmentToggleAdjustment(USER, 'unknown-group', true);
+
+    expect(result).toBeNull();
+  });
+
+  it('수입(type=income) 그룹 → deltaAmount=0 (보정 불필요)', async () => {
+    mockTargetDate2('2026-08');
+    mockMeta({ exclude_from_budget: false, type: 'income' });
+
+    const result = await computeInstallmentToggleAdjustment(USER, 'A', true);
+
+    expect(result).toEqual({ groupId: 'A', deltaAmount: 0 });
+  });
+
+  it('exclude_from_budget=true 그룹 → deltaAmount=0 (보정 불필요)', async () => {
+    mockTargetDate2('2026-08');
+    mockMeta({ exclude_from_budget: true, type: 'expense' });
+
+    const result = await computeInstallmentToggleAdjustment(USER, 'A', false);
+
+    expect(result).toEqual({ groupId: 'A', deltaAmount: 0 });
+  });
+
+  it('OFF → ON: boundary 밖 회차 합만큼 추가 차감 (+)', async () => {
+    mockTargetDate2('2026-08');
+    mockMeta({ exclude_from_budget: false, type: 'expense' });
+    // 미래 회차: 6/7/8월(target 안), 9/10월(target 밖)
+    mockGroupRows([
+      { amount: 100_000, billing_month: '2026-06' },
+      { amount: 100_000, billing_month: '2026-07' },
+      { amount: 100_000, billing_month: '2026-08' }, // target 경계 — 안
+      { amount: 100_000, billing_month: '2026-09' }, // 밖
+      { amount: 100_000, billing_month: '2026-10' }, // 밖
+    ]);
+
+    const result = await computeInstallmentToggleAdjustment(USER, 'A', true);
+
+    expect(result).toEqual({ groupId: 'A', deltaAmount: 200_000 });
+  });
+
+  it('ON → OFF: boundary 밖 회차 합만큼 환원 (-)', async () => {
+    mockTargetDate2('2026-08');
+    mockMeta({ exclude_from_budget: false, type: 'expense' });
+    mockGroupRows([
+      { amount: 100_000, billing_month: '2026-09' },
+      { amount: 100_000, billing_month: '2026-10' },
+    ]);
+
+    const result = await computeInstallmentToggleAdjustment(USER, 'A', false);
+
+    expect(result).toEqual({ groupId: 'A', deltaAmount: -200_000 });
+  });
+
+  it('target_date=null + ON → OFF: 모든 미래 회차가 boundary 밖 → 전체 환원', async () => {
+    mockTargetDate2(null);
+    mockMeta({ exclude_from_budget: false, type: 'expense' });
+    mockGroupRows([
+      { amount: 100_000, billing_month: '2026-09' },
+      { amount: 100_000, billing_month: '2026-10' },
+      { amount: 100_000, billing_month: '2026-11' },
+    ]);
+
+    const result = await computeInstallmentToggleAdjustment(USER, 'A', false);
+
+    expect(result).toEqual({ groupId: 'A', deltaAmount: -300_000 });
+  });
+
+  it('boundary 안에만 있는 회차 → boundarySum=0 → deltaAmount=0', async () => {
+    mockTargetDate2('2026-12');
+    mockMeta({ exclude_from_budget: false, type: 'expense' });
+    mockGroupRows([
+      { amount: 100_000, billing_month: '2026-06' },
+      { amount: 100_000, billing_month: '2026-07' },
+    ]);
+
+    const result = await computeInstallmentToggleAdjustment(USER, 'A', true);
+
+    expect(result).toEqual({ groupId: 'A', deltaAmount: 0 });
+  });
+});
+
+describe('applyInstallmentToggleAdjustment — 자산 변동 디스패처', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('deltaAmount > 0 → applyAssetDeduction', async () => {
+    await applyInstallmentToggleAdjustment(USER, { groupId: 'A', deltaAmount: 100_000 });
+    expect(applyAssetDeduction).toHaveBeenCalledWith(USER, 100_000);
+    expect(applyAssetIncrease).not.toHaveBeenCalled();
+  });
+
+  it('deltaAmount < 0 → applyAssetIncrease (절대값)', async () => {
+    await applyInstallmentToggleAdjustment(USER, { groupId: 'A', deltaAmount: -100_000 });
+    expect(applyAssetIncrease).toHaveBeenCalledWith(USER, 100_000);
+    expect(applyAssetDeduction).not.toHaveBeenCalled();
+  });
+
+  it('deltaAmount === 0 → 자산 변동 없음', async () => {
+    await applyInstallmentToggleAdjustment(USER, { groupId: 'A', deltaAmount: 0 });
+    expect(applyAssetDeduction).not.toHaveBeenCalled();
+    expect(applyAssetIncrease).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/features/budget/lib/repository/settings-repo.ts
+++ b/web/src/features/budget/lib/repository/settings-repo.ts
@@ -1,4 +1,6 @@
-import { query } from '@/lib/db';
+import { query, queryOne } from '@/lib/db';
+import { getCurrentBillingMonth } from '../billing/cycle';
+import { applyAssetDeduction, applyAssetIncrease } from './assets-repo';
 
 export async function readTargetMonth(userId: number): Promise<string | null> {
   const result = await query<{ target_date: string | null }>(
@@ -8,11 +10,7 @@ export async function readTargetMonth(userId: number): Promise<string | null> {
   return result.rows[0]?.target_date ?? null;
 }
 
-
-export async function upsertTargetDate(
-  userId: number,
-  targetDate: string | null,
-): Promise<void> {
+export async function upsertTargetDate(userId: number, targetDate: string | null): Promise<void> {
   await query(
     `INSERT INTO budget_settings (user_id, target_date, updated_at)
      VALUES ($1, $2, NOW())
@@ -20,4 +18,87 @@ export async function upsertTargetDate(
      SET target_date = EXCLUDED.target_date, updated_at = NOW()`,
     [userId, targetDate],
   );
+}
+
+// ─── 할부 토글 사후 변경 보정 (ADR 0018) ──────────────────
+
+export interface InstallmentToggleAdjustment {
+  groupId: string;
+  /** 자산 변화량. 양수=추가 차감, 음수=환원 */
+  deltaAmount: number;
+}
+
+/**
+ * `distribute_to_runway` 토글 변경 시 그룹 전체 자산 보정 계산.
+ *
+ * 대상: 같은 installment_group의 아직 정산 안 된 미래 회차 (installment_num >= 2 AND billing_month > 현재).
+ * 그 중 billing_month > target_date 인 회차의 amount 합 = boundarySum.
+ *
+ * - 토글이 ON(true) → OFF(false): boundarySum 만큼 환원 (이미 차감했던 회차를 자산에서 빼지 않도록)
+ * - 토글이 OFF(false) → ON(true): boundarySum 만큼 추가 차감 (예전에 안 빠졌던 회차 분만큼 빼야 함)
+ *
+ * target_date가 null이면 모든 미래 회차가 boundary 밖 → ON↔OFF가 전체 미래 회차 합에 영향.
+ * exclude_from_budget=true 또는 type='income' 인 그룹은 INSERT 시 자산 변동이 없었으므로 보정 대상 X.
+ */
+export async function computeInstallmentToggleAdjustment(
+  userId: number,
+  installmentGroup: string,
+  newValue: boolean,
+): Promise<InstallmentToggleAdjustment | null> {
+  const currentBillingMonth = getCurrentBillingMonth(new Date());
+  const targetDate = await readTargetMonth(userId);
+
+  // 그룹의 미래 회차 + 그룹 메타데이터 (exclude_from_budget / type) 확인
+  const meta = await queryOne<{
+    exclude_from_budget: boolean;
+    type: string;
+  }>(
+    `SELECT COALESCE(exclude_from_budget, false) AS exclude_from_budget,
+            COALESCE(type, 'expense') AS type
+     FROM expenses
+     WHERE user_id = $1 AND installment_group = $2
+     LIMIT 1`,
+    [userId, installmentGroup],
+  );
+  if (!meta) return null;
+  if (meta.type !== 'expense' || meta.exclude_from_budget) {
+    // 자산 변동이 INSERT에서 이미 없었으므로 보정 불필요
+    return { groupId: installmentGroup, deltaAmount: 0 };
+  }
+
+  const { rows } = await query<{ amount: number; billing_month: string }>(
+    `SELECT amount, billing_month
+     FROM expenses
+     WHERE user_id = $1
+       AND installment_group = $2
+       AND is_installment = true
+       AND installment_num >= 2
+       AND billing_month > $3`,
+    [userId, installmentGroup, currentBillingMonth],
+  );
+
+  // boundary 밖 = billing_month > target_date (target 없으면 모두 밖)
+  const boundarySum = rows.reduce((sum, r) => {
+    const beyondTarget = targetDate === null || r.billing_month > targetDate;
+    return beyondTarget ? sum + r.amount : sum;
+  }, 0);
+
+  if (boundarySum === 0) return { groupId: installmentGroup, deltaAmount: 0 };
+
+  // newValue=true (ON): 예전에 안 빠지던 boundary 밖 회차를 차감 → +
+  // newValue=false (OFF): 예전에 빠지던 boundary 밖 회차를 환원 → -
+  const deltaAmount = newValue ? boundarySum : -boundarySum;
+  return { groupId: installmentGroup, deltaAmount };
+}
+
+/** computeInstallmentToggleAdjustment 결과를 받아 실제 자산 변동을 수행 */
+export async function applyInstallmentToggleAdjustment(
+  userId: number,
+  adjustment: InstallmentToggleAdjustment,
+): Promise<void> {
+  if (adjustment.deltaAmount > 0) {
+    await applyAssetDeduction(userId, adjustment.deltaAmount);
+  } else if (adjustment.deltaAmount < 0) {
+    await applyAssetIncrease(userId, -adjustment.deltaAmount);
+  }
 }

--- a/web/src/features/budget/lib/repository/settings-repo.ts
+++ b/web/src/features/budget/lib/repository/settings-repo.ts
@@ -20,6 +20,125 @@ export async function upsertTargetDate(userId: number, targetDate: string | null
   );
 }
 
+// ─── target_date 변경 시 OFF 할부 자산 보정 (ADR 0018) ──────────
+
+/** target_date 변경으로 영향 받는 OFF 할부 그룹 단위 변화 */
+export interface TargetDateChangeGroup {
+  groupId: string;
+  description: string | null;
+  /** 자산 변화량. 양수=추가 차감, 음수=환원 */
+  deltaAmount: number;
+}
+
+export interface TargetDateChangePreview {
+  oldTargetDate: string | null;
+  newTargetDate: string | null;
+  affectedGroups: TargetDateChangeGroup[];
+  /** 모든 그룹 deltaAmount 합. 양수=총 추가 차감, 음수=총 환원 */
+  totalDelta: number;
+}
+
+interface InstallmentRow {
+  installment_group: string;
+  description: string | null;
+  amount: number;
+  billing_month: string;
+}
+
+/**
+ * target_date 변경이 OFF 할부 자산 차감에 미치는 영향 분석 (DB 미변경).
+ *
+ * 대상: distribute_to_runway=false 인 할부의 "아직 결제주기 시작 안 된" 미래 회차
+ *   (installment_num >= 2 AND billing_month > 현재_billing_month).
+ *
+ * 각 회차의 billing_month가 old / new target 경계를 넘나드는지 판정해 delta 계산:
+ * - old: target 이내(차감됨), new: target 밖(무영향) → -amount (환원)
+ * - old: target 밖(무영향), new: target 이내(차감됨) → +amount (추가 차감)
+ *
+ * newTargetDate=null 이면 모든 미래 회차가 "target 밖"으로 → 전부 환원 분석.
+ */
+export async function analyzeTargetDateChange(
+  userId: number,
+  newTargetDate: string | null,
+): Promise<TargetDateChangePreview> {
+  const oldTargetDate = await readTargetMonth(userId);
+  if (oldTargetDate === newTargetDate) {
+    return { oldTargetDate, newTargetDate, affectedGroups: [], totalDelta: 0 };
+  }
+
+  const currentBillingMonth = getCurrentBillingMonth(new Date());
+
+  // OFF 할부의 아직 정산 안 된 미래 회차
+  const { rows } = await query<InstallmentRow>(
+    `SELECT installment_group, description, amount, billing_month
+     FROM expenses
+     WHERE user_id = $1
+       AND is_installment = true
+       AND installment_num >= 2
+       AND billing_month > $2
+       AND COALESCE(type, 'expense') = 'expense'
+       AND COALESCE(exclude_from_budget, false) = false
+       AND COALESCE(distribute_to_runway, true) = false
+       AND installment_group IS NOT NULL`,
+    [userId, currentBillingMonth],
+  );
+
+  const groupDeltas = new Map<string, { description: string | null; delta: number }>();
+
+  for (const row of rows) {
+    const wasInTarget = oldTargetDate !== null && row.billing_month <= oldTargetDate;
+    const willBeInTarget = newTargetDate !== null && row.billing_month <= newTargetDate;
+    if (wasInTarget === willBeInTarget) continue;
+
+    // wasInTarget true → willBeInTarget false: 이전엔 차감됐는데 이제 무영향 → 환원
+    // wasInTarget false → willBeInTarget true: 이전엔 무영향이었는데 이제 차감 → 추가 차감
+    const delta = willBeInTarget ? row.amount : -row.amount;
+    const existing = groupDeltas.get(row.installment_group);
+    if (existing) {
+      existing.delta += delta;
+    } else {
+      groupDeltas.set(row.installment_group, {
+        description: row.description,
+        delta,
+      });
+    }
+  }
+
+  const affectedGroups: TargetDateChangeGroup[] = Array.from(groupDeltas.entries())
+    .filter(([, info]) => info.delta !== 0)
+    .map(([groupId, info]) => ({
+      groupId,
+      description: info.description,
+      deltaAmount: info.delta,
+    }));
+  const totalDelta = affectedGroups.reduce((s, g) => s + g.deltaAmount, 0);
+
+  return { oldTargetDate, newTargetDate, affectedGroups, totalDelta };
+}
+
+/**
+ * target_date 변경 확정 — 영향 분석 + 자산 보정 + budget_settings 갱신.
+ *
+ * 자산 보정은 분석 단계의 totalDelta를 기준으로 양수면 applyAssetDeduction,
+ * 음수면 applyAssetIncrease 한 번씩만 호출 (그룹 개별 처리 X — 자산 풀은 공용).
+ */
+export async function applyTargetDateChange(
+  userId: number,
+  newTargetDate: string | null,
+): Promise<TargetDateChangePreview> {
+  const preview = await analyzeTargetDateChange(userId, newTargetDate);
+
+  if (preview.totalDelta > 0) {
+    await applyAssetDeduction(userId, preview.totalDelta);
+  } else if (preview.totalDelta < 0) {
+    await applyAssetIncrease(userId, -preview.totalDelta);
+  }
+
+  await upsertTargetDate(userId, newTargetDate);
+
+  return preview;
+}
+
 // ─── 할부 토글 사후 변경 보정 (ADR 0018) ──────────────────
 
 export interface InstallmentToggleAdjustment {

--- a/web/src/features/budget/lib/types.ts
+++ b/web/src/features/budget/lib/types.ts
@@ -146,6 +146,7 @@ export const BUDGET_EXCLUDED_CATEGORIES = new Set([
   '공과금',
   '리커밋 사업',
   '리커밋 택배',
+  '세금',
 ]);
 
 /** 하루 최소 자유 예산 경고 기준 (원) */
@@ -171,6 +172,7 @@ export const EXPENSE_CATEGORIES = [
   '고양이',
   '리커밋 사업',
   '리커밋 택배',
+  '세금',
   '기타',
 ] as const;
 

--- a/web/src/features/budget/lib/types.ts
+++ b/web/src/features/budget/lib/types.ts
@@ -18,6 +18,13 @@ export interface ExpenseRow {
   exclude_from_budget: boolean;
   /** 수입을 전체 기간에 분배할지 여부 (type='income'에서만 사용) */
   distribute_to_budget: boolean;
+  /**
+   * 할부 자산 차감 범위 토글 (ADR 0018).
+   * - true (default): 2+회차 전부 INSERT 즉시 자산 차감 (ADR 0015 그대로)
+   * - false: 2회차부터 target_date 이내 회차만 차감, 이후 회차는 결제주기 cron에서 자유지출로 처리
+   * 할부가 아닌 일반 지출/수입에서는 의미 없음 (default true 저장).
+   */
+  distribute_to_runway: boolean;
 }
 
 export interface PlannedExpenseRow {


### PR DESCRIPTION
## 관련 이슈
Closes #411

## 변경 내용

### ADR 0018 — 할부 자산 차감 범위 토글
ADR 0015(즉시 차감 정책) 보완. 할부 입력 시 `런웨이까지만 차감` vs `전체 즉시 차감` 라디오를 노출, target_date 이내 회차만 즉시 자산 차감하고 이후 회차는 결제주기 cron으로 자유 지출 처리.

- 컬럼 추가: `expenses.distribute_to_runway` (default true = 기존 ADR 0015 동작 그대로)
- 조건부 노출: 마지막 회차가 target_date를 넘는 경우에만 라디오 노출 (`computeLastInstallmentBillingMonth`)
- 입력 분기: `createInstallmentExpenses`에서 OFF 할부는 target 이내 회차 합만 자산 차감
- 사후 토글 변경: `computeInstallmentToggleAdjustment` — 그룹 boundary 밖 회차 합만큼 자산 보정
- target_date 변경: `analyzeTargetDateChange` / `applyTargetDateChange` — OFF 할부 미래 회차가 경계 넘나들면 자동 보정 (Preview API + 확인 모달 후 확정)
- 금액·삭제·exclude_from_budget 토글 변경 시 `wasDeductedFromAssetAtInsert` 가드로 이중 차감/환원 방지

### 세금 카테고리
- `EXPENSE_CATEGORIES` 에 '세금' 추가 (기타 앞)
- `BUDGET_EXCLUDED_CATEGORIES` 에 '세금' 추가 (기본 예산 제외)

### 부수 — 정산 테스트 결제주기 보정
#410 (대금기간 15→14 보정) 후속으로 facade.test.ts 의 settlementNow 날짜를 한 칸 이동 (어제=14일 트리거 정합).

## 코드 리뷰 결과
- [x] 보안 감사 통과 (raw query 없음, 외부 입력 검증, 민감 정보 로그 없음)
- [x] 타입 안전성 (any 없음, exhaustive 분기)
- [x] 컨벤션 점검 (네이밍, 파일 크기, 함수 크기)
- [x] 코드 품질 (단일 책임, group 단위 UPDATE, idempotent 보정)

## 테스트
- [x] computeLastInstallmentBillingMonth 6 케이스 (카드/months/연도 넘김)
- [x] analyzeTargetDateChange 6 (target 확장/축소/null↔값/경계 ≤)
- [x] applyTargetDateChange 3 (Deduction/Increase/0)
- [x] computeInstallmentToggleAdjustment 6 (그룹 없음 / type=income / exclude / ON↔OFF / target=null / boundary 내부만)
- [x] applyInstallmentToggleAdjustment 3
- [x] 기존 budget 테스트 230건 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)