### PR TITLE
feat(insight): 프로액티브 인사이트 v2 Phase 4 — 가설-검증 정량 파이프라인 (#392, #409)

### DIFF
--- a/db/migrations/058_saju_hypotheses_stats.sql
+++ b/db/migrations/058_saju_hypotheses_stats.sql
@@ -1,0 +1,40 @@
+-- ADR-0019 Phase 4: 가설-검증 정량 파이프라인
+-- saju_hypotheses: 등록된 가설 정의 (시드 catalog 참조 또는 신규 조합)
+-- saju_stats: 주간 검증 결과 시계열 (Fisher's exact + BH-FDR 결과)
+
+CREATE TABLE IF NOT EXISTS saju_hypotheses (
+  id              SERIAL PRIMARY KEY,
+  user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  trigger_spec    JSONB NOT NULL,                       -- {type:'seed',signalId:N} 또는 {type:'composite',...}
+  enum_target     TEXT NOT NULL,                        -- diary_meta_tags.tag
+  status          TEXT NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active', 'confirmed', 'rejected', 'archived')),
+  source          TEXT NOT NULL DEFAULT 'discovery'
+                  CHECK (source IN ('discovery', 'manual')),
+  registered_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  confirmed_at    TIMESTAMPTZ,
+  rejected_at     TIMESTAMPTZ,
+  archived_at     TIMESTAMPTZ,
+  notes           TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_saju_hypotheses_status
+  ON saju_hypotheses(user_id, status);
+
+CREATE TABLE IF NOT EXISTS saju_stats (
+  id              SERIAL PRIMARY KEY,
+  hypothesis_id   INTEGER NOT NULL REFERENCES saju_hypotheses(id) ON DELETE CASCADE,
+  week_start      DATE NOT NULL,                        -- 월요일 (전주 윈도우의 시작일)
+  n_trigger_days  INTEGER NOT NULL,                     -- trigger 발현일 수 (해당 윈도우 + baseline 누적)
+  n_total_days    INTEGER NOT NULL,                     -- 분석 대상 전체 일수
+  rate_trigger    NUMERIC(6,4) NOT NULL,                -- trigger 발현일의 enum 빈도
+  rate_baseline   NUMERIC(6,4) NOT NULL,                -- 비발현일의 enum 빈도
+  rate_ratio      NUMERIC(8,4) NOT NULL,                -- rate_trigger / rate_baseline (NaN 가능)
+  raw_p           NUMERIC(10,8) NOT NULL,               -- Fisher's exact p-value (NaN = skip)
+  fdr_q           NUMERIC(10,8) NOT NULL,               -- BH-FDR q-value (NaN = skip)
+  computed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (hypothesis_id, week_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_saju_stats_hypothesis_week
+  ON saju_stats(hypothesis_id, week_start DESC);

--- a/db/migrations/059_diary_meta_tags_enum_expand.sql
+++ b/db/migrations/059_diary_meta_tags_enum_expand.sql
@@ -1,0 +1,22 @@
+-- diary_meta_tags enum 확장 (16 → 22)
+-- ADR-0019 Phase 4: 가설 검증에 필요한 새 태그 6개 추가
+--   wealth_awareness   : 돈 관련 인식·결정 (재성 매핑)
+--   self_observation   : 본인 사주·신살·일진 직접 언급 (가설 검증 골드 시그널)
+--   social_activity    : 가족·친구·지인 만남/통화 (비겁/관성)
+--   physical_activity  : 운동·산책·외출/이동 (역마)
+--   task_completion    : 업무·과제 처리/완료 (식상/관성)
+--   clumsy_overflow    : 실수·물건 떨어뜨림·놓침 (충/공망)
+
+ALTER TABLE diary_meta_tags
+  DROP CONSTRAINT IF EXISTS diary_meta_tags_tag_check;
+
+ALTER TABLE diary_meta_tags
+  ADD CONSTRAINT diary_meta_tags_tag_check
+  CHECK (tag IN (
+    'irritation','health_complaint','low_energy','mood_down',
+    'confidence_high','analytical_mode','deep_thought','rest',
+    'peaceful','mood_high','cooking','creating','talkative',
+    'nostalgia','anxiety','past_memory',
+    'wealth_awareness','self_observation','social_activity',
+    'physical_activity','task_completion','clumsy_overflow'
+  ));

--- a/db/migrations/060_weekly_hypothesis_review_slot.sql
+++ b/db/migrations/060_weekly_hypothesis_review_slot.sql
@@ -1,0 +1,6 @@
+-- ADR-0019 Phase 4: 주간 가설 리포트 cron 슬롯 시드.
+-- 매일 08:00 발사되지만 cron 본체가 월요일 외 return — weeklyReport와 동일 패턴.
+
+INSERT INTO notification_settings (slot_name, time_value, label, active)
+VALUES ('weeklyHypothesisReview', '08:00', '주간 가설 리포트', true)
+ON CONFLICT (slot_name) DO NOTHING;

--- a/docs/adr/0019-saju-hypothesis-verification-pipeline.md
+++ b/docs/adr/0019-saju-hypothesis-verification-pipeline.md
@@ -1,0 +1,184 @@
+# 0019. 프로액티브 인사이트 v2 Phase 4 — 가설-검증 정량 파이프라인
+
+- Status: Accepted
+- Date: 2026-05-21
+- Related: [#392](https://github.com/hyewon3938/slack-ai-agents/issues/392), [#393](https://github.com/hyewon3938/slack-ai-agents/issues/393) (마스터), [#408](https://github.com/hyewon3938/slack-ai-agents/issues/408) (Phase 5 분리), [#409](https://github.com/hyewon3938/slack-ai-agents/issues/409) (Opus 이관)
+- Tags: data, llm, statistics
+
+## Context
+
+Phase 3 ([ADR-0017](0017-saju-ganji-master-normalization.md))에서 60갑자 마스터 정규화 + 시드 catalog + 일일 매칭 + outcome 검증 구조를 구축했다. 사용자가 임상적으로 관찰한 16개 사주 가설을 시드로 등록 → 일일 매칭으로 hit/miss 누적 → 약한 시드 자동 식별까지 작동한다. 그러나 다음 단계 — **"이 시드들 중 어떤 게 진짜 통계적으로 유의한가? 또 시드로 등록 안 된 새 가설은 어떻게 발견하나?"** — 가 미정의 상태였다.
+
+원래 마스터 #393 Phase 4 정의(이슈 #392)는 "사주 × 라이프 Hybrid Pipeline 정량 검증"으로 정성 분석 위주의 weekly-saju-review 재설계를 목표로 했으나, Phase 3 진행 중 시드 작성 책임이 Phase 3로 이동하면서 Phase 4의 scope가 **시드 outcome 데이터의 통계 검정 + LLM 자율 후보 발견 + 가설 운영 사이클 정립**으로 재정의 필요해졌다.
+
+추가 제약:
+- **Phase 5 (월운·세운·대운 시기 단위 확장, [#408](https://github.com/hyewon3938/slack-ai-agents/issues/408))은 별도 마일스톤** — 이전에 #392 본문이 시기 단위 확장도 포함했으나 Phase 4 인터뷰에서 분리 결정
+- **1인 환경 + 60일 누적 데이터의 통계적 한계** — 일부 시드는 60일에 0\~3회 발현. 정식 검증은 불가, 1차 탐색 + 가설 등록이 현실적 목표
+- **v2 헌장 cross-check 통과 필요** — LLM 텍스트 의존 최소화, 결정론 ↔ LLM 자율 분리, outcome-based 검증, 신뢰 비용 분리
+
+## Decision
+
+**가설-검증 정량 파이프라인** 도입:
+
+### 인프라
+
+```sql
+-- 가설 정의 (사용자가 자동 발견 후보 중 선택해 등록)
+CREATE TABLE saju_hypotheses (
+  id              SERIAL PRIMARY KEY,
+  trigger_spec    JSONB NOT NULL,        -- 시드 catalog 참조 또는 신규 조합
+  enum_target     TEXT NOT NULL,         -- diary_meta_tags.tag
+  status          TEXT NOT NULL DEFAULT 'active',  -- active | confirmed | rejected | archived
+  registered_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  confirmed_at    TIMESTAMPTZ,
+  archived_at     TIMESTAMPTZ,
+  notes           TEXT                    -- 사용자 임상 설명
+);
+
+-- 주간 검증 결과 누적 (시계열)
+CREATE TABLE saju_stats (
+  id              SERIAL PRIMARY KEY,
+  hypothesis_id   INTEGER NOT NULL REFERENCES saju_hypotheses(id),
+  week_start      DATE NOT NULL,
+  n_trigger_days  INTEGER NOT NULL,
+  n_total_days    INTEGER NOT NULL,
+  rate_trigger    NUMERIC(6,4) NOT NULL,
+  rate_baseline   NUMERIC(6,4) NOT NULL,
+  rate_ratio      NUMERIC(8,4) NOT NULL,
+  raw_p           NUMERIC(10,8) NOT NULL,
+  fdr_q           NUMERIC(10,8) NOT NULL,
+  computed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (hypothesis_id, week_start)
+);
+```
+
+### 통계 알고리즘
+
+- **검정**: Fisher's exact test (소표본 + 이진 outcome에 robust, t-test는 부적합)
+- **효과 크기**: rate ratio = (trigger 발현일의 enum 빈도) / (비발현일의 enum 빈도)
+- **최소 샘플**: trigger 발현 ≥ 5일 (n<5는 "샘플 부족"으로 skip, 강제 검정 X)
+- **유의 필터** (1차 탐색용): raw p<0.1 AND BH-FDR q<0.2
+- **다중 비교 보정**: BH-FDR — 시드 × enum 수백 조합 동시 검정 시 false positive 통제
+
+### 운영 사이클
+
+1. **자동 패턴 발견** (시드 등록 후보 발굴, 트리거 모드 2종):
+   - **1차 셋업 모드**: 사용자가 수동 1회 실행 → 시드 전체 × 누적 enum × 과거 데이터 → 유의 후보 N개 → 사용자가 골라 가설 등록 (Phase 4 도입 시점)
+   - **운영 모드**: 주간 cron 자동 → 새 enum/누적 데이터 변동분 → 후보 발견 → Slack Block Kit 카드로 사용자에게 제안
+   - 같은 인프라 (Fisher's exact + FDR), 트리거만 다름
+
+2. **가설 lifecycle**:
+   - `active` → `confirmed`: n_trigger_days ≥ 30 AND fdr_q < 0.05 안정적
+   - `active` → `rejected`: n_trigger_days ≥ 30 AND rate_ratio → 1 수렴 (효과 없음 확정)
+   - `active` → `archived`: 사용자 수동 폐기
+
+3. **주간 검증 cron** — 월요일 08:00 KST, 전주 데이터 기준:
+   - active 가설 전체에 대해 saju_stats INSERT
+   - 상태 자동 전이 (confirmed/rejected)
+   - `#insight` 채널에 Block Kit 리포트 (가설별 현재 통계 + 직전 주 대비 변화)
+   - 신규 자동 발견 후보도 같은 리포트에 첨부
+
+4. **confirmed 가설 → 일일 잔소리 통합**: Phase 1 결정론 SQL 11패턴에 **확장 슬롯**으로 자동 합류. 매일 09:00 cron이 11패턴 + active confirmed 가설 모두 평가 → trigger 발현일이면 잔소리 후보로 추가. 기존 11패턴 코드 무수정.
+
+5. **신규 cron `weeklyHypothesisReview` 추가**: notification_settings에 슬롯 신규 등록. 기존 `weeklyReport` (Phase 1 결정론 SQL 주간 리포트)는 분리 유지 — 목적이 다름. ADR-0011 등 과거 문서에 언급된 `weekly-saju-review` cron은 v2 이전에 폐기된 routine이라 재설계 대상 아님.
+
+### LLM 사용 범위
+
+- **유지**: diary → diary_meta_tags enum 추출 (현 Sonnet, [#409](https://github.com/hyewon3938/slack-ai-agents/issues/409)에서 Opus 이관)
+- **신규**: 자동 패턴 발견에서 LLM 사용 X (Fisher's exact + FDR로 결정론 검정). 가설 카드 짧은 자연어 설명 정도만 Sonnet 사용 가능
+
+### enum 확장 (16 → 22)
+
+기존 16개 + 6개 신규 (Phase 4 도입 시 migration):
+- `wealth_awareness` — 돈 관련 인식·결정·기회 (사주 재성 매핑 직결)
+- `self_observation` — 본인 사주 패턴·신살·일진을 직접 언급 (가설 검증 골드 시그널)
+- `social_activity` — 가족·친구·지인 만남/통화 (비겁/관성 매핑)
+- `physical_activity` — 운동·산책·외출 (역마 매핑)
+- `task_completion` — 업무·과제 처리/완료 (식상/관성 매핑)
+- `clumsy_overflow` — 실수·물건 떨어뜨림·놓침 (충/공망 매핑)
+
+`self_observation`은 `analytical_mode`·`deep_thought`와 겹치지 않도록 "본인 사주·신살·일진 직접 언급"으로 정의 좁힘. SYSTEM_PROMPT에 예시 1\~2개 명시.
+
+## Alternatives considered
+
+### A. 최소 샘플 3일 + p<0.05 만 사용
+
+- 장점: 가설 발견 폭 ↑, 운영 1\~2개월 만에도 confirmed 발생 가능
+- 단점: n=3는 Fisher's exact 검출력 거의 0 — false positive 폭증. 다중 비교 무시하면 60일×시드 100개×enum 22개 = 2,200 조합 중 100여 개가 우연히 유의로 잡힘
+- 기각 이유: 1차 탐색이라도 노이즈만 양산. 신뢰 비용 분리 원칙 위배
+
+### B. t-test 또는 Cohen's d 사용
+
+- 장점: 학계 친숙도 높음, 효과 크기 표준 지표
+- 단점: t-test는 연속 변수·정규분포 전제 — diary_meta_tags는 이진(있음/없음)이라 부적합. Cohen's d는 효과 크기만 있고 유의 검정 안 함
+- 기각 이유: 데이터 형식 불일치. Fisher's exact가 작은 샘플 + 이진 outcome에 가장 robust
+
+### C. 가설 검증 주기를 매일
+
+- 장점: 즉각 피드백
+- 단점: 매일 1일 추가 = 통계 거의 안 바뀜. 가설 5\~10개 × 매일 = 사용자 인지 과부하
+- 기각 이유: 주간 호흡이 적절. 일일은 잔소리로 별도 채널 (confirmed 통합 슬롯)
+
+### D. confirmed 가설을 결정론 11패턴과 분리 운영
+
+- 장점: 가설 영역 깔끔. 11패턴 코드 변경 0
+- 단점: 어렵게 검증한 가설을 일상에 못 씀. confirmed 의미 약화
+- 기각 이유: 확장 슬롯 패턴으로 통합해도 11패턴 코드 무수정 가능 — 분리 이점 사라짐
+
+### E. 웹 대시보드에서 가설 그래프 제공
+
+- 장점: 시계열 시각화 직관적
+- 단점: Phase 4 작업량 ↑. Slack Block Kit으로 충분히 운영 가능
+- 기각 이유: Phase 4 범위에서 보류. 운영 후 필요해지면 별도 phase
+
+### F. 시기 단위 확장(월운·세운·대운)을 Phase 4에 포함
+
+- 장점: 사주 매칭 인프라 한번에 확장
+- 단점: 통계 사이클 길이 차이로 검증 메커니즘 자체가 다름 (월운 \~2년, 세운 \~28년). 가설 검증 인프라와 작업 성격이 다름
+- 기각 이유: Phase 5([#408](https://github.com/hyewon3938/slack-ai-agents/issues/408))로 분리. Phase 4는 가설 검증 인프라에 집중
+
+### G. (선택) Fisher's exact + BH-FDR + n≥5 + p<0.1 / q<0.2 (Decision 섹션 참조)
+
+- 장점: 1차 탐색에 적절한 보수성, 다중 비교 자동 보정, 1인 환경 소표본 robust
+- 단점: 60일 데이터로는 confirmed까지 1\~5년 걸림 — 단기 만족 약함
+
+## Consequences
+
+### 장점
+
+- **시드 outcome 데이터의 통계적 의미가 정량 측정 가능** — 임상 직관 → 가설 → 통계 검정 사이클 완성
+- **자동 발견 + 가설 등록의 단일 인프라** — 1차 셋업과 운영이 같은 알고리즘. 코드 재사용
+- **결정론 ↔ LLM 자율 헌장 준수** — 잔소리=SQL, enum 추출=LLM, 통계 검정=결정론. LLM 텍스트 의존 없음
+- **confirmed 가설의 일상 통합** — 어렵게 검증한 가설이 매일 09:00 잔소리에 자연 반영
+- **운영 흐름 정렬** — Phase 1 `weeklyReport` (SQL 결정론)와 Phase 4 `weeklyHypothesisReview` (가설 통계) 분리 운영. 목적·발송 시각(월요일 09:00 vs 08:00)·채널 모두 명확히 구분
+
+### 단점 / 제약
+
+- **confirmed까지 시간 오래 걸림** — n≥30 + q<0.05는 자주 발현 시드도 1년, 희귀 시드는 3\~5년. 단기 성취감 약함
+- **자료 누적 의존** — 1\~2년 후에야 진짜 가설 운영 사이클이 정상 작동. 초기에는 candidates만 누적
+- **enum 22개 분류기 부담** — Opus 이관([#409](https://github.com/hyewon3938/slack-ai-agents/issues/409))으로 완화하지만, enum 정의 명확화 + spot check 필요
+- **다중 비교 통제의 한계** — BH-FDR도 조합 수 수천이면 q < 0.2 라도 false positive 가능. 사용자 직접 카드 보고 판단 단계 유지
+
+### 후속 작업
+
+- [ ] migration 058: `saju_hypotheses` + `saju_stats` 테이블 생성
+- [ ] migration 059: `diary_meta_tags` enum 6개 추가 (DIARY_META_TAGS 배열 동기화)
+- [ ] [#409](https://github.com/hyewon3938/slack-ai-agents/issues/409) diary-meta-extract Opus 이관 (Phase 4 작업 1)
+- [ ] `src/shared/saju-hypothesis.ts` — Fisher's exact + BH-FDR 계산
+- [ ] `src/agents/insight/hypothesis-discovery.ts` — 자동 패턴 발견 (수동 트리거 + 주간 cron 공용)
+- [ ] `src/agents/insight/hypothesis-cards.ts` — Block Kit 카드 빌더 (등록/폐기 버튼 + 액션 핸들러)
+- [ ] `src/cron/weekly-hypothesis-review.ts` — 월요일 08:00 신규 cron
+- [ ] notification_settings: `weeklyHypothesisReview` 슬롯 신규 등록 (Phase 1 `weeklyReport`과 분리)
+- [ ] `src/shared/insights.ts` 확장 슬롯 — confirmed 가설 자동 합류 로직
+- [ ] 1차 셋업 명령어 또는 admin script — 60일 데이터 백테스팅 1회 실행
+- [ ] 운영 후 임계치 튜닝 — n<5 skip이 너무 빡빡한지, q<0.2 노이즈 적당한지 (Phase 4.5 후속)
+
+---
+
+**참고 자료**
+
+- Benjamini, Y., & Hochberg, Y. (1995). Controlling the false discovery rate. *Journal of the Royal Statistical Society, Series B, 57(1)*, 289–300.
+- Fisher's exact test — 소표본 + 이진 outcome 표준 검정
+- [ADR-0014](0014-insight-engine-unification.md) — Phase 1 SQL 패턴 통합
+- [ADR-0016](0016-llm-autonomous-slot-outcome-verification.md) — Phase 2 LLM 자율 슬롯 outcome 검증
+- [ADR-0017](0017-saju-ganji-master-normalization.md) — Phase 3 60갑자 마스터 정규화

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -125,6 +125,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0016](0016-llm-autonomous-slot-outcome-verification.md) | LLM 자율 발견 슬롯 + Outcome-based 검증 | Accepted | 2026-05-16 | data, insight, llm |
 | [0017](0017-saju-ganji-master-normalization.md) | 사주 60갑자 마스터 정규화 + 카탈로그 기반 일일 매칭 | Accepted | 2026-05-17 | data, architecture |
 | [0018](0018-installment-runway-scope-toggle.md) | 할부 자산 차감 범위 토글 — `distribute_to_runway` 분기 | Accepted | 2026-05-20 | data, budget |
+| [0019](0019-saju-hypothesis-verification-pipeline.md) | 프로액티브 인사이트 v2 Phase 4 — 가설-검증 정량 파이프라인 | Accepted | 2026-05-21 | data, llm, statistics |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/insight-engine-v2.md
+++ b/docs/design-notebook/insight-engine-v2.md
@@ -17,8 +17,9 @@
 
 - [x] **Phase 1**: 패턴 통합 · 임계치 외부화 · 주간 리포트 재구성 ([#389](https://github.com/hyewon3938/slack-ai-agents/issues/389), 2026-05-14 머지)
 - [x] **Phase 2**: LLM 자율 슬롯 + 측정 ([#390](https://github.com/hyewon3938/slack-ai-agents/issues/390), 2026-05-16 머지)
-- [ ] **Phase 3**: 사주 60갑자 마스터 정규화 + 일일 매칭 catalog ([#391](https://github.com/hyewon3938/slack-ai-agents/issues/391), 설계 완료 2026-05-17)
-- [ ] **Phase 4**: 사주 × 라이프 Hybrid Pipeline 정량 검증 ([#392](https://github.com/hyewon3938/slack-ai-agents/issues/392))
+- [x] **Phase 3**: 사주 60갑자 마스터 정규화 + 일일 매칭 catalog ([#391](https://github.com/hyewon3938/slack-ai-agents/issues/391), 2026-05-17 머지)
+- [ ] **Phase 4**: 가설-검증 정량 파이프라인 + 자동 패턴 발견 ([#392](https://github.com/hyewon3938/slack-ai-agents/issues/392), 설계 완료 2026-05-21)
+- [ ] **Phase 5**: 월운·세운·대운 시기 단위 확장 ([#408](https://github.com/hyewon3938/slack-ai-agents/issues/408), Phase 4 이후)
 
 ---
 
@@ -201,3 +202,70 @@ SQL 결정론(Phase 1, 11개 패턴) 위에 **LLM 자율 발견 슬롯**을 추�
 
 - **사주 도메인의 정량 가설-검증 시스템 first**: 한국 전통 명리학의 임상 가설을 개인 라이프 데이터로 정량 검증하는 시도. 사주 자료를 마스터로 정규화하고 시드 catalog가 참조하는 데이터 모델 + outcome 누적 사이클 자체가 새로운 패턴
 - **결정론적 catalog ↔ LLM 자율 발견의 듀얼트랙 패턴 재활용**: Phase 2에서 cross-domain 일상 데이터에 적용한 outcome 검증 패턴이 사주 영역에도 동일 구조로 작동. 헌장이 phase 도메인을 넘어 일관 적용된 사례
+
+---
+
+## Phase 4: 가설-검증 정량 파이프라인 + 자동 패턴 발견 (2026-05-21 설계)
+
+- 이슈: [#392](https://github.com/hyewon3938/slack-ai-agents/issues/392)
+- 관련 ADR: [ADR-0019](../adr/0019-saju-hypothesis-verification-pipeline.md) (#392 머지 직전 budget PR이 0018 선점)
+- 관련 계획서: `.claude/plans/392-phase4-hypothesis-pipeline.md`
+- 연관 이슈: [#409](https://github.com/hyewon3938/slack-ai-agents/issues/409) (diary-meta-extract Opus 이관, Phase 4 작업 1), [#408](https://github.com/hyewon3938/slack-ai-agents/issues/408) (Phase 5 분리)
+- Phase 4 scope 재정의: 원래 "사주 × 라이프 Hybrid Pipeline 정량 검증"이었으나 Phase 3에서 시드 작성 책임이 이동하면서 **시드 outcome 통계 검정 + 자동 패턴 발견 + 가설 운영 사이클**로 재정의
+- 상태: 설계 완료 / 구현 예정
+
+### 결정 요약
+
+Phase 3에서 누적되는 시드 outcome 데이터(hit/miss/inconclusive)와 일기 enum 태그(`diary_meta_tags`)를 결합해 **가설-검증 정량 파이프라인**을 도입한다. 결정론 통계(Fisher's exact + BH-FDR)로 자동 패턴을 발견하고, 사용자가 Block Kit 카드에서 선택해 가설로 등록(`saju_hypotheses`)하면 주간 cron이 통계 누적(`saju_stats`) → confirmed/rejected 자동 전이까지 처리. confirmed 가설은 Phase 1 결정론 11패턴에 **확장 슬롯**으로 자동 합류해 매일 잔소리에 반영. 신규 `weeklyHypothesisReview` cron을 월요일 08:00 KST에 추가 (Phase 1 `weeklyReport` 09:00 분리 유지 — 목적·시각·채널 모두 별도). enum은 16개 → 22개로 확장 (wealth_awareness / self_observation / social_activity / physical_activity / task_completion / clumsy_overflow 추가). LLM은 enum 추출 1회만 사용([#409](https://github.com/hyewon3938/slack-ai-agents/issues/409) Opus 이관 동반), 통계 검정 자체는 결정론 — v2 헌장(LLM 텍스트 의존 최소화) 준수.
+
+### 의사결정 분기점
+
+- **시기 단위 확장(월운·세운·대운) 포함 여부**: Phase 4 통합 / **Phase 5 분리 (선택)** / 영구 미루기. → 분리. 이유: 통계 사이클 길이 차이로 검증 메커니즘 자체가 다름(월운 \~2년, 세운 \~28년). 가설 검증 인프라와 작업 성격이 분리되어 같은 phase로 묶기엔 응집도 약함. #392 본문이 시기 단위 확장도 포함했으나 인터뷰에서 #408로 이관 결정
+- **일일 분석 출력 재설계 범위**: 주간 리포트만 재설계 / **일일 메시지도 가설 인프라 흡수 (선택)**. → 흡수. 이유: 어렵게 검증한 가설을 일상에 못 쓰면 의미 없음. 확장 슬롯 패턴으로 11패턴 코드 무수정 가능
+- **통계 검정 방식**: t-test / Cohen's d 단독 / **Fisher's exact + rate ratio (선택)** / chi-square / Mann-Whitney U. → Fisher's exact. 이유: diary_meta_tags가 이진(있음/없음)이라 t-test 부적합. 소표본에 가장 robust. rate ratio로 효과 크기 별도 표시
+- **최소 샘플 (n_trigger_days)**: 3일 / **5일 (선택)** / 10일. → 5일. 이유: n=3는 Fisher's exact 검출력 거의 0 — false positive 폭증. 10일은 60일 데이터로는 희귀 시드 영원히 못 잡음. 5일이 균형
+- **유의 임계치 (p / q)**: p<0.05만 / p<0.01 / **p<0.1 AND FDR q<0.2 (선택)** / FDR q<0.05만. → 후자. 이유: 1차 탐색이라 false negative가 false positive보다 비용 큼. 그러나 다중 비교 무시하면 시드×enum 수천 조합에서 노이즈 폭증 → BH-FDR로 통제. q<0.2는 "후보 중 20% false positive 예상" 수준으로 사용자 직접 카드 보고 판단 단계 유지
+- **confirmed 전이 임계**: n≥20 + q<0.1 / **n≥30 + q<0.05 (선택)** / n≥50 + q<0.01. → 중간. 이유: 느슨하면 confirmed로 잘못 전이된 가설이 잔소리에 들어옴(신뢰 무너짐). 빡세면 1\~5년 걸려 사용자 동기 약화. n=30이면 자주 발현 시드는 1년, 희귀 시드는 3\~5년 — 받아들일 만함
+- **자동 발견 vs 백테스팅 관계**: 별도 도구 / **같은 인프라, 트리거만 다름 (선택)**. → 통합. 이유: 1차 셋업 백테스팅(60일 데이터로 1회 스캔) = 운영 자동 발견(주간 cron). Fisher's exact + FDR 계산 코드를 단일 소스로 유지 가능. 사용자 인터뷰에서 직접 확인: "자동 패턴 발견은 기능이고 지금 개발하면서 하는 것도 자동 패턴 발견인데"
+- **가설 등록 UI**: 슬래시 명령어 / **Block Kit 카드 버튼 (선택)** / 웹 페이지. → Block Kit. 이유: 자동 발견 후보 자체가 Slack 카드로 오는데 등록 버튼이 같은 카드에 있는 게 동선 자연스러움. 웹 페이지는 Phase 4 제외 결정과 충돌
+- **confirmed 가설 → 일일 잔소리 통합 메커니즘**: 별도 영역 유지 / **결정론 11패턴 확장 슬롯 (선택)**. → 확장 슬롯. 이유: 11패턴 코드 무수정으로 통합 가능 — 분리 유지의 이점 사라짐. 매일 cron이 11패턴 + active confirmed 가설 모두 평가하면 됨
+- **enum 확장 개수**: 신규 0개 (16개로 충분) / **6개 (선택, 16 → 22)** / 10개 이상. → 6개. 이유: 사용자 60일 일기 분석 결과 6개 패턴이 16개로 못 잡힘 (wealth_awareness 핵심). 22개는 Opus 분류기에게 부담 아니고 self_observation 정의 명확화(예: "본인 사주·신살·일진 직접 언급")로 overlap 최소화
+- **주간 리포트 발송 시각**: 일요일 23시 / 일요일 23:55 (현 weekly-saju-review) / **월요일 08:00 (선택)** / 월요일 09:00 (09:05 일/루틴 알림과 충돌). → 월요일 08:00. 이유: 사용자 명시 "월요일 아침에 전주 데이터 보는 식으로". 09:05 일/루틴 알림과 충분히 분리. 일요일 23시는 아직 주가 안 끝남 + Phase 1에서 같은 이유로 주간 리포트를 월요일로 이동했던 결정 일관
+- **diary-meta-extract Opus 이관 위치**: Phase 4 작업 1 / 별도 phase / **Phase 4 첫 작업 (선택)**. → Phase 4 첫 작업. 이유: enum 분류 정확도가 후속 통계 검정의 입력 품질을 결정 → 추출 정확도가 시스템 전체 정확도의 상한선. 가설 인프라 구축 전에 입력 품질부터 안정화
+
+### 포기한 안 / 미룬 항목
+
+- **시기 단위 확장 (월운·세운·대운)**: Phase 5([#408](https://github.com/hyewon3938/slack-ai-agents/issues/408))로 분리. 트리거: Phase 4 운영 1\~3개월 후 검증 메커니즘 안정화 + 사용자 시기 단위 분석 수요 확인
+- **웹 대시보드에서 가설 그래프 제공**: 보류. Slack Block Kit으로 충분히 운영 가능. 트리거: 가설 5+ confirmed 누적되어 시계열 시각화 필요해지면 별도 phase
+- **t-test / Cohen's d 통계 도입**: 영구 기각. diary_meta_tags가 이진이라 부적합
+- **자동 신뢰도 % 표시 (예: "이 가설 87% 신뢰")**: 보류. rate ratio + p + q 3종 표시가 더 정직(단일 % 환산은 오해 소지). 운영 후 사용자 인지 어렵다 피드백 오면 단순화 검토
+- **가설 폐기 후 재등록 시 이전 통계 승계 여부**: 1차안은 새 ID로 시작(통계 0부터). 같은 trigger_spec+enum_target 폐기 가설이 있으면 등록 시 경고만 표시. 트리거: 사용자가 같은 가설 반복 등록 시 운영 부담 보이면 머지 옵션 도입
+- **자유언어 가설 등록 (사용자가 직접 SQL 또는 텍스트로 작성)**: 영구 기각. Block Kit 카드(자동 발견 후보) 기반 선택만 — 자유 입력은 trigger_spec JSONB 검증 부담 + v2 헌장(결정론) 위배 가능
+- **가설 등록 후 즉시 검증 (등록 즉시 1회 통계 INSERT)**: 보류. 1차안은 다음 월요일 cron에서 첫 통계 — 사용자가 등록 직후 결과 보고 싶다 피드백 오면 즉시 모드 추가
+
+### 미해결·가설
+
+- **n<5 skip이 사용자에게 답답한가**: 검증 시점 = 운영 4\~8주 후. 자동 발견 후보가 자주 "샘플 부족" 표시되면 3일까지 낮추는 옵션 검토 (이때는 카드에 "잠정" 라벨 명시 필요)
+- **q<0.2 노이즈 정도**: 시드 16개 × enum 22개 = 352 기본 조합 + element_density 조합 → 운영 시 BH-FDR 효과 어느 정도인지 불확실. 초기 후보 카드가 매주 10+장 쏟아지면 q<0.1로 조이기
+- **confirmed 임계 n≥30이 1인 환경에서 도달 가능한가**: 자주 발현 시드(예: 매일 evaluating)는 1년 이내, 희귀 시드는 3\~5년. 1년 운영 후 confirmed 0건이면 임계 완화 검토
+- **rate ratio = 1 수렴 판정**: rejected 전이 조건 "rate_ratio → 1"의 구체 임계 미정 (예: 0.95 \~ 1.05 범위 4주 유지?). 운영 데이터 보고 결정
+- **Opus 이관 후 enum 추출 정확도 향상 정도**: 사용자가 Opus가 더 정확할 거라 가정하지만 spot check 전엔 미검증. Phase 4 작업 1 완료 후 1주 spot check 필수
+- **enum 6개 추가 후 분류 충돌 빈도**: self_observation ↔ analytical_mode / deep_thought 정의 좁혔지만 LLM이 헷갈릴 가능성. 첫 2주 일기-태그 결과 사용자 spot check 필요
+- **자동 발견 카드의 "정확도"**: rate ratio·p·q 셋 다 표시한다는 결정인데, 사용자가 직접 판단할 때 어떤 지표를 가장 무겁게 보는지 운영 후 관찰. 패턴 발견하면 카드 정렬·강조 재설계
+- **weekly-hypothesis-review 메시지 길이**: 가설 10개 active + 신규 후보 5장 = Slack 한 메시지 한계(Block Kit 50 blocks) 근접 가능. 1차안은 active 가설만 묶음 카드 + 후보는 별도 메시지로 분리 고려
+
+### 회고
+
+> 설계 단계 회고 (구현 후 머지 직후 회고 별도 추가 예정)
+
+- **인터뷰 중 phase scope 재정의가 자연스럽게 풀린 사례**: 초기 #392는 "사주 × 라이프 Hybrid Pipeline 정량 검증"이었으나 Phase 3에서 시드 작성 책임이 이동하면서 Phase 4 정체성이 모호해졌다. 사용자가 "phase3은 시드 확인 장치, phase4는 그 데이터 보고 리포트?"로 물어 즉시 재정의 — "Phase 3 = 시드 운영, Phase 4 = 가설 운영" 구분으로 정리. design-notebook이 phase 사이 책임 이동을 흡수하는 도구로 작동
+- **사용자가 직접 다른 이슈와의 관계를 짚어준 사례**: 사용자가 "#408 ... 이거 읽어보고 Phase 4랑 비슷한 내용이면 합치고 아니면 분리해서 진행하자"로 제안 → Phase 5 분리 결정. 메타 이슈(#393) 마스터가 phase 흐름을 추적하는 동안 사용자가 별도 후속 이슈를 cross-check하는 패턴이 다음 마스터에서도 유효할 듯
+- **백테스팅 ↔ 자동 패턴 발견 통합이 사용자 인터뷰로 풀린 사례**: 처음에 두 개념을 분리해서 작업 항목 2개로 두었는데 사용자가 "이게 아니야? 다시 자세히 설명 부탁"으로 짚어 통합 발견. 같은 Fisher's exact + FDR 코드를 트리거만 다르게 재사용하면 됨 → 코드 재사용 + 작업 항목 절감. 사용자의 "이것 같은데?" 질문이 설계 시야를 좁혀준 패턴
+- **통계 학습 모먼트 흡수**: 사용자가 p-value / q-value 의미 학습 중. 인터뷰에서 직관적 설명(p="우연 확률", q="후보 중 false positive 예상 비율") + 표 + 함정(p 작다 ≠ 효과 크다) 형식으로 풀어냄. 다음 phase부터 통계·인프라 용어 등장 시 한 줄 정의 + 본인 시스템 예시 패턴 정착
+- **Phase 3 회고 교훈 적용 — 도메인 문서 phase 섹션 미리 작성**: Phase 3에서 도메인 문서가 `/design` 단계에 누락된 사례 → Phase 4에서는 `/design`이 docs/domains/insight.md Section 11 골격(TODO 마커)을 미리 작성하고 `/build`가 본문 채우는 패턴 적용. 4문서 → 5문서 아키텍처 owner 명시 결정의 첫 실전 적용
+
+### 기술적 의의
+
+- **개인 라이프 데이터의 통계적 가설 검증 사이클**: Fisher's exact + BH-FDR 다중 비교 보정 + Block Kit UI를 결합해 1인 환경에서도 가설 운영 사이클을 학술 수준 통계 기준으로 굴리는 시도
+- **결정론 통계 ↔ LLM 자율 발견의 균형**: 자동 패턴 발견에 LLM 텍스트 추론을 쓰지 않고 결정론적 통계로 후보를 발굴 — v2 헌장(LLM 텍스트 의존 최소화) 가설 검증 영역까지 일관 적용
+- **백테스팅 ↔ 자동 발견 단일 인프라 패턴**: 동일 알고리즘을 트리거만 다르게 두 가지 모드로 운용. 셋업 도구가 운영 도구가 되는 코드 재사용 패턴

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -364,6 +364,22 @@ Baseline 윈도우는 `BASELINE_WINDOW_DAYS = 28`. SQL 템플릿은 `$user_id`, 
 
 설계 배경 및 대안 비교는 [ADR-0017](../adr/0017-saju-ganji-master-normalization.md) 참조.
 
+### 11. 프로액티브 인사이트 v2 — Phase 4 (가설-검증 정량 파이프라인)
+
+> TODO(`/build`): 구현 후 본문 채우기. Phase 4 산출물 요약:
+> - **데이터 모델**: `saju_hypotheses` (가설 정의) + `saju_stats` (주간 통계 시계열) 테이블 + migration 058/059
+> - **enum 확장**: `diary_meta_tags` 16 → 22 (wealth_awareness / self_observation / social_activity / physical_activity / task_completion / clumsy_overflow 추가, self_observation 정의 명확화)
+> - **통계 알고리즘**: Fisher's exact test + rate ratio + BH-FDR (`src/shared/saju-hypothesis.ts`)
+> - **자동 패턴 발견**: 1차 셋업(수동 1회) + 운영(주간 cron) 단일 인프라
+> - **가설 lifecycle**: active → confirmed (n≥30 + q<0.05) / rejected (n≥30 + rate→1) / archived (수동)
+> - **Block Kit 카드**: 후보 카드 (등록/폐기 버튼) + 액션 핸들러
+> - **주간 cron**: `weekly-hypothesis-review` 월요일 08:00 KST (신규 슬롯, 기존 weeklyReport와 분리)
+> - **일일 통합**: confirmed 가설 → Phase 1 결정론 11패턴 확장 슬롯으로 자동 합류 (11패턴 코드 무수정)
+> - **LLM 사용**: enum 추출 1회만 (Sonnet → Opus 이관, [#409](https://github.com/hyewon3938/slack-ai-agents/issues/409))
+> - **회고 / 운영 메트릭 / 임계치 튜닝 노트**
+
+설계 배경 및 대안 비교는 [ADR-0019](../adr/0019-saju-hypothesis-verification-pipeline.md) 참조.
+
 ## 파일 구조
 
 ```

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -366,17 +366,111 @@ Baseline 윈도우는 `BASELINE_WINDOW_DAYS = 28`. SQL 템플릿은 `$user_id`, 
 
 ### 11. 프로액티브 인사이트 v2 — Phase 4 (가설-검증 정량 파이프라인)
 
-> TODO(`/build`): 구현 후 본문 채우기. Phase 4 산출물 요약:
-> - **데이터 모델**: `saju_hypotheses` (가설 정의) + `saju_stats` (주간 통계 시계열) 테이블 + migration 058/059
-> - **enum 확장**: `diary_meta_tags` 16 → 22 (wealth_awareness / self_observation / social_activity / physical_activity / task_completion / clumsy_overflow 추가, self_observation 정의 명확화)
-> - **통계 알고리즘**: Fisher's exact test + rate ratio + BH-FDR (`src/shared/saju-hypothesis.ts`)
-> - **자동 패턴 발견**: 1차 셋업(수동 1회) + 운영(주간 cron) 단일 인프라
-> - **가설 lifecycle**: active → confirmed (n≥30 + q<0.05) / rejected (n≥30 + rate→1) / archived (수동)
-> - **Block Kit 카드**: 후보 카드 (등록/폐기 버튼) + 액션 핸들러
-> - **주간 cron**: `weekly-hypothesis-review` 월요일 08:00 KST (신규 슬롯, 기존 weeklyReport와 분리)
-> - **일일 통합**: confirmed 가설 → Phase 1 결정론 11패턴 확장 슬롯으로 자동 합류 (11패턴 코드 무수정)
-> - **LLM 사용**: enum 추출 1회만 (Sonnet → Opus 이관, [#409](https://github.com/hyewon3938/slack-ai-agents/issues/409))
-> - **회고 / 운영 메트릭 / 임계치 튜닝 노트**
+Phase 3까지는 11종 결정론 패턴 + 60갑자 일일 매칭으로 "기록"만 했다. Phase 4는 그 위에 통계적으로 검증된 가설만 잔소리로 노출하는 자동 파이프라인을 얹는다. 사람 직관(혹은 LLM 추측)이 아니라 누적 데이터의 효과량 + p-value로 active/confirmed/rejected를 판정.
+
+#### 데이터 모델 (migration 058)
+
+| 테이블 | 역할 | 키 컬럼 |
+|--------|------|---------|
+| `saju_hypotheses` | 가설 정의 + 현재 상태 | `trigger_spec` JSONB, `enum_target`, `status`, `source` |
+| `saju_stats` | 주간 통계 시계열 (`UNIQUE(hypothesis_id, week_start)`) | `n_trigger_days`, `n_total_days`, `rate_trigger`, `rate_baseline`, `rate_ratio`, `raw_p`, `fdr_q` |
+
+`trigger_spec`은 polymorphic 구조 — 현재는 `{type:'seed', signalId}` (Phase 3 시드 ID 재사용). 향후 합성 트리거(`{type:'and', specs:[...]}` 등) 확장 여지.
+
+`status`: `active` → `confirmed` / `rejected` / `archived`(수동). `source`: `discovery`(자동 발견 후 사용자 등록) / `manual`(직접 입력).
+
+#### enum 확장 (migration 059)
+
+`diary_meta_tags` CHECK 제약 16 → 22. 추가: `wealth_awareness` / `self_observation` / `social_activity` / `physical_activity` / `task_completion` / `clumsy_overflow`. `self_observation` 정의도 명확화(메타 인지/내성).
+
+LLM 추출은 Sonnet → Opus 이관 ([#409](https://github.com/hyewon3938/slack-ai-agents/issues/409)) — meta-extract cron이 createDiaryMetaLLMClient() 경유로 Opus 호출.
+
+#### 통계 알고리즘 (`src/shared/saju-hypothesis.ts`)
+
+- **Fisher's exact test (two-sided)**: hypergeometric log-space sum. n_trigger_days × n_baseline_days 2×2 분할표.
+- **Rate ratio**: `rate_trigger / rate_baseline` (효과량). 통계적 유의성 ≠ 실질적 의미를 분리 판단.
+- **BH-FDR**: Benjamini-Hochberg False Discovery Rate. 같은 주에 평가하는 가설 수만큼 multiple testing 보정. NaN(n<5 skip) 보존.
+
+임계치 (`saju-hypothesis.ts` 모듈 상단 상수, Phase 4에서만 사용):
+
+| 변수 | 값 | 의미 |
+|------|----|----|
+| `MIN_TRIGGER_SAMPLE` | 5 | 통계 계산 skip 하한 (trigger 발현일 < 5면 raw_p = NaN) |
+| `BASELINE_LOOKBACK_DAYS` | 90 | rate_baseline 계산 윈도우 |
+| `CONFIRM_MIN_N` | 30 | confirmed 진입 누적 trigger 발현일 |
+| `CONFIRM_MAX_Q` | 0.05 | 최근 4주 평균 FDR-corrected q-value 상한 |
+| `CONFIRM_MIN_RATE_RATIO` | 1.3 | 최근 4주 평균 효과량 하한 |
+| `REJECT_RATE_LOW` / `HIGH` | 0.95 / 1.05 | rejected: 최근 4주 모두 rate_ratio가 1 근처 |
+| `RECENT_WEEKS` | 4 | 상태 평가 윈도우 |
+
+발견 단계 임계치 (`hypothesis-discovery.ts`):
+
+| 변수 | 값 | 의미 |
+|------|----|----|
+| `DISCOVERY_MIN_N` | 5 | 후보 평가 최소 trigger 발현일 |
+| `DISCOVERY_MAX_RAW_P` | 0.1 | 1차 거르기 (BH-FDR 전, 보수적) |
+| `DISCOVERY_MAX_FDR_Q` | 0.2 | 다중 비교 보정 후 q-value 상한 |
+| `DISCOVERY_MIN_RATE_RATIO` | 1.3 | 효과량 하한 |
+
+#### 자동 패턴 발견 (`src/agents/insight/hypothesis-discovery.ts`)
+
+단일 함수 `discoverCandidates(userId, mode)`로 1차 셋업(`{mode:'setup', lookbackDays}`)과 주간 운영(`{mode:'recurring', weekStart}`) 모두 처리. 모든 (signalId × enum_target) 조합을 평가해 다음 조건 통과한 후보만 반환:
+
+- `DISCOVERY_MIN_N` (5)
+- `DISCOVERY_MAX_RAW_P` (0.1) → 1차 거르기 (보수적, BH-FDR 전)
+- `DISCOVERY_MAX_FDR_Q` (0.2) → multiple testing 보정 후
+- `DISCOVERY_MIN_RATE_RATIO` (1.3)
+
+`rate_ratio` 내림차순 정렬. CLI 백테스트는 `scripts/saju-hypothesis-backtest.ts` (`yarn tsx scripts/saju-hypothesis-backtest.ts --user 1 --lookback 60`).
+
+#### Block Kit 카드 (`src/agents/insight/hypothesis-cards.ts`)
+
+- **`buildCandidateCard`**: discoverCandidates 결과를 등록/폐기 버튼 카드로 변환. action_id: `hypothesis_register` / `hypothesis_dismiss`. payload는 type-safe JSON 인코딩.
+- **`buildWeeklyReviewBlocks`**: active 가설 표 (전주 대비 rate_ratio 변화 ▲▼─ 10% 임계) + 신규 후보 묶음.
+
+액션 핸들러 (`src/agents/insight/actions.ts`):
+- `hypothesis_register`: `INSERT INTO saju_hypotheses (status=active, source=auto_discovered)`
+- `hypothesis_dismiss`: 카드 메시지 update (DB 변경 X — 거부 기록만)
+
+#### Cron 시각
+
+| 시각 | 슬롯 | 의도 | 산출물 |
+|------|------|------|--------|
+| 월 08:00 KST | `weeklyHypothesisReview` | 주간 가설 통계 갱신 + 상태 평가 + 신규 후보 발굴 | #insight 묶음 카드 (active 표 + 후보 리스트) |
+
+`weekly-hypothesis-review.ts`는 매일 08:00 발사되지만 `getKSTDayOfWeek() !== 1`이면 즉시 return — `weeklyReport` / `weeklyLlmInsight`와 동일 패턴 (cron 슬롯 하나당 매일 발사 + 본체에서 요일 게이트).
+
+#### 일일 통합 흐름
+
+09:00 #life 사주 매칭 메시지 (Phase 3) 직후, 같은 cron에서 confirmed 가설을 1줄 잔소리로 추가 노출:
+
+```
+[Phase 3 결정론 + 60갑자 매칭 라인]
+[Phase 1 LLM 인사이트 ── 있을 때]
+*<signal_name>* 패턴 켜졌어 → `<enum_target>` 주의 (평균 1.5x).
+```
+
+`pickConfirmedHypothesisLines`는 `saju_hypotheses` confirmed × 오늘 `saju_daily_matches.trigger_activated = true` JOIN. Phase 1 11패턴 코드는 **무수정** — confirmed 가설이 11패턴 옆에 자동 합류하는 것은 별도 함수로 분리해 dedupe 로직과 격리.
+
+#### 가설 lifecycle
+
+```
+auto_discovered → active → confirmed → (영구 노출)
+                       ↓
+                    rejected (rate_ratio → 1, 4주 연속) → 잔소리 미노출
+                       ↓
+                    archived (수동, 본인이 더 안 보고 싶을 때)
+```
+
+상태 전이는 `evaluateStatusTransition(hypothesisId)` 단일 함수 — pure logic, DB 적용은 `applyStatusTransition`이 별도 수행.
+
+#### Phase 5 확장 가능성
+
+`trigger_spec`의 polymorphic JSONB 구조 덕에 시간 단위 확장(일운/월운/세운/대운)이 데이터 모델 변경 없이 가능 — 새 시드 카탈로그 + period 컬럼만 추가하면 동일 통계 파이프라인이 그대로 적용. 검증 사이클이 길어 누적 속도 차이 큼(세운 1년/대운 10년 단위). 상세: [#408](https://github.com/hyewon3938/slack-ai-agents/issues/408).
+
+#### Fast Path 명령어
+
+Phase 4는 신규 fast path 명령어 없음. 카드 액션 버튼(`hypothesis_register` / `hypothesis_dismiss`)만 노출.
 
 설계 배경 및 대안 비교는 [ADR-0019](../adr/0019-saju-hypothesis-verification-pipeline.md) 참조.
 
@@ -384,20 +478,27 @@ Baseline 윈도우는 `BASELINE_WINDOW_DAYS = 28`. SQL 템플릿은 `$user_id`, 
 
 ```
 src/agents/insight/
-├── index.ts                  # 에이전트 생성, fast path 매칭, LLM 에이전트 루프
-├── prompt.ts                 # 시스템 프롬프트 빌더 (DB 데이터 실시간 로드)
-├── actions.ts                # 인터랙티브 버튼 핸들러
-├── blocks.ts                 # Slack Block Kit 메시지 빌더
-├── diary-fast-path.ts        # 일기 저장 + 자연스러운 응답
-└── saju-seed-fast-path.ts    # 사주 시드 보기/끄기/켜기 (Phase 3)
+├── index.ts                       # 에이전트 생성, fast path 매칭, LLM 에이전트 루프
+├── prompt.ts                      # 시스템 프롬프트 빌더 (DB 데이터 실시간 로드)
+├── actions.ts                     # 인터랙티브 버튼 핸들러 (+ Phase 4 가설 등록/폐기)
+├── blocks.ts                      # Slack Block Kit 메시지 빌더
+├── diary-fast-path.ts             # 일기 저장 + 자연스러운 응답
+├── saju-seed-fast-path.ts         # 사주 시드 보기/끄기/켜기 (Phase 3)
+├── hypothesis-discovery.ts        # Phase 4 자동 패턴 발견 (setup/recurring)
+└── hypothesis-cards.ts            # Phase 4 카드 빌더 + 액션 payload
 
 src/shared/
-├── saju-match.ts             # Phase 3 매칭 엔진 (evaluateTrigger 6종 + evaluateMetric)
-├── saju-mappings.ts          # 십성 알고리즘 계산 (LLM 프롬프트용)
-├── insight-thresholds.ts     # 인사이트·시드 임계치 단일 관리
-└── insights.ts               # Phase 1 SQL 결정론 11종
+├── saju-match.ts                  # Phase 3 매칭 엔진 (evaluateTrigger 6종 + evaluateMetric)
+├── saju-mappings.ts               # 십성 알고리즘 계산 (LLM 프롬프트용)
+├── insight-thresholds.ts          # Phase 1/3 인사이트·시드 임계치 단일 관리 (Phase 4 임계치는 saju-hypothesis.ts 상수)
+├── insights.ts                    # Phase 1 SQL 결정론 11종 + Phase 4 confirmed 가설 라인
+└── saju-hypothesis.ts             # Phase 4 통계 (Fisher + BH-FDR + lifecycle)
 
 src/cron/
-├── daily-saju-matching.ts    # 09:00 사주 일일 매칭 (Phase 3)
-└── diary-meta-extract.ts     # 일기 → enum 태그 추출 cron (Phase 3)
+├── daily-saju-matching.ts         # 09:00 사주 일일 매칭 + confirmed 가설 슬롯 (Phase 3/4)
+├── diary-meta-extract.ts          # 일기 → enum 태그 추출 cron (Phase 3, Opus)
+└── weekly-hypothesis-review.ts    # 월 08:00 주간 가설 리포트 (Phase 4)
+
+scripts/
+└── saju-hypothesis-backtest.ts    # Phase 4 임계치 튜닝 CLI
 ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,14 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/explicit-function-return-type': 'warn',
       'no-console': ['warn', { allow: ['warn', 'error'] }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
     },
   },
   {

--- a/scripts/saju-hypothesis-backtest.ts
+++ b/scripts/saju-hypothesis-backtest.ts
@@ -1,0 +1,79 @@
+/**
+ * 사주 가설 1차 셋업 백테스팅 — admin script.
+ * ADR-0019 Phase 4.
+ *
+ * 누적된 시드 outcome + diary_meta_tags 60일을 1회 스캔해 후보 가설 콘솔 출력.
+ * 사용자가 결과를 보고 가설 5\~10개를 직접 등록 (`/insight 가설` 명령 또는 신규 register API).
+ *
+ * 실행: yarn tsx scripts/saju-hypothesis-backtest.ts --user 1 --lookback 60
+ */
+
+import { discoverCandidates } from '../src/agents/insight/hypothesis-discovery.js';
+
+interface CliArgs {
+  userId: number;
+  lookbackDays: number;
+}
+
+const parseArgs = (argv: string[]): CliArgs => {
+  let userId = 1;
+  let lookbackDays = 60;
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === '--user' && value) {
+      userId = Number(value);
+      i++;
+    } else if (flag === '--lookback' && value) {
+      lookbackDays = Number(value);
+      i++;
+    }
+  }
+  if (!Number.isFinite(userId) || userId <= 0) {
+    throw new Error('--user 옵션이 양의 정수여야 함');
+  }
+  if (!Number.isFinite(lookbackDays) || lookbackDays < 14) {
+    throw new Error('--lookback 옵션은 14 이상이어야 함 (통계 안정성)');
+  }
+  return { userId, lookbackDays };
+};
+
+const main = async (): Promise<void> => {
+  const { userId, lookbackDays } = parseArgs(process.argv.slice(2));
+  console.warn(`[Backtest] user=${userId} lookback=${lookbackDays}일 스캔 시작`);
+
+  const candidates = await discoverCandidates(userId, {
+    mode: 'setup',
+    lookbackDays,
+  });
+
+  if (candidates.length === 0) {
+    console.warn('[Backtest] 통계 임계 통과 후보 없음. lookback 늘리거나 데이터 누적 더 기다려.');
+    return;
+  }
+
+  console.warn(`\n[Backtest] 후보 ${candidates.length}건 (rate_ratio 내림차순):\n`);
+  console.warn(
+    '시드 → enum                        | n  | trig%  | base%  | ratio | raw_p   | fdr_q',
+  );
+  console.warn(
+    '----------------------------------|----|--------|--------|-------|---------|--------',
+  );
+  for (const c of candidates) {
+    const label = `${c.signalName} → ${c.enumTarget}`.padEnd(34);
+    const n = String(c.nTriggerDays).padStart(3);
+    const trigPct = `${(c.rateTrigger * 100).toFixed(1)}%`.padStart(6);
+    const basePct = `${(c.rateBaseline * 100).toFixed(1)}%`.padStart(6);
+    const ratio = c.rateRatio.toFixed(2).padStart(5);
+    const rawP = c.rawP.toFixed(4).padStart(7);
+    const fdrQ = c.fdrQ.toFixed(4).padStart(7);
+    console.warn(`${label} | ${n} | ${trigPct} | ${basePct} | ${ratio} | ${rawP} | ${fdrQ}`);
+  }
+};
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('[Backtest] 실패:', err);
+    process.exit(1);
+  });

--- a/src/agents/insight/actions.ts
+++ b/src/agents/insight/actions.ts
@@ -1,0 +1,84 @@
+/**
+ * Insight 에이전트 Slack 액션 핸들러 — ADR-0019 Phase 4.
+ *
+ * 가설 후보 카드의 등록/패스 버튼 처리.
+ */
+
+import type { App } from '@slack/bolt';
+import { query } from '../../shared/db.js';
+import { updateMessage } from '../../shared/slack.js';
+import { resolveUserId, DEFAULT_USER_ID } from '../../shared/user-resolver.js';
+import {
+  HYPOTHESIS_REGISTER_ACTION_ID,
+  HYPOTHESIS_DISMISS_ACTION_ID,
+  decodeActionPayload,
+} from './hypothesis-cards.js';
+
+const resolveBodyUserId = async (body: { user?: string | { id: string } }): Promise<number> => {
+  const slackUserId = body.user ? (typeof body.user === 'string' ? body.user : body.user.id) : '';
+  if (!slackUserId) return DEFAULT_USER_ID;
+  return (await resolveUserId(slackUserId)) ?? DEFAULT_USER_ID;
+};
+
+const extractRawValue = (body: unknown): string | null => {
+  if (!body || typeof body !== 'object') return null;
+  const actions = (body as { actions?: unknown }).actions;
+  if (!Array.isArray(actions) || actions.length === 0) return null;
+  const first = actions[0];
+  if (!first || typeof first !== 'object') return null;
+  const value = (first as { value?: unknown }).value;
+  return typeof value === 'string' ? value : null;
+};
+
+export const registerInsightActions = (app: App): void => {
+  app.action(HYPOTHESIS_REGISTER_ACTION_ID, async ({ ack, body, client }) => {
+    await ack();
+    const raw = extractRawValue(body);
+    if (!raw) return;
+    const payload = decodeActionPayload(raw);
+    if (!payload) {
+      console.warn('[Insight Action] hypothesis_register: payload 디코딩 실패');
+      return;
+    }
+    try {
+      const userId = await resolveBodyUserId(body);
+      await query(
+        `INSERT INTO saju_hypotheses (user_id, trigger_spec, enum_target, source)
+         VALUES ($1, $2, $3, 'discovery')`,
+        [userId, payload.triggerSpec, payload.enumTarget],
+      );
+      const channelId = 'channel' in body && body.channel ? body.channel.id : undefined;
+      const messageTs = 'message' in body && body.message ? body.message.ts : undefined;
+      if (channelId && messageTs) {
+        await updateMessage(
+          client,
+          channelId,
+          messageTs,
+          `가설 등록 완료 — \`${payload.enumTarget}\` 주간 추적 시작.`,
+          [],
+        );
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`[Insight Action] hypothesis_register 오류: ${msg}`);
+    }
+  });
+
+  app.action(HYPOTHESIS_DISMISS_ACTION_ID, async ({ ack, body, client }) => {
+    await ack();
+    const raw = extractRawValue(body);
+    if (!raw) return;
+    const payload = decodeActionPayload(raw);
+    try {
+      const channelId = 'channel' in body && body.channel ? body.channel.id : undefined;
+      const messageTs = 'message' in body && body.message ? body.message.ts : undefined;
+      if (channelId && messageTs) {
+        const label = payload?.enumTarget ?? '후보';
+        await updateMessage(client, channelId, messageTs, `_${label} 후보 패스함._`, []);
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`[Insight Action] hypothesis_dismiss 오류: ${msg}`);
+    }
+  });
+};

--- a/src/agents/insight/hypothesis-cards.ts
+++ b/src/agents/insight/hypothesis-cards.ts
@@ -1,0 +1,157 @@
+/**
+ * 가설 Block Kit 카드 빌더 — ADR-0019 Phase 4.
+ *
+ * - 후보 카드 (discovery → 등록/패스 액션)
+ * - 주간 리뷰 묶음 (active 가설 stat 변화 + 신규 후보)
+ */
+
+import type { KnownBlock } from '@slack/types';
+import type { CandidateHypothesis } from './hypothesis-discovery.js';
+import type { Hypothesis, HypothesisStat, TriggerSpec } from '../../shared/saju-hypothesis.js';
+
+export const HYPOTHESIS_REGISTER_ACTION_ID = 'hypothesis_register';
+export const HYPOTHESIS_DISMISS_ACTION_ID = 'hypothesis_dismiss';
+
+/** Slack action value 직렬화 — JSON 한도(2000자) 안전 */
+export interface HypothesisActionPayload {
+  triggerSpec: TriggerSpec;
+  enumTarget: string;
+}
+
+export const encodeActionPayload = (payload: HypothesisActionPayload): string =>
+  JSON.stringify(payload);
+
+export const decodeActionPayload = (raw: string): HypothesisActionPayload | null => {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const obj = parsed as Record<string, unknown>;
+    const ts = obj.triggerSpec;
+    const en = obj.enumTarget;
+    if (
+      !ts ||
+      typeof ts !== 'object' ||
+      typeof (ts as { type?: unknown }).type !== 'string' ||
+      typeof en !== 'string'
+    ) {
+      return null;
+    }
+    return parsed as HypothesisActionPayload;
+  } catch {
+    return null;
+  }
+};
+
+const arrow = (latest: number, prev: number | null): string => {
+  if (prev === null || !Number.isFinite(prev) || !Number.isFinite(latest)) return '─';
+  if (latest > prev * 1.1) return '▲';
+  if (latest < prev * 0.9) return '▼';
+  return '─';
+};
+
+const formatPercent = (v: number): string =>
+  Number.isFinite(v) ? `${(v * 100).toFixed(1)}%` : '—';
+
+const formatRatio = (v: number): string => (Number.isFinite(v) ? v.toFixed(2) : '—');
+
+const formatPValue = (v: number): string => (Number.isFinite(v) ? v.toFixed(3) : '—');
+
+/** 단일 후보 카드 — 등록/패스 버튼 포함 */
+export const buildCandidateCard = (cand: CandidateHypothesis): KnownBlock[] => {
+  const payload = encodeActionPayload({
+    triggerSpec: cand.triggerSpec,
+    enumTarget: cand.enumTarget,
+  });
+  const header = `*${cand.signalName}* → \`${cand.enumTarget}\``;
+  const detail =
+    `발현일 n=${cand.nTriggerDays} · trigger ${formatPercent(cand.rateTrigger)} ` +
+    `vs baseline ${formatPercent(cand.rateBaseline)} ` +
+    `· ratio ${formatRatio(cand.rateRatio)}x ` +
+    `· p=${formatPValue(cand.rawP)} q=${formatPValue(cand.fdrQ)}`;
+
+  return [
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: `${header}\n${detail}` },
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: '가설 등록' },
+          style: 'primary',
+          action_id: HYPOTHESIS_REGISTER_ACTION_ID,
+          value: payload,
+        },
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: '이번엔 패스' },
+          action_id: HYPOTHESIS_DISMISS_ACTION_ID,
+          value: payload,
+        },
+      ],
+    },
+  ];
+};
+
+export interface ActiveHypothesisRow {
+  hypothesis: Hypothesis;
+  signalName: string;
+  latest: HypothesisStat;
+  prev: HypothesisStat | null;
+}
+
+/** 주간 리뷰 묶음 — active 가설 표 + 신규 후보 카드 */
+export const buildWeeklyReviewBlocks = (
+  active: ActiveHypothesisRow[],
+  candidates: CandidateHypothesis[],
+  weekStart: string,
+): KnownBlock[] => {
+  const blocks: KnownBlock[] = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `가설 주간 리포트 (${weekStart} ~)` },
+    },
+  ];
+
+  if (active.length === 0) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: '_active 가설 없음 — 아래 후보에서 골라 등록해._' },
+    });
+  } else {
+    const lines = active.map((row) => {
+      const prev = row.prev;
+      const trigArrow = arrow(row.latest.rateTrigger, prev?.rateTrigger ?? null);
+      const qArrow = arrow(row.latest.fdrQ, prev?.fdrQ ?? null);
+      return (
+        `• *${row.signalName}* → \`${row.hypothesis.enumTarget}\` — ` +
+        `n=${row.latest.nTriggerDays} ` +
+        `trig ${formatPercent(row.latest.rateTrigger)} ${trigArrow} ` +
+        `ratio ${formatRatio(row.latest.rateRatio)}x ` +
+        `q=${formatPValue(row.latest.fdrQ)} ${qArrow}`
+      );
+    });
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*active 가설 (${active.length}건)*\n${lines.join('\n')}` },
+    });
+  }
+
+  if (candidates.length > 0) {
+    blocks.push({ type: 'divider' });
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*신규 후보 (${candidates.length}건)* — 등록할 거 골라`,
+      },
+    });
+    for (const cand of candidates.slice(0, 5)) {
+      blocks.push(...buildCandidateCard(cand));
+    }
+  }
+
+  return blocks;
+};

--- a/src/agents/insight/hypothesis-discovery.ts
+++ b/src/agents/insight/hypothesis-discovery.ts
@@ -1,0 +1,236 @@
+/**
+ * 자동 패턴 발견 — 시드 × enum 전수 스캔으로 후보 가설 발굴.
+ * ADR-0019 Phase 4.
+ *
+ * 두 모드:
+ *   - setup: lookbackDays 윈도우 전체 → 1차 셋업 시 backtest CLI에서 호출
+ *   - recurring: 전주만 → 주간 cron에서 호출, 이미 active/confirmed 가설은 자동 제외
+ */
+
+import { query } from '../../shared/db.js';
+import { fisherExact, bhFdr, type TriggerSpec } from '../../shared/saju-hypothesis.js';
+import { DIARY_META_TAGS, type DiaryMetaTag } from '../../cron/diary-meta-extract.js';
+
+export type DiscoveryMode =
+  | { mode: 'setup'; lookbackDays: number }
+  | { mode: 'recurring'; weekStart: string };
+
+export interface CandidateHypothesis {
+  triggerSpec: TriggerSpec;
+  signalName: string;
+  enumTarget: DiaryMetaTag;
+  nTriggerDays: number;
+  nTotalDays: number;
+  rateTrigger: number;
+  rateBaseline: number;
+  rateRatio: number;
+  rawP: number;
+  fdrQ: number;
+}
+
+const DISCOVERY_MIN_N = 5;
+const DISCOVERY_MAX_RAW_P = 0.1;
+const DISCOVERY_MAX_FDR_Q = 0.2;
+const DISCOVERY_MIN_RATE_RATIO = 1.3;
+
+interface ActiveSignal {
+  id: number;
+  name: string;
+}
+
+const loadActiveSignals = async (userId: number): Promise<ActiveSignal[]> => {
+  const res = await query<{ id: number; name: string }>(
+    `SELECT id, name FROM saju_signal_catalog
+       WHERE user_id = $1 AND active = true
+       ORDER BY id`,
+    [userId],
+  );
+  return res.rows;
+};
+
+const loadRegisteredCombos = async (userId: number): Promise<Set<string>> => {
+  const res = await query<{ trigger_spec: TriggerSpec; enum_target: string }>(
+    `SELECT trigger_spec, enum_target FROM saju_hypotheses
+       WHERE user_id = $1 AND status IN ('active', 'confirmed')`,
+    [userId],
+  );
+  return new Set(res.rows.map((r) => `${JSON.stringify(r.trigger_spec)}::${r.enum_target}`));
+};
+
+const shiftDate = (date: string, days: number): string => {
+  const d = new Date(`${date}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+};
+
+const resolveWindow = (mode: DiscoveryMode): { startDate: string; endDate: string } => {
+  if (mode.mode === 'setup') {
+    const today = new Date().toISOString().slice(0, 10);
+    const startDate = shiftDate(today, -mode.lookbackDays);
+    return { startDate, endDate: today };
+  }
+  const endDate = shiftDate(mode.weekStart, 6);
+  return { startDate: mode.weekStart, endDate };
+};
+
+interface DayMap {
+  triggerByDate: Map<number, Set<string>>;
+  enumByDate: Map<string, Set<string>>;
+  totalDays: number;
+}
+
+const loadDayMap = async (userId: number, startDate: string, endDate: string): Promise<DayMap> => {
+  const triggerRes = await query<{ signal_id: number; date: string }>(
+    `SELECT signal_id, TO_CHAR(date, 'YYYY-MM-DD') AS date
+       FROM saju_daily_matches
+      WHERE user_id = $1
+        AND date >= $2 AND date <= $3
+        AND trigger_activated = true`,
+    [userId, startDate, endDate],
+  );
+  const enumRes = await query<{ tag: string; date: string }>(
+    `SELECT tag, TO_CHAR(date, 'YYYY-MM-DD') AS date
+       FROM diary_meta_tags
+      WHERE user_id = $1 AND date >= $2 AND date <= $3`,
+    [userId, startDate, endDate],
+  );
+  const dayCountRes = await query<{ days: string }>(
+    `SELECT (DATE($2) - DATE($1) + 1)::TEXT AS days`,
+    [startDate, endDate],
+  );
+
+  const triggerByDate = new Map<number, Set<string>>();
+  for (const row of triggerRes.rows) {
+    const set = triggerByDate.get(row.signal_id) ?? new Set();
+    set.add(row.date);
+    triggerByDate.set(row.signal_id, set);
+  }
+  const enumByDate = new Map<string, Set<string>>();
+  for (const row of enumRes.rows) {
+    const set = enumByDate.get(row.tag) ?? new Set();
+    set.add(row.date);
+    enumByDate.set(row.tag, set);
+  }
+  return {
+    triggerByDate,
+    enumByDate,
+    totalDays: Number(dayCountRes.rows[0]?.days ?? 0),
+  };
+};
+
+interface RawComboStat {
+  signal: ActiveSignal;
+  enumTarget: DiaryMetaTag;
+  triggerHits: number;
+  triggerDays: number;
+  nonTriggerHits: number;
+  nonTriggerDays: number;
+  totalDays: number;
+}
+
+const computeRawStat = (
+  signal: ActiveSignal,
+  enumTarget: DiaryMetaTag,
+  triggerDates: Set<string> | undefined,
+  enumDates: Set<string> | undefined,
+  totalDays: number,
+): RawComboStat => {
+  const triggers = triggerDates ?? new Set<string>();
+  const enums = enumDates ?? new Set<string>();
+  const triggerDays = triggers.size;
+  const nonTriggerDays = totalDays - triggerDays;
+  let triggerHits = 0;
+  let nonTriggerHits = 0;
+  for (const d of enums) {
+    if (triggers.has(d)) triggerHits++;
+    else nonTriggerHits++;
+  }
+  return {
+    signal,
+    enumTarget,
+    triggerHits,
+    triggerDays,
+    nonTriggerHits,
+    nonTriggerDays,
+    totalDays,
+  };
+};
+
+/**
+ * 시드 × enum 전수 스캔. 임계 필터(p<0.1, q<0.2, ratio≥1.3, n≥5) 통과 후보만 반환.
+ * 효과 크기(rate_ratio) 내림차순 정렬.
+ */
+export const discoverCandidates = async (
+  userId: number,
+  discovery: DiscoveryMode,
+): Promise<CandidateHypothesis[]> => {
+  const signals = await loadActiveSignals(userId);
+  if (signals.length === 0) return [];
+
+  const { startDate, endDate } = resolveWindow(discovery);
+  const dayMap = await loadDayMap(userId, startDate, endDate);
+  const registered =
+    discovery.mode === 'recurring' ? await loadRegisteredCombos(userId) : new Set<string>();
+
+  const rawCombos: RawComboStat[] = [];
+  for (const signal of signals) {
+    const triggerDates = dayMap.triggerByDate.get(signal.id);
+    for (const enumTarget of DIARY_META_TAGS) {
+      const triggerSpec: TriggerSpec = { type: 'seed', signalId: signal.id };
+      const key = `${JSON.stringify(triggerSpec)}::${enumTarget}`;
+      if (registered.has(key)) continue;
+      rawCombos.push(
+        computeRawStat(
+          signal,
+          enumTarget,
+          triggerDates,
+          dayMap.enumByDate.get(enumTarget),
+          dayMap.totalDays,
+        ),
+      );
+    }
+  }
+
+  const pValues = rawCombos.map((c) => {
+    if (c.triggerDays < DISCOVERY_MIN_N) return NaN;
+    return fisherExact(
+      c.triggerHits,
+      c.triggerDays - c.triggerHits,
+      c.nonTriggerHits,
+      c.nonTriggerDays - c.nonTriggerHits,
+    );
+  });
+  const qValues = bhFdr(pValues);
+
+  const candidates: CandidateHypothesis[] = [];
+  for (let i = 0; i < rawCombos.length; i++) {
+    const raw = rawCombos[i];
+    const p = pValues[i];
+    const q = qValues[i];
+    if (!raw || p === undefined || q === undefined) continue;
+    if (Number.isNaN(p) || Number.isNaN(q)) continue;
+    if (p >= DISCOVERY_MAX_RAW_P) continue;
+    if (q >= DISCOVERY_MAX_FDR_Q) continue;
+
+    const rateTrigger = raw.triggerDays > 0 ? raw.triggerHits / raw.triggerDays : 0;
+    const rateBaseline = raw.nonTriggerDays > 0 ? raw.nonTriggerHits / raw.nonTriggerDays : 0;
+    const rateRatio = rateBaseline > 0 ? rateTrigger / rateBaseline : 0;
+    if (rateRatio < DISCOVERY_MIN_RATE_RATIO) continue;
+
+    candidates.push({
+      triggerSpec: { type: 'seed', signalId: raw.signal.id },
+      signalName: raw.signal.name,
+      enumTarget: raw.enumTarget,
+      nTriggerDays: raw.triggerDays,
+      nTotalDays: raw.totalDays,
+      rateTrigger,
+      rateBaseline,
+      rateRatio,
+      rawP: p,
+      fdrQ: q,
+    });
+  }
+
+  candidates.sort((a, b) => b.rateRatio - a.rateRatio);
+  return candidates;
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { createLifeAgent } from './agents/life/index.js';
 import { registerLifeActions } from './agents/life/actions.js';
 import { registerHomeTab } from './agents/life/home.js';
 import { createInsightAgent } from './agents/insight/index.js';
+import { registerInsightActions } from './agents/insight/actions.js';
 import { CronScheduler } from './cron/life-cron.js';
 import { setPostModifyHook, setConfirmCardSender } from './shared/sql-tools.js';
 import { buildConfirmModifyCard } from './agents/life/blocks.js';
@@ -42,6 +43,7 @@ const startApp = async (): Promise<void> => {
     const insightAgent = createInsightAgent(llmClient);
     registerAgent(CONFIG.channels.insight, insightAgent);
   }
+  registerInsightActions(app);
 
   // 크론 스케줄러 (DB 기반 동적 스케줄)
   const cronScheduler = new CronScheduler(app, {

--- a/src/cron/__tests__/diary-meta-extract.test.ts
+++ b/src/cron/__tests__/diary-meta-extract.test.ts
@@ -45,9 +45,10 @@ describe('parseTagResponse', () => {
     expect(parseTagResponse('["irritation",42,{"x":1},"rest"]')).toEqual(['irritation', 'rest']);
   });
 
-  it('허용 태그 16개 전부 정상 통과', () => {
+  it('허용 태그 전부 정상 통과 (22개)', () => {
     const all = JSON.stringify(DIARY_META_TAGS);
     expect(parseTagResponse(all).length).toBe(DIARY_META_TAGS.length);
+    expect(DIARY_META_TAGS.length).toBe(22);
   });
 });
 
@@ -89,7 +90,7 @@ describe('extractDiaryTags', () => {
     expect(messages).toHaveLength(2);
     expect(messages[0]?.role).toBe('system');
     expect(messages[1]?.role).toBe('user');
-    // 시스템 프롬프트에 enum 16개 모두 포함되어야 함 (LLM이 enum 외 출력하지 않도록)
+    // 시스템 프롬프트에 enum 22개 모두 포함되어야 함 (LLM이 enum 외 출력하지 않도록)
     const systemContent = messages[0]?.content as string;
     for (const tag of DIARY_META_TAGS) {
       expect(systemContent).toContain(tag);

--- a/src/cron/daily-saju-matching.ts
+++ b/src/cron/daily-saju-matching.ts
@@ -19,6 +19,7 @@ import {
 import { postToChannel } from '../shared/slack.js';
 import { getEffectiveTodayISO } from '../shared/kst.js';
 import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
+import { pickConfirmedHypothesisLines } from '../shared/insights.js';
 import type { LifeCronConfig } from './life-cron.js';
 
 export interface DailySajuMatchingResult {
@@ -26,6 +27,7 @@ export interface DailySajuMatchingResult {
   triggeredCount: number;
   matchedCount: number;
   line: string | null;
+  hypothesisLines: string[];
 }
 
 /**
@@ -37,7 +39,7 @@ export const runDailySajuMatchingDryRun = async (
 ): Promise<DailySajuMatchingResult> => {
   const ctx = await getDailyContext(userId, date);
   if (!ctx) {
-    return { date, triggeredCount: 0, matchedCount: 0, line: null };
+    return { date, triggeredCount: 0, matchedCount: 0, line: null, hypothesisLines: [] };
   }
 
   const results = await matchAllSeedsForDay(userId, date);
@@ -46,8 +48,9 @@ export const runDailySajuMatchingDryRun = async (
   const triggeredCount = results.filter((r) => r.triggerActivated).length;
   const matchedCount = results.filter((r) => r.matched).length;
   const line = compactMatchedLine(ctx, results);
+  const hypothesisLines = await pickConfirmedHypothesisLines(userId, date);
 
-  return { date, triggeredCount, matchedCount, line };
+  return { date, triggeredCount, matchedCount, line, hypothesisLines };
 };
 
 /**
@@ -85,6 +88,15 @@ export const dailySajuMatchingForUser = async (
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[Saju Match] Slack 전송 실패 user=${userId}: ${msg}`);
+    }
+  }
+
+  if (result.hypothesisLines.length > 0) {
+    try {
+      await postToChannel(app.client, channelId, result.hypothesisLines.join('\n'));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[Saju Match] 가설 라인 전송 실패 user=${userId}: ${msg}`);
     }
   }
 };

--- a/src/cron/diary-meta-extract.ts
+++ b/src/cron/diary-meta-extract.ts
@@ -1,22 +1,24 @@
 /**
  * 일기 → 메타 태그 LLM 추출 cron.
  * ADR-0017 / v2 헌장: 일기 원문은 저장하지 않고 enum 플래그만 보존.
+ * ADR-0019 Phase 4: enum 16 → 22 확장 + Opus 분류기로 이관 (#409).
  *
  * 흐름:
  *   1) 오늘 diary_entries 로드
- *   2) LLM에게 고정 enum 16개 중 해당되는 태그만 JSON 배열로 요청
+ *   2) LLM(Opus)에게 고정 enum 22개 중 해당되는 태그만 JSON 배열로 요청
  *   3) 결과 파싱 → enum 화이트리스트 필터 → diary_meta_tags UPSERT
  */
 
 import type { App } from '@slack/bolt';
-import type { LLMClient, LLMMessage } from '../shared/llm.js';
+import { createDiaryMetaLLMClient, type LLMClient, type LLMMessage } from '../shared/llm.js';
 import { query } from '../shared/db.js';
 import { getYesterdayISO } from '../shared/kst.js';
 import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
 import type { LifeCronConfig } from './life-cron.js';
 
-/** 허용된 16개 enum (migration 053과 동기화 필수) */
+/** 허용된 22개 enum (migration 053 + 059와 동기화 필수) */
 export const DIARY_META_TAGS = [
+  // 기존 16 (migration 053)
   'irritation',
   'health_complaint',
   'low_energy',
@@ -33,6 +35,13 @@ export const DIARY_META_TAGS = [
   'nostalgia',
   'anxiety',
   'past_memory',
+  // 신규 6 (migration 059 — Phase 4 가설 검증용)
+  'wealth_awareness',
+  'self_observation',
+  'social_activity',
+  'physical_activity',
+  'task_completion',
+  'clumsy_overflow',
 ] as const;
 
 export type DiaryMetaTag = (typeof DIARY_META_TAGS)[number];
@@ -41,14 +50,14 @@ const TAG_SET = new Set<string>(DIARY_META_TAGS);
 
 const SYSTEM_PROMPT = `너는 일기 텍스트에서 정해진 enum 태그만 추출하는 분류기.
 
-허용된 태그 (이 16개 외엔 절대 출력 금지):
+허용된 태그 (이 22개 외엔 절대 출력 금지):
 - irritation: 짜증/화남/예민
 - health_complaint: 몸 아픔/통증/컨디션 난조 호소
 - low_energy: 무기력/피곤/늘어짐
 - mood_down: 우울/기분 가라앉음
 - confidence_high: 자신감 충만/주도성
-- analytical_mode: 분석/사고/계획 모드
-- deep_thought: 깊은 사색/철학적 사고
+- analytical_mode: 분석/사고/계획 모드 (일반)
+- deep_thought: 깊은 사색/철학적 사고 (일반)
 - rest: 휴식/이완
 - peaceful: 평온/만족
 - mood_high: 기분 좋음/들뜸
@@ -58,11 +67,18 @@ const SYSTEM_PROMPT = `너는 일기 텍스트에서 정해진 enum 태그만 �
 - nostalgia: 향수/추억 떠올림
 - anxiety: 불안/걱정
 - past_memory: 과거 회상
+- wealth_awareness: 돈 관련 인식·결정·기회 (예: 채용 제안, 알바, 지출 결정, 자산 변동 의식)
+- self_observation: 본인 사주·신살·일진·운을 직접 언급 (예: "을경합 작동", "편재 떴다", "오늘 일진 느낌")
+  ※ analytical_mode(일반 분석)·deep_thought(철학적 사색)와 구분 — 사주 패턴을 명시적으로 언급한 경우만
+- social_activity: 가족·친구·지인 만남 또는 통화
+- physical_activity: 운동·산책·외출·이동 (단순 외출도 포함)
+- task_completion: 업무·과제 처리/완료 (구체적 일을 마쳤다는 언급)
+- clumsy_overflow: 실수·물건 떨어뜨림·놓침·잊음
 
 출력 규칙:
 - 출력은 오로지 JSON 배열만. 예: ["irritation","low_energy"]
 - 해당 없으면 빈 배열 [].
-- 추론·확장 금지. 위 16개 외 태그를 만들지 마.
+- 추론·확장 금지. 위 22개 외 태그를 만들지 마.
 - 설명·주석·코드블록 마커 출력 금지.`;
 
 const buildContext = (content: string): string =>
@@ -154,15 +170,17 @@ export const extractAndPersistForUser = async (
  * Slack 전송 X — 백그라운드 데이터 적재만.
  *
  * 익일 05:30에 실행되어 어제 일기를 추출 (자정 넘긴 일기·누락 방지 — migration 054).
+ * Opus client 사용 — 분류기 정밀도가 가설 검증 품질에 직결 (ADR-0019).
  */
-export const diaryMetaExtractTask = async (_app: App, config: LifeCronConfig): Promise<void> => {
+export const diaryMetaExtractTask = async (_app: App, _config: LifeCronConfig): Promise<void> => {
   const targetDate = getYesterdayISO();
   const mappings = await queryAllUserMappings();
   const userIds = mappings.length > 0 ? mappings.map((m) => m.userId) : [DEFAULT_USER_ID];
+  const opusClient = await createDiaryMetaLLMClient();
 
   for (const userId of userIds) {
     try {
-      const result = await extractAndPersistForUser(config.llmClient, userId, targetDate);
+      const result = await extractAndPersistForUser(opusClient, userId, targetDate);
       if (!result) {
         console.warn(`[Diary Meta] 일기 없음 user=${userId} date=${targetDate}`);
         continue;

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -52,6 +52,7 @@ import { monthlyLlmInsightTask } from './monthly-llm-insight.js';
 import { verifyLlmInsightsTask } from './verify-llm-insights.js';
 import { dailySajuMatchingTask } from './daily-saju-matching.js';
 import { diaryMetaExtractTask } from './diary-meta-extract.js';
+import { weeklyHypothesisReviewTask } from './weekly-hypothesis-review.js';
 import { buildLifeContext } from '../shared/life-context.js';
 import { publishHomeView } from '../agents/life/home.js';
 
@@ -658,6 +659,7 @@ const SLOT_TASKS: Record<string, CronTaskFn> = {
   },
   dailySajuMatching: dailySajuMatchingTask,
   diaryMetaExtract: diaryMetaExtractTask,
+  weeklyHypothesisReview: weeklyHypothesisReviewTask,
 };
 
 // ─── CronScheduler 클래스 ───────────────────────────────

--- a/src/cron/weekly-hypothesis-review.ts
+++ b/src/cron/weekly-hypothesis-review.ts
@@ -1,0 +1,182 @@
+/**
+ * 주간 가설 리포트 cron — 월요일 08:00 KST.
+ * ADR-0019 Phase 4.
+ *
+ * 흐름:
+ *   1) 전주 월요일~일요일 윈도우 계산
+ *   2) 유저별 active 가설 → computeAndPersistWeeklyStats (Fisher + BH-FDR)
+ *   3) 가설별 evaluateStatusTransition → DB UPDATE
+ *   4) discoverCandidates (recurring 모드) → 신규 후보
+ *   5) #insight 채널로 묶음 카드 발송
+ */
+
+import type { App } from '@slack/bolt';
+import { query } from '../shared/db.js';
+import { addDays, getKSTDayOfWeek, getTodayISO } from '../shared/kst.js';
+import { postBlockMessage } from '../shared/slack.js';
+import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
+import {
+  applyStatusTransition,
+  computeAndPersistWeeklyStats,
+  evaluateStatusTransition,
+  loadActiveHypotheses,
+  type HypothesisStat,
+} from '../shared/saju-hypothesis.js';
+import { discoverCandidates } from '../agents/insight/hypothesis-discovery.js';
+import {
+  buildWeeklyReviewBlocks,
+  type ActiveHypothesisRow,
+} from '../agents/insight/hypothesis-cards.js';
+import type { LifeCronConfig } from './life-cron.js';
+
+/** 오늘이 월요일이라는 전제 — 전주 월요일(=7일 전) 반환 */
+export const previousMondayISO = (todayIso: string): string => {
+  const d = new Date(`${todayIso}T12:00:00+09:00`);
+  const dow = d.getUTCDay(); // 0=일, 1=월
+  const daysSinceMonday = (dow + 6) % 7; // 월요일=0, 일요일=6
+  return addDays(todayIso, -(daysSinceMonday + 7));
+};
+
+const loadSignalNames = async (signalIds: number[]): Promise<Map<number, string>> => {
+  if (signalIds.length === 0) return new Map();
+  const res = await query<{ id: number; name: string }>(
+    `SELECT id, name FROM saju_signal_catalog WHERE id = ANY($1::int[])`,
+    [signalIds],
+  );
+  return new Map(res.rows.map((r) => [r.id, r.name]));
+};
+
+const loadPrevStat = async (
+  hypothesisId: number,
+  beforeWeek: string,
+): Promise<HypothesisStat | null> => {
+  const res = await query<{
+    hypothesis_id: number;
+    week_start: string;
+    n_trigger_days: number;
+    n_total_days: number;
+    rate_trigger: string;
+    rate_baseline: string;
+    rate_ratio: string;
+    raw_p: string;
+    fdr_q: string;
+  }>(
+    `SELECT hypothesis_id, TO_CHAR(week_start, 'YYYY-MM-DD') AS week_start,
+            n_trigger_days, n_total_days,
+            rate_trigger::TEXT, rate_baseline::TEXT, rate_ratio::TEXT,
+            raw_p::TEXT, fdr_q::TEXT
+       FROM saju_stats
+      WHERE hypothesis_id = $1 AND week_start < $2
+      ORDER BY week_start DESC LIMIT 1`,
+    [hypothesisId, beforeWeek],
+  );
+  const row = res.rows[0];
+  if (!row) return null;
+  return {
+    hypothesisId: row.hypothesis_id,
+    weekStart: row.week_start,
+    nTriggerDays: row.n_trigger_days,
+    nTotalDays: row.n_total_days,
+    rateTrigger: Number(row.rate_trigger),
+    rateBaseline: Number(row.rate_baseline),
+    rateRatio: Number(row.rate_ratio),
+    rawP: Number(row.raw_p),
+    fdrQ: Number(row.fdr_q),
+  };
+};
+
+const processUser = async (
+  app: App,
+  userId: number,
+  channelId: string,
+  weekStart: string,
+): Promise<void> => {
+  const active = await loadActiveHypotheses(userId);
+
+  const stats = await computeAndPersistWeeklyStats(userId, active, weekStart);
+
+  for (const h of active) {
+    try {
+      const next = await evaluateStatusTransition(h.id);
+      if (next !== 'active') {
+        await applyStatusTransition(h.id, next);
+        console.warn(`[Hypothesis Review] hypothesis ${h.id}: active → ${next}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[Hypothesis Review] 상태 평가 실패 hypothesis=${h.id}: ${msg}`);
+    }
+  }
+
+  const stillActive = await loadActiveHypotheses(userId);
+  const signalIds = Array.from(
+    new Set([
+      ...stillActive.map((h) => h.triggerSpec.signalId),
+      ...active.map((h) => h.triggerSpec.signalId),
+    ]),
+  );
+  const signalNameMap = await loadSignalNames(signalIds);
+
+  const statByHypothesisId = new Map(stats.map((s) => [s.hypothesisId, s]));
+  const rows: ActiveHypothesisRow[] = [];
+  for (const h of stillActive) {
+    const latest = statByHypothesisId.get(h.id);
+    if (!latest) continue;
+    const prev = await loadPrevStat(h.id, weekStart);
+    rows.push({
+      hypothesis: h,
+      signalName: signalNameMap.get(h.triggerSpec.signalId) ?? `signal#${h.triggerSpec.signalId}`,
+      latest,
+      prev,
+    });
+  }
+
+  let candidates: Awaited<ReturnType<typeof discoverCandidates>> = [];
+  try {
+    candidates = await discoverCandidates(userId, { mode: 'recurring', weekStart });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[Hypothesis Review] discover 실패 user=${userId}: ${msg}`);
+  }
+
+  const blocks = buildWeeklyReviewBlocks(rows, candidates, weekStart);
+  const fallback = `가설 주간 리포트 (${weekStart} ~) — active ${rows.length}건, 신규 후보 ${candidates.length}건`;
+
+  try {
+    await postBlockMessage(app.client, channelId, fallback, blocks);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[Hypothesis Review] 카드 전송 실패 user=${userId}: ${msg}`);
+  }
+};
+
+/**
+ * 본체 — life-cron SLOT_TASKS에서 호출.
+ * cron은 매일 08:00에 발사되지만 월요일만 실행 (weeklyReport 패턴과 동일).
+ */
+export const weeklyHypothesisReviewTask = async (
+  app: App,
+  config: LifeCronConfig,
+): Promise<void> => {
+  if (getKSTDayOfWeek() !== 1) return;
+  const weekStart = previousMondayISO(getTodayISO());
+  const mappings = await queryAllUserMappings();
+  const insightFallback = process.env['INSIGHT_CHANNEL_ID'] ?? config.channelId;
+
+  if (mappings.length === 0) {
+    if (!insightFallback) return;
+    await processUser(app, DEFAULT_USER_ID, insightFallback, weekStart);
+    return;
+  }
+
+  for (const mapping of mappings) {
+    const channelId = mapping.insightChannelId ?? insightFallback;
+    if (!channelId) continue;
+    try {
+      await processUser(app, mapping.userId, channelId, weekStart);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[Hypothesis Review] user=${mapping.userId} 처리 실패: ${msg}`);
+    }
+  }
+};

--- a/src/shared/__tests__/saju-hypothesis.test.ts
+++ b/src/shared/__tests__/saju-hypothesis.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { fisherExact, bhFdr } from '../saju-hypothesis.js';
+
+// ─── fisherExact ─────────────────────────────────────────
+
+describe('fisherExact', () => {
+  it('빈 표 → p=1', () => {
+    expect(fisherExact(0, 0, 0, 0)).toBe(1);
+  });
+
+  it('Lady tasting tea (4우유+4차, 답 3/4 일치) → 양측 p ≈ 0.4857', () => {
+    // 2x2: [[3,1],[1,3]]
+    // 양측 = 2 * P(X=3) (P(X=3) = P(X=1) 대칭) — k∈{0,1,2,3,4}
+    // P(X=3) = C(4,3)*C(4,1)/C(8,4) = 16/70
+    // P(X=4) = C(4,4)*C(4,0)/C(8,4) = 1/70
+    // P(X=0) = 1/70, P(X=1) = 16/70 (대칭)
+    // obs P(X=3)=16/70 → 같거나 작은: 0,1,3,4 → (1+16+16+1)/70 = 34/70 ≈ 0.4857
+    expect(fisherExact(3, 1, 1, 3)).toBeCloseTo(34 / 70, 4);
+  });
+
+  it('완전 분리 [[10,0],[0,10]] → 매우 작은 p', () => {
+    const p = fisherExact(10, 0, 0, 10);
+    expect(p).toBeLessThan(0.001);
+    expect(p).toBeGreaterThan(0);
+  });
+
+  it('완전 균등 [[5,5],[5,5]] → p=1 (전혀 다르지 않음)', () => {
+    expect(fisherExact(5, 5, 5, 5)).toBeCloseTo(1, 4);
+  });
+
+  it('대칭성 — [[a,b],[c,d]] = [[c,d],[a,b]]', () => {
+    expect(fisherExact(3, 7, 8, 2)).toBeCloseTo(fisherExact(8, 2, 3, 7), 6);
+  });
+
+  it('음수 입력 → NaN', () => {
+    expect(Number.isNaN(fisherExact(-1, 2, 3, 4))).toBe(true);
+  });
+
+  it('p-value는 [0, 1] 범위', () => {
+    const tables: Array<[number, number, number, number]> = [
+      [3, 5, 4, 8],
+      [1, 9, 9, 1],
+      [7, 3, 2, 8],
+    ];
+    for (const [a, b, c, d] of tables) {
+      const p = fisherExact(a, b, c, d);
+      expect(p).toBeGreaterThanOrEqual(0);
+      expect(p).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+// ─── bhFdr ───────────────────────────────────────────────
+
+describe('bhFdr', () => {
+  it('단일 p-value → q = p', () => {
+    expect(bhFdr([0.04])).toEqual([0.04]);
+  });
+
+  it('빈 입력 → 빈 배열', () => {
+    expect(bhFdr([])).toEqual([]);
+  });
+
+  it('monotone 보장 — 정렬 후 q[i] ≤ q[i+1]', () => {
+    const p = [0.001, 0.05, 0.5, 0.9];
+    const [q0, q1, q2, q3] = bhFdr(p) as [number, number, number, number];
+    expect(q0).toBeLessThanOrEqual(q1);
+    expect(q1).toBeLessThanOrEqual(q2);
+    expect(q2).toBeLessThanOrEqual(q3);
+  });
+
+  it('원래 순서 유지 — shuffled input', () => {
+    const p = [0.5, 0.001, 0.9, 0.05];
+    const q = bhFdr(p) as [number, number, number, number];
+    expect(q).toHaveLength(4);
+    // smallest p (0.001) at index 1 → q[1]은 모든 인덱스 중 최소
+    expect(q[1]).toBeLessThan(q[0]);
+    expect(q[1]).toBeLessThan(q[2]);
+    expect(q[1]).toBeLessThan(q[3]);
+  });
+
+  it('알려진 결과 — Benjamini-Hochberg 1995 표준 사례', () => {
+    // p = [0.0001, 0.0004, 0.0019, 0.0095, 0.0201, 0.0278, 0.0298, 0.0344, 0.0459, 0.3240, 0.4262, 0.5719, 0.6528, 0.7590, 1.0]
+    // N=15. q[1] = 0.0001 * 15 / 1 = 0.0015 (then monotone)
+    // 첫 7개는 통상 q<0.05
+    const p = [
+      0.0001, 0.0004, 0.0019, 0.0095, 0.0201, 0.0278, 0.0298, 0.0344, 0.0459, 0.324, 0.4262, 0.5719,
+      0.6528, 0.759, 1.0,
+    ];
+    const q = bhFdr(p);
+    expect(q[0]).toBeCloseTo(0.0015, 4); // 0.0001 * 15 / 1
+    // q monotone 검증
+    for (let i = 1; i < q.length; i++) {
+      const cur = q[i] ?? -Infinity;
+      const prev = q[i - 1] ?? -Infinity;
+      expect(cur).toBeGreaterThanOrEqual(prev);
+    }
+    // q ≤ 1
+    for (const v of q) expect(v).toBeLessThanOrEqual(1);
+  });
+
+  it('NaN p-value는 NaN q로 유지, 나머지만 보정', () => {
+    const [q0, q1, q2, q3, q4] = bhFdr([0.01, NaN, 0.5, NaN, 0.02]) as [
+      number,
+      number,
+      number,
+      number,
+      number,
+    ];
+    expect(Number.isNaN(q1)).toBe(true);
+    expect(Number.isNaN(q3)).toBe(true);
+    expect(Number.isNaN(q0)).toBe(false);
+    expect(Number.isNaN(q2)).toBe(false);
+    expect(Number.isNaN(q4)).toBe(false);
+    // 유효 3개에 대한 BH-FDR
+    // sorted: [0.01, 0.02, 0.5], rank 1,2,3
+    // qRaw: 0.03, 0.03, 0.5 → monotone: 0.03, 0.03, 0.5
+    expect(q0).toBeCloseTo(0.03, 4); // 0.01
+    expect(q4).toBeCloseTo(0.03, 4); // 0.02
+    expect(q2).toBeCloseTo(0.5, 4); // 0.5
+  });
+
+  it('모두 NaN → 모두 NaN', () => {
+    const q = bhFdr([NaN, NaN, NaN]);
+    expect(q.every((v) => Number.isNaN(v))).toBe(true);
+  });
+});

--- a/src/shared/insights.ts
+++ b/src/shared/insights.ts
@@ -737,3 +737,55 @@ export const pickNightNudges = (today: string, userId: number): Promise<Insight[
 /** 주간 리포트용: weekly 인사이트 (도메인 dedupe + cap 동일) */
 export const pickWeeklyInsights = (today: string, userId: number): Promise<Insight[]> =>
   pickByTiming(today, userId, 'weekly');
+
+// ─── ADR-0019 Phase 4: confirmed 가설 → 일일 잔소리 합류 ───
+
+interface ConfirmedHypothesisRow {
+  enum_target: string;
+  signal_name: string;
+  rate_ratio: string | null;
+}
+
+/**
+ * 오늘 trigger가 발현한 confirmed 가설들의 잔소리 라인 반환.
+ * - confirmed 가설(saju_hypotheses.status='confirmed') × 오늘 saju_daily_matches.trigger_activated=true 조인
+ * - 가설별 최신 rate_ratio를 같이 보여줘 효과 크기 인지
+ * - 빈 결과면 빈 배열 반환 → daily-saju-matching 측에서 분기
+ */
+export const pickConfirmedHypothesisLines = async (
+  userId: number,
+  today: string,
+): Promise<string[]> => {
+  try {
+    const res = await query<ConfirmedHypothesisRow>(
+      `SELECT
+         h.enum_target,
+         c.name AS signal_name,
+         (
+           SELECT s.rate_ratio::TEXT
+             FROM saju_stats s
+            WHERE s.hypothesis_id = h.id
+            ORDER BY s.week_start DESC LIMIT 1
+         ) AS rate_ratio
+       FROM saju_hypotheses h
+       JOIN saju_signal_catalog c ON c.id = (h.trigger_spec->>'signalId')::INTEGER
+       JOIN saju_daily_matches m
+         ON m.user_id = h.user_id
+        AND m.signal_id = c.id
+        AND m.date = $2
+        AND m.trigger_activated = true
+       WHERE h.user_id = $1 AND h.status = 'confirmed'
+       ORDER BY c.name`,
+      [userId, today],
+    );
+    return res.rows.map((row) => {
+      const ratio = Number(row.rate_ratio);
+      const ratioPart = Number.isFinite(ratio) ? ` (평균 ${ratio.toFixed(1)}x)` : '';
+      return `*${row.signal_name}* 패턴 켜졌어 → \`${row.enum_target}\` 주의${ratioPart}.`;
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[Insights] confirmed 가설 라인 조회 실패: ${msg}`);
+    return [];
+  }
+};

--- a/src/shared/llm.ts
+++ b/src/shared/llm.ts
@@ -110,6 +110,24 @@ export const createCronLLMClient = async (): Promise<LLMClient> => {
   return createLLMClient();
 };
 
+/**
+ * 일기 메타 추출 전용 LLM 클라이언트 (Opus).
+ * enum 분류기 — Sonnet 대비 enum 정의 ambiguity 해석(예: self_observation vs analytical_mode)
+ * 정밀도가 가설 검증 품질에 직결.
+ */
+export const createDiaryMetaLLMClient = async (): Promise<LLMClient> => {
+  const { CONFIG } = await import('./config.js');
+
+  if (CONFIG.llm.anthropicApiKey) {
+    // eslint-disable-next-line no-console
+    console.log('[LLM] 일기 메타 추출용 Opus 클라이언트 생성');
+    return new ClaudeLLMClient(CONFIG.llm.anthropicApiKey, 'claude-opus-4-7');
+  }
+
+  // Anthropic 키 없으면 크론 클라이언트로 폴백
+  return createCronLLMClient();
+};
+
 // ---- Claude 변환 함수 (테스트 가능하도록 export) ----
 
 export function toClaudeMessages(messages: LLMMessage[]): {

--- a/src/shared/saju-hypothesis.ts
+++ b/src/shared/saju-hypothesis.ts
@@ -1,0 +1,390 @@
+/**
+ * 사주 가설-검증 정량 파이프라인 — ADR-0019 Phase 4
+ *
+ * - Fisher's exact test (소표본 + 이진 outcome)
+ * - rate ratio (효과 크기)
+ * - BH-FDR (다중 비교 보정)
+ * - 주간 통계 영속화 + 상태 전이 평가
+ */
+
+import { query } from './db.js';
+
+// ─── 타입 정의 ───────────────────────────────────────────
+
+export type TriggerSpec = { type: 'seed'; signalId: number };
+
+export type HypothesisStatus = 'active' | 'confirmed' | 'rejected' | 'archived';
+
+export interface Hypothesis {
+  id: number;
+  userId: number;
+  triggerSpec: TriggerSpec;
+  enumTarget: string;
+  status: HypothesisStatus;
+  source: 'discovery' | 'manual';
+  registeredAt: Date;
+  confirmedAt: Date | null;
+  rejectedAt: Date | null;
+  archivedAt: Date | null;
+  notes: string | null;
+}
+
+export interface HypothesisStat {
+  hypothesisId: number;
+  weekStart: string;
+  nTriggerDays: number;
+  nTotalDays: number;
+  rateTrigger: number;
+  rateBaseline: number;
+  rateRatio: number;
+  rawP: number;
+  fdrQ: number;
+}
+
+// ─── 통계 알고리즘 (pure 함수) ─────────────────────────
+
+const logFact = (n: number): number => {
+  if (n < 0 || !Number.isFinite(n)) return NaN;
+  if (n < 2) return 0;
+  let sum = 0;
+  for (let i = 2; i <= n; i++) sum += Math.log(i);
+  return sum;
+};
+
+const logBinom = (n: number, k: number): number => {
+  if (k < 0 || k > n) return -Infinity;
+  return logFact(n) - logFact(k) - logFact(n - k);
+};
+
+const hypergeomLogP = (a: number, b: number, c: number, d: number): number =>
+  logBinom(a + b, a) + logBinom(c + d, c) - logBinom(a + b + c + d, a + c);
+
+/**
+ * Fisher's exact test (양측). 2x2 분할표 [[a,b],[c,d]].
+ * 관찰된 표보다 같거나 더 극단적인 모든 표의 hypergeometric 확률 합.
+ */
+export const fisherExact = (a: number, b: number, c: number, d: number): number => {
+  if (!Number.isFinite(a) || !Number.isFinite(b) || !Number.isFinite(c) || !Number.isFinite(d)) {
+    return NaN;
+  }
+  if (a < 0 || b < 0 || c < 0 || d < 0) return NaN;
+  const n = a + b + c + d;
+  if (n === 0) return 1;
+
+  const row1 = a + b;
+  const row2 = c + d;
+  const col1 = a + c;
+  const obsLogP = hypergeomLogP(a, b, c, d);
+  const epsilon = 1e-9;
+  const kMin = Math.max(0, col1 - row2);
+  const kMax = Math.min(row1, col1);
+  let p = 0;
+  for (let k = kMin; k <= kMax; k++) {
+    const a2 = k;
+    const b2 = row1 - k;
+    const c2 = col1 - k;
+    const d2 = row2 - c2;
+    const logP = hypergeomLogP(a2, b2, c2, d2);
+    if (logP <= obsLogP + epsilon) {
+      p += Math.exp(logP);
+    }
+  }
+  return Math.min(p, 1);
+};
+
+/**
+ * Benjamini-Hochberg FDR 보정.
+ * NaN p-value는 skip 마커로 보고 q도 NaN으로 둠.
+ * monotone 보장: q[i] ≤ q[i+1] (정렬 후 역방향 누적 최소).
+ */
+export const bhFdr = (pValues: number[]): number[] => {
+  const valid = pValues.map((p, i) => ({ p, i })).filter((x) => !Number.isNaN(x.p));
+  const N = valid.length;
+  if (N === 0) return pValues.map(() => NaN);
+
+  valid.sort((a, b) => a.p - b.p);
+
+  const qRaw = valid.map((item, rank) => (item.p * N) / (rank + 1));
+  for (let i = qRaw.length - 2; i >= 0; i--) {
+    const cur = qRaw[i] ?? Infinity;
+    const next = qRaw[i + 1] ?? Infinity;
+    qRaw[i] = Math.min(cur, next);
+  }
+
+  const result = pValues.map((p) => (Number.isNaN(p) ? NaN : 0));
+  valid.forEach((item, sortedIdx) => {
+    const q = qRaw[sortedIdx] ?? 1;
+    result[item.i] = Math.min(q, 1);
+  });
+  return result;
+};
+
+// ─── DB 조회 + 통계 계산 ────────────────────────────────
+
+const MIN_TRIGGER_SAMPLE = 5;
+const BASELINE_LOOKBACK_DAYS = 90;
+
+interface TriggerWindow {
+  triggerDates: Set<string>;
+  enumDates: Set<string>;
+  totalDays: number;
+}
+
+const loadTriggerWindow = async (
+  userId: number,
+  signalId: number,
+  enumTarget: string,
+  startDate: string,
+  endDate: string,
+): Promise<TriggerWindow> => {
+  const triggerRes = await query<{ date: string }>(
+    `SELECT TO_CHAR(date, 'YYYY-MM-DD') AS date
+       FROM saju_daily_matches
+      WHERE user_id = $1 AND signal_id = $2
+        AND date >= $3 AND date <= $4
+        AND trigger_activated = true`,
+    [userId, signalId, startDate, endDate],
+  );
+  const enumRes = await query<{ date: string }>(
+    `SELECT TO_CHAR(date, 'YYYY-MM-DD') AS date
+       FROM diary_meta_tags
+      WHERE user_id = $1 AND tag = $2
+        AND date >= $3 AND date <= $4`,
+    [userId, enumTarget, startDate, endDate],
+  );
+  const dayCountRes = await query<{ days: string }>(
+    `SELECT (DATE($2) - DATE($1) + 1)::TEXT AS days`,
+    [startDate, endDate],
+  );
+  return {
+    triggerDates: new Set(triggerRes.rows.map((r) => r.date)),
+    enumDates: new Set(enumRes.rows.map((r) => r.date)),
+    totalDays: Number(dayCountRes.rows[0]?.days ?? 0),
+  };
+};
+
+/**
+ * 단일 가설 통계 계산 — fdr_q는 별도 보정 단계에서 채움.
+ * baseline은 BASELINE_LOOKBACK_DAYS(90일) 윈도우의 trigger 비발현일.
+ * trigger 발현 < MIN_TRIGGER_SAMPLE(5)이면 raw_p = NaN(skip).
+ */
+export const computeHypothesisStat = async (
+  userId: number,
+  hypothesis: Pick<Hypothesis, 'id' | 'triggerSpec' | 'enumTarget'>,
+  weekStart: string,
+): Promise<Omit<HypothesisStat, 'fdrQ'>> => {
+  const baselineStart = shiftDate(weekStart, -BASELINE_LOOKBACK_DAYS + 7);
+  const weekEnd = shiftDate(weekStart, 6);
+  const window = await loadTriggerWindow(
+    userId,
+    hypothesis.triggerSpec.signalId,
+    hypothesis.enumTarget,
+    baselineStart,
+    weekEnd,
+  );
+
+  const triggerDays = window.triggerDates.size;
+  const totalDays = window.totalDays;
+  const nonTriggerDays = totalDays - triggerDays;
+
+  let triggerHits = 0;
+  let nonTriggerHits = 0;
+  for (const date of window.enumDates) {
+    if (window.triggerDates.has(date)) triggerHits++;
+    else nonTriggerHits++;
+  }
+
+  const rateTrigger = triggerDays > 0 ? triggerHits / triggerDays : 0;
+  const rateBaseline = nonTriggerDays > 0 ? nonTriggerHits / nonTriggerDays : 0;
+  const rateRatio = rateBaseline > 0 ? rateTrigger / rateBaseline : NaN;
+
+  const rawP =
+    triggerDays < MIN_TRIGGER_SAMPLE
+      ? NaN
+      : fisherExact(
+          triggerHits,
+          triggerDays - triggerHits,
+          nonTriggerHits,
+          nonTriggerDays - nonTriggerHits,
+        );
+
+  return {
+    hypothesisId: hypothesis.id,
+    weekStart,
+    nTriggerDays: triggerDays,
+    nTotalDays: totalDays,
+    rateTrigger,
+    rateBaseline,
+    rateRatio,
+    rawP,
+  };
+};
+
+/**
+ * 다중 가설 통계 일괄 계산 + BH-FDR 보정 + saju_stats UPSERT.
+ * UPSERT는 (hypothesis_id, week_start) UNIQUE 충돌 시 갱신.
+ */
+export const computeAndPersistWeeklyStats = async (
+  userId: number,
+  hypotheses: Pick<Hypothesis, 'id' | 'triggerSpec' | 'enumTarget'>[],
+  weekStart: string,
+): Promise<HypothesisStat[]> => {
+  if (hypotheses.length === 0) return [];
+
+  const rawStats = await Promise.all(
+    hypotheses.map((h) => computeHypothesisStat(userId, h, weekStart)),
+  );
+  const qValues = bhFdr(rawStats.map((s) => s.rawP));
+
+  const finalStats: HypothesisStat[] = rawStats.map((s, i) => ({
+    ...s,
+    fdrQ: qValues[i] ?? NaN,
+  }));
+
+  for (const stat of finalStats) {
+    await query(
+      `INSERT INTO saju_stats
+         (hypothesis_id, week_start, n_trigger_days, n_total_days,
+          rate_trigger, rate_baseline, rate_ratio, raw_p, fdr_q)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+       ON CONFLICT (hypothesis_id, week_start) DO UPDATE SET
+         n_trigger_days = EXCLUDED.n_trigger_days,
+         n_total_days   = EXCLUDED.n_total_days,
+         rate_trigger   = EXCLUDED.rate_trigger,
+         rate_baseline  = EXCLUDED.rate_baseline,
+         rate_ratio     = EXCLUDED.rate_ratio,
+         raw_p          = EXCLUDED.raw_p,
+         fdr_q          = EXCLUDED.fdr_q,
+         computed_at    = NOW()`,
+      [
+        stat.hypothesisId,
+        stat.weekStart,
+        stat.nTriggerDays,
+        stat.nTotalDays,
+        stat.rateTrigger,
+        stat.rateBaseline,
+        Number.isNaN(stat.rateRatio) ? 'NaN' : stat.rateRatio,
+        Number.isNaN(stat.rawP) ? 'NaN' : stat.rawP,
+        Number.isNaN(stat.fdrQ) ? 'NaN' : stat.fdrQ,
+      ],
+    );
+  }
+
+  return finalStats;
+};
+
+// ─── 상태 전이 평가 ─────────────────────────────────────
+
+const CONFIRM_MIN_N = 30;
+const CONFIRM_MAX_Q = 0.05;
+const CONFIRM_MIN_RATE_RATIO = 1.3;
+const REJECT_RATE_LOW = 0.95;
+const REJECT_RATE_HIGH = 1.05;
+const RECENT_WEEKS = 4;
+
+/**
+ * 가설 상태 전이 평가 (active만 대상).
+ *   active → confirmed: 누적 n_trigger_days ≥ 30 AND 최근 4주 평균 q < 0.05 AND 평균 rate_ratio ≥ 1.3
+ *   active → rejected:  누적 n_trigger_days ≥ 30 AND 최근 4주 모두 rate_ratio in [0.95, 1.05]
+ *   둘 다 아니면 active 유지.
+ */
+export const evaluateStatusTransition = async (hypothesisId: number): Promise<HypothesisStatus> => {
+  const cumulativeRes = await query<{ total: string }>(
+    `SELECT COALESCE(SUM(n_trigger_days), 0)::TEXT AS total
+       FROM saju_stats WHERE hypothesis_id = $1`,
+    [hypothesisId],
+  );
+  const cumulativeN = Number(cumulativeRes.rows[0]?.total ?? 0);
+  if (cumulativeN < CONFIRM_MIN_N) return 'active';
+
+  const recentRes = await query<{
+    rate_ratio: string;
+    fdr_q: string;
+  }>(
+    `SELECT rate_ratio::TEXT, fdr_q::TEXT
+       FROM saju_stats WHERE hypothesis_id = $1
+       ORDER BY week_start DESC LIMIT $2`,
+    [hypothesisId, RECENT_WEEKS],
+  );
+  if (recentRes.rows.length < RECENT_WEEKS) return 'active';
+
+  const ratios = recentRes.rows.map((r) => Number(r.rate_ratio));
+  const qs = recentRes.rows.map((r) => Number(r.fdr_q));
+
+  const validQs = qs.filter((q) => Number.isFinite(q));
+  const validRatios = ratios.filter((r) => Number.isFinite(r));
+  if (validQs.length < RECENT_WEEKS || validRatios.length < RECENT_WEEKS) return 'active';
+
+  const avgQ = validQs.reduce((a, b) => a + b, 0) / validQs.length;
+  const avgRatio = validRatios.reduce((a, b) => a + b, 0) / validRatios.length;
+
+  if (avgQ < CONFIRM_MAX_Q && avgRatio >= CONFIRM_MIN_RATE_RATIO) return 'confirmed';
+
+  const allFlat = validRatios.every((r) => r >= REJECT_RATE_LOW && r <= REJECT_RATE_HIGH);
+  if (allFlat) return 'rejected';
+
+  return 'active';
+};
+
+/** 상태 전이 적용 — DB 갱신 + timestamp 기록 */
+export const applyStatusTransition = async (
+  hypothesisId: number,
+  next: HypothesisStatus,
+): Promise<void> => {
+  if (next === 'active') return;
+  const columnMap: Record<Exclude<HypothesisStatus, 'active'>, string> = {
+    confirmed: 'confirmed_at',
+    rejected: 'rejected_at',
+    archived: 'archived_at',
+  };
+  const column = columnMap[next];
+  await query(
+    `UPDATE saju_hypotheses
+        SET status = $1, ${column} = NOW()
+      WHERE id = $2 AND status = 'active'`,
+    [next, hypothesisId],
+  );
+};
+
+// ─── 헬퍼 ────────────────────────────────────────────────
+
+const shiftDate = (date: string, days: number): string => {
+  const d = new Date(`${date}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+};
+
+export const loadActiveHypotheses = async (userId: number): Promise<Hypothesis[]> => {
+  const res = await query<{
+    id: number;
+    user_id: number;
+    trigger_spec: TriggerSpec;
+    enum_target: string;
+    status: HypothesisStatus;
+    source: 'discovery' | 'manual';
+    registered_at: Date;
+    confirmed_at: Date | null;
+    rejected_at: Date | null;
+    archived_at: Date | null;
+    notes: string | null;
+  }>(
+    `SELECT id, user_id, trigger_spec, enum_target, status, source,
+            registered_at, confirmed_at, rejected_at, archived_at, notes
+       FROM saju_hypotheses WHERE user_id = $1 AND status = 'active'
+       ORDER BY id`,
+    [userId],
+  );
+  return res.rows.map((r) => ({
+    id: r.id,
+    userId: r.user_id,
+    triggerSpec: r.trigger_spec,
+    enumTarget: r.enum_target,
+    status: r.status,
+    source: r.source,
+    registeredAt: r.registered_at,
+    confirmedAt: r.confirmed_at,
+    rejectedAt: r.rejected_at,
+    archivedAt: r.archived_at,
+    notes: r.notes,
+  }));
+};


### PR DESCRIPTION
## 관련 이슈

Closes #392
Closes #409

마스터 #393 (프로액티브 인사이트 v2) Phase 4. 설계 ADR-0019 + 계획서 `.claude/plans/392-phase4-hypothesis-pipeline.md`.

## 변경 내용

### 인프라
- **migration 058**: `saju_hypotheses` (가설 정의) + `saju_stats` (주간 통계 시계열, `UNIQUE(hypothesis_id, week_start)`)
- **migration 059**: `diary_meta_tags` enum 16 → 22 (wealth_awareness / self_observation / social_activity / physical_activity / task_completion / clumsy_overflow)
- **migration 060**: `weeklyHypothesisReview` cron 슬롯 (월 08:00 KST)

### 통계 백엔드 (`src/shared/saju-hypothesis.ts`)
- Fisher's exact test (양측, hypergeometric log-space sum)
- BH-FDR 보정 (NaN skip 보존, monotone 보장)
- rate ratio 효과 크기
- 가설 lifecycle: active → confirmed(n≥30 ∧ q<0.05 ∧ ratio≥1.3) / rejected(ratio→1, 4주 연속)
- 14 단위 테스트 (Lady tasting tea / BH-1995 표준 사례 / 완전 분리 / NaN 보존 / monotone)

### 자동 패턴 발견 (`src/agents/insight/hypothesis-discovery.ts`)
- 단일 함수 `discoverCandidates(userId, mode)` — setup(lookbackDays) / recurring(weekStart)
- 시드 × enum 전수 스캔 → 임계 필터 → rate_ratio 내림차순
- CLI 백테스트: `scripts/saju-hypothesis-backtest.ts`

### Block Kit + 액션 핸들러
- `hypothesis-cards.ts`: 후보 카드 (등록/패스 버튼) + 주간 리뷰 묶음 (▲▼─ 10% 임계)
- `actions.ts`: `hypothesis_register` (INSERT) + `hypothesis_dismiss` (message update)
- `src/app.ts`에 `registerInsightActions` 연결

### Cron
- `weekly-hypothesis-review.ts`: 월요일 08:00 → active 가설 통계 갱신 + 상태 평가 + 신규 후보 발견 → #insight 묶음 카드
- `life-cron.ts` SLOT_TASKS에 `weeklyHypothesisReview` 등록

### 일일 통합
- `pickConfirmedHypothesisLines` 추가 — confirmed 가설 × 오늘 trigger_activated JOIN
- `daily-saju-matching.ts`에서 09:00 매칭 라인 직후 잔소리 추가 노출 (Phase 1 11패턴 코드 무수정)

### Opus 분류기 이관 (#409 흡수)
- `createDiaryMetaLLMClient()` 추가 → `claude-opus-4-7`
- enum ambiguity 해석(`self_observation` vs `analytical_mode`) 정밀도 강화

### 문서
- ADR-0019 + design-notebook Phase 4 섹션
- 도메인 문서 `docs/domains/insight.md` Section 11 본문 + 파일 구조 갱신
- eslint.config.mjs: `argsIgnorePattern: '^_'` (cron 태스크 unused params 처리)

## 코드 리뷰 결과

- [x] 보안 감사 통과 — 모든 SQL 파라미터화, 액션 payload 타입 가드, 크리덴셜 없음
- [x] 타입 안전성 확인 — `any` 0, non-null assertion 0, `unknown` + 타입 가드 사용
- [x] 컨벤션 점검 완료 — named export, camelCase/PascalCase/UPPER_SNAKE_CASE, 함수 분해
- [x] 코드 품질 확인 — tsc clean, eslint clean

## 테스트

- [x] vitest 487 테스트 전부 통과 (saju-hypothesis 14건 + diary-meta-extract 13건 신규)
- [x] tsc --noEmit clean
- [x] eslint clean

## Phase 5 분리

월운/세운/대운 시기 단위 확장은 #408로 분리 — Phase 4 인프라(`trigger_spec` polymorphic JSONB) 위에서 새 시드 카탈로그만 추가하면 통계 파이프라인 그대로 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)