### PR TITLE
fix(schedule): 캘린더 일주 표시 레이아웃 보완

### DIFF
--- a/web/src/features/schedule/components/day-view.tsx
+++ b/web/src/features/schedule/components/day-view.tsx
@@ -65,7 +65,7 @@ export function DayView({
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-baseline gap-3">
           <h2 className="text-lg font-bold text-gray-800">{formatted}</h2>
-          <span className="flex items-baseline gap-1 text-blue-600">
+          <span className="flex items-baseline gap-1 rounded-md bg-blue-50 px-2 py-0.5 text-blue-600">
             <span className="text-base font-semibold">{dayPillar.hanja}</span>
             <span className="text-xs">{dayPillar.hangul}</span>
           </span>

--- a/web/src/features/schedule/components/week-view.tsx
+++ b/web/src/features/schedule/components/week-view.tsx
@@ -40,7 +40,9 @@ interface WeekViewProps {
 
 const TASK_LANE_HEIGHT = 76;
 const EVENT_LANE_HEIGHT = 30;
-const DATE_ROW_HEIGHT = 72;
+// 헤더 영역 높이 (요일 + 날짜 동그라미 + 일주 라벨 + 여백).
+// 스패닝 바 top 위치 계산 기준 — 일주가 flex-wrap으로 두 줄이 되어도 가리지 않도록 여유 포함.
+const DATE_ROW_HEIGHT = 100;
 
 const NEXT_STATUS: Record<string, string> = {
   todo: 'in-progress',
@@ -486,7 +488,7 @@ function SajuPillarLabel({
   const pillar = getDayPillar(dateStr);
   return (
     <div
-      className={`flex flex-wrap items-baseline justify-center gap-x-1 text-[10px] leading-tight ${
+      className={`flex flex-wrap items-baseline justify-center gap-x-1 text-[11px] leading-tight ${
         today ? 'text-blue-600' : 'text-gray-500'
       } ${className}`}
     >


### PR DESCRIPTION
## 관련 이슈
Closes #430

## 변경 내용
- 데스크탑 주간 뷰: `DATE_ROW_HEIGHT` 72→100. 일주 라벨 추가 후 헤더 실제 높이가 늘어났는데 스패닝 바 top 계산 상수가 그대로라 기간 일정 카드가 일주 한자 위로 겹쳐 그려지던 문제 해소. flex-wrap으로 일주가 두 줄이 되는 케이스까지 대비한 여유 포함
- 일주 글자 크기 10px→11px (가독성 보완)
- 일간 뷰 헤더 일주 표시에 `bg-blue-50 rounded-md` 박스 추가 — 시각적으로 날짜 텍스트와 그룹 구분

## 코드 리뷰 결과
- [x] 보안 감사: 외부 입력 없음, 시각 조정만
- [x] 컨벤션 점검: 상수 주석 추가, 기존 스타일 패턴 재사용
- [x] 코드 품질: 매직 넘버에 의도 주석 부착

## 테스트
- [x] vitest 전체 281개 통과
- [x] yarn build 성공
- [x] preview에서 헤더 끝~스패닝 바 시작 사이 여유 18.25px 측정 확인
- [x] 모바일/데스크탑 양쪽 시각 검증
- [x] 콘솔 에러 없음