### PR TITLE
chore: routine 트리거 표현 '발사' → '발송' 통일

### DIFF
--- a/db/migrations/060_weekly_hypothesis_review_slot.sql
+++ b/db/migrations/060_weekly_hypothesis_review_slot.sql
@@ -1,5 +1,5 @@
 -- ADR-0019 Phase 4: 주간 가설 리포트 cron 슬롯 시드.
--- 매일 08:00 발사되지만 cron 본체가 월요일 외 return — weeklyReport와 동일 패턴.
+-- 매일 08:00 발송되지만 cron 본체가 월요일 외 return — weeklyReport와 동일 패턴.
 
 INSERT INTO notification_settings (slot_name, time_value, label, active)
 VALUES ('weeklyHypothesisReview', '08:00', '주간 가설 리포트', true)

--- a/docs/design-notebook/fortune-rework.md
+++ b/docs/design-notebook/fortune-rework.md
@@ -89,14 +89,14 @@
 
 - PR #422 (Phase A2): `saju_influence_summary` view + `saju_weekly_reviews` 테이블 + ADR-0020 + design-notebook 갱신
 - PR #423 (Phase A1): `weekly-saju-review-v2` Routine 등록 + 도메인 문서 Phase A1 본문 + 카탈로그 잔존 흔적 정리
-- 두 PR이 같은 날 머지되어 다음 월요일 첫 발사 준비 완료
+- 두 PR이 같은 날 머지되어 다음 월요일 첫 발송 준비 완료
 
 ### 구현 단계에서 발견된 것
 
 - **plan SQL 버그 사전 캐치**: `.claude/plans/421-fortune-rework-A1-A2.md`의 view DDL 초안에서 `accumulating` dedup이 `WHERE a.id = r.signal_id` (실제 alias는 `signal_id`). 마이그레이션 작성 단계에서 CTE 컬럼 alias 일관성 점검 중 발견 → `a.signal_id = r.signal_id`로 수정. plan은 휘발 메모이므로 실제 마이그레이션 단계에서 한 번 더 검증해야 한다는 5문서 아키텍처의 owner 분리 가치를 재확인
-- **view 운영 환경 첫 SELECT 결과**: verified 0 / accumulating 0 / recent 14. 데이터 상태(Phase 4 fdr_q 통과 시드 아직 없음, accumulating 임계 hit rate > 55%·n≥5 미달) 자연 반영 — 쿼리 버그가 아님을 raw count 점검으로 확인. 첫 주 routine 발사 시 verified·accumulating 0건 메시지 표시 (`_아직 통계 검증 통과한 시드 없음_` / `_아직 누적 패턴 없음_`) 검증 대상
+- **view 운영 환경 첫 SELECT 결과**: verified 0 / accumulating 0 / recent 14. 데이터 상태(Phase 4 fdr_q 통과 시드 아직 없음, accumulating 임계 hit rate > 55%·n≥5 미달) 자연 반영 — 쿼리 버그가 아님을 raw count 점검으로 확인. 첫 주 routine 발송 시 verified·accumulating 0건 메시지 표시 (`_아직 통계 검증 통과한 시드 없음_` / `_아직 누적 패턴 없음_`) 검증 대상
 - **SKILL.md 위치 혼동**: routine SKILL.md는 repo 내가 아니라 사용자 HOME `~/.claude/scheduled-tasks/<id>/SKILL.md`에 배치. 도메인 문서에 위치 명시 + 향후 routine 변경 시 SKILL.md 경로 추적 가능하도록 기록
-- **Opus 모델 지정 메커니즘**: `mcp__scheduled-tasks__create_scheduled_task` schema에 model 파라미터 없음. Claude 앱 model selector에서 사용자가 직접 지정 필요. SKILL.md 주의사항에 명시 + 도메인 문서 발사 메타에도 명시
+- **Opus 모델 지정 메커니즘**: `mcp__scheduled-tasks__create_scheduled_task` schema에 model 파라미터 없음. Claude 앱 model selector에서 사용자가 직접 지정 필요. SKILL.md 주의사항에 명시 + 도메인 문서 발송 메타에도 명시
 
 ### 폐기 처리 결정
 
@@ -105,6 +105,6 @@
 
 ### 다음 액션
 
-- 다음 월요일(2026-06-01) 08:00 KST 첫 발사 — Block Kit 카드 가독성·idempotency 동작·Opus prose 톤 운영 검증
+- 다음 월요일(2026-06-01) 08:00 KST 첫 발송 — Block Kit 카드 가독성·idempotency 동작·Opus prose 톤 운영 검증
 - Phase A3 (4층 레이어 expose) — #408 Phase 5-B 머지 후 view에 월운 layer 추가 (컬럼 contract 유지)
 - A1 첫 주 운영 후 임계치 조정 여부 판단: accumulating tier hit rate > 55% / 5건 임계가 카드에 너무 많이/적게 잡으면 외부화 검토 (ADR-0020 후속 작업 항목)

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -438,7 +438,7 @@ LLM 추출은 Sonnet → Opus 이관 ([#409](https://github.com/hyewon3938/slack
 |------|------|------|--------|
 | 월 08:00 KST | `weeklyHypothesisReview` | 주간 가설 통계 갱신 + 상태 평가 + 신규 후보 발굴 | #insight 묶음 카드 (active 표 + 후보 리스트) |
 
-`weekly-hypothesis-review.ts`는 매일 08:00 발사되지만 `getKSTDayOfWeek() !== 1`이면 즉시 return — `weeklyReport` / `weeklyLlmInsight`와 동일 패턴 (cron 슬롯 하나당 매일 발사 + 본체에서 요일 게이트).
+`weekly-hypothesis-review.ts`는 매일 08:00 발송되지만 `getKSTDayOfWeek() !== 1`이면 즉시 return — `weeklyReport` / `weeklyLlmInsight`와 동일 패턴 (cron 슬롯 하나당 매일 발송 + 본체에서 요일 게이트).
 
 #### 일일 통합 흐름
 
@@ -546,10 +546,10 @@ idempotency 테이블 `saju_weekly_reviews`:
 
 신 Routine `weekly-saju-review-v2` 배치 (Claude 앱 scheduled tasks 영역, 봇 cron 아님).
 
-**발사 메타**
+**발송 메타**
 - Routine ID: `weekly-saju-review-v2`
 - 위치: `~/.claude/scheduled-tasks/weekly-saju-review-v2/SKILL.md` (사용자 HOME, repo 외부)
-- cron: `0 8 * * 1` (매주 월요일 08:00 KST, scheduler jitter로 실제 발사는 08:04 표기)
+- cron: `0 8 * * 1` (매주 월요일 08:00 KST, scheduler jitter로 실제 발송는 08:04 표기)
 - 발송 채널: `#insight`
 - LLM: Claude Opus (Claude 앱 model selector에서 사용자가 지정 — schema에 model 파라미터 없음, 주의사항으로 명시)
 - 의존: `saju_influence_summary` view + `saju_weekly_reviews` 테이블 (A2 머지 후 사용 가능)

--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -18,7 +18,7 @@
 - **view 인터페이스 도입** — `saju_influence_summary` PostgreSQL view 하나로 verified(BH-FDR 통과 시드) · accumulating(catalog hit rate > 55%, n≥5) · recent(지난 7일 매칭) 3 tier를 통합 노출. 풀이 routine은 raw 테이블 4개를 직접 SELECT하지 않고 view만 SELECT
 - **신뢰도 라벨링 자동화** — `confidence_tier` 컬럼이 데이터 레벨에서 신뢰도 단계를 강제 (v2 헌장 ④ 신뢰 비용 분리 준수). 풀이 LLM이 신뢰도에 따른 해석 강도 조절 가능
 - **idempotency 테이블 신설** — `saju_weekly_reviews (user_id, week_start)` UNIQUE 제약 + ON CONFLICT DO NOTHING RETURNING. routine retry·prompt 중복 호출 어떤 원인이든 차단해 발송 정확히 1회 보장
-- **신 routine `weekly-saju-review-v2`** — Claude 앱 scheduled task로 매주 월요일 08:00 KST 발사. Opus가 view 결과 + 라이프 메트릭(schedule done/total · routine rate · diary_meta_tag · sleep avg)으로 사주 관점 회고 prose 4\~6줄 + 학습 3섹션을 Block Kit 카드 한 장으로 `#insight` 발송. 일기 원문 LLM 입력 금지(헌장 ①)
+- **신 routine `weekly-saju-review-v2`** — Claude 앱 scheduled task로 매주 월요일 08:00 KST 발송. Opus가 view 결과 + 라이프 메트릭(schedule done/total · routine rate · diary_meta_tag · sleep avg)으로 사주 관점 회고 prose 4\~6줄 + 학습 3섹션을 Block Kit 카드 한 장으로 `#insight` 발송. 일기 원문 LLM 입력 금지(헌장 ①)
 - **마스터 분리 후 view 매개 통합** — 매칭 마스터(#393)와 풀이 마스터(#421)가 같은 view를 진화시키며 책임은 분리, 데이터 흐름은 단일. Phase A3에서 #408 머지 후 월운 layer를 view에 추가 예정 (컬럼 contract 유지로 후방 호환)
 
 설계 판단 → [ADR-0020](adr/0020-fortune-system-responsibility-split-via-view.md). 마스터 서사 → [design-notebook/fortune-rework.md](design-notebook/fortune-rework.md).

--- a/src/cron/weekly-hypothesis-review.ts
+++ b/src/cron/weekly-hypothesis-review.ts
@@ -152,7 +152,7 @@ const processUser = async (
 
 /**
  * 본체 — life-cron SLOT_TASKS에서 호출.
- * cron은 매일 08:00에 발사되지만 월요일만 실행 (weeklyReport 패턴과 동일).
+ * cron은 매일 08:00에 발송되지만 월요일만 실행 (weeklyReport 패턴과 동일).
  */
 export const weeklyHypothesisReviewTask = async (
   app: App,


### PR DESCRIPTION
## 변경 내용

routine·cron 발송 맥락에서 쓰던 '발사' 표현을 '발송'으로 통일. 의미 변경 없음 — 코드 주석·마이그레이션 주석·문서 표현 일관성 정리.

| 파일 | 변경 |
|------|------|
| docs/project-history.md | 1곳 |
| docs/domains/insight.md | 4곳 |
| docs/design-notebook/fortune-rework.md | 4곳 |
| src/cron/weekly-hypothesis-review.ts (주석) | 1곳 |
| db/migrations/060_weekly_hypothesis_review_slot.sql (주석) | 1곳 |

## 코드 리뷰 결과
- [x] 보안 감사 통과 (주석/문서 표현만 변경 — 비밀정보 노출 없음)
- [x] 타입 안전성 확인 (런타임 코드 변경 없음)
- [x] 컨벤션 점검 완료 (주석 표현 통일)
- [x] 코드 품질 확인 (의미 변경 없는 표현 통일)

## 테스트
- [x] grep 잔존 점검: main 디렉터리(`docs/` `src/` `db/`)에 '발사' 잔존 없음 (archive·worktrees 제외)