### PR TITLE
feat(web): 캘린더 주간·일간 뷰에 사주 일주 표시 (#427)

### DIFF
--- a/db/migrations/060_weekly_hypothesis_review_slot.sql
+++ b/db/migrations/060_weekly_hypothesis_review_slot.sql
@@ -1,5 +1,5 @@
 -- ADR-0019 Phase 4: 주간 가설 리포트 cron 슬롯 시드.
--- 매일 08:00 발사되지만 cron 본체가 월요일 외 return — weeklyReport와 동일 패턴.
+-- 매일 08:00 발송되지만 cron 본체가 월요일 외 return — weeklyReport와 동일 패턴.
 
 INSERT INTO notification_settings (slot_name, time_value, label, active)
 VALUES ('weeklyHypothesisReview', '08:00', '주간 가설 리포트', true)

--- a/docs/adr/0021-web-shared-saju-code-duplication.md
+++ b/docs/adr/0021-web-shared-saju-code-duplication.md
@@ -1,0 +1,93 @@
+# 0021. web shared 사주 계산 코드 — 복제 방식 채택
+
+- Status: Accepted
+- Date: 2026-05-26
+- Related: #427
+- Tags: process, web, shared-code
+
+## Context
+
+이 프로젝트는 봇(`src/`)과 웹 대시보드(`web/src/`)가 같은 repo 안 다른 디렉토리로 분리되어 운영된다. 둘은 독립적인 `tsconfig.json`을 가지며, web의 `@/*` alias는 `web/src/*`만 가리켜 봇의 `src/shared`를 import할 수 없다.
+
+이번에 캘린더 주간·일간 뷰에 사주 일주를 표시하려면, 봇에 있던 `getDayPillar()` 함수(`src/shared/saju-calendar.ts`)를 웹에서도 호출해야 한다.
+
+제약:
+- web은 Vercel에 배포되어 봇 서버의 코드에 접근 불가 (런타임/빌드타임 모두)
+- 봇은 Oracle VM Docker 컨테이너로 별도 빌드·배포
+- 일주 계산은 순수 함수 — 입력(date string) → 출력(Pillar), DB·외부 I/O 없음
+- 60갑자 순환 알고리즘은 거의 변경되지 않음 (2024-02-04 기준 index 34 = 戊戌, 검증된 상수)
+
+## Decision
+
+**web에서 사용할 일주 계산 함수를 `web/src/lib/saju.ts`로 복제한다.**
+
+복제 범위는 최소화 — `getDayPillar`와 그 직접 의존성만 (~50줄):
+
+- 타입: `Pillar`, `Cheongan`, `Jiji`
+- 상수: `CHEONGAN_LIST`, `JIJI_LIST`, `CHEONGAN_HANJA`, `JIJI_HANJA`
+- 헬퍼: `parseDate`, `daysDiff`, `indexToPillar`
+- 메인: `getDayPillar(dateStr: string): Pillar`
+
+`getYearPillar` / `getMonthPillar` / 십성 / 십이운성 등 다른 함수는 절기 데이터·일간 컨텍스트가 필요하고 봇 전용이므로 복제 대상에서 제외.
+
+복제본 상단에 `src/shared/saju-calendar.ts`의 동기화 책임을 주석으로 명시:
+
+```ts
+/**
+ * 사주 일주 계산 (web용 복제본).
+ * 원본: src/shared/saju-calendar.ts (봇 사용).
+ * 동기화 대상: getDayPillar 알고리즘 + 천간/지지 상수.
+ * 변경 시 양쪽 모두 갱신할 것 (ADR-0021 참조).
+ */
+```
+
+## Alternatives considered
+
+### A. 봇 API 경유 (DB Proxy 패턴 확장)
+
+봇 서버에 `GET /api/saju/day-pillar?date=YYYY-MM-DD` 엔드포인트를 추가하고, web에서 fetch로 호출.
+
+- 장점: 단일 진실의 소스 유지. 알고리즘 수정 시 한 곳만.
+- 단점: 매번 네트워크 호출 — 주간 뷰는 7일치 × 매 페이지 로드. 봇 서버 다운 시 캘린더 사용 불가 (현재는 무관). 캐싱 레이어 별도 필요.
+- 기각 이유: 순수 함수에 네트워크 비용을 얹는 건 과함. 캘린더가 봇 서버 가용성에 결합되는 것도 회피하고 싶음.
+
+### B. packages/shared-saju 모노레포 분리
+
+루트에 `packages/shared-saju` 디렉토리 신설하고, 봇/웹 양쪽에서 import. pnpm workspaces 또는 npm workspaces 도입.
+
+- 장점: 진정한 단일 소스. 동기화 부담 0. 다른 shared 로직(예: `kst.ts`)에도 동일 패턴 적용 가능.
+- 단점: 빌드 시스템 큰 변경. Vercel 배포 설정(monorepo 모드) 조정 필요. 봇의 Docker 빌드 컨텍스트도 재설계. 현재 코드 공유 이슈가 이 한 건뿐이라 ROI 낮음.
+- 기각 이유: 단발 이슈 하나 때문에 빌드 시스템 전체를 건드리는 건 명백한 오버엔지니어링. 코드 공유 이슈가 2\~3건 더 누적되면 그때 재검토.
+
+### C. web/src/lib/saju.ts 복제 (Decision 채택안)
+
+- 장점: 변경 즉시 효과. 외부 의존성 0. 빌드 시스템 무변경. ~50줄 순수 함수라 검증 가능.
+- 단점: 알고리즘 수정 시 두 곳 동기화 필요. 누락 시 봇/웹이 다른 일주를 표시할 위험.
+
+## Consequences
+
+### 장점
+
+- 캘린더 일주 표시 기능 구현·배포가 web 단독으로 가능 (봇 서버 변경 0)
+- 봇 서버 가용성과 캘린더 가용성이 독립
+- 클라이언트에서 계산 → 7일치 계산도 1ms 미만
+
+### 단점 / 제약
+
+- `getDayPillar` 알고리즘 또는 천간/지지 상수가 바뀌면 양쪽 동기화 필수
+  - 완화: 복제본 상단 주석에 동기화 책임 명시
+  - 완화: 알고리즘은 결정론적·검증된 상수라 변경 가능성 낮음
+- 다른 사주 함수(`getYearPillar`, 십성 등)를 web에서 쓰려면 같은 복제 패턴이 반복될 가능성
+
+### 후속 작업
+
+- [ ] `web/src/lib/saju.ts` 신규 작성 + 상단 동기화 주석
+- [ ] 두 번째 코드 공유 이슈가 생기면 ADR-B(모노레포 분리) 재검토
+- [ ] 봇 측 `saju-calendar.ts`의 일주 계산 부분 수정 시 web 측 동기화 점검을 PR 체크리스트에 추가 (선택)
+
+---
+
+**참고 자료**
+
+- 원본 함수: [src/shared/saju-calendar.ts:414](../../src/shared/saju-calendar.ts)
+- 60갑자 기준일: 2024-02-04 = 戊戌 (index 34). 검증: 2026-03-14 = 丁亥 (index 23)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -127,6 +127,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0018](0018-installment-runway-scope-toggle.md) | 할부 자산 차감 범위 토글 — `distribute_to_runway` 분기 | Accepted | 2026-05-20 | data, budget |
 | [0019](0019-saju-hypothesis-verification-pipeline.md) | 프로액티브 인사이트 v2 Phase 4 — 가설-검증 정량 파이프라인 | Accepted | 2026-05-21 | data, llm, statistics |
 | [0020](0020-fortune-system-responsibility-split-via-view.md) | 사주 풀이 시스템과 v2 매칭 시스템 책임 분리 + view 인터페이스 도입 | Accepted | 2026-05-26 | data, insight, architecture |
+| [0021](0021-web-shared-saju-code-duplication.md) | web shared 사주 계산 코드 — 복제 방식 채택 | Accepted | 2026-05-26 | process, web, shared-code |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/fortune-rework.md
+++ b/docs/design-notebook/fortune-rework.md
@@ -89,14 +89,14 @@
 
 - PR #422 (Phase A2): `saju_influence_summary` view + `saju_weekly_reviews` 테이블 + ADR-0020 + design-notebook 갱신
 - PR #423 (Phase A1): `weekly-saju-review-v2` Routine 등록 + 도메인 문서 Phase A1 본문 + 카탈로그 잔존 흔적 정리
-- 두 PR이 같은 날 머지되어 다음 월요일 첫 발사 준비 완료
+- 두 PR이 같은 날 머지되어 다음 월요일 첫 발송 준비 완료
 
 ### 구현 단계에서 발견된 것
 
 - **plan SQL 버그 사전 캐치**: `.claude/plans/421-fortune-rework-A1-A2.md`의 view DDL 초안에서 `accumulating` dedup이 `WHERE a.id = r.signal_id` (실제 alias는 `signal_id`). 마이그레이션 작성 단계에서 CTE 컬럼 alias 일관성 점검 중 발견 → `a.signal_id = r.signal_id`로 수정. plan은 휘발 메모이므로 실제 마이그레이션 단계에서 한 번 더 검증해야 한다는 5문서 아키텍처의 owner 분리 가치를 재확인
-- **view 운영 환경 첫 SELECT 결과**: verified 0 / accumulating 0 / recent 14. 데이터 상태(Phase 4 fdr_q 통과 시드 아직 없음, accumulating 임계 hit rate > 55%·n≥5 미달) 자연 반영 — 쿼리 버그가 아님을 raw count 점검으로 확인. 첫 주 routine 발사 시 verified·accumulating 0건 메시지 표시 (`_아직 통계 검증 통과한 시드 없음_` / `_아직 누적 패턴 없음_`) 검증 대상
+- **view 운영 환경 첫 SELECT 결과**: verified 0 / accumulating 0 / recent 14. 데이터 상태(Phase 4 fdr_q 통과 시드 아직 없음, accumulating 임계 hit rate > 55%·n≥5 미달) 자연 반영 — 쿼리 버그가 아님을 raw count 점검으로 확인. 첫 주 routine 발송 시 verified·accumulating 0건 메시지 표시 (`_아직 통계 검증 통과한 시드 없음_` / `_아직 누적 패턴 없음_`) 검증 대상
 - **SKILL.md 위치 혼동**: routine SKILL.md는 repo 내가 아니라 사용자 HOME `~/.claude/scheduled-tasks/<id>/SKILL.md`에 배치. 도메인 문서에 위치 명시 + 향후 routine 변경 시 SKILL.md 경로 추적 가능하도록 기록
-- **Opus 모델 지정 메커니즘**: `mcp__scheduled-tasks__create_scheduled_task` schema에 model 파라미터 없음. Claude 앱 model selector에서 사용자가 직접 지정 필요. SKILL.md 주의사항에 명시 + 도메인 문서 발사 메타에도 명시
+- **Opus 모델 지정 메커니즘**: `mcp__scheduled-tasks__create_scheduled_task` schema에 model 파라미터 없음. Claude 앱 model selector에서 사용자가 직접 지정 필요. SKILL.md 주의사항에 명시 + 도메인 문서 발송 메타에도 명시
 
 ### 폐기 처리 결정
 
@@ -105,6 +105,6 @@
 
 ### 다음 액션
 
-- 다음 월요일(2026-06-01) 08:00 KST 첫 발사 — Block Kit 카드 가독성·idempotency 동작·Opus prose 톤 운영 검증
+- 다음 월요일(2026-06-01) 08:00 KST 첫 발송 — Block Kit 카드 가독성·idempotency 동작·Opus prose 톤 운영 검증
 - Phase A3 (4층 레이어 expose) — #408 Phase 5-B 머지 후 view에 월운 layer 추가 (컬럼 contract 유지)
 - A1 첫 주 운영 후 임계치 조정 여부 판단: accumulating tier hit rate > 55% / 5건 임계가 카드에 너무 많이/적게 잡으면 외부화 검토 (ADR-0020 후속 작업 항목)

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -438,7 +438,7 @@ LLM 추출은 Sonnet → Opus 이관 ([#409](https://github.com/hyewon3938/slack
 |------|------|------|--------|
 | 월 08:00 KST | `weeklyHypothesisReview` | 주간 가설 통계 갱신 + 상태 평가 + 신규 후보 발굴 | #insight 묶음 카드 (active 표 + 후보 리스트) |
 
-`weekly-hypothesis-review.ts`는 매일 08:00 발사되지만 `getKSTDayOfWeek() !== 1`이면 즉시 return — `weeklyReport` / `weeklyLlmInsight`와 동일 패턴 (cron 슬롯 하나당 매일 발사 + 본체에서 요일 게이트).
+`weekly-hypothesis-review.ts`는 매일 08:00 발송되지만 `getKSTDayOfWeek() !== 1`이면 즉시 return — `weeklyReport` / `weeklyLlmInsight`와 동일 패턴 (cron 슬롯 하나당 매일 발송 + 본체에서 요일 게이트).
 
 #### 일일 통합 흐름
 
@@ -546,10 +546,10 @@ idempotency 테이블 `saju_weekly_reviews`:
 
 신 Routine `weekly-saju-review-v2` 배치 (Claude 앱 scheduled tasks 영역, 봇 cron 아님).
 
-**발사 메타**
+**발송 메타**
 - Routine ID: `weekly-saju-review-v2`
 - 위치: `~/.claude/scheduled-tasks/weekly-saju-review-v2/SKILL.md` (사용자 HOME, repo 외부)
-- cron: `0 8 * * 1` (매주 월요일 08:00 KST, scheduler jitter로 실제 발사는 08:04 표기)
+- cron: `0 8 * * 1` (매주 월요일 08:00 KST, scheduler jitter로 실제 발송는 08:04 표기)
 - 발송 채널: `#insight`
 - LLM: Claude Opus (Claude 앱 model selector에서 사용자가 지정 — schema에 model 파라미터 없음, 주의사항으로 명시)
 - 의존: `saju_influence_summary` view + `saju_weekly_reviews` 테이블 (A2 머지 후 사용 가능)

--- a/docs/domains/schedule.md
+++ b/docs/domains/schedule.md
@@ -133,6 +133,12 @@ features/schedule/
 - 3가지 뷰: month / week / day
 - 초기 뷰: 모바일(< 768px) = day, 데스크톱 = week
 - 15초 폴링 (탭 활성 시), 탭 복귀 시 날짜 갱신
+- 사주 일주 표시 (2026-05-26, #427): 주간·일간 뷰 날짜 셀에 일주(천간+지지) 한자+한글 병기
+  - 계산: `web/src/lib/saju.ts` `getDayPillar(dateStr)` — 봇 `src/shared/saju-calendar.ts`의 복제본 (순수 함수, ~50줄). 동기화 책임은 [ADR-0021](../adr/0021-web-shared-saju-code-duplication.md)
+  - 표시 형식: `庚子 경자` 한 줄 (한자 명조체 `font-serif` + 한글), `flex-wrap`으로 좁아지면 두 줄 자동 분리
+  - 적용 위치: `week-view.tsx` 데스크탑 grid 날짜 셀 + 모바일 세로 리스트 카드, `day-view.tsx` 헤더 옆
+  - 색상: 오늘 `text-blue-600`, 그 외 `text-gray-500` (day-view 헤더는 항상 `text-blue-600`)
+  - 컴포넌트: `SajuPillarLabel`은 week-view.tsx 내부 정의 (재사용 범위가 한 파일이라 별도 분리 안 함)
 
 ### 필터링
 - 카테고리 필터 (상위 + 하위 카테고리)

--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -18,7 +18,7 @@
 - **view 인터페이스 도입** — `saju_influence_summary` PostgreSQL view 하나로 verified(BH-FDR 통과 시드) · accumulating(catalog hit rate > 55%, n≥5) · recent(지난 7일 매칭) 3 tier를 통합 노출. 풀이 routine은 raw 테이블 4개를 직접 SELECT하지 않고 view만 SELECT
 - **신뢰도 라벨링 자동화** — `confidence_tier` 컬럼이 데이터 레벨에서 신뢰도 단계를 강제 (v2 헌장 ④ 신뢰 비용 분리 준수). 풀이 LLM이 신뢰도에 따른 해석 강도 조절 가능
 - **idempotency 테이블 신설** — `saju_weekly_reviews (user_id, week_start)` UNIQUE 제약 + ON CONFLICT DO NOTHING RETURNING. routine retry·prompt 중복 호출 어떤 원인이든 차단해 발송 정확히 1회 보장
-- **신 routine `weekly-saju-review-v2`** — Claude 앱 scheduled task로 매주 월요일 08:00 KST 발사. Opus가 view 결과 + 라이프 메트릭(schedule done/total · routine rate · diary_meta_tag · sleep avg)으로 사주 관점 회고 prose 4\~6줄 + 학습 3섹션을 Block Kit 카드 한 장으로 `#insight` 발송. 일기 원문 LLM 입력 금지(헌장 ①)
+- **신 routine `weekly-saju-review-v2`** — Claude 앱 scheduled task로 매주 월요일 08:00 KST 발송. Opus가 view 결과 + 라이프 메트릭(schedule done/total · routine rate · diary_meta_tag · sleep avg)으로 사주 관점 회고 prose 4\~6줄 + 학습 3섹션을 Block Kit 카드 한 장으로 `#insight` 발송. 일기 원문 LLM 입력 금지(헌장 ①)
 - **마스터 분리 후 view 매개 통합** — 매칭 마스터(#393)와 풀이 마스터(#421)가 같은 view를 진화시키며 책임은 분리, 데이터 흐름은 단일. Phase A3에서 #408 머지 후 월운 layer를 view에 추가 예정 (컬럼 contract 유지로 후방 호환)
 
 설계 판단 → [ADR-0020](adr/0020-fortune-system-responsibility-split-via-view.md). 마스터 서사 → [design-notebook/fortune-rework.md](design-notebook/fortune-rework.md).

--- a/src/cron/weekly-hypothesis-review.ts
+++ b/src/cron/weekly-hypothesis-review.ts
@@ -152,7 +152,7 @@ const processUser = async (
 
 /**
  * 본체 — life-cron SLOT_TASKS에서 호출.
- * cron은 매일 08:00에 발사되지만 월요일만 실행 (weeklyReport 패턴과 동일).
+ * cron은 매일 08:00에 발송되지만 월요일만 실행 (weeklyReport 패턴과 동일).
  */
 export const weeklyHypothesisReviewTask = async (
   app: App,

--- a/web/src/features/schedule/components/day-view.tsx
+++ b/web/src/features/schedule/components/day-view.tsx
@@ -66,7 +66,7 @@ export function DayView({
         <div className="flex items-baseline gap-3">
           <h2 className="text-lg font-bold text-gray-800">{formatted}</h2>
           <span className="flex items-baseline gap-1 text-blue-600">
-            <span className="font-serif text-base font-semibold">{dayPillar.hanja}</span>
+            <span className="text-base font-semibold">{dayPillar.hanja}</span>
             <span className="text-xs">{dayPillar.hangul}</span>
           </span>
         </div>

--- a/web/src/features/schedule/components/day-view.tsx
+++ b/web/src/features/schedule/components/day-view.tsx
@@ -11,6 +11,7 @@ import {
   getScheduleTopCategoryName,
 } from '@/features/schedule/lib/types';
 import type { CategoryRow } from '@/lib/types';
+import { getDayPillar } from '@/lib/saju';
 import { ScheduleCard } from './schedule-card';
 import { ActionMenu } from './action-menu';
 
@@ -50,6 +51,7 @@ export function DayView({
   });
 
   const formatted = format(currentDate, 'yyyy년 M월 d일 (EEE)', { locale: ko });
+  const dayPillar = getDayPillar(dateStr);
 
   // 3단 섹션 분리: 기간 일정 → 중요 → 카테고리별
   const sections = buildDaySections(daySchedules, categories);
@@ -61,7 +63,13 @@ export function DayView({
   return (
     <div className="mx-auto w-full max-w-3xl p-4 pb-24 md:flex-1 md:pb-4">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-bold text-gray-800">{formatted}</h2>
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-lg font-bold text-gray-800">{formatted}</h2>
+          <span className="flex items-baseline gap-1 text-blue-600">
+            <span className="font-serif text-base font-semibold">{dayPillar.hanja}</span>
+            <span className="text-xs">{dayPillar.hangul}</span>
+          </span>
+        </div>
         {totalTasks > 0 && (
           <span className="text-sm text-gray-500">
             {doneTasks}/{totalTasks} 완료

--- a/web/src/features/schedule/components/week-view.tsx
+++ b/web/src/features/schedule/components/week-view.tsx
@@ -231,7 +231,7 @@ export function WeekView({
                     </span>
                     <span className="text-base font-bold leading-tight">{format(day, 'd')}</span>
                   </div>
-                  <SajuPillarLabel dateStr={dateStr} today={today} />
+                  <SajuPillarLabel dateStr={dateStr} today={today} className="mt-1.5" />
                   {daySchedules.length > 0 && (
                     <span className="mt-0.5 text-[10px] text-gray-400">
                       {daySchedules.length}건
@@ -474,16 +474,24 @@ function WeekSpanBar({
   );
 }
 
-function SajuPillarLabel({ dateStr, today }: { dateStr: string; today: boolean }) {
+function SajuPillarLabel({
+  dateStr,
+  today,
+  className = '',
+}: {
+  dateStr: string;
+  today: boolean;
+  className?: string;
+}) {
   const pillar = getDayPillar(dateStr);
   return (
     <div
       className={`flex flex-wrap items-baseline justify-center gap-x-1 text-[10px] leading-tight ${
         today ? 'text-blue-600' : 'text-gray-500'
-      }`}
+      } ${className}`}
     >
-      <span className="font-serif font-medium">{pillar.hanja}</span>
-      <span className="text-[10px]">{pillar.hangul}</span>
+      <span className="font-medium">{pillar.hanja}</span>
+      <span>{pillar.hangul}</span>
     </div>
   );
 }

--- a/web/src/features/schedule/components/week-view.tsx
+++ b/web/src/features/schedule/components/week-view.tsx
@@ -13,6 +13,7 @@ import {
 import type { CategoryRow } from '@/lib/types';
 import { getCategoryStyle } from '@/lib/types';
 import { getTodayISO } from '@/lib/kst';
+import { getDayPillar } from '@/lib/saju';
 import {
   computeWeekLayout,
   WEEK_START,
@@ -149,6 +150,7 @@ export function WeekView({
                     {format(day, 'd')}
                   </span>
                 </div>
+                <SajuPillarLabel dateStr={dateStr} today={today} />
               </div>
 
               {/* 스패닝 바 공간 확보 — 열별 실제 레인 수 기준 */}
@@ -229,8 +231,11 @@ export function WeekView({
                     </span>
                     <span className="text-base font-bold leading-tight">{format(day, 'd')}</span>
                   </div>
+                  <SajuPillarLabel dateStr={dateStr} today={today} />
                   {daySchedules.length > 0 && (
-                    <span className="mt-1 text-[10px] text-gray-400">{daySchedules.length}건</span>
+                    <span className="mt-0.5 text-[10px] text-gray-400">
+                      {daySchedules.length}건
+                    </span>
                   )}
                 </div>
 
@@ -465,6 +470,20 @@ function WeekSpanBar({
           <div className="mx-auto h-full w-0.5 rounded bg-gray-200" />
         </div>
       )}
+    </div>
+  );
+}
+
+function SajuPillarLabel({ dateStr, today }: { dateStr: string; today: boolean }) {
+  const pillar = getDayPillar(dateStr);
+  return (
+    <div
+      className={`flex flex-wrap items-baseline justify-center gap-x-1 text-[10px] leading-tight ${
+        today ? 'text-blue-600' : 'text-gray-500'
+      }`}
+    >
+      <span className="font-serif font-medium">{pillar.hanja}</span>
+      <span className="text-[10px]">{pillar.hangul}</span>
     </div>
   );
 }

--- a/web/src/lib/__tests__/saju.test.ts
+++ b/web/src/lib/__tests__/saju.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getDayPillar } from '../saju';
+
+describe('getDayPillar', () => {
+  it('기준일 2024-02-04 → 戊戌 (index 34)', () => {
+    const p = getDayPillar('2024-02-04');
+    expect(p.index).toBe(34);
+    expect(p.hanja).toBe('戊戌');
+    expect(p.hangul).toBe('무술');
+    expect(p.cheongan).toBe('무');
+    expect(p.jiji).toBe('술');
+  });
+
+  it('ADR 검증 케이스 2026-03-14 → 丁亥 (index 23)', () => {
+    const p = getDayPillar('2026-03-14');
+    expect(p.index).toBe(23);
+    expect(p.hanja).toBe('丁亥');
+    expect(p.hangul).toBe('정해');
+  });
+
+  it('사용자 예시 2026-05-26 → 庚子 (경자)', () => {
+    const p = getDayPillar('2026-05-26');
+    expect(p.hanja).toBe('庚子');
+    expect(p.hangul).toBe('경자');
+    expect(p.cheongan).toBe('경');
+    expect(p.jiji).toBe('자');
+  });
+
+  it('기준일 다음날 2024-02-05 → 己亥 (index 35)', () => {
+    const p = getDayPillar('2024-02-05');
+    expect(p.index).toBe(35);
+    expect(p.hanja).toBe('己亥');
+  });
+
+  it('기준일 전날 2024-02-03 → 丁酉 (index 33)', () => {
+    const p = getDayPillar('2024-02-03');
+    expect(p.index).toBe(33);
+    expect(p.hanja).toBe('丁酉');
+  });
+});

--- a/web/src/lib/saju.ts
+++ b/web/src/lib/saju.ts
@@ -1,0 +1,110 @@
+/**
+ * 사주 일주 계산 (web용 복제본).
+ * 원본: src/shared/saju-calendar.ts (봇 사용).
+ * 동기화 대상: getDayPillar 알고리즘 + 천간/지지 상수.
+ * 변경 시 양쪽 모두 갱신할 것 (ADR-0021 참조).
+ */
+
+export type Cheongan = '갑' | '을' | '병' | '정' | '무' | '기' | '경' | '신' | '임' | '계';
+export type Jiji =
+  | '자'
+  | '축'
+  | '인'
+  | '묘'
+  | '진'
+  | '사'
+  | '오'
+  | '미'
+  | '신'
+  | '유'
+  | '술'
+  | '해';
+
+export interface Pillar {
+  index: number;
+  hanja: string;
+  hangul: string;
+  cheongan: Cheongan;
+  jiji: Jiji;
+}
+
+const CHEONGAN_LIST: readonly Cheongan[] = [
+  '갑',
+  '을',
+  '병',
+  '정',
+  '무',
+  '기',
+  '경',
+  '신',
+  '임',
+  '계',
+];
+const JIJI_LIST: readonly Jiji[] = [
+  '자',
+  '축',
+  '인',
+  '묘',
+  '진',
+  '사',
+  '오',
+  '미',
+  '신',
+  '유',
+  '술',
+  '해',
+];
+const CHEONGAN_HANJA: readonly string[] = [
+  '甲',
+  '乙',
+  '丙',
+  '丁',
+  '戊',
+  '己',
+  '庚',
+  '辛',
+  '壬',
+  '癸',
+];
+const JIJI_HANJA: readonly string[] = [
+  '子',
+  '丑',
+  '寅',
+  '卯',
+  '辰',
+  '巳',
+  '午',
+  '未',
+  '申',
+  '酉',
+  '戌',
+  '亥',
+];
+
+const parseDate = (dateStr: string): Date => new Date(`${dateStr}T12:00:00+09:00`);
+
+const daysDiff = (a: string, b: string): number => {
+  const msPerDay = 86_400_000;
+  return Math.round((parseDate(a).getTime() - parseDate(b).getTime()) / msPerDay);
+};
+
+const indexToPillar = (idx: number): Pillar => {
+  const i = ((idx % 60) + 60) % 60;
+  const cIdx = i % 10;
+  const jIdx = i % 12;
+  return {
+    index: i,
+    hanja: `${CHEONGAN_HANJA[cIdx]}${JIJI_HANJA[jIdx]}`,
+    hangul: `${CHEONGAN_LIST[cIdx]}${JIJI_LIST[jIdx]}`,
+    cheongan: CHEONGAN_LIST[cIdx]!,
+    jiji: JIJI_LIST[jIdx]!,
+  };
+};
+
+/** 일주(日柱) 계산. 기준: 2024-02-04 = 戊戌(index 34). */
+export const getDayPillar = (dateStr: string): Pillar => {
+  const REF_DATE = '2024-02-04';
+  const REF_INDEX = 34;
+  const diff = daysDiff(dateStr, REF_DATE);
+  return indexToPillar(REF_INDEX + diff);
+};


### PR DESCRIPTION
## 관련 이슈

Closes #427

## 변경 내용

대시보드 캘린더 주간·일간 뷰의 각 날짜 셀에 사주 일주(천간+지지)를 한자+한글로 병기 표시.

- 주간 뷰 데스크탑 grid: 날짜 숫자 아래 `庚子 경자` 표기
- 주간 뷰 모바일 세로 리스트: 둥근 원 아래 표기
- 일간 뷰 헤더: 날짜 옆에 약간 작게 표기
- 표시 형식: 한자(`font-serif` 명조체) + 한글, `flex-wrap`으로 좁은 공간에서 두 줄 자동 분리
- 색상: 오늘 `text-blue-600`, 그 외 `text-gray-500`

## 설계 결정

봇 `src/shared/saju-calendar.ts`의 `getDayPillar` 함수를 `web/src/lib/saju.ts`로 복제 (~50줄, 순수 함수). API 경유 / 모노레포 분리 대안은 [ADR-0021](docs/adr/0021-web-shared-saju-code-duplication.md)에서 기각.

## 코드 리뷰

- [x] 보안 감사: 사주 데이터는 공개 가능한 상수, 크리덴셜·외부 입력 없음
- [x] 타입 안전성: `Cheongan`/`Jiji` 리터럴 union, non-null assertion (`noUncheckedIndexedAccess` 대응)
- [x] 컨벤션: named export, any 없음, kebab-case 파일명
- [x] 코드 품질: `SajuPillarLabel`은 week-view 데스크탑/모바일 공통 재사용

## 테스트

- [x] vitest 5 케이스 통과
  - 2024-02-04 → 戊戌 (기준일, index 34)
  - 2026-03-14 → 丁亥 (ADR 검증, index 23)
  - 2026-05-26 → 庚子 (사용자 예시)
  - 2024-02-03 / 2024-02-05 경계 케이스
- [x] `yarn build` 통과 (Next.js, TypeScript strict)
- [x] 브라우저 검증: 데스크탑/모바일 뷰포트 모두 정상, 콘솔 에러 없음

## 기타

- 동일 브랜치에 별개 chore commit (`91ee2cd` routine 트리거 표현 '발사' → '발송' 통일) 1건 포함 — 설계 단계에서 같이 정리됨