### PR TITLE
fix(insight): Phase 4 운영 UX 2건 — 가설 리포트 분기 + 사주 시드 라벨

### DIFF
--- a/src/agents/insight/hypothesis-cards.ts
+++ b/src/agents/insight/hypothesis-cards.ts
@@ -116,9 +116,13 @@ export const buildWeeklyReviewBlocks = (
   ];
 
   if (active.length === 0) {
+    const noActiveText =
+      candidates.length === 0
+        ? '_active 가설 없음 — 신규 후보도 아직 없어. 데이터 더 쌓이면 자동으로 떠올거야._'
+        : '_active 가설 없음 — 아래 후보에서 골라 등록해._';
     blocks.push({
       type: 'section',
-      text: { type: 'mrkdwn', text: '_active 가설 없음 — 아래 후보에서 골라 등록해._' },
+      text: { type: 'mrkdwn', text: noActiveText },
     });
   } else {
     const lines = active.map((row) => {

--- a/src/cron/__tests__/weekly-report.test.ts
+++ b/src/cron/__tests__/weekly-report.test.ts
@@ -324,8 +324,22 @@ describe('aggregateSajuOutcome', () => {
       if (/saju_signal_catalog/.test(sql)) {
         return Promise.resolve({
           rows: [
-            { name: 'S1', sipsin: '편재', hit_count: 7, miss_count: 3, inconclusive_count: 1 },
-            { name: 'S2', sipsin: null, hit_count: 0, miss_count: 0, inconclusive_count: 5 },
+            {
+              name: 'S1',
+              sipsin: '편재',
+              description: '일운 천간 갑목(편재) → 일정/지출 폭증 가능성',
+              hit_count: 7,
+              miss_count: 3,
+              inconclusive_count: 1,
+            },
+            {
+              name: 'S2',
+              sipsin: null,
+              description: null,
+              hit_count: 0,
+              miss_count: 0,
+              inconclusive_count: 5,
+            },
           ],
         });
       }
@@ -337,6 +351,7 @@ describe('aggregateSajuOutcome', () => {
     expect(result.seeds[0]).toEqual({
       name: 'S1',
       sipsin: '편재',
+      description: '일운 천간 갑목(편재) → 일정/지출 폭증 가능성',
       hit: 7,
       miss: 3,
       inconclusive: 1,
@@ -344,6 +359,8 @@ describe('aggregateSajuOutcome', () => {
     });
     // total=0이면 hitRate null
     expect(result.seeds[1]?.hitRate).toBeNull();
+    // description null 허용
+    expect(result.seeds[1]?.description).toBeNull();
   });
 
   it('약화 후보: total ≥ 10 + hitRate < 0.3 인 시드만 포함', async () => {
@@ -352,13 +369,41 @@ describe('aggregateSajuOutcome', () => {
         return Promise.resolve({
           rows: [
             // 약화: total=12, hitRate=2/12≈0.17 < 0.3
-            { name: 'WEAK1', sipsin: null, hit_count: 2, miss_count: 10, inconclusive_count: 0 },
+            {
+              name: 'WEAK1',
+              sipsin: null,
+              description: null,
+              hit_count: 2,
+              miss_count: 10,
+              inconclusive_count: 0,
+            },
             // 약화 X (total<10): total=8
-            { name: 'SMALL', sipsin: null, hit_count: 0, miss_count: 8, inconclusive_count: 0 },
+            {
+              name: 'SMALL',
+              sipsin: null,
+              description: null,
+              hit_count: 0,
+              miss_count: 8,
+              inconclusive_count: 0,
+            },
             // 약화 X (hitRate 충분): total=10, hitRate=0.5
-            { name: 'OKAY', sipsin: null, hit_count: 5, miss_count: 5, inconclusive_count: 0 },
+            {
+              name: 'OKAY',
+              sipsin: null,
+              description: null,
+              hit_count: 5,
+              miss_count: 5,
+              inconclusive_count: 0,
+            },
             // 약화 경계: total=10, hitRate=0.2 < 0.3
-            { name: 'WEAK2', sipsin: null, hit_count: 2, miss_count: 8, inconclusive_count: 0 },
+            {
+              name: 'WEAK2',
+              sipsin: null,
+              description: null,
+              hit_count: 2,
+              miss_count: 8,
+              inconclusive_count: 0,
+            },
           ],
         });
       }

--- a/src/cron/weekly-report.ts
+++ b/src/cron/weekly-report.ts
@@ -50,6 +50,7 @@ export interface SleepRoutineCorrelation {
 export interface SajuSeedOutcome {
   name: string;
   sipsin: string | null;
+  description: string | null;
   hit: number;
   miss: number;
   inconclusive: number;
@@ -379,6 +380,7 @@ const WEAK_HIT_RATE = 0.3;
 interface SajuSeedRow {
   name: string;
   sipsin: string | null;
+  description: string | null;
   hit_count: number;
   miss_count: number;
   inconclusive_count: number;
@@ -389,7 +391,7 @@ export const aggregateSajuOutcome = async (
 ): Promise<SajuOutcomeData> => {
   try {
     const result = await query<SajuSeedRow>(
-      `SELECT name, sipsin, hit_count, miss_count, inconclusive_count
+      `SELECT name, sipsin, description, hit_count, miss_count, inconclusive_count
        FROM saju_signal_catalog
        WHERE user_id = $1 AND active = true
        ORDER BY (hit_count + miss_count) DESC, name`,
@@ -401,6 +403,7 @@ export const aggregateSajuOutcome = async (
       return {
         name: row.name,
         sipsin: row.sipsin,
+        description: row.description,
         hit: row.hit_count,
         miss: row.miss_count,
         inconclusive: row.inconclusive_count,
@@ -514,8 +517,8 @@ const buildSajuOutcomeLines = (saju: SajuOutcomeData): string | null => {
   for (const s of active.slice(0, 5)) {
     const total = s.hit + s.miss;
     const rate = s.hitRate !== null ? `${Math.round(s.hitRate * 100)}%` : '-';
-    const label = s.sipsin ? `${s.name} (${s.sipsin})` : s.name;
-    lines.push(`• ${label}: hit ${s.hit}/${total} (${rate})`);
+    const label = s.description ?? s.name;
+    lines.push(`• ${label} — hit ${s.hit}/${total} (${rate})`);
   }
 
   if (saju.weakCandidates.length > 0) {


### PR DESCRIPTION
Closes #418.

## 변경 요약

Phase 4 (#392, PR #415) 운영 첫 주에 발견된 UX 이슈 2건 수정.

### 작업 A — 가설 주간 리포트 메시지 분기

`active` 가설 0건일 때 무조건 "아래 후보에서 골라 등록해" 안내가 출력되지만, 신규 후보도 0건이면 본문이 비어 안내가 허공으로 빠짐. 양쪽 빈 경우와 후보만 있는 경우를 분기.

- `src/agents/insight/hypothesis-cards.ts:118-125`
- Before:
  > active 가설 없음 — 아래 후보에서 골라 등록해. _(후보 0건 — 공백)_
- After (둘 다 0):
  > active 가설 없음 — 신규 후보도 아직 없어. 데이터 더 쌓이면 자동으로 떠올거야.
- After (후보만 있을 때): 기존 안내 유지

### 작업 B — 주간 리포트 사주 시드 outcome 라벨 친화화

`saju_signal_catalog.name`(내부 ID `N1_임수_식신_천간` 등)을 그대로 라벨로 사용해 사용자가 의미 파악 어려움. 같은 테이블의 `description` 컬럼(예: `일운 천간 임수(식신) → 요리/창작/대화/먹기`)이 이미 존재해 라벨로 사용. `null`이면 `name` fallback.

- `src/cron/weekly-report.ts` — `SajuSeedOutcome` 타입에 `description` 추가, SELECT에 컬럼 추가, `buildSajuOutcomeLines` 라벨 교체
- Before:
  > • N1_임수_식신_천간 (식신): hit 0/1 (0%)
- After:
  > • 일운 천간 임수(식신) → 요리/창작/대화/먹기 — hit 0/1 (0%)

## 검증

- `yarn build` (tsc) — clean
- `yarn lint` — 0 errors (37 pre-existing warnings 무관)
- `yarn test --run` — 28 files / 487 tests 모두 통과
- 변경된 `aggregateSajuOutcome` 테스트 케이스 `description` 처리 보강 (null fallback 포함)

## Test plan

- [ ] 다음 월요일 08:00 KST `가설 주간 리포트` 발송 시 active/candidates 0/0 분기 메시지 확인
- [ ] 다음 월요일 09:00 KST `지난주 리포트` 의 사주 시드 outcome 라인이 description 라벨로 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)