### PR TITLE
docs(readme): AI-Native Engineer 어필 + 출력 신뢰도 자동 검증 축 부각

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ graph LR
 
 ### 2. LLM 자율성 + 출력 신뢰도 자동 검증
 
+> **운영 철학** — **LLM은 적극적으로 쓰되, 그 출력은 통계·DB 제약·도구 권한으로 시스템이 직접 검증한다.** LLM에겐 발견·합성·해석의 자율을 주고, 채택·기각·중복 방지·할루시네이션 차단은 결정론적 코드가 책임진다.
+
 LLM이 SQL을 자율로 쓰고 가설까지 자율 생성하는 구조는 강력하지만, "**LLM이 만든 게 진짜 맞나?**"를 사람이 매번 검증할 수는 없다. 이 시스템은 세 층의 자동화로 LLM 출력을 통제·검증한다.
 
 #### (a) 실행 안전 가드레일 — LLM이 짠 SQL이 위험하지 않은가
@@ -97,25 +99,34 @@ graph LR
 
 #### (b) 출력 신뢰도 자동 검증 — LLM이 만든 가설이 정말 맞나
 
+**용어 정리** — 이 시스템에서 가설(hypothesis)은 **"trigger 조건 X일 때 → outcome Y가 자주 발생한다"** 형태.
+
+- **trigger** (입력 조건, **SQL 결정론**) — 사주 시드 점수·천간 지지 관계·원진/충 등. 예: "정인 시드 점수 50 초과인 날"
+- **outcome** (결과, **22 enum 화이트리스트 + SQL 지표**) — 일기 메타 태그 또는 수면·루틴 SQL 지표. 예: "irritation 태그 등장"
+- **hit** = trigger 발현한 날에 outcome도 발생 (예측 적중) / **miss** = trigger 발현했으나 outcome 없음
+
+→ 입력은 결정론, 결과는 enum 강제. **LLM 자유 텍스트는 가설 평가에 어디에도 안 들어감.**
+
 두 시스템이 병렬로 돌고, 결과는 view 하나로 묶인다.
 
-- **카탈로그 누적 매칭** — 매일 사주 시드 점수 + 일기 22 enum 태그를 페어로 카운트. `saju_seed_outcome_catalog`가 hit/miss 카운터로 단순 누적 (통계 검정 없음, 빠른 시그널 트래킹)
+- **카탈로그 누적 매칭** — 매일 사주 시드 × 22 enum 태그를 페어로 카운트. `saju_seed_outcome_catalog`가 hit/miss 카운터로 단순 누적 (통계 검정 없음, 빠른 시그널 트래킹)
 - **가설 검증 파이프라인** — 충분히 누적된 페어 + Opus 자율 발견을 `saju_hypotheses`에 등록. status는 `active`/`confirmed`/`rejected`/`archived` 4종. 매주 월요일 cron이 통계로 자동 전이
 - **신뢰도 라벨링 view** — `saju_influence_summary` view가 두 시스템 결과를 confidence_tier로 묶어 실시간 응답에 노출 ([ADR 0020](docs/adr/0020-fortune-system-responsibility-split-via-view.md))
 
 ```mermaid
 graph TB
-    D[일기 22 enum 태그<br/>+ 일운 시드 점수] --> CAT[(카탈로그 카운터<br/>seed × tag · hit/miss)]
+    D[일기 22 enum 태그<br/>일운 시드 점수] --> CAT[(카탈로그 카운터<br/>seed x tag · hit/miss)]
     CAT -->|충분히 누적된 페어 승격<br/>+ Opus 자율 발견| H[(가설 saju_hypotheses<br/>status = active)]
-    H -->|매주 월요일 cron| ST[Fisher's exact + BH-FDR<br/>+ 4주 추세]
+    H -->|매주 월요일 cron| ST[Fisher's exact + BH-FDR<br/>4주 추세 평가]
     ST --> V{자동 전이 평가}
-    V -->|q < 0.05<br/>AND rate_ratio ≥ 1.3<br/>AND 누적 trigger ≥ 30일| CF[status = confirmed]
-    V -->|최근 4주 rate_ratio<br/>0.95 ~ 1.05 평탄| RJ[status = rejected]
+    V -->|q 임계치 이하 + 효과 크기 충분<br/>+ 누적 trigger 30일 이상| CF[status = confirmed]
+    V -->|4주 평탄 = 효과 없음| RJ[status = rejected]
     V -->|조건 미달| H
 
-    CF -. verified tier .-> VIEW[saju_influence_summary VIEW<br/>신뢰도 라벨링]
-    CAT -. accumulating tier<br/>hit_rate ≥ 0.55, n ≥ 5 .-> VIEW
-    REC[(최근 7일 trigger 발현)] -. recent tier .-> VIEW
+    CF --> VIEW
+    CAT --> VIEW
+    REC[(최근 7일<br/>trigger 발현)] --> VIEW
+    VIEW[saju_influence_summary VIEW<br/>신뢰도 라벨링<br/>verified · accumulating · recent]
     VIEW --> O([실시간 LLM 응답에<br/>tier별 노출])
 
     classDef io fill:#f3f4f6,stroke:#6b7280,color:#111827
@@ -134,7 +145,15 @@ graph TB
 - `active → rejected`: 최근 4주 rate_ratio가 **0.95 ~ 1.05에서 평탄** = 효과 없음
 - 조건 미달이면 `active` 유지하고 다음 주 재평가
 
+**3 tier 라벨링 — OR 조건 아닌 신뢰도 등급 표시** — view는 동일 페어가 어느 단계의 근거인지 동시에 라벨링한다. LLM은 tier에 따라 어휘 강도를 조절(verified는 단정, accumulating은 가능성, recent는 즉시성).
+
+- **verified**: 통계 검증 통과한 가설 (강한 신뢰도)
+- **accumulating**: 카탈로그 누적 충분(hit_rate ≥ 0.55, n ≥ 5) — 검증 전이지만 신호 있음
+- **recent**: 최근 7일 trigger 발현 — 즉시성
+
 **왜 두 시스템으로 나눴나** — catalog는 "이 페어가 자주 같이 나옴"의 빠른 트래킹(통계 검정 없이 카운터만). 검증된 신호로 격상하려면 가설 파이프라인을 거쳐 통계 검정을 받아야 함. 두 단계를 view로 묶어 신뢰도 단계별로 라벨링.
+
+**시간이 흐를수록 시스템이 자율로 학습한다** — 사용자는 일기·일정·수면을 기록하기만 하면 된다. 카탈로그가 자동으로 시드 × 태그 페어를 누적 카운트하고, 충분히 모이면 가설로 승격되어 통계 검증을 받는다. 통과한 가설만 잔소리에 등장. **사용자 손은 데이터 입력에만, 패턴 발견·검증·노출 결정은 모두 시스템이.**
 
 **왜 outcome 기반 검증인가** — LLM이 텍스트로 그럴듯한 가설을 만드는 건 쉽지만, **사용자 실제 데이터에 맞는지는 별개**. 이 시스템은 LLM 텍스트 의존을 최소화하고(일기 태그도 22 enum 화이트리스트로 강제), 가설의 채택·기각을 **실제 outcome 통계로만** 결정한다. 결정론(SQL 패턴·카탈로그 카운터)과 자율(LLM 가설)의 책임을 분리하고, 자율 출력엔 검증 기간을 의무화 — 신뢰 비용을 시스템에 외주화한다 ([ADR 0019](docs/adr/0019-saju-hypothesis-verification-pipeline.md)).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# 내 라이프를 관찰하고 잔소리하는 LLM 에이전트
+# 라이프 데이터 LLM 에이전트 — 잔소리도 하고, 잔소리 근거도 통계로 검증한다
 
 > 자연어로 일정·루틴·수면·지출·일기를 기록하면, Claude가 SQL로 DB를 관리하고 크로스 분석해 "일찍 자야 일정 다 해내" 같은 잔소리를 먼저 건넨다.
-> **LLM이 자율 생성한 가설은 실제 outcome으로 통계 검정(Fisher's exact + BH-FDR)을 거쳐 lifecycle이 자동으로 관리된다** — 자기 출력의 신뢰도를 시스템이 직접 측정한다.
+> **LLM이 자율로 발견한 가설은 매주 통계 검정(Fisher's exact + BH-FDR)을 거쳐 채택·기각이 자동 결정된다** — 자기 출력의 신뢰도를 시스템이 직접 측정한다.
 > 기획·보안·운영까지 1인, 2026-03-05 시작 후 매일 사용 중.
 
 <p align="center">
@@ -26,8 +26,8 @@ LLM이 그날의 라이프 데이터(일정·루틴·수면·일기) + 명리학
 
 ```mermaid
 graph LR
-    D[일정 · 루틴 · 수면 · 일기] -->|즉시| P[SQL 패턴 5종<br/>비용 0]
-    D -->|사전 누적| L[(일기 테마 · 사주 패턴<br/>· 일운)]
+    D[일정 · 루틴 · 수면 · 일기] -->|즉시| P[SQL 패턴 11종<br/>비용 0]
+    D -->|사전 누적| L[(일기 22 enum 태그<br/>· 사주 패턴 · 일운)]
     P --> SY[잔소리 합성<br/>Sonnet]
     L --> SY
     SY --> O([Slack 잔소리<br/>아침 · 밤 크론])
@@ -42,18 +42,16 @@ graph LR
 
 **SQL이 잡는 패턴** (LLM 미경유, 비용 0)
 
-- **5가지 감지 패턴** — `streak`(연속 기록), `sleepTrend`(수면 추세), `slotGap`(시간대별 루틴 격차), `weekComparison`(전주 대비), `overdueAlert`(기한 초과). CTE·window function으로 직접 감지
+- **11가지 감지 패턴** — `streak`(연속 기록), `sleepTrend`(수면 추세), `slotGap`(시간대별 루틴 격차), `weekComparison`(전주 대비), `overdueAlert`(기한 초과), `categorySkew`(카테고리 편향), `drift`(점진적 이탈), `recovery`(회복 신호), `lapseAlert`(단절 경보), `weeklyRegression`(주간 회귀), `spottyPattern`(산발 패턴). CTE·window function으로 직접 감지
 - **수면·루틴·일정 영향 분석** — `sleepTrend` 패턴이 수면 부족 → 루틴/일정 하락 상관을 자동 감지
 
-**LLM이 합성하는 영역**
+**LLM이 합성하는 영역 — 출력은 다 화이트리스트·DB 제약으로 검증**
 
-- **일기 테마 추출** — 일기 텍스트에서 반복 테마/감정을 LLM이 추출 → `life_themes`에 누적. 2회 이상 감지되면 활성으로 승격되어 응답 프롬프트에 자동 주입
-- **주간 사주 회고** — 매주 월요일 아침 Opus가 지난 7일 메트릭 + 신뢰도 단계별 영향력(verified/accumulating/recent)을 받아 사주 관점 회고를 Block Kit 카드로 발송 (idempotency 테이블로 정확히 1회 보장)
+- **일기 메타 태그 추출 (22 enum 화이트리스트)** — Opus가 일기 텍스트에서 `irritation`·`mood_down`·`task_completion` 같은 22개 enum 태그를 골라낸다. 시스템 프롬프트가 "이 22개 외엔 절대 출력 금지"로 강제 + 응답 파싱 후 `TAG_SET` 화이트리스트로 한 번 더 필터. **자유 텍스트로 새 태그가 들어올 수 없는 구조** → 카탈로그·가설 검증의 입력 일관성 보장
+- **주간 사주 회고** — 매주 월요일 아침 Opus가 지난 7일 메트릭 + 신뢰도 단계별 영향력(verified/accumulating/recent)을 받아 사주 관점 회고를 Block Kit 카드로 발송. 멱등성(idempotency) DB 제약(`UNIQUE(user_id, week_start) ON CONFLICT DO NOTHING RETURNING`)으로 크론 재실행·재시도에도 정확히 1회 영속화
 - **잔소리 합성** — SQL이 모은 패턴 + 일기 + 사주 패턴을 받아 그날 톤·맥락에 맞는 잔소리로 합성
 
 **하루 두 번 작동** — 밤은 그날 데이터를 엮은 잔소리, 아침은 어제 루틴 달성도 + 오늘 일정 안내.
-
-> "일기 보니까 아침에 몸 무겁고 귀찮은 느낌으로 시작했는데, 그 상태로 루틴 95% 찍었어. 운세대로라면 오늘 진술충 강제 재충전일이었는데, 그 날에 이 정도면 솔직히 잘한 거야. 10일 연속 자정 이후 취침이 좀 쌓이고 있어서, 오늘은 일찍 자봐."
 
 <p align="center">
   <img src="docs/images/cron-night.jpg" alt="밤 크론 잔소리" width="80%"/>
@@ -67,7 +65,7 @@ LLM이 SQL을 자율로 쓰고 가설까지 자율 생성하는 구조는 강력
 
 ```mermaid
 graph LR
-    U([Slack 메시지]) --> R[라우터<br/>Rate Limit]
+    U([Slack 메시지]) --> R[라우터<br/>채널 매핑 · 봇 필터<br/>Rate Limit · 길이 제한]
     R --> F{Fast Path<br/>정규식 매칭}
     F -->|적중| FP[SQL 직접 조회]
     F -->|미적중| AL[Agent Loop<br/>Sonnet ↔ SQL 도구]
@@ -86,9 +84,10 @@ graph LR
     class A guard
 ```
 
+- **라우터 1차 필터** — 채널별 에이전트 매핑(`#life`/`#insight`/`#money`), 봇 메시지·subtype 필터(에코·루프 차단), 사용자별 슬라이딩 윈도우 Rate Limit(1분 5회), 메시지 길이 10KB 제한
 - **DB Proxy + SQL 화이트리스트** — DDL(테이블 생성·삭제·구조 변경) 차단, 위험 함수 차단, WHERE 필수, 벌크 처리 행 수 제한
 - **modify_db 승인 플로우** — 변경 쿼리는 Slack 카드로 dry-run 결과를 보여주고 사용자 승인 후 실행
-- **LLM 자율 슬롯 4중 안전장치** — LLM이 자유롭게 발견 쿼리를 짤 수 있는 슬롯엔 (1) SELECT-only 강제 (2) `get_schema` 사전 호출 의무 (3) `result_type` 화이트리스트 (4) `verify_after_days` 1\~28 clamp으로 폭주 방지 ([ADR 0016](docs/adr/0016-llm-autonomous-slot-outcome-verification.md))
+- **LLM 자율 슬롯 4중 안전장치** — LLM이 자유롭게 발견 쿼리를 짤 수 있는 슬롯엔 (1) SELECT-only 강제 (2) `get_schema` 사전 호출 의무 (3) `result_type` 화이트리스트 (4) `verify_after_days` 1\~28 clamp으로 폭주 방지. 슬롯 설계 전반 + 4중 안전장치 상세는 [ADR 0016](docs/adr/0016-llm-autonomous-slot-outcome-verification.md) Section 3
 
 <p align="center">
   <img src="docs/images/llm-approval-card-01.png" alt="modify_db 승인 카드 — dry-run 결과" width="45%" />
@@ -98,34 +97,48 @@ graph LR
 
 #### (b) 출력 신뢰도 자동 검증 — LLM이 만든 가설이 정말 맞나
 
+두 시스템이 병렬로 돌고, 결과는 view 하나로 묶인다.
+
+- **카탈로그 누적 매칭** — 매일 사주 시드 점수 + 일기 22 enum 태그를 페어로 카운트. `saju_seed_outcome_catalog`가 hit/miss 카운터로 단순 누적 (통계 검정 없음, 빠른 시그널 트래킹)
+- **가설 검증 파이프라인** — 충분히 누적된 페어 + Opus 자율 발견을 `saju_hypotheses`에 등록. status는 `active`/`confirmed`/`rejected`/`archived` 4종. 매주 월요일 cron이 통계로 자동 전이
+- **신뢰도 라벨링 view** — `saju_influence_summary` view가 두 시스템 결과를 confidence_tier로 묶어 실시간 응답에 노출 ([ADR 0020](docs/adr/0020-fortune-system-responsibility-split-via-view.md))
+
 ```mermaid
-graph LR
-    LLM[Opus<br/>자율 가설 발견] --> H[(saju_hypotheses<br/>active)]
-    DATA[(7일치 라이프 데이터<br/>+ 운세 + 일기)] --> LLM
-    H -->|월요일 cron<br/>Fisher + BH-FDR| V{검정 결과}
-    V -->|유의 + FDR pass| VR[verified]
-    V -->|기각| AR[archived]
-    V -->|n 부족| IC[inconclusive]
-    VR --> VIEW[saju_influence_summary<br/>신뢰도 라벨링 view]
-    VIEW --> RT([실시간 LLM 응답<br/>verified만 노출])
+graph TB
+    D[일기 22 enum 태그<br/>+ 일운 시드 점수] --> CAT[(카탈로그 카운터<br/>seed × tag · hit/miss)]
+    CAT -->|충분히 누적된 페어 승격<br/>+ Opus 자율 발견| H[(가설 saju_hypotheses<br/>status = active)]
+    H -->|매주 월요일 cron| ST[Fisher's exact + BH-FDR<br/>+ 4주 추세]
+    ST --> V{자동 전이 평가}
+    V -->|q < 0.05<br/>AND rate_ratio ≥ 1.3<br/>AND 누적 trigger ≥ 30일| CF[status = confirmed]
+    V -->|최근 4주 rate_ratio<br/>0.95 ~ 1.05 평탄| RJ[status = rejected]
+    V -->|조건 미달| H
+
+    CF -. verified tier .-> VIEW[saju_influence_summary VIEW<br/>신뢰도 라벨링]
+    CAT -. accumulating tier<br/>hit_rate ≥ 0.55, n ≥ 5 .-> VIEW
+    REC[(최근 7일 trigger 발현)] -. recent tier .-> VIEW
+    VIEW --> O([실시간 LLM 응답에<br/>tier별 노출])
 
     classDef io fill:#f3f4f6,stroke:#6b7280,color:#111827
-    classDef llm fill:#fff7ed,stroke:#f97316,color:#9a3412
-    classDef verify fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
-    classDef result fill:#ecfdf5,stroke:#10b981,color:#065f46
-    class DATA,RT io
-    class LLM llm
-    class H,VIEW verify
-    class VR,AR,IC result
+    classDef stat fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+    classDef store fill:#ecfdf5,stroke:#10b981,color:#065f46
+    classDef view fill:#fef3c7,stroke:#d97706,color:#92400e
+    class D,O,REC io
+    class V,CF,RJ,ST stat
+    class CAT,H store
+    class VIEW view
 ```
 
-- **자율 가설 등록** — Opus가 라이프 데이터에서 발견한 가설(trigger 조건 + outcome 정의)을 `saju_hypotheses`에 `active` 상태로 등록
-- **주간 통계 검정** — 매주 월요일 cron이 가설별 trigger/non-trigger 일에 outcome 비율을 비교 → **Fisher's exact test**로 p-value 계산 + **BH-FDR**로 다중 비교 보정
-- **자동 상태 전이** — 결과에 따라 `active → verified` / `archived` / `inconclusive`로 lifecycle 자동 관리. 사람 개입 없이 검증된 가설만 누적
-- **신뢰도 라벨링 view** — `saju_influence_summary` view가 confidence_tier(verified / accumulating / recent)에 따라 LLM에 노출할 영향력만 필터링 → **검증 안 된 가설이 실시간 잔소리에 섞이지 않음**. 마스터 시스템 통합에서 view를 인터페이스로 두는 패턴 ([ADR 0020](docs/adr/0020-fortune-system-responsibility-split-via-view.md))
-- **idempotency DB 제약** — 주간 회고 생성은 `UNIQUE(user_id, week_start) ON CONFLICT DO NOTHING RETURNING`으로 강제. 크론 재실행/Opus 처리 재시도가 있어도 정확히 1회 영속화
+**자동 전이 조건 — 코드가 가설을 결정한다 (사람 개입 0)**
 
-**왜 outcome 기반 검증인가** — LLM이 텍스트로 그럴듯한 가설을 만드는 건 쉽지만, **사용자 실제 데이터에 맞는지는 별개**. 이 시스템은 LLM 텍스트 의존을 최소화하고, 가설의 채택·기각을 **실제 outcome 통계로만** 결정한다. 결정론(SQL 패턴)과 자율(LLM 가설)의 책임을 분리하고, 자율 출력엔 검증 기간을 의무화 — 신뢰 비용을 시스템에 외주화한다 ([ADR 0019](docs/adr/0019-saju-hypothesis-verification-pipeline.md)).
+- `active → confirmed`: BH 보정 후 **q < 0.05** AND **rate_ratio ≥ 1.3** (effect size 컷 — 통계적 유의해도 효과 미미하면 채택 안 함) AND **누적 trigger 발현일 ≥ 30**
+- `active → rejected`: 최근 4주 rate_ratio가 **0.95 ~ 1.05에서 평탄** = 효과 없음
+- 조건 미달이면 `active` 유지하고 다음 주 재평가
+
+**왜 두 시스템으로 나눴나** — catalog는 "이 페어가 자주 같이 나옴"의 빠른 트래킹(통계 검정 없이 카운터만). 검증된 신호로 격상하려면 가설 파이프라인을 거쳐 통계 검정을 받아야 함. 두 단계를 view로 묶어 신뢰도 단계별로 라벨링.
+
+**왜 outcome 기반 검증인가** — LLM이 텍스트로 그럴듯한 가설을 만드는 건 쉽지만, **사용자 실제 데이터에 맞는지는 별개**. 이 시스템은 LLM 텍스트 의존을 최소화하고(일기 태그도 22 enum 화이트리스트로 강제), 가설의 채택·기각을 **실제 outcome 통계로만** 결정한다. 결정론(SQL 패턴·카탈로그 카운터)과 자율(LLM 가설)의 책임을 분리하고, 자율 출력엔 검증 기간을 의무화 — 신뢰 비용을 시스템에 외주화한다 ([ADR 0019](docs/adr/0019-saju-hypothesis-verification-pipeline.md)).
+
+**멱등성(idempotency) DB 제약** — 주간 회고 생성·일기 메타 적재 등은 `UNIQUE + ON CONFLICT DO NOTHING RETURNING`으로 강제. 크론 재실행·LLM 재시도가 일어나도 정확히 1회 영속화. LLM은 매번 다른 답을 줄 수 있으므로 신뢰 비용을 DB 제약으로 흡수.
 
 #### (c) 비용·품질·속도 제어 — 출력은 어떻게 빨라지나
 
@@ -234,7 +247,7 @@ graph LR
 
 **(3) 주간 분석 (두 routine 순차)** — 매주 일요일 Opus가 두 단계로 작동. 먼저 누적된 일기·지출·일정·루틴·수면 + 일운을 28일 윈도우로 cross-domain 분석해 `saju_patterns`·`life_themes`를 갱신, 이어서 다음 일주일치 일운을 사전 분석해 `fortune_analyses`에 저장. 활성 패턴은 다음 주 일운부터 자동 반영 → 해석이 매주 강화되는 루프.
 
-**(4) 가설-검증 정량 파이프라인** — Opus가 자율로 발견한 사주 trigger ↔ 라이프 outcome 가설을 매주 Fisher's exact + BH-FDR로 검정. verified로 승격된 가설만 잔소리·회고에 노출 ([2 (b)](#b-출력-신뢰도-자동-검증--llm이-만든-가설이-정말-맞나) 참조).
+**(4) 가설-검증 정량 파이프라인** — Opus가 자율로 발견한 사주 trigger ↔ 라이프 outcome 가설을 매주 Fisher's exact + BH-FDR로 검정. `confirmed`로 자동 전이된 가설만 잔소리·회고에 노출 ([2 (b)](#b-출력-신뢰도-자동-검증--llm이-만든-가설이-정말-맞나) 참조).
 
 **(5) 잔소리에 재활용** — 같은 날의 일기는 1번 차별점의 밤 잔소리 LLM에도 주입. 본인 진술과 데이터 패턴을 함께 짚는 잔소리가 가능.
 
@@ -250,6 +263,7 @@ graph LR
 - **할부 분산** — 결제 시점이 아닌 실제 지출 시점 기준으로 월별 배분 + 자산 차감 범위 토글
 - **고정비/결제수단 관리** — 반복 지출과 카드별 청구 주기 추적
 - **결제주기 종료 자동 정산** — 결제주기 종료 cron이 카드 자산을 자동 차감, 할부 미래 회차도 즉시 반영
+- **카테고리별 횟수 제한 트래커** — "이번 결제주기에 외식 N회 이하" 같은 카테고리별 횟수 목표를 설정하고 진행을 시각적으로 확인
 
 <p align="center">
   <img src="docs/images/budget-dashboard.png" alt="예산 대시보드" width="45%" />

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # 내 라이프를 관찰하고 잔소리하는 LLM 에이전트
 
-> 자연어로 일정·루틴·수면·지출·일기를 기록하면, Claude가 SQL로 DB를 관리하고 크로스 분석.
-> "일찍 자야 일정 다 해내" 같은 잔소리를 먼저 건넨다. 기획·보안·운영까지 1인, 2026-03-05 시작 후 매일 사용 중.
+> 자연어로 일정·루틴·수면·지출·일기를 기록하면, Claude가 SQL로 DB를 관리하고 크로스 분석해 "일찍 자야 일정 다 해내" 같은 잔소리를 먼저 건넨다.
+> **LLM이 자율 생성한 가설은 실제 outcome으로 통계 검정(Fisher's exact + BH-FDR)을 거쳐 lifecycle이 자동으로 관리된다** — 자기 출력의 신뢰도를 시스템이 직접 측정한다.
+> 기획·보안·운영까지 1인, 2026-03-05 시작 후 매일 사용 중.
 
 <p align="center">
   <img src="docs/images/01-conversation.png" alt="자연어 대화로 일정 등록 + 잔소리" width="100%" />
@@ -12,7 +13,7 @@
   <img src="https://img.shields.io/badge/A_to_Z_1인_제작-2d3748?style=flat-square" alt="A to Z 1인 제작" height="40" />
   <img src="https://img.shields.io/badge/LLM_운영_하네스-2d3748?style=flat-square" alt="LLM 운영 하네스" height="40" />
   <img src="https://img.shields.io/badge/Public_저장소_보안-2d3748?style=flat-square" alt="Public 저장소 보안" height="40" />
-  <img src="https://img.shields.io/badge/설계_판단_기록_ADR-2d3748?style=flat-square" alt="ADR" height="40" />
+  <img src="https://img.shields.io/badge/LLM_출력_outcome_자동_검증-1d4ed8?style=flat-square" alt="LLM 출력 outcome 자동 검증" height="40" />
 </p>
 
 ---
@@ -58,9 +59,11 @@ graph LR
   <img src="docs/images/cron-night.jpg" alt="밤 크론 잔소리" width="80%"/>
 </p>
 
-### 2. LLM 자율 SQL 에이전트 + 운영 하네스
+### 2. LLM 자율성 + 출력 신뢰도 자동 검증
 
-LLM이 SQL을 직접 쓰는 구조는 강력하지만 할루시네이션·비용·안전 문제가 따라온다. 이를 두 층의 하네스로 제어한다.
+LLM이 SQL을 자율로 쓰고 가설까지 자율 생성하는 구조는 강력하지만, "**LLM이 만든 게 진짜 맞나?**"를 사람이 매번 검증할 수는 없다. 이 시스템은 세 층의 자동화로 LLM 출력을 통제·검증한다.
+
+#### (a) 실행 안전 가드레일 — LLM이 짠 SQL이 위험하지 않은가
 
 ```mermaid
 graph LR
@@ -83,11 +86,9 @@ graph LR
     class A guard
 ```
 
-**안전 가드레일**
-
 - **DB Proxy + SQL 화이트리스트** — DDL(테이블 생성·삭제·구조 변경) 차단, 위험 함수 차단, WHERE 필수, 벌크 처리 행 수 제한
 - **modify_db 승인 플로우** — 변경 쿼리는 Slack 카드로 dry-run 결과를 보여주고 사용자 승인 후 실행
-- **할루시네이션 감지** — LLM 반복 실수를 관찰·분류해 검증 로직·프롬프트 규칙으로 차단
+- **LLM 자율 슬롯 4중 안전장치** — LLM이 자유롭게 발견 쿼리를 짤 수 있는 슬롯엔 (1) SELECT-only 강제 (2) `get_schema` 사전 호출 의무 (3) `result_type` 화이트리스트 (4) `verify_after_days` 1\~28 clamp으로 폭주 방지 ([ADR 0016](docs/adr/0016-llm-autonomous-slot-outcome-verification.md))
 
 <p align="center">
   <img src="docs/images/llm-approval-card-01.png" alt="modify_db 승인 카드 — dry-run 결과" width="45%" />
@@ -95,11 +96,42 @@ graph LR
   <img src="docs/images/llm-approval-card-02.png" alt="modify_db 승인 카드 — 실행 결과" width="45%"  />
 </p>
 
-**비용·품질·속도 제어**
+#### (b) 출력 신뢰도 자동 검증 — LLM이 만든 가설이 정말 맞나
 
+```mermaid
+graph LR
+    LLM[Opus<br/>자율 가설 발견] --> H[(saju_hypotheses<br/>active)]
+    DATA[(7일치 라이프 데이터<br/>+ 운세 + 일기)] --> LLM
+    H -->|월요일 cron<br/>Fisher + BH-FDR| V{검정 결과}
+    V -->|유의 + FDR pass| VR[verified]
+    V -->|기각| AR[archived]
+    V -->|n 부족| IC[inconclusive]
+    VR --> VIEW[saju_influence_summary<br/>신뢰도 라벨링 view]
+    VIEW --> RT([실시간 LLM 응답<br/>verified만 노출])
+
+    classDef io fill:#f3f4f6,stroke:#6b7280,color:#111827
+    classDef llm fill:#fff7ed,stroke:#f97316,color:#9a3412
+    classDef verify fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+    classDef result fill:#ecfdf5,stroke:#10b981,color:#065f46
+    class DATA,RT io
+    class LLM llm
+    class H,VIEW verify
+    class VR,AR,IC result
+```
+
+- **자율 가설 등록** — Opus가 라이프 데이터에서 발견한 가설(trigger 조건 + outcome 정의)을 `saju_hypotheses`에 `active` 상태로 등록
+- **주간 통계 검정** — 매주 월요일 cron이 가설별 trigger/non-trigger 일에 outcome 비율을 비교 → **Fisher's exact test**로 p-value 계산 + **BH-FDR**로 다중 비교 보정
+- **자동 상태 전이** — 결과에 따라 `active → verified` / `archived` / `inconclusive`로 lifecycle 자동 관리. 사람 개입 없이 검증된 가설만 누적
+- **신뢰도 라벨링 view** — `saju_influence_summary` view가 confidence_tier(verified / accumulating / recent)에 따라 LLM에 노출할 영향력만 필터링 → **검증 안 된 가설이 실시간 잔소리에 섞이지 않음**. 마스터 시스템 통합에서 view를 인터페이스로 두는 패턴 ([ADR 0020](docs/adr/0020-fortune-system-responsibility-split-via-view.md))
+- **idempotency DB 제약** — 주간 회고 생성은 `UNIQUE(user_id, week_start) ON CONFLICT DO NOTHING RETURNING`으로 강제. 크론 재실행/Opus 처리 재시도가 있어도 정확히 1회 영속화
+
+**왜 outcome 기반 검증인가** — LLM이 텍스트로 그럴듯한 가설을 만드는 건 쉽지만, **사용자 실제 데이터에 맞는지는 별개**. 이 시스템은 LLM 텍스트 의존을 최소화하고, 가설의 채택·기각을 **실제 outcome 통계로만** 결정한다. 결정론(SQL 패턴)과 자율(LLM 가설)의 책임을 분리하고, 자율 출력엔 검증 기간을 의무화 — 신뢰 비용을 시스템에 외주화한다 ([ADR 0019](docs/adr/0019-saju-hypothesis-verification-pipeline.md)).
+
+#### (c) 비용·품질·속도 제어 — 출력은 어떻게 빨라지나
+
+- **Sonnet/Opus 분리** — 실시간 대화는 Sonnet, 비동기 깊은 분석(주간 사주 회고·일기 메타 추출·가설 발견)은 Opus + Scheduled Task로 분리해 결과를 DB에 영속화. 실시간 응답은 DB 조회로 풍부한 맥락을 프롬프트에 주입
 - **프롬프트 캐싱** — Anthropic `cache_control: ephemeral`로 시스템 프롬프트·도구 정의 캐시 → 토큰 비용 최대 90% 절감
-- **3-tier 분리** — 실시간 대화는 Sonnet, 비동기 깊은 분석(주간 사주 회고·일기 메타 추출 등)은 Opus + scheduled task로 분리해 결과를 DB에 저장. 실시간 응답은 DB 조회로 풍부한 맥락을 프롬프트에 주입
-- **fast path 바이패스** — 정규식 매칭 가능한 단순 조회는 LLM 우회 → \~1초 응답 (LLM 경유 시 7\~11초)
+- **Fast path 바이패스** — 정규식 매칭 가능한 단순 조회는 LLM 우회 → \~1초 응답 (LLM 경유 시 7\~11초)
 
 ### 3. Public 저장소 개인 데이터 다층 보안
 
@@ -110,13 +142,13 @@ graph LR
 | 네트워크      | DB·API 포트 루프백 바인딩, 외부 트래픽은 Caddy TLS 종료 강제, HTTPS API 프록시 경유               |
 | 인증          | Bearer API Key(타이밍 세이프 비교), iron-session, 요청 크기 1MB 제한                              |
 | SQL 실행      | 테넌트 격리 검증, DDL/위험 함수 차단, WHERE 필수 + 벌크 행 수 제한, `statement_timeout` 파라미터화 |
-| LLM           | 프롬프트 인젝션 패턴 감지, SQL 감사 로그                                                          |
+| LLM           | 프롬프트 인젝션 패턴 감지, SQL 감사 로그, 자율 슬롯 4중 안전장치                                  |
 | 요청 제어     | 슬라이딩 윈도우 Rate Limiter, 메시지 크기 제한, 봇 루프 필터                                      |
 | 개발 프로세스 | 커밋 전 시크릿 스캔 Hook, PR 리뷰 스킬에 보안 감사 체크리스트 내장                                |
 
 ### 4. A to Z 1인 제작 + AI 협업 파이프라인
 
-기획·설계·구현·보안·배포·운영까지 혼자. Claude Code의 기능을 조합해 개발 프로세스 자체를 자동화.
+기획·설계·구현·보안·배포·운영까지 혼자. Claude Code의 기능을 조합해 **AI를 코딩 보조가 아니라 협업 개발자**로 다루는 흐름을 세웠다.
 
 ```
 /design  →  .claude/plans/  →  /compact  →  /build
@@ -127,10 +159,22 @@ graph LR
 - **Custom Skills**: `/init-project`, `/design`, `/build` — 계획서 파일로 세션 간 핸드오프
 - **MCP**: Slack(에이전트 응답 품질 점검)
 - **Scheduled Tasks (비동기 깊은 분석 전용)**: 주간 사주 회고(Opus, 신뢰도 단계별 영향력 통합), 일기 메타 추출(Opus), 주간 일운 사전 분석, 밤 응원 메시지
-- **설계 사고 5문서 아키텍처**: `plans/`(휘발 메모) · `design-notebook/`(마스터 단위 서사·분기점·회고) · `adr/`(되돌리기 어려운 결정, Michael Nygard 포맷) · `features.md`(현황 카탈로그) · `domains/`(도메인별 스키마·로직 상세)로 사고를 분산 → 인터뷰 분기점·포기·회고가 코드만 남고 휘발되는 문제 해결. 각 문서마다 owner(`/design` / `/build`)가 명시되어 단계별로 자동 갱신
-- **자체 업타임 모니터링**: GitHub Actions cron으로 봇·웹 5분 간격 폴링 + Slack DOWN/RECOVERY 알림
 
-AI를 **코딩 보조**가 아니라 협업 개발자로 취급하고, 작업 단위는 GitHub Issues·PR로 리뷰·검증한다.
+**설계 사고 5문서 아키텍처** — 인터뷰 분기점·포기·회고가 코드만 남고 휘발되는 문제를 해결하기 위해 사고를 5문서로 분산. 각 문서마다 owner(`/design` / `/build`)가 명시되어 단계별로 자동 갱신된다.
+
+| 문서                  | 역할                                | owner             |
+| --------------------- | ----------------------------------- | ----------------- |
+| `plans/`              | 구현 직전 메모 (휘발)               | `/design`         |
+| `design-notebook/`    | 마스터 단위 서사·분기점·회고 누적   | `/design`+`/build`|
+| `adr/`                | 되돌리기 어려운 결정 (Michael Nygard, 불변) | `/design`   |
+| `features.md`         | 현재 기능 카탈로그                  | `/build`          |
+| `domains/<domain>.md` | 도메인별 스키마·API·로직 상세       | `/design`+`/build`|
+
+**비공개 어필 누적본** — phase 마감마다 비자명한 작업 패턴(헌장 cross-check, view 매개 통합, idempotency DB 제약 같은 것)을 `_personal/portfolio-candidates.md`에 누적. 추천 시점에 Claude가 평가 기준(일반화 가치·비자명성·원천 안정성·단발 vs 누적)으로 후보를 제안하고 사용자가 선택. README·이력서 갱신 시 이 누적본을 단일 소스로 사용.
+
+**자체 업타임 모니터링**: GitHub Actions cron으로 봇·웹 5분 간격 폴링 + Slack DOWN/RECOVERY 알림.
+
+작업 단위는 GitHub Issues·PR로 리뷰·검증한다. 작업 방식 자체는 별도 메타 repo([build-with-ai](https://github.com/hyewon3938/build-with-ai))에 누적.
 
 ---
 
@@ -190,18 +234,22 @@ graph LR
 
 **(3) 주간 분석 (두 routine 순차)** — 매주 일요일 Opus가 두 단계로 작동. 먼저 누적된 일기·지출·일정·루틴·수면 + 일운을 28일 윈도우로 cross-domain 분석해 `saju_patterns`·`life_themes`를 갱신, 이어서 다음 일주일치 일운을 사전 분석해 `fortune_analyses`에 저장. 활성 패턴은 다음 주 일운부터 자동 반영 → 해석이 매주 강화되는 루프.
 
-**(4) 잔소리에 재활용** — 같은 날의 일기는 1번 차별점의 밤 잔소리 LLM에도 주입. 본인 진술과 데이터 패턴을 함께 짚는 잔소리가 가능.
+**(4) 가설-검증 정량 파이프라인** — Opus가 자율로 발견한 사주 trigger ↔ 라이프 outcome 가설을 매주 Fisher's exact + BH-FDR로 검정. verified로 승격된 가설만 잔소리·회고에 노출 ([2 (b)](#b-출력-신뢰도-자동-검증--llm이-만든-가설이-정말-맞나) 참조).
+
+**(5) 잔소리에 재활용** — 같은 날의 일기는 1번 차별점의 밤 잔소리 LLM에도 주입. 본인 진술과 데이터 패턴을 함께 짚는 잔소리가 가능.
 
 - **만세력 계산 유틸** — LLM 할루시네이션 방지를 위해 직접 코드로 구현 ([docs/domains/insight.md](docs/domains/insight.md))
 - **운세 fast path** — `일운`/`월운` 등은 정규식 매칭 → DB 직접 조회로 LLM 우회
+- **60갑자 카탈로그 정규화** — 천간·지지·갑자 마스터를 SQL 테이블로 분리하고 일일 매칭은 카탈로그 lookup으로 처리 ([ADR 0017](docs/adr/0017-saju-ganji-master-normalization.md))
 
 ### 5. 지출·예산 — 개인 예산 엔진
 
 목표 기간을 설정하면 월·일 단위 예산이 자동 분배되고, 일일 소비 패턴을 추적해 초과·절약 여부를 기록. 결제수단·할부·고정비까지 포함한 다층 지출 구조.
 
 - **일일 집계** — 매일 소비액과 예산 대비 차이 기록
-- **할부 분산** — 결제 시점이 아닌 실제 지출 시점 기준으로 월별 배분
+- **할부 분산** — 결제 시점이 아닌 실제 지출 시점 기준으로 월별 배분 + 자산 차감 범위 토글
 - **고정비/결제수단 관리** — 반복 지출과 카드별 청구 주기 추적
+- **결제주기 종료 자동 정산** — 결제주기 종료 cron이 카드 자산을 자동 차감, 할부 미래 회차도 즉시 반영
 
 <p align="center">
   <img src="docs/images/budget-dashboard.png" alt="예산 대시보드" width="45%" />
@@ -252,8 +300,8 @@ graph LR
 
 **비동기 분석 파이프라인**
 
-- **node-cron** (Asia/Seoul): 아침/밤 알림 + 일요일 주간 리포트 — Sonnet으로 합성
-- **Scheduled Task**: 매주 일요일 사주 패턴·테마 갱신 + 일주일치 일운 사전 분석 + 매일 개발 리포트 — Opus가 분석 후 DB에 결과 영속화 → 매일 크론·실시간 응답 시점엔 SELECT만으로 비용·지연 분리
+- **node-cron** (Asia/Seoul): 아침/밤 알림 + 일요일 주간 리포트 + 월요일 가설 검증·주간 사주 회고 — Sonnet/Opus로 합성
+- **Scheduled Task**: 매주 일요일 사주 패턴·테마 갱신 + 일주일치 일운 사전 분석 + LLM 자율 가설 발견 — Opus가 분석 후 DB에 결과 영속화 → 매일 크론·실시간 응답 시점엔 SELECT만으로 비용·지연 분리
 
 **배포·관측**
 
@@ -270,9 +318,9 @@ src/                       # Slack 에이전트 (VM + Docker)
 ├── router.ts              # 채널별 라우팅 + Rate Limiting
 ├── db-proxy.ts            # DB Proxy API (Vercel → HTTPS → DB)
 ├── agents/life/           # 통합 라이프 에이전트 (일정·루틴·수면·리마인더)
-├── agents/insight/        # 사주·일기 에이전트
-├── cron/                  # 크론 알림 + 주간 리포트
-└── shared/                # LLM, agent-loop, sql-tools, insights, ...
+├── agents/insight/        # 사주·일기 에이전트 + 가설 발견·카드 빌더
+├── cron/                  # 크론 알림 + 주간 리포트 + 가설 검증
+└── shared/                # LLM, agent-loop, sql-tools, saju-hypothesis, ...
 
 web/                       # 웹 대시보드 (Vercel 자동 배포)
 └── src/app/               # schedules · backlog · categories · routines · budget · ...
@@ -284,12 +332,13 @@ web/                       # 웹 대시보드 (Vercel 자동 배포)
 
 | 영역      | 선택                                                                              |
 | --------- | --------------------------------------------------------------------------------- |
-| AI/LLM    | Claude (Opus: 비동기 깊은 분석 / Sonnet: 실시간 대화·크론·주간 리포트) + Tool Use |
+| AI/LLM    | Claude (Opus: 비동기 깊은 분석·가설 발견 / Sonnet: 실시간 대화·크론·잔소리 합성) + Tool Use |
 | AI 개발   | Claude Code — Hooks · Custom Skills · MCP · Scheduled Tasks                       |
 | Backend   | Node.js + TypeScript (strict)                                                     |
 | Frontend  | Next.js 16 (App Router) + Tailwind v4 + @dnd-kit                                  |
 | Messaging | Slack Bolt (Socket Mode)                                                          |
 | Database  | PostgreSQL 17 (Docker, TLS on)                                                    |
+| Stats     | Fisher's exact test + Benjamini-Hochberg FDR (가설 lifecycle 자동 관리)            |
 | Auth      | iron-session (암호화 쿠키 세션)                                                   |
 | Infra     | Docker Compose + 클라우드 VM · Vercel · Caddy(자동 TLS)                           |
 | CI/CD     | GitHub Actions → GHCR 이미지 빌드·자동 정리 → VM pull + 재기동                    |
@@ -299,7 +348,7 @@ web/                       # 웹 대시보드 (Vercel 자동 배포)
 
 ## 개발 히스토리
 
-**2026-03-05 시작, 매일 사용·운영 중.** 5주차 보안·배포 안정화, 6주차 예산 엔진 v2, 7주차 ADR 체계 + LLM 하네스 정착.
+**2026-03-05 시작, 매일 사용·운영 중.** 초반은 도메인 확장과 인프라 분리, 5월 이후는 LLM 자율성·출력 신뢰도 검증 파이프라인이 중심.
 
 | 주차                  | 핵심 변화                                                                                                                                                              |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -309,6 +358,10 @@ web/                       # 웹 대시보드 (Vercel 자동 배포)
 | W5 (04-09\~10)        | **보안 아키텍처 전면 강화** · **배포 파이프라인 최적화** (warm cache \~81초, 편차 13배→2배)                                                                            |
 | W6 (04-13\~15)        | **API 비용 최적화** · **지출·예산 v2 엔진 재설계** (목표 기간·금액 → 월/일 예산 자동 분배 + 동적 재조정, 4-Phase TDD)                                                  |
 | W7 (04-21\~23)        | **자체 업타임 모니터링** · **ADR 체계 도입** · **LLM 하네스 강화**(modify_db 대량 변경 승인 플로우)                                                                    |
+| W8 (05-04\~10)        | **예산 정의 통일** (자유지출·일 예산 산정·일별 로그 baseline·cron 시각 재정렬) · **사주 패턴 cross-domain 통합** · **운세 분석 개인화** (라이프 테마 두 트랙 + 의사결정 가이드) |
+| W9 (05-11\~17)        | **프로액티브 인사이트 v2 마스터 진입** — Phase 1 (인사이트 엔진 통합·임계치 외부화) · **Phase 2** (LLM 자율 발견 슬롯 + Outcome 검증, ADR 0016) · **Phase 3** (60갑자 정규화 + 일일 매칭, ADR 0017) · 일정 카테고리 FK 전환 · 결제주기 종료 자산 자동 차감 |
+| W10 (05-20\~24)       | **할부 자산 차감 범위 토글** · **인사이트 Phase 4 — 가설-검증 정량 파이프라인** (Fisher's exact + BH-FDR + lifecycle 자동 관리, ADR 0019)                              |
+| W11 (05-25\~26)       | **사주 풀이 책임 분리 + view 매개 마스터 통합** (`saju_influence_summary` 신뢰도 라벨링 + idempotency DB 제약, ADR 0020·0021) · 5문서 아키텍처 + portfolio-candidates 워크플로우 정착 |
 
 상세 → [docs/project-history.md](docs/project-history.md)
 
@@ -334,7 +387,7 @@ yarn dev
 
 ## 관련 문서
 
-문서 운영 — 마일스톤은 `project-history.md`, 마스터 단위 설계 서사는 `design-notebook/`, 되돌리기 어려운 판단은 `adr/`, 현재 기능 카탈로그는 `features.md`, 일상 작업·성향 분석 등 비공개 정보는 `_personal/`(gitignored)로 분리.
+문서 운영 — 마일스톤은 `project-history.md`, 마스터 단위 설계 서사는 `design-notebook/`, 되돌리기 어려운 판단은 `adr/`, 현재 기능 카탈로그는 `features.md`, 도메인별 스키마·로직은 `domains/`, 일상 작업·성향 분석 등 비공개 정보는 `_personal/`(gitignored)로 분리.
 
 | 문서                                                           | 내용                                                                                                                         |
 | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## 목적

마스터 #393 Phase 1\~4 + 마스터 #421이 누적되면서 **"LLM 출력 신뢰도 자동 검증"** 이라는 새 어필 축이 생겼다. README가 W7(2026-04-23)에 멈춰 있어 이 축이 전혀 노출되지 않은 상태 → AI-Native Engineer 직무 어필을 위해 전면 보강.

draft 상태로 올림. 머지 전 검토용.

## 핵심 변경

### AI-Native Engineer 축 부각
- **Lead 단락**: Fisher's exact + BH-FDR로 가설 lifecycle 자동 관리를 두 번째 문장에 부각
- **Signal bar**: "설계 판단 기록 ADR" → **"LLM 출력 outcome 자동 검증"** (primary color highlight)
- **Section 2 제목**: "LLM 자율 SQL 에이전트 + 운영 하네스" → **"LLM 자율성 + 출력 신뢰도 자동 검증"**
- **Section 2 구조**: 2 sub-block → **3 sub-block** (a) 실행 안전 (b) 출력 신뢰도 검증 NEW (c) 비용·품질
- **새 다이어그램**: Hypothesis verification flow (Opus→Fisher→verified/archived/inconclusive→view 라벨링)
- **기술 스택**: Stats 라인 추가 (Fisher + BH-FDR)

### 협업 자산 표면화
- **Section 4**: 5문서 아키텍처 owner 표 + portfolio-candidates 워크플로우 + build-with-ai 메타 repo 링크
- **Section 4 (일기·사주) 기능**: (4) 가설-검증 정량 파이프라인 항목 추가

### 히스토리 갱신
- **W8 (05-04~10)**: 예산 정의 통일 + 사주 cross-domain + 운세 분석 개인화
- **W9 (05-11~17)**: 인사이트 v2 Phase 1·2·3 + 일정 카테고리 FK + 자산 자동 차감
- **W10 (05-20~24)**: 할부 토글 + Phase 4 가설 검증 파이프라인 (ADR 0019)
- **W11 (05-25~26)**: 사주 풀이 책임 분리 + view 매개 통합 (ADR 0020·0021)

## 유지한 것

- 타이틀: "내 라이프를 관찰하고 잔소리하는 LLM 에이전트" — 구체적·기억되는 정체성
- Section 1 (잔소리): 결정론↔자율 분리가 이미 잘 표현되어 있어 거의 그대로
- Section 3 (보안): 한 줄(LLM 자율 슬롯 4중 안전장치)만 보강
- 이미지·다이어그램: 기존 5개 모두 유지 + Section 2(b) 다이어그램 추가

## 톤

"잔소리꾼 친구" 정체성은 Section 1·cron quote에 보존, Section 2/4는 **"자기 출력의 신뢰도를 시스템이 직접 측정하는 LLM 시스템 엔지니어"** 톤으로 이동. 두 톤이 한 README 안에서 충돌 없이 작동하는지가 검토 포인트.

## 보안 체크

- [x] 재정·취업 키워드 없음
- [x] 그리스 문자 없음 (옵션 라벨 컨벤션)
- [x] 시크릿 패턴 없음
- [x] 공용 IP 없음 (127.0.0.1만 정당)
- [x] 톤 분기 사실 노출 없음

## 변경량

1 file, +79 -26 (358 → 410 lines, \~+15%)