### PR TITLE
style(schedule): 일간 뷰 일주 박스 — 배경 제거하고 테두리만

### DIFF
--- a/web/src/features/schedule/components/day-view.tsx
+++ b/web/src/features/schedule/components/day-view.tsx
@@ -65,7 +65,7 @@ export function DayView({
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-baseline gap-3">
           <h2 className="text-lg font-bold text-gray-800">{formatted}</h2>
-          <span className="flex items-baseline gap-1 rounded-md bg-blue-50 px-2 py-0.5 text-blue-600">
+          <span className="flex items-baseline gap-1 rounded-md border border-gray-300 bg-white px-2 py-0.5 text-gray-700">
             <span className="text-base font-semibold">{dayPillar.hanja}</span>
             <span className="text-xs">{dayPillar.hangul}</span>
           </span>


### PR DESCRIPTION
## 변경 내용
- 일간 뷰 헤더의 일주(庚子 경자) 박스에서 파란 배경/텍스트 제거
- white 배경 + `border-gray-300` 테두리 + `text-gray-700` 텍스트로 변경
- 미니멀 라벨 스타일 — 다른 카테고리 색상과 충돌 가능성 줄임

## 테스트
- [x] vitest 281개 통과
- [x] preview 시각 검증 (데스크탑)
- [x] 콘솔 에러 없음