### PR TITLE
fix(budget): 할부 exclude_from_budget 토글 그룹 동기화 + 자산 보정 (#413)

### DIFF
--- a/docs/domains/budget.md
+++ b/docs/domains/budget.md
@@ -214,6 +214,7 @@ features/budget/
 | 12 | 월별 예산 스냅샷 | — (내부) | 정산 cron 진입점 | `buildSettlementSnapshot` | 14일 종료 → 15일 새벽 cron, idempotent |
 | 13 | 결제주기 유틸 | — | — | billing/cycle.ts, billing/card-billing.ts | 전월 15일\~당월 14일, 카드별 startDay |
 | 14 | 할부 자산 차감 범위 토글 | expense-form / expense-edit-modal 조건부 라디오 | `/api/expenses` POST/PATCH + `/api/budget/settings` `?preview=true` | createInstallmentExpenses, updateExpense, settings-repo (analyzeTargetDateChange / applyTargetDateChange / computeInstallmentToggleAdjustment) | ADR 0018. 마지막 회차 > target_date 일 때만 노출. 그룹 단위 적용 |
+| 15 | 할부 exclude_from_budget 그룹 동기화 | expense-edit-modal 예산 토글 + 할부 그룹 안내 | `/api/expenses/[id]` PATCH | updateExpense, settings-repo `computeExcludeToggleAdjustment` / `applyExcludeToggleAdjustment` | 할부 행 토글 시 같은 installment_group 전체 UPDATE + 자산 보정 (delta 계산) |
 
 ### 🟡 부분 구현 (4)
 
@@ -299,6 +300,22 @@ detectSettlementTrigger() → 어제가 14일(주기 마지막)인지 판정
      ├─ totalDelta > 0: applyAssetDeduction
      ├─ totalDelta < 0: applyAssetIncrease
      └─ upsertTargetDate
+```
+
+### 할부 exclude_from_budget 토글 (ADR 0015 보강)
+```
+[모달에서 사용자가 "예산 미포함" 토글]
+  → PATCH /api/expenses/[id] { exclude_from_budget }
+    → updateExpense
+       ├─ computeExcludeToggleAdjustment(그룹 미래 회차 자산 차감 delta)
+       │   ├─ 현재 차감 합 = exclude=false AND (distribute_to_runway OR billing_month ≤ target_date)
+       │   ├─ 변경 후 차감 합 = newValue=true ? 0 : (차감 대상 회차 전부)
+       │   └─ delta = newDeducted - currentDeducted
+       ├─ delta > 0: applyAssetDeduction
+       ├─ delta < 0: applyAssetIncrease
+       └─ UPDATE expenses SET exclude_from_budget WHERE installment_group = ? (그룹 전체 동기화)
+
+비할부/그룹 없는 행은 단일 행 UPDATE만 — 결제주기 cron이 자유지출/제외지출로 처리.
 ```
 
 ## 주요 계산 규칙

--- a/web/src/features/budget/components/expense-edit-modal.tsx
+++ b/web/src/features/budget/components/expense-edit-modal.tsx
@@ -246,6 +246,11 @@ export function ExpenseEditModal({
                 제외
               </button>
             </div>
+            {expense.is_installment && (
+              <p className="mt-1 text-[10px] text-gray-500">
+                할부 그룹 전체에 적용 (모든 회차 동시 변경 + 자산 보정)
+              </p>
+            )}
           </div>
 
           {/* 할부 자산 차감 범위 토글 (ADR 0018) — 마지막 회차가 target_date 이후일 때만 노출 */}

--- a/web/src/features/budget/lib/__tests__/update-expense.test.ts
+++ b/web/src/features/budget/lib/__tests__/update-expense.test.ts
@@ -5,7 +5,24 @@ vi.mock('@/lib/db', () => ({
   queryOne: vi.fn(),
 }));
 
+vi.mock('../repository/settings-repo', () => ({
+  readTargetMonth: vi.fn(),
+  computeInstallmentToggleAdjustment: vi.fn(),
+  applyInstallmentToggleAdjustment: vi.fn(),
+  computeExcludeToggleAdjustment: vi.fn(),
+  applyExcludeToggleAdjustment: vi.fn(),
+}));
+
+vi.mock('../repository/assets-repo', () => ({
+  applyAssetDeduction: vi.fn(),
+  applyAssetIncrease: vi.fn(),
+}));
+
 import { query, queryOne } from '@/lib/db';
+import {
+  computeExcludeToggleAdjustment,
+  applyExcludeToggleAdjustment,
+} from '../repository/settings-repo';
 import { updateExpense, FIXED_SOURCE_EXCLUDE_LOCKED } from '../queries';
 
 // biome-ignore lint/suspicious/noExplicitAny: test mock convenience
@@ -28,23 +45,27 @@ describe('updateExpense — source=fixed 행 exclude_from_budget 가드', () => 
     expect(query).not.toHaveBeenCalled();
   });
 
-  it("source='manual' 행 + exclude_from_budget 변경 → 정상 진행", async () => {
+  it("source='manual' 행 + exclude_from_budget 변경 (비할부) → 정상 진행", async () => {
     vi.mocked(queryOne)
       .mockResolvedValueOnce({ source: 'manual' } as Any) // 가드 SELECT
+      .mockResolvedValueOnce({ installment_group: null } as Any) // existingForAsset (excludeChanging 추가)
       .mockResolvedValueOnce({ id: 100, exclude_from_budget: true } as Any); // UPDATE RETURNING
 
     const result = await updateExpense(1, 100, { exclude_from_budget: true });
 
     expect(result).toEqual({ id: 100, exclude_from_budget: true });
-    expect(queryOne).toHaveBeenCalledTimes(2);
+    expect(queryOne).toHaveBeenCalledTimes(3);
+    expect(computeExcludeToggleAdjustment).not.toHaveBeenCalled();
   });
 
-  it('source=null 행 + exclude_from_budget 변경 → 정상 진행', async () => {
+  it('source=null 행 + exclude_from_budget 변경 (비할부) → 정상 진행', async () => {
     vi.mocked(queryOne)
       .mockResolvedValueOnce({ source: null } as Any)
+      .mockResolvedValueOnce({ installment_group: null } as Any)
       .mockResolvedValueOnce({ id: 200 } as Any);
 
     await expect(updateExpense(1, 200, { exclude_from_budget: false })).resolves.toBeTruthy();
+    expect(computeExcludeToggleAdjustment).not.toHaveBeenCalled();
   });
 
   it("source='fixed' 행 + amount만 변경(exclude_from_budget 미포함) → 자산 보정용 SELECT + UPDATE", async () => {
@@ -79,5 +100,141 @@ describe('updateExpense — source=fixed 행 exclude_from_budget 가드', () => 
     const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
     expect(sql).toMatch(/SELECT/i);
     expect(sql).not.toMatch(/UPDATE/i);
+  });
+});
+
+describe('updateExpense — exclude_from_budget 할부 그룹 동기화', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('할부 행 + exclude=false→true: 그룹 UPDATE 호출 + applyExcludeToggleAdjustment 호출 (delta 음수)', async () => {
+    vi.mocked(queryOne)
+      .mockResolvedValueOnce({ source: 'manual' } as Any) // 가드
+      .mockResolvedValueOnce({
+        amount: 100000,
+        is_installment: true,
+        installment_num: 3,
+        type: 'expense',
+        exclude_from_budget: false,
+        distribute_to_runway: true,
+        billing_month: '2026-07',
+        installment_group: 'group-1',
+      } as Any) // existingForAsset
+      .mockResolvedValueOnce({ id: 100, exclude_from_budget: true } as Any); // queryExpense (setKeys empty)
+
+    vi.mocked(computeExcludeToggleAdjustment).mockResolvedValueOnce({
+      groupId: 'group-1',
+      deltaAmount: -200000,
+    });
+
+    await updateExpense(1, 100, { exclude_from_budget: true });
+
+    expect(computeExcludeToggleAdjustment).toHaveBeenCalledWith(1, 'group-1', true);
+    expect(applyExcludeToggleAdjustment).toHaveBeenCalledWith(1, {
+      groupId: 'group-1',
+      deltaAmount: -200000,
+    });
+    const groupUpdate = vi
+      .mocked(query)
+      .mock.calls.find((c) =>
+        (c[0] as string).match(/UPDATE\s+expenses\s+SET\s+exclude_from_budget/i),
+      );
+    expect(groupUpdate).toBeDefined();
+    expect((groupUpdate![1] as unknown[])[2]).toBe('group-1');
+  });
+
+  it('할부 행 + exclude=true→false: 그룹 UPDATE 호출 + applyExcludeToggleAdjustment 호출 (delta 양수)', async () => {
+    vi.mocked(queryOne)
+      .mockResolvedValueOnce({ source: 'manual' } as Any)
+      .mockResolvedValueOnce({
+        amount: 100000,
+        is_installment: true,
+        installment_num: 3,
+        type: 'expense',
+        exclude_from_budget: true,
+        distribute_to_runway: true,
+        billing_month: '2026-07',
+        installment_group: 'group-2',
+      } as Any)
+      .mockResolvedValueOnce({ id: 101, exclude_from_budget: false } as Any);
+
+    vi.mocked(computeExcludeToggleAdjustment).mockResolvedValueOnce({
+      groupId: 'group-2',
+      deltaAmount: 300000,
+    });
+
+    await updateExpense(1, 101, { exclude_from_budget: false });
+
+    expect(computeExcludeToggleAdjustment).toHaveBeenCalledWith(1, 'group-2', false);
+    expect(applyExcludeToggleAdjustment).toHaveBeenCalledWith(1, {
+      groupId: 'group-2',
+      deltaAmount: 300000,
+    });
+  });
+
+  it('비할부 행 (installment_group=null) + exclude 변경: 단일 행 UPDATE만, 자산 보정 호출 없음', async () => {
+    vi.mocked(queryOne)
+      .mockResolvedValueOnce({ source: 'manual' } as Any)
+      .mockResolvedValueOnce({
+        amount: 50000,
+        is_installment: false,
+        installment_num: null,
+        type: 'expense',
+        exclude_from_budget: false,
+        distribute_to_runway: true,
+        billing_month: '2026-05',
+        installment_group: null,
+      } as Any)
+      .mockResolvedValueOnce({ id: 200, exclude_from_budget: true } as Any); // UPDATE single row RETURNING
+
+    await updateExpense(1, 200, { exclude_from_budget: true });
+
+    expect(computeExcludeToggleAdjustment).not.toHaveBeenCalled();
+    expect(applyExcludeToggleAdjustment).not.toHaveBeenCalled();
+    // 그룹 UPDATE는 호출되지 않음 — 단일 행 UPDATE만 (UPDATE RETURNING)
+    const groupUpdate = vi
+      .mocked(query)
+      .mock.calls.find((c) =>
+        (c[0] as string).match(/UPDATE\s+expenses\s+SET\s+exclude_from_budget/i),
+      );
+    expect(groupUpdate).toBeUndefined();
+  });
+
+  it('할부 행 + exclude + amount 동시 변경: 그룹 UPDATE + 자산 보정 + 단일행 UPDATE 모두 실행', async () => {
+    vi.mocked(queryOne)
+      .mockResolvedValueOnce({ source: 'manual' } as Any)
+      .mockResolvedValueOnce({
+        amount: 100000,
+        is_installment: true,
+        installment_num: 3,
+        type: 'expense',
+        exclude_from_budget: false,
+        distribute_to_runway: true,
+        billing_month: '2026-07',
+        installment_group: 'group-3',
+      } as Any)
+      .mockResolvedValueOnce({ id: 102, amount: 120000, exclude_from_budget: true } as Any);
+
+    vi.mocked(computeExcludeToggleAdjustment).mockResolvedValueOnce({
+      groupId: 'group-3',
+      deltaAmount: -200000,
+    });
+
+    await updateExpense(1, 102, { exclude_from_budget: true, amount: 120000 });
+
+    expect(computeExcludeToggleAdjustment).toHaveBeenCalled();
+    expect(applyExcludeToggleAdjustment).toHaveBeenCalled();
+    // 그룹 UPDATE (exclude_from_budget) — query 호출
+    const groupUpdate = vi
+      .mocked(query)
+      .mock.calls.find((c) =>
+        (c[0] as string).match(/UPDATE\s+expenses\s+SET\s+exclude_from_budget/i),
+      );
+    expect(groupUpdate).toBeDefined();
+    // 단일행 UPDATE (amount만, exclude_from_budget는 filter됨) — queryOne 호출
+    const lastQueryOneCall = vi.mocked(queryOne).mock.calls.at(-1);
+    expect(lastQueryOneCall![0]).toMatch(/UPDATE\s+expenses\s+SET\s+amount/i);
+    expect(lastQueryOneCall![0]).not.toMatch(/exclude_from_budget\s*=/i);
   });
 });

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -10,6 +10,8 @@ import {
   readTargetMonth,
   computeInstallmentToggleAdjustment,
   applyInstallmentToggleAdjustment,
+  computeExcludeToggleAdjustment,
+  applyExcludeToggleAdjustment,
 } from './repository/settings-repo';
 import type {
   ExpenseRow,
@@ -319,11 +321,12 @@ export async function updateExpense(
     }
   }
 
-  // 할부 미래 회차 amount/distribute_to_runway 변경 시 자산 보정용 사전 조회
+  // 할부 미래 회차 amount/distribute_to_runway/exclude_from_budget 변경 시 자산 보정용 사전 조회
   const amountChanging = keys.includes('amount');
   const toggleChanging = keys.includes('distribute_to_runway');
+  const excludeChanging = keys.includes('exclude_from_budget');
   const existingForAsset =
-    amountChanging || toggleChanging
+    amountChanging || toggleChanging || excludeChanging
       ? await queryOne<ExistingForAsset>(
           `${EXISTING_FOR_ASSET_SELECT}
            FROM expenses WHERE id = $1 AND user_id = $2`,
@@ -351,8 +354,32 @@ export async function updateExpense(
     );
   }
 
-  // distribute_to_runway는 그룹 UPDATE에서 이미 처리 → 단일행 SET clause에서 제외
-  const setKeys = toggleChanging ? keys.filter((k) => k !== 'distribute_to_runway') : keys;
+  // exclude_from_budget 변경: 할부 그룹은 그룹 전체 동기화 + 자산 보정.
+  // 비할부/그룹 없는 행은 아래 단일 행 UPDATE에 맡김 (cron이 처리).
+  if (excludeChanging && existingForAsset?.installment_group) {
+    const newValue = Boolean(updates['exclude_from_budget']);
+    const adjustment = await computeExcludeToggleAdjustment(
+      userId,
+      existingForAsset.installment_group,
+      newValue,
+    );
+    if (adjustment) {
+      await applyExcludeToggleAdjustment(userId, adjustment);
+    }
+    await query(
+      `UPDATE expenses SET exclude_from_budget = $1
+       WHERE user_id = $2 AND installment_group = $3`,
+      [newValue, userId, existingForAsset.installment_group],
+    );
+  }
+
+  // distribute_to_runway / exclude_from_budget(할부 그룹)는 그룹 UPDATE에서 이미 처리 → 단일행 SET clause에서 제외
+  const setKeys = keys.filter((k) => {
+    if (toggleChanging && k === 'distribute_to_runway') return false;
+    if (excludeChanging && existingForAsset?.installment_group && k === 'exclude_from_budget')
+      return false;
+    return true;
+  });
   if (setKeys.length === 0) {
     return queryExpense(userId, id);
   }

--- a/web/src/features/budget/lib/repository/settings-repo.ts
+++ b/web/src/features/budget/lib/repository/settings-repo.ts
@@ -221,3 +221,92 @@ export async function applyInstallmentToggleAdjustment(
     await applyAssetIncrease(userId, -adjustment.deltaAmount);
   }
 }
+
+// ─── 할부 exclude_from_budget 토글 사후 변경 보정 ──────────
+
+export interface ExcludeToggleAdjustment {
+  groupId: string;
+  /** 자산 변화량. 양수=추가 차감, 음수=환원 */
+  deltaAmount: number;
+}
+
+/**
+ * `exclude_from_budget` 토글 변경 시 그룹 전체 자산 보정 계산.
+ *
+ * 대상: 같은 installment_group의 미래 회차 (installment_num >= 2 AND billing_month > 현재).
+ * 그 중 INSERT 시점에 자산 차감된 회차 = exclude=false AND
+ *   (distribute_to_runway=true OR billing_month <= target_date).
+ *
+ * - newValue=true (모두 미포함): 현재 차감되어 있던 합만큼 환원 → 음수 delta
+ * - newValue=false (모두 포함): 모든 차감 대상 회차 합만큼 차감 → 양수 delta
+ *
+ * type='income' 그룹은 INSERT 시 자산 변동이 없었으므로 보정 대상 X.
+ */
+export async function computeExcludeToggleAdjustment(
+  userId: number,
+  installmentGroup: string,
+  newValue: boolean,
+): Promise<ExcludeToggleAdjustment | null> {
+  const currentBillingMonth = getCurrentBillingMonth(new Date());
+  const targetDate = await readTargetMonth(userId);
+
+  const meta = await queryOne<{ type: string }>(
+    `SELECT COALESCE(type, 'expense') AS type
+     FROM expenses
+     WHERE user_id = $1 AND installment_group = $2
+     LIMIT 1`,
+    [userId, installmentGroup],
+  );
+  if (!meta) return null;
+  if (meta.type !== 'expense') {
+    return { groupId: installmentGroup, deltaAmount: 0 };
+  }
+
+  const { rows } = await query<{
+    amount: number;
+    billing_month: string;
+    distribute_to_runway: boolean;
+    exclude_from_budget: boolean;
+  }>(
+    `SELECT amount, billing_month,
+            COALESCE(distribute_to_runway, true) AS distribute_to_runway,
+            COALESCE(exclude_from_budget, false) AS exclude_from_budget
+     FROM expenses
+     WHERE user_id = $1
+       AND installment_group = $2
+       AND is_installment = true
+       AND installment_num >= 2
+       AND billing_month > $3`,
+    [userId, installmentGroup, currentBillingMonth],
+  );
+
+  const isAssetDeductionTarget = (r: {
+    billing_month: string;
+    distribute_to_runway: boolean;
+  }): boolean => r.distribute_to_runway || (targetDate !== null && r.billing_month <= targetDate);
+
+  // 현재 자산에 차감되어 있는 회차 합 (exclude=false AND 차감 대상 조건)
+  const currentDeducted = rows.reduce((sum, r) => {
+    if (r.exclude_from_budget) return sum;
+    return isAssetDeductionTarget(r) ? sum + r.amount : sum;
+  }, 0);
+
+  // 변경 후 차감되어 있어야 할 합
+  const newDeducted = newValue
+    ? 0
+    : rows.reduce((sum, r) => (isAssetDeductionTarget(r) ? sum + r.amount : sum), 0);
+
+  return { groupId: installmentGroup, deltaAmount: newDeducted - currentDeducted };
+}
+
+/** computeExcludeToggleAdjustment 결과를 받아 실제 자산 변동을 수행 */
+export async function applyExcludeToggleAdjustment(
+  userId: number,
+  adjustment: ExcludeToggleAdjustment,
+): Promise<void> {
+  if (adjustment.deltaAmount > 0) {
+    await applyAssetDeduction(userId, adjustment.deltaAmount);
+  } else if (adjustment.deltaAmount < 0) {
+    await applyAssetIncrease(userId, -adjustment.deltaAmount);
+  }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #413

## 변경 내용
- `settings-repo.ts`: `computeExcludeToggleAdjustment` + `applyExcludeToggleAdjustment` 추가 — 그룹 미래 회차의 자산 차감 delta 계산/적용
- `queries.updateExpense`: `excludeChanging` 분기 추가, 할부 그룹은 그룹 단위 UPDATE + 자산 보정, 단일행 UPDATE에서는 제외
- `expense-edit-modal.tsx`: 할부 행에 "할부 그룹 전체에 적용" 안내 라벨
- `docs/domains/budget.md`: ADR 0015 보강 흐름 섹션 + 기능 카탈로그 #15 추가
- `update-expense.test.ts`: 그룹 동기화 4 케이스 추가 + 기존 테스트 호출 수 보정

## 코드 리뷰 결과
- [x] 보안 감사 통과 (파라미터 바인딩, 화이트리스트, 민감정보 로그 없음)
- [x] 타입 안전성 확인 (`any` 없음, 테스트 mock만 명시적 ignore)
- [x] 컨벤션 점검 완료 (기존 `distribute_to_runway` 토글 패턴 평행 구조)
- [x] 코드 품질 확인 (단일 책임, 일관 네이밍)

## 테스트
- [x] vitest 전체 276/276 통과
- [x] 할부 행 exclude false→true: 그룹 UPDATE + `applyExcludeToggleAdjustment` 호출 (delta 음수)
- [x] 할부 행 exclude true→false: 그룹 UPDATE + `applyExcludeToggleAdjustment` 호출 (delta 양수)
- [x] 비할부 행 exclude 변경: 단일행 UPDATE만, 자산 보정 미호출
- [x] 할부 행 exclude + amount 동시 변경: 그룹 UPDATE + 단일행 UPDATE 모두 실행