### PR TITLE
docs(readme): build-with-ai 메타 repo 링크 섹션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,3 +347,11 @@ yarn dev
 | [docs/optimization/](docs/optimization/)                       | 최적화 기록 — LLM 비용, 응답 속도, 배포 파이프라인                                                                           |
 | [docs/ops/db-backup.md](docs/ops/db-backup.md)                 | DB 백업/복원 운영 가이드                                                                                                     |
 | [docs/ops/health-monitoring.md](docs/ops/health-monitoring.md) | 업타임 모니터링 운영 가이드                                                                                                  |
+
+---
+
+## 작업 방식 / AI 협업
+
+이 프로젝트를 만들면서 다듬어 온 작업 방식 — Claude와 일하는 흐름, 문서 운영 체계, 의사결정 기록 — 은 별도 메타 repo에 정리되어 있다.
+
+- [hyewon3938/build-with-ai](https://github.com/hyewon3938/build-with-ai) — `/design`·`/build`·`/init-project` 스킬 흐름, 5문서 아키텍처(plans · design-notebook · ADR · features · domains), progressive disclosure 등 AI 협업 자산 누적


### PR DESCRIPTION
## 변경 내용

README 하단에 작업 방식 / AI 협업 자산이 누적되는 위치(`hyewon3938/build-with-ai` 메타 repo) 안내 섹션 추가.

- 본 프로젝트의 5문서 아키텍처·`/design`·`/build`·`/init-project` 스킬 흐름 같은 일반화 가능한 작업 방식은 메타 repo로 이관되어 누적되고 있다는 사실을 README에 명시
- 외부 청중(포트폴리오·소개·신규 합류자)이 본 프로젝트만으로는 안 보이는 작업 방식 자산을 메타 repo에서 찾을 수 있도록 진입점 제공

## 코드 리뷰
- [x] 보안 감사: 크리덴셜·재정·개인정보 일체 미포함
- [x] 단순 추가 (8줄), 기존 내용 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)