### PR TITLE
docs(insight): 마스터 #393 close + #434 setup

### DIFF
--- a/docs/adr/0022-target-type-generalization.md
+++ b/docs/adr/0022-target-type-generalization.md
@@ -1,0 +1,82 @@
+# 0022. target-type 일반화 — 사주 6종 + life_signal 통합 (단일 카탈로그)
+
+- Status: Accepted
+- Date: 2026-05-27
+- Related: [#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)
+- Tags: data, insight, architecture
+
+## Context
+
+마스터 #393 (v2) Phase 3에서 `saju_signal_catalog` 테이블을 만들고 사주 60갑자 매핑을 위한 target_type 6종(`stem`, `branch`, `ganji`, `element_density`, `sibiunsung`, `relation`)을 정의했다 (ADR-0017).
+
+마스터 #434는 이를 **본인 1명 패턴 발견 시스템**으로 일반화한다. 사주 갑자 외에도 라이프 통념(요일·주말·월말·계절 등)을 동일한 가설-검증 파이프라인에서 다루기로 한다.
+
+문제:
+
+- 라이프 통념을 어디에 둘 것인가 — 사주 시드 카탈로그와 같은 테이블? 별도 테이블?
+- 매칭·매트릭·가설·검증 코드가 사주 한정인 상태인데 두 종류의 시드를 어떻게 처리할 것인가
+- 테이블명 `saju_signal_catalog`은 역사적 명칭. rename할 가치가 있는가
+
+## Decision
+
+`saju_signal_catalog` 테이블의 `target_type` enum에 **`life_signal`** 1종을 추가한다. 별도 테이블을 만들지 않는다. 테이블명은 유지 (역사적 명칭).
+
+세부 구조:
+
+```sql
+-- migration: 063_signal_catalog_generalization.sql (예정)
+ALTER TYPE target_type ADD VALUE IF NOT EXISTS 'life_signal';
+
+ALTER TABLE saju_signal_catalog
+  ADD COLUMN seed_kind TEXT NOT NULL DEFAULT 'saju'
+    CHECK (seed_kind IN ('saju', 'life_signal'));
+```
+
+이후 매칭·매트릭·가설·검증 코드는 `target_type`만 보고 분기하면 됨 (사주 6종은 사주 도메인, `life_signal`은 라이프 도메인).
+
+## Alternatives considered
+
+### A. 별도 `life_signal_catalog` 테이블 신설
+
+- 장점: 테이블명이 의미적으로 정확. 사주와 라이프 통념의 출처 분리가 스키마 레벨에서 강제됨
+- 단점: 매칭·매트릭·가설·검증 4개 시스템의 코드가 모두 두 테이블 분기 처리 필요. 동일 통계 파이프라인이 분리되면 유지보수 부담 ↑
+- 기각 이유: 가설-검증 파이프라인이 동일하므로 분리할 의미 X. 통계 처리는 출처를 가리지 않는다
+
+### B. catalog를 `signal_catalog`로 rename
+
+- 장점: 가장 의미적. 테이블명이 마스터 정체성과 일치
+- 단점: v2 운영 중 마이그레이션 + view/외부 API 일괄 변경. PR #422의 `saju_influence_summary` 등 의존 entity도 같이 rename 필요
+- 기각 이유: 변경 폭이 너무 크고 의미적 이득은 작음. 테이블명은 코드만 봐서 의미 파악이 어렵지 않다 (도메인 문서에서 명시)
+
+### C. `target_type` enum 확장 + `seed_kind` 컬럼 추가 (선택)
+
+- 장점: 마이그레이션 비용 최소. 매칭·매트릭·가설·검증 코드 재사용
+- 단점: 테이블명에 `saju` 잔존 (역사적 부채)
+
+→ **C 선택**. 통계 파이프라인 통일 + 확장 비용 최소가 핵심. 테이블명 부채는 마스터 회고에 명시.
+
+## Consequences
+
+### 장점
+
+- 매칭 cron(`daily-saju-matching.ts`), `hypothesis-discovery.ts`, weekly 가설 리뷰가 단일 분기로 사주 + life_signal 모두 처리
+- view (`saju_signal_summary`) 한 개로 두 종류 시드의 hit/miss 통계 expose
+- 향후 새로운 시드 종류(예: 날씨, 생리 주기 등) 추가 시 `seed_kind`만 추가하면 됨
+
+### 단점 / 제약
+
+- 테이블명 `saju_signal_catalog`이 의미적으로 부정확 — `life_signal`도 들어 있음. 도메인 문서에서 명시 (코드 자체로는 직관 부족)
+- 사주와 life_signal의 출처 차이가 스키마로 강제되지 않음 — `seed_kind` CHECK constraint로 보강
+
+### 후속 작업
+
+- [ ] Phase 1 migration에 `target_type` enum 확장 + `seed_kind` 컬럼 추가
+- [ ] Phase 3에서 `life_signal` 시드 14\~20개 작성 (요일 7 + 주말/평일 2 + 월말/월초 2 + 계절 4 + 기타)
+- [ ] 도메인 문서(`docs/domains/insight.md`)에 테이블명의 역사적 부채 명시
+
+---
+
+**참고 자료**
+
+- [ADR-0017](0017-saju-ganji-master-normalization.md) — saju_signal_catalog 원본 설계
+- [ADR-0020](0020-fortune-system-responsibility-split-via-view.md) — view 인터페이스 패턴

--- a/docs/adr/0023-metric-unit-counter-and-summary-view.md
+++ b/docs/adr/0023-metric-unit-counter-and-summary-view.md
@@ -1,0 +1,106 @@
+# 0023. hit/miss 카운터는 매트릭 단위 + seed 합계는 view로 derive
+
+- Status: Accepted
+- Date: 2026-05-27
+- Related: [#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)
+- Tags: data, insight, schema
+
+## Context
+
+마스터 #434는 시드 → 매트릭 → 매칭 → 가설 → 검증 5어휘 데이터 모델 위에서 동작한다.
+
+hit / miss / inconclusive 카운터를 어디에 둘지가 결정 필요:
+
+- 시드(seed) 단위로 두면 시드 1:N 매트릭 관계에서 카운트가 어느 매트릭에서 왔는지 추적 불가
+- 매트릭(metric) 단위로 두면 시드 합계는 매번 집계 필요
+- v2 마스터 #421 (PR #422, ADR-0020) 패턴: `saju_influence_summary` view로 집계 derive
+
+또한 본 마스터에서 hit/miss 누적은 검증(Fisher, BH-FDR, Bayesian)의 입력이 되므로 **source of truth** 위치가 명확해야 한다.
+
+## Decision
+
+**hit/miss/inconclusive 카운터는 `saju_signal_metrics` 테이블에 직접 컬럼으로 둔다 (source of truth).** 시드 단위 합계는 `saju_signal_summary` view로 derive.
+
+세부 구조:
+
+```sql
+-- migration: 064_signal_metrics_counters.sql (예정)
+ALTER TABLE saju_signal_metrics
+  ADD COLUMN hit_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN miss_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN inconclusive_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN last_matched_at TIMESTAMPTZ;
+
+CREATE VIEW saju_signal_summary AS
+SELECT
+  c.id AS seed_id,
+  c.target_type,
+  c.target_value,
+  c.seed_kind,
+  COUNT(m.id) AS metric_count,
+  SUM(m.hit_count) AS total_hits,
+  SUM(m.miss_count) AS total_misses,
+  SUM(m.inconclusive_count) AS total_inconclusive,
+  MAX(m.last_matched_at) AS last_matched_at
+FROM saju_signal_catalog c
+LEFT JOIN saju_signal_metrics m ON m.seed_id = c.id
+WHERE m.status = 'active'
+GROUP BY c.id;
+```
+
+매칭 cron(`daily-saju-matching.ts`)이 매일 평가할 때마다 해당 매트릭의 카운트를 UPDATE.
+
+## Alternatives considered
+
+### A. seed에 카운트 컬럼
+
+- 장점: seed 단위 단순 SELECT 가능
+- 단점:
+  - 시드 1:N 매트릭일 때 어느 매트릭이 hit인지 추적 불가
+  - 매트릭이 비활성화(`status='rejected'`)되어도 시드 카운트에 잔존 (history 오염)
+  - PR #422 view 패턴과 일관성 ↓
+- 기각 이유: source of truth가 매트릭이 아닌 시드가 되면 검증(Fisher 등) 입력 정의가 흐려진다
+
+### B. matches만 두고 매번 집계
+
+- 장점: 정규화 완벽 (DRY)
+- 단점: 검증 cron(weekly-hypothesis-review)이 매주 수십 가설을 평가할 때마다 `saju_daily_matches` 전체 집계 → 비용 ↑. 운영 누적이 1년치 쌓이면 더 무거워짐
+- 기각 이유: 매주 비용보다 매일 cron이 카운트 1 UPDATE하는 비용이 압도적으로 작음
+
+### C. metric에 카운트 컬럼 + view derive (선택)
+
+- 장점:
+  - source of truth가 매트릭 (검증 입력과 일치)
+  - 시드 단위 합계는 view로 조회 시점 derive (v2 PR #422 패턴 계승)
+  - 매트릭 status 변경 시(rejected) view가 자동으로 제외
+- 단점: view 정의가 추가 entity
+
+→ **C 선택**. v2 마스터 #421의 view 인터페이스 패턴(ADR-0020)을 마스터 #434에 일관 적용.
+
+## Consequences
+
+### 장점
+
+- 매트릭이 검증의 단위와 일치 (Fisher 검증, Bayesian posterior 모두 매트릭 단위)
+- 시드 단위 view derive로 조회 단순성 유지
+- LLM 매트릭이 거절(`status='rejected'`)되어도 시드 카운트에 잔존하지 않음 (history 오염 방지)
+- v2 PR #422 view 패턴 일관 (`saju_influence_summary` ← view 패턴 → `saju_signal_summary`)
+
+### 단점 / 제약
+
+- view 조회 시 매번 GROUP BY 집계 비용 (다만 매트릭 수가 시드의 1\~5배 수준이라 무거움 X)
+- 매트릭 1행이 검증 단위가 되므로, "동일 시드를 다른 window로 평가하는 매트릭 N개"가 검증에서 별개로 취급됨 (의도된 동작)
+
+### 후속 작업
+
+- [ ] Phase 1 migration에 hit/miss/inconclusive 컬럼 추가
+- [ ] `saju_signal_summary` view 작성
+- [ ] 매칭 cron이 매트릭 카운트 UPDATE하도록 수정
+- [ ] 기존 시드의 카운트 backfill (Phase 1)
+
+---
+
+**참고 자료**
+
+- [ADR-0020](0020-fortune-system-responsibility-split-via-view.md) — view 인터페이스 패턴 원본
+- [ADR-0019](0019-saju-hypothesis-verification-pipeline.md) — Fisher + BH-FDR 검증 입력 정의

--- a/docs/adr/0024-bayesian-posterior-update.md
+++ b/docs/adr/0024-bayesian-posterior-update.md
@@ -1,0 +1,117 @@
+# 0024. Beta-Binomial Bayesian posterior 도입 — frequentist 검증과 병기
+
+- Status: Accepted
+- Date: 2026-05-27
+- Related: [#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)
+- Tags: data, statistics, insight
+
+## Context
+
+마스터 #393 Phase 4 (ADR-0019)는 가설 검증에 **Fisher's exact test + BH-FDR multiple testing correction**을 도입했다. 이는 frequentist 통계로, **누적이 충분할 때만** 유의미.
+
+본 마스터 #434는 n=1 단일 환경에서 동작한다. 1인 환경에서 가설 누적 속도가 느려, frequentist 검증으로는 **초기 단계의 hit/miss가 적은 가설**을 평가하기 어렵다 (예: 매트릭 hit 3 / miss 1 → 어떻게 해석?).
+
+또한 frequentist는 "이 가설이 참일 확률"을 직접 답하지 않는다 (p값은 "귀무가설이 참일 때 이 데이터가 우연히 나올 확률"). 사용자에게 가설 카드를 보여줄 때 사후 확신도가 더 직관적.
+
+문제:
+
+- 누적 적은 가설을 어떻게 평가할 것인가
+- 사후 확신도를 직접 표현할 수단 필요
+- frequentist를 폐기하지 말 것 (multiple testing correction 등 BH-FDR 가치 유지)
+
+## Decision
+
+**Beta-Binomial Bayesian posterior**를 도입해 frequentist 검증과 **병기**한다.
+
+세부 구조:
+
+```sql
+-- migration: 065_metric_posterior.sql (예정)
+ALTER TABLE saju_signal_metrics
+  ADD COLUMN posterior_alpha NUMERIC(8,2) NOT NULL DEFAULT 1.0,
+  ADD COLUMN posterior_beta NUMERIC(8,2) NOT NULL DEFAULT 1.0,
+  ADD COLUMN posterior_p NUMERIC(6,4);  -- 사후 평균 = alpha / (alpha + beta)
+```
+
+업데이트 규칙 (\~100줄 헬퍼):
+
+```typescript
+// src/shared/bayesian-posterior.ts (예정)
+function updatePosterior(prior: { alpha: number; beta: number }, outcome: 'hit' | 'miss') {
+  return outcome === 'hit'
+    ? { alpha: prior.alpha + 1, beta: prior.beta }
+    : { alpha: prior.alpha, beta: prior.beta + 1 };
+}
+// inconclusive는 갱신 안 함 (정보 0)
+
+// posterior_p = E[θ|data] = α / (α + β)
+// 95% credible interval: betaInv(0.025, α, β), betaInv(0.975, α, β)
+```
+
+가설 카드에 frequentist p값 + Bayesian posterior 병기:
+
+```
+시드: 甲일 → 수면 7h 미만
+검증: Fisher p=0.08 (q=0.21), Bayesian 사후 0.62 [0.41, 0.81]
+```
+
+prior: Beta(1, 1) uniform 시작 (운영 누적 후 informed prior 검토).
+
+## Alternatives considered
+
+### A. 본 마스터에서 도입 안 함, 운영 1\~3개월 후 follow-up
+
+- 장점: 본 마스터 scope 작아짐. 검증 운영 데이터를 본 뒤 도입 결정
+- 단점:
+  - n=1 환경에서 frequentist만으로 누적 적은 단계가 길어짐 (가설 카드 노출 미루기 vs. 노이즈 카드 노출 둘 중 하나)
+  - prior 없이 frequentist만 운영 후 도입 시 마이그레이션 + 회고 부담
+- 기각 이유: 추가 코드 \~100줄에 비해 n=1 적합성 가치가 큼. 미루는 비용이 도입 비용보다 큼
+
+### B. frequentist 폐기 + Bayesian 단독
+
+- 장점: 단일 통계 모델로 단순화
+- 단점:
+  - BH-FDR multiple testing correction의 가치 (수십\~수백 가설 평가 시) 손실
+  - Frequentist p값은 학술 표준 — 본 시스템의 검증 신뢰성을 외부에 설명할 때 유용
+- 기각 이유: 두 통계 모델은 답하는 질문이 다르다. 병기가 적합
+
+### C. frequentist + Bayesian 병기 (선택)
+
+- 장점:
+  - frequentist: "이 가설이 우연이 아닌 정도" (p값, q값)
+  - Bayesian: "이 가설이 참일 확률 추정치" (사후 확신도)
+  - 누적 적은 단계에서도 사후 확신도가 prior로 안정 + 누적 늘면 posterior 자연 수렴
+- 단점: 통계 모델 2종 운영 (코드 \~100줄 추가, 컬럼 3개 추가)
+
+→ **C 선택**. 추가 비용 작고 n=1 환경 적합성 큼.
+
+## Consequences
+
+### 장점
+
+- 누적 적은 가설도 사후 확신도로 평가 가능 (초기 단계 hit 3/miss 1 = posterior 0.67)
+- 가설 카드 표현이 더 직관적 ("Fisher p=0.08, 사후 0.62" — 사용자 친화)
+- frequentist BH-FDR 가치 유지
+- 운영 누적 후 informed prior 도입 시 컬럼 구조 그대로 사용 가능
+
+### 단점 / 제약
+
+- 코드 \~100줄 추가 (`src/shared/bayesian-posterior.ts`)
+- 컬럼 3개 추가 (`posterior_alpha`, `posterior_beta`, `posterior_p`)
+- 매칭 cron에서 매트릭 카운트 UPDATE 시 posterior도 같이 UPDATE (단순 산술)
+- credible interval은 beta inverse CDF 필요 — 외부 라이브러리(`@stdlib/stats-base-dists-beta-quantile` 등) 또는 직접 구현
+
+### 후속 작업
+
+- [ ] Phase 1 migration에 `posterior_alpha`, `posterior_beta`, `posterior_p` 컬럼 추가
+- [ ] Phase 7 `src/shared/bayesian-posterior.ts` 헬퍼 작성
+- [ ] 매칭 cron이 posterior도 UPDATE하도록 수정
+- [ ] 가설 카드 본문에 frequentist + Bayesian 병기
+- [ ] beta inverse CDF 라이브러리 선택 + 의존성 추가
+
+---
+
+**참고 자료**
+
+- [ADR-0019](0019-saju-hypothesis-verification-pipeline.md) — frequentist 검증 (Fisher + BH-FDR) 원본
+- Beta-Binomial 모델: 누적 사건의 사후 확신도를 단순한 산술로 유지하는 Conjugate prior 패턴

--- a/docs/adr/0025-llm-metric-approval-gate.md
+++ b/docs/adr/0025-llm-metric-approval-gate.md
@@ -1,0 +1,113 @@
+# 0025. LLM 자율 매트릭 승인 게이트 — `description NOT NULL` + Slack inline button
+
+- Status: Accepted
+- Date: 2026-05-27
+- Related: [#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)
+- Tags: data, llm, ux
+
+## Context
+
+마스터 #393 Phase 2 (ADR-0016)는 LLM 자율 발견 슬롯을 도입했다. LLM은 가설을 제기하지만, 매트릭(평가 SQL + window)은 시드 카탈로그 작성 시점에 결정론적으로 작성된 상태였다.
+
+마스터 #434는 매트릭 작성 자체를 LLM이 자율적으로 할 수 있도록 확장한다. LLM이 매트릭 후보를 제안 → 사용자 승인 → 활성화. 활성 매트릭만 매칭 cron에 진입.
+
+문제:
+
+- LLM 자율 매트릭을 자동 활성화하면 v2 헌장 ② (결정론 ↔ 자율 역할 분리) 위배
+- 사용자가 매트릭 SQL 본문을 매번 검토하는 건 비효율적
+- 매트릭 cap을 두지 않으면 슬롯 폭주 가능
+
+## Decision
+
+**LLM 자율 매트릭은 `status: 'pending'`으로 생성되며, 사용자 승인 후에만 `'active'`로 전환**. 매칭 cron은 `status='active'`만 처리.
+
+세부 구조:
+
+```sql
+-- migration: 066_llm_metric_approval.sql (예정)
+ALTER TABLE saju_signal_metrics
+  ADD COLUMN description TEXT NOT NULL DEFAULT '',
+  ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'pending', 'rejected')),
+  ADD COLUMN source TEXT NOT NULL DEFAULT 'deterministic'
+    CHECK (source IN ('deterministic', 'llm_autonomous')),
+  ADD COLUMN proposed_at TIMESTAMPTZ,
+  ADD COLUMN approved_at TIMESTAMPTZ;
+```
+
+승인 UX (Slack):
+
+1. 월간 LLM 슬롯이 매트릭 후보 N개(cap 5) 제안 → DB에 `status='pending'` 저장
+2. `#insight` 채널에 Block Kit 카드 자동 발송 (또는 사용자가 `/insight metric-approve` 호출)
+3. 카드 본문:
+   - 매트릭 이름
+   - 의도 (`description` 컬럼, 자연어)
+   - 평가 시드(어떤 seed를 검증하는지)
+   - window_days (예: "최근 7일 기준")
+   - hit/miss 분류 기준 (예: "수면 7시간 미만이면 hit")
+4. inline button: `[승인]` / `[거절]`
+5. 승인 시 `status='active'` + `approved_at=now()`. 다음 cron 사이클부터 매칭 시작.
+
+cap: 월 최대 5개 매트릭 제안 (`status='pending'` 누적이 cap 도달 시 추가 제안 차단). 잔여 cap은 누적 X (월간 reset).
+
+`description` 컬럼이 `NOT NULL`인 이유:
+
+- LLM 매트릭 승인 시 사용자가 SQL 본문 대신 자연어 설명을 검토. SQL 검토 부담 없이 매트릭 의도를 명확히 전달
+- 결정론 매트릭(Phase 1 backfill)도 description 채움 — 도메인 문서나 추후 디버깅 시 동일하게 유용
+
+## Alternatives considered
+
+### A. Slack 명령어 + Block Kit 카드 + 자연어 description (선택)
+
+- 장점:
+  - description으로 매트릭 의도 명확히 전달 (사용자 검토 부담 ↓)
+  - Slack 동선 통합 (별도 웹 페이지 X)
+  - inline button으로 1-click 승인
+- 단점: Block Kit 카드 한 종류 추가 (`src/agents/insight/metric-approval-cards.ts` 신규)
+
+### B. 웹 대시보드 승인 페이지
+
+- 장점: SQL 본문 + 평가 시뮬레이션 등 풍부한 UX 가능
+- 단점:
+  - 웹 작업 동선 추가 부담 (Next.js 페이지 + DB Proxy API 라우트 추가)
+  - 본 마스터 scope에서 웹 작업까지 끌어오면 Phase 수 ↑
+- 기각 이유: 자연어 description으로 Slack에서 충분히 검토 가능. 웹 페이지는 향후 운영 누적 후 follow-up 검토
+
+### C. 자동 승인 (검토 없음)
+
+- 장점: UX 가장 단순
+- 단점: v2 헌장 ② 위배. LLM 매트릭 폭주 위험. 잘못된 매트릭이 hit/miss 누적 시 노이즈 → 검증 오염
+- 기각 이유: 자율 영역과 결정론 영역의 신뢰 비용 분리 무너짐
+
+→ **A 선택**.
+
+## Consequences
+
+### 장점
+
+- LLM 자율 매트릭이 결정론 매트릭과 동일 테이블에 공존하되 활성화 게이트로 분리
+- `description NOT NULL`로 모든 매트릭의 의도가 자연어로 문서화 (결정론·자율 모두)
+- Slack 동선 통합, 사용자 1-click 승인
+- 월 cap으로 매트릭 폭주 방지
+
+### 단점 / 제약
+
+- description 컬럼 추가 + 기존 결정론 매트릭 backfill 필요 (Phase 1)
+- Block Kit 승인 카드 컴포넌트 한 종류 추가 (`metric-approval-cards.ts`)
+- `/insight metric-approve` 명령어 추가 (fast path 정규식 1줄)
+- 승인 후 30일 이상 미평가 매트릭 자동 비활성화 정책은 별도 follow-up (운영 누적 후)
+
+### 후속 작업
+
+- [ ] Phase 1 migration에 `description NOT NULL`, `status`, `source`, `proposed_at`, `approved_at` 컬럼 추가
+- [ ] 기존 결정론 매트릭의 description backfill (Phase 1)
+- [ ] Phase 6에서 월간 LLM 슬롯이 `status='pending'` 매트릭 생성
+- [ ] Phase 6에서 Block Kit 승인 카드 + `/insight metric-approve` 명령어 구현
+- [ ] Phase 8에서 카드 UI 통합
+
+---
+
+**참고 자료**
+
+- [ADR-0016](0016-llm-autonomous-slot-outcome-verification.md) — LLM 자율 슬롯 + 4안전장치 원본
+- [v2 헌장 ② — 결정론 ↔ LLM 자율 역할 분리](../../.claude/projects/-Users-ihyewon-slack-ai-agents/memory/project_insight_v2_core_principles.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -128,6 +128,10 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0019](0019-saju-hypothesis-verification-pipeline.md) | 프로액티브 인사이트 v2 Phase 4 — 가설-검증 정량 파이프라인 | Accepted | 2026-05-21 | data, llm, statistics |
 | [0020](0020-fortune-system-responsibility-split-via-view.md) | 사주 풀이 시스템과 v2 매칭 시스템 책임 분리 + view 인터페이스 도입 | Accepted | 2026-05-26 | data, insight, architecture |
 | [0021](0021-web-shared-saju-code-duplication.md) | web shared 사주 계산 코드 — 복제 방식 채택 | Accepted | 2026-05-26 | process, web, shared-code |
+| [0022](0022-target-type-generalization.md) | target-type 일반화 — 사주 6종 + life_signal 통합 (단일 카탈로그) | Accepted | 2026-05-27 | data, insight, architecture |
+| [0023](0023-metric-unit-counter-and-summary-view.md) | hit/miss 카운터는 매트릭 단위 + seed 합계는 view로 derive | Accepted | 2026-05-27 | data, insight, schema |
+| [0024](0024-bayesian-posterior-update.md) | Beta-Binomial Bayesian posterior 도입 — frequentist 검증과 병기 | Accepted | 2026-05-27 | data, statistics, insight |
+| [0025](0025-llm-metric-approval-gate.md) | LLM 자율 매트릭 승인 게이트 — `description NOT NULL` + Slack inline button | Accepted | 2026-05-27 | data, llm, ux |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/insight-engine-v2.md
+++ b/docs/design-notebook/insight-engine-v2.md
@@ -326,3 +326,44 @@ Phase 4 머지(2026-05-22) 직후 4일 만에 사용자가 Phase 5 진입을 요
 - **마스터 분리 결정이 헌장 cross-check로 자동 도출된 패턴**: design 단계에서 헌장(v2 4개 원칙)이 단순 가이드가 아니라 "이 마스터에 속하는가" 판정 도구로 작동. 외부 폐기·내부 채택 사이 빠른 결정 가능
 - **마스터 사이 의존 관계 명시 (5-B → A3)**: design-notebook끼리 cross-link로 두 마스터의 만나는 지점이 문서 차원에서 추적 가능. 단일 마스터 안에 모든 걸 두지 않아도 책임 분리와 통합을 동시에 가능
 
+---
+
+## 마스터 close (2026-05-27)
+
+본 마스터(#393, 프로액티브 인사이트 v2)는 **2026-05-27 close** 되었다. Phase 1\~4 머지 완료, Phase 5 분리.
+
+### Close 이유
+
+마스터 정체성이 "사주 검증 시스템"에서 "**본인 1명 패턴 발견 시스템 — 라이프 통념 + 사주 통합 시드 카탈로그**"로 진화. 새 정체성은 사주 갑자뿐 아니라 라이프 통념(요일·계절·월말 등)을 동일 가설-검증 파이프라인에서 다루므로 마스터 단위로 재구성하는 것이 자연스러움. 새 마스터 [#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)로 이관.
+
+### 누적 결과 (Phase 1\~4)
+
+- **Phase 1**: SQL 결정론 잔소리 엔진 11개 패턴 + 임계치 외부화 + 주간 리포트 재구성 (PR #396)
+- **Phase 2**: LLM 자율 발견 슬롯 + outcome 검증 + 점진적 노출 (PR #404, #405, #406)
+- **Phase 3**: 사주 60갑자 마스터 정규화 + Polymorphic Trigger 6종 + 일일 매칭 catalog + 28일 baseline outcome + S2(사술원진) 분석/영화 메트릭 (PR #407)
+- **Phase 4**: 가설-검증 정량 파이프라인 (Fisher's exact + BH-FDR) + weeklyHypothesisReview + diary-meta-extract Opus 이관 + 가설 lifecycle (PR #415, fix PR #420)
+
+### 이관 처리
+
+- **Phase 5 (#408, 월운 매칭 + 4층 영향력 데이터)** → **마스터 #434로 흡수**되지 않고 **별도 트랙 유지**. 검증 사이클 길이 차이(\~2년 4개월)로 본격 진입 보류 정책 유지. 본 마스터 종료와 무관하게 운영 1\~3개월 누적 후 본격 인터뷰 진입
+- **세운·대운 LLM 회고 해석 (구 Phase 5-B)**: 마스터 [#421](https://github.com/hyewon3938/slack-ai-agents/issues/421) (사주 풀이 재설계)로 이관 완료 (2026-05-26)
+- **v2 헌장 4개**: 마스터 #434에 그대로 계승 + 자체 헌장 5개 추가. [project_insight_v2_core_principles 메모리](../../.claude/projects/-Users-ihyewon-slack-ai-agents/memory/project_insight_v2_core_principles.md)는 v2 헌장 본가로 유지
+
+### 후속 관련 ADR
+
+마스터 #434에서 v2 데이터 모델을 확장:
+
+- [ADR-0022](../adr/0022-target-type-generalization.md): target-type 일반화 — 사주 6종 + life_signal 통합
+- [ADR-0023](../adr/0023-metric-unit-counter-and-summary-view.md): hit/miss 카운터 위치 + saju_signal_summary view
+- [ADR-0024](../adr/0024-bayesian-posterior-update.md): Beta-Binomial Bayesian posterior 도입
+- [ADR-0025](../adr/0025-llm-metric-approval-gate.md): LLM 자율 매트릭 승인 게이트
+
+### 회고 (마스터 단위)
+
+- **Phase 1\~4가 \~13일 만에 머지** (2026-05-14 \~ 2026-05-22): 헌장 cross-check + 5문서 아키텍처 + ADR 누적이 phase 사이 컨텍스트 손실을 방지한 사례. 평균 phase 당 3\~5일이라는 속도는 design-notebook 누적 + ADR 명시가 없었으면 어려웠을 것
+- **마스터 close가 새 마스터 시작 직전에 결정된 패턴**: 새 마스터 #434 인터뷰 중 "정체성이 바뀐다"는 자각이 마스터 단위 close 트리거가 됨. 마스터 close 시점을 "다음 마스터 인터뷰의 마지막 분기점"으로 두는 패턴 확인. close-only PR을 별도로 두지 않고 #434 setup PR에 close docs 통합
+- **헌장이 도구로 작동한 누적 사례**: Phase 2 (#354 흡수), Phase 5 분리 (#421 spawn), 마스터 #434 정체성 결정 — 세 분기점 모두 헌장 cross-check가 결정의 기준이 됐음. 헌장이 "변경 불가 원칙" 역할 외에도 "마스터 경계 판정 도구" 역할까지 수행
+
+### 다음 마스터
+
+→ [마스터 #434 personal-pattern-discovery.md](./personal-pattern-discovery.md)

--- a/docs/design-notebook/personal-pattern-discovery.md
+++ b/docs/design-notebook/personal-pattern-discovery.md
@@ -1,0 +1,206 @@
+# 본인 1명 패턴 발견 시스템 — 라이프 통념 + 사주 통합 시드 카탈로그
+
+> 마스터 이슈: [#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)
+> 시작: 2026-05-27
+> 상태: 설계 완료, Phase 1 진입 대기
+> Successor of: 마스터 [#393](https://github.com/hyewon3938/slack-ai-agents/issues/393) (v2, 사주 검증 시스템) — 일반화·확장
+
+## 개요
+
+마스터 #393 (프로액티브 인사이트 v2, Phase 1\~4 머지 완료)는 사주를 검증하기 위한 시스템이었다. 본 마스터는 동일한 가설-검증 파이프라인을 **본인 1명 패턴 발견 시스템**으로 일반화한다.
+
+핵심 변화:
+
+- **시드 출처 확장**: 사주 60갑자 6종(stem/branch/ganji/element_density/sibiunsung/relation) → 사주 6종 + 라이프 통념 1종(`life_signal`: 요일·주말·월말·계절 등 결정론적 환경 변수) 통합
+- **매트릭 작성 권한 확장**: 결정론 시드(SQL 카탈로그에 작성됨) + **LLM 자율 매트릭(미사용 자료에서 발견, 사용자 승인 후 활성)**
+- **검증 모델 확장**: Frequentist(Fisher's exact + BH-FDR, v2 Phase 4 계승) + **Bayesian(Beta-Binomial posterior 사후 확신도)**
+
+## 핵심 원칙 — 자체 헌장 (변경 불가, 변경 시 ADR)
+
+v2 헌장 4개([project_insight_v2_core_principles 메모리](../../.claude/projects/-Users-ihyewon-slack-ai-agents/memory/project_insight_v2_core_principles.md))는 본 마스터에도 그대로 적용된다. 그 위에 본 마스터의 자체 헌장 5개를 더한다.
+
+### 1. 본인 1명 통계 (n=1, single-case design)
+
+모집단 통계 가정 X. 본인 시계열만 추적해 본인 baseline 대비 차이를 측정한다. 다른 사람의 패턴을 차용하지 않고, 본인 데이터가 누적되는 만큼만 검증 신뢰도가 올라간다.
+
+### 2. 5어휘 분리 — 시드(seed) → 매트릭(metric) → 매칭(matching) → 가설(hypothesis) → 검증(verification)
+
+데이터 흐름 어휘를 5개로 명확히 분리한다.
+
+| 어휘 | 정의 | 테이블 |
+|------|------|--------|
+| **시드** (seed) | "어떤 환경/조건이 자주 등장하는가" 카탈로그 (사주 갑자 + 라이프 통념) | `saju_signal_catalog` |
+| **매트릭** (metric) | 시드를 검증하기 위한 평가 방법 (SQL + window_days + 임계치) | `saju_signal_metrics` |
+| **매칭** (matching) | 매트릭 평가가 발생한 단일 사건 기록 (trigger 발동일 + outcome 결과) | `saju_daily_matches` |
+| **가설** (hypothesis) | trigger seed × outcome seed 인과 후보 (자동 발견 + LLM 발견) | `saju_hypotheses` |
+| **검증** (verification) | 매칭 누적 → Fisher's exact + BH-FDR + Bayesian posterior | `saju_stats` |
+
+### 3. target-type 일반화 — 사주 + life_signal 통합 (ADR-0022)
+
+v2 Phase 3의 6종(stem/branch/ganji/element_density/sibiunsung/relation)에 **`life_signal`** 1종을 추가한다. 사주 갑자와 라이프 통념(요일·주말·월말·계절 등)을 동일한 `saju_signal_catalog` 스키마에서 다룬다. 별도 테이블 분리하지 않는 이유는 매칭·매트릭·가설 파이프라인이 모두 동일하기 때문 — 출처만 다르고 통계 처리는 동일.
+
+### 4. 결정론 ↔ LLM 자율 + 승인 게이트 (ADR-0025)
+
+매트릭의 출처를 구분한다.
+
+- **결정론 매트릭**: 시드 카탈로그에 SQL 작성됨 (Phase 1\~3 시드 시드 작업에서 작성). 즉시 매칭 cron에 진입.
+- **LLM 자율 매트릭**: 월간 LLM 슬롯이 미사용 데이터 조합에서 발견. **사용자 승인 후에만 활성** — 매트릭에 `status: 'pending' | 'active' | 'rejected'` 컬럼 + Slack 승인 카드 UI.
+
+LLM 매트릭은 월 최대 N개 cap(예: 5개)으로 슬롯 폭주 방지. 매트릭 본문에 `description TEXT NOT NULL` 컬럼을 두어 의도를 자연어로 전달 (SQL 본문은 매트릭 활성화 시점에 사용자가 별도 검토 안 해도 되게).
+
+### 5. 신뢰 비용 분리 (v2 헌장 ④ 계승 + Bayesian 추가)
+
+- **결정론**: 명시 임계치 + Fisher's exact + BH-FDR (v2 Phase 4 계승)
+- **자율**: 4안전장치(SELECT-only, get_schema 선호출, 결과 형식 제약, SQL 영속) + outcome 검증
+- **공통**: 모든 매트릭이 Beta-Binomial **posterior 확신도**를 누적 (Phase 7 도입). hit/miss 카운트가 적은 초기 단계에서도 prior로 안정 + 누적이 늘면 자연스럽게 posterior 수렴 (ADR-0024).
+
+## 컨텍스트 도메인
+
+- **포함**: schedule(카테고리/상태/시기) + sleep + routine + expense(카테고리 빈도/시기, 금액 노출 X) + saju(원국 데이터) + life_signal(요일/주말/월말/계절 등)
+- **제외**: diary(텍스트 의존도 ↑) — v2 헌장 ① 계승
+
+## 8-Phase 흐름 — 운영 검증은 단축 PR 검증으로 대체
+
+> Phase 사이에 1주 운영 검증을 두지 않는다. 짧은 PR 검증(코드 리뷰 + 테스트 + setup 모드 단위 검증)으로 대체. 통계 누적 검증은 마스터 종료 후 운영 1\~3개월 누적 시점에 [부록 E](#부록-e-운영-1-3개월-후-도입-검토-기능-7건) 7건과 함께 회고.
+
+- [ ] **Phase 1**: 스키마 일반화 — target_type enum 확장(`life_signal` 추가), `saju_signal_metrics`에 `description TEXT NOT NULL` + `window_days INTEGER` + `hit_count/miss_count/inconclusive_count` + `status` 컬럼, `posterior_p NUMERIC(6,4)` 예약, `saju_signal_summary` view 추가
+- [ ] **Phase 2**: 사주 시드 풀 셋 — Phase 3에서 작성된 시드를 카탈로그 풀(전체) 검토 + 누락 보완 (s1 일부만 작성된 상태였음)
+- [ ] **Phase 3**: `life_signal` 시드 풀 셋 — 요일(월\~일 7) / 주말(2) / 월말(1) / 월초(1) / 계절(4) 등 1차 셋. 결정론 매트릭으로 작성
+- [ ] **Phase 4**: 매칭 cron + view 정비 — `daily-saju-matching` cron이 `target_type='life_signal'`도 처리하도록 확장. `saju_signal_summary` view 본문 작성
+- [ ] **Phase 5**: 가설 발견·검증 업데이트 — `hypothesis-discovery`가 `life_signal` trigger를 포함하도록 일반화. weekly 가설 리뷰 카드 본문에 출처(seed_kind) 표시
+- [ ] **Phase 6**: LLM 자율 매트릭 + 승인 게이트 — 월간 LLM 슬롯이 매트릭 후보를 생성, Slack 승인 UI(`/insight metric-approve` + Block Kit inline button). 활성화된 매트릭만 매칭 cron 진입
+- [ ] **Phase 7**: Bayesian update 도입 — `posterior_p` 컬럼 채움. Beta-Binomial 사후 갱신 헬퍼(\~100줄). 가설 카드에 frequentist p값 + Bayesian posterior 병기
+- [ ] **Phase 8**: 인사이트 카드 UI + 마스터 close — `#insight` 채널 패턴 발견 카드(Block Kit). `life_signal` 패턴(요일 효과 등)도 같은 카드에서 출력. 마스터 회고 + 운영 1\~3개월 시점 follow-up 이슈 7건 일괄 등록
+
+---
+
+## 의사결정 분기점 — 마스터 setup 단계
+
+> 설계 단계에서 사용자와 합의된 분기점들. Phase별 분기점은 각 Phase 섹션에서 추가.
+
+### 1. 마스터 #393 처리 방식
+
+- A. #393 유지 + Phase 5에 흡수 — 마스터가 길어져 응집도 ↓, "사주 검증" 정체성이 흐려짐
+- B. #393 close + 새 마스터 신규 — 정체성 재정의 명확, 회고와 후속 작업 경계 분리 (선택)
+- C. 별도 PR로 #393 close를 분리 — 본 마스터 시작과 동시에 closing 작업도 분리 PR
+
+→ **B (선택)**. 마스터 정체성이 "사주 검증" → "본인 1명 패턴 발견"으로 바뀌므로 새 마스터가 자연스럽다. 본 PR에 #393 close docs도 함께(c 부분 통합) 포함.
+
+### 2. target-type 확장 위치
+
+- A. `saju_signal_catalog`에 `life_signal` target_type 추가 (선택) — 동일 파이프라인 재사용. 별도 카탈로그 분리 시 매칭·가설 코드 중복
+- B. 별도 `life_signal_catalog` 테이블 신설 — 테이블명이 의미적으로 정확하나, 매칭·매트릭·가설·검증 코드 4중 중복
+- C. catalog를 `signal_catalog`로 rename — 가장 의미적이지만 v2 마이그레이션 부담 + 외부 API 변경 폭증
+
+→ **A (선택)**. target_type enum 확장만으로 모든 파이프라인 재사용. 테이블명 `saju_*`는 역사적 명칭으로 보존 (ADR-0022).
+
+### 3. hit/miss/inconclusive 카운터 위치
+
+- A. seed에 카운트 컬럼 — v2 PR #422 패턴과 일관되지 않음
+- B. metric에 카운트 컬럼 (선택) — 매트릭이 단위 검증 주체이므로 source of truth. seed는 view로 derive
+- C. matches만 두고 매번 집계 — view derive 비용 ↑
+
+→ **B + view (선택)**. metric에 hit/miss/inconclusive 컬럼을 source of truth로 두고, `saju_signal_summary` view가 seed 단위 합산을 derive (v2 PR #422 `saju_influence_summary` view 패턴 계승). ADR-0023.
+
+### 4. Bayesian update 도입 시점
+
+- A. 본 마스터에서 도입하지 않고 운영 1\~3개월 후 — frequentist만으로 신뢰도 부족할 수 있음
+- B. 본 마스터 Phase 7에서 도입 (선택) — 추가 코드 \~100줄, posterior_p 컬럼 1개. 초기 hit 부족 시 prior로 안정.
+- C. frequentist만 영구 유지 — n=1 환경에서 누적 적은 가설 평가 어려움
+
+→ **B (선택)**. 본 마스터 안에서 도입. 추가 비용 작고 n=1 환경 적합성 큼. ADR-0024.
+
+### 5. LLM 자율 매트릭 승인 UI
+
+- A. Slack 명령어 + Block Kit 카드 + 자연어 description (선택) — 매트릭 의도를 자연어로 명확히 전달, 사용자가 SQL 본문 검토 안 해도 됨
+- B. 웹 대시보드 승인 페이지 — 웹 작업 동선 추가 부담
+- C. 자동 승인 (검토 없음) — v2 헌장 ② "결정론↔자율 역할 분리" 위배
+
+→ **A (선택)**. `description TEXT NOT NULL` 컬럼이 자연어 설명을 담고, Slack inline button으로 승인/거절. ADR-0025.
+
+### 6. Phase 사이 1주 운영 검증
+
+- A. Phase별 1주 운영 — 통계 누적 검증 가능하나 마스터 완성 시점이 8주+ 미뤄짐
+- B. 짧은 PR 검증(코드 리뷰 + 테스트 + setup 모드)만 (선택) — 통계 누적 검증은 마스터 close 후 운영 1\~3개월 누적 시점에 모아서
+
+→ **B (선택)**. Phase별 코드 검증으로 충분. 통계 검증은 마스터 종료 후 follow-up 7건과 함께.
+
+## 포기한 안 / 미룬 항목
+
+- **세운·대운 LLM 회고 해석** (v2 Phase 5-B): 이미 마스터 #421로 이관됨 (ADR-0020). 본 마스터에서 다시 다루지 않음
+- **diary 텍스트 LLM 분석**: 본 마스터 컨텍스트 도메인에서 제외. v2 헌장 ① 계승
+- **카테고리 가중치 자동 튜닝**: 운영 1\~3개월 누적 후 별도 이슈로 검토 (부록 E)
+- **SPRT / Change Point Detection 등 통계 도구 7건**: 운영 1\~3개월 후 follow-up 이슈로 일괄 등록 (부록 E)
+
+## 미해결 / 가설
+
+- **LLM 매트릭 월 cap**: 초기 5개로 시작. 자율 슬롯이 5건 채워지지 않으면 매월 잔여 cap 소멸 (누적 X). 운영 후 cap 적정성 재평가
+- **`life_signal` 시드 첫 셋 범위**: 1차에 14\~20개 시드 (요일 7 + 주말 1 + 평일 1 + 월말 1 + 월초 1 + 계절 4 + 월초후반/월말직전 2\~6). 운영 후 추가
+- **Bayesian prior**: Beta(1,1) uniform 시작. 운영 누적 후 informed prior 검토
+
+## 부록 A — 5어휘 데이터 모델 빠른 참조
+
+> [portfolio-candidates 부록 B](../_personal/portfolio-candidates.md)의 표를 공개용으로 간소화한 버전.
+
+```
+시드 (saju_signal_catalog)
+  ├─ target_type ∈ {stem, branch, ganji, element_density, sibiunsung, relation, life_signal}
+  ├─ target_value (예: '甲', '주말', '월말', '木 강')
+  ├─ seed_kind ∈ {saju, life_signal}
+  └─ description (자연어)
+
+매트릭 (saju_signal_metrics) ← seed 1:N
+  ├─ window_days  (외부화된 윈도우 길이)
+  ├─ sql_body     (평가 SQL)
+  ├─ description  (자연어 설명 — LLM 매트릭 승인 UI에 노출)
+  ├─ status ∈ {active, pending, rejected}
+  ├─ source ∈ {deterministic, llm_autonomous}
+  ├─ hit_count / miss_count / inconclusive_count  (source of truth)
+  └─ posterior_p  (Beta-Binomial 사후, Phase 7~)
+
+매칭 (saju_daily_matches) ← metric 1:N (매일 평가 결과 1행)
+  ├─ matched_date
+  ├─ outcome ∈ {hit, miss, inconclusive}
+  └─ evidence (JSONB, 평가 시점 컨텍스트)
+
+가설 (saju_hypotheses) ← trigger seed × outcome seed
+  ├─ trigger_seed_id / outcome_seed_id
+  ├─ status ∈ {candidate, active, confirmed, rejected}
+  └─ source ∈ {auto_discovered, llm_proposed}
+
+검증 (saju_stats) ← hypothesis 1:1 (snapshot per cycle)
+  ├─ p_value (Fisher's exact)
+  ├─ q_value (BH-FDR adjusted)
+  └─ posterior_p (Beta-Binomial)
+
+뷰 (saju_signal_summary) ← metric 집계로 seed 단위 derive
+```
+
+---
+
+## Phase 1: 스키마 일반화 (예정)
+
+- 이슈: TBD (Phase 1 진입 시 생성)
+- 관련 ADR: ADR-0022, ADR-0023, ADR-0025
+- 관련 계획서: `.claude/plans/434-phase-1-schema.md`
+- 상태: 설계 완료, 구현 대기
+
+### 결정 요약 (TODO: `/build` 구현 후 보강)
+
+target_type enum에 `life_signal` 추가. `saju_signal_metrics`에 `description NOT NULL` + `window_days` + `hit_count/miss_count/inconclusive_count` + `status` + `source` 컬럼 + `posterior_p` 예약. `saju_signal_summary` view 신설. 결정론 매트릭 backfill (기존 시드의 카운트 채움).
+
+### 의사결정 분기점 (TODO)
+
+### 회고 (TODO)
+
+---
+
+## Phase 2\~8 (TODO: 각 Phase 진입 시 섹션 누적)
+
+> 각 Phase 진입 시 `/design`이 본 문서에 해당 Phase 섹션을 추가한다. 템플릿: 결정 요약 / 의사결정 분기점 / 포기한 안 / 회고.
+
+## 기술적 의의
+
+- target-type 일반화로 사주 검증 시스템을 본인 1명 패턴 발견 시스템으로 확장. 사주 갑자와 라이프 통념(요일·계절 등)을 동일 통계 파이프라인에서 처리
+- Frequentist(Fisher + BH-FDR)와 Bayesian(Beta-Binomial posterior)을 병기해 n=1 환경의 누적 단계별 신뢰도 추정 강화
+- LLM 자율 매트릭 + 사용자 승인 게이트로 결정론과 자율 영역의 신뢰 비용 분리 유지

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -602,6 +602,42 @@ TODO: #408 Phase 5-B(영향력 데이터 expose) 완료 후 view 확장 + 풀이
 
 설계 결정 배경: [ADR-0020](../adr/0020-fortune-system-responsibility-split-via-view.md) — 사주 풀이 시스템과 v2 매칭 시스템 책임 분리 + view 인터페이스 도입.
 
+### 14. 본인 1명 패턴 발견 시스템 — Phase 1 (스키마 일반화)
+
+> TODO(`/build`): 구현 후 본문 채우기. target_type enum 확장(`life_signal`), `saju_signal_metrics` 컬럼 추가(description NOT NULL, window_days, hit/miss/inconclusive counts, status, source, proposed_at/approved_at, posterior_alpha/beta/p), `saju_signal_summary` view 신설, 결정론 매트릭 description backfill, seed_kind 컬럼 + CHECK constraint
+
+설계 결정 배경: [ADR-0022](../adr/0022-target-type-generalization.md), [ADR-0023](../adr/0023-metric-unit-counter-and-summary-view.md), [ADR-0024](../adr/0024-bayesian-posterior-update.md), [ADR-0025](../adr/0025-llm-metric-approval-gate.md)
+
+### 15. 본인 1명 패턴 발견 시스템 — Phase 2 (사주 시드 풀 셋)
+
+> TODO(`/build`): 구현 후 본문 채우기. Phase 3에서 작성된 사주 시드 카탈로그 풀(전체) 검토 + 누락 보완 (s1 일부만 작성된 상태에서 풀 셋으로). 누락 시드 식별 방법, 추가 시드 목록, 매트릭 description 작성
+
+### 16. 본인 1명 패턴 발견 시스템 — Phase 3 (life_signal 시드 풀 셋)
+
+> TODO(`/build`): 구현 후 본문 채우기. `life_signal` 시드 1차 셋(14\~20개 — 요일 7 + 주말 1 + 평일 1 + 월말 1 + 월초 1 + 계절 4 + 기타). 각 시드의 매트릭(SQL + window_days + description). 결정론 매트릭으로 작성
+
+### 17. 본인 1명 패턴 발견 시스템 — Phase 4 (매칭 cron + view 정비)
+
+> TODO(`/build`): 구현 후 본문 채우기. `daily-saju-matching` cron이 `target_type='life_signal'`도 처리하도록 확장. `saju_signal_summary` view 본문 작성 + 사용 예시. 카운트 UPDATE 로직 변경
+
+### 18. 본인 1명 패턴 발견 시스템 — Phase 5 (가설 발견·검증 업데이트)
+
+> TODO(`/build`): 구현 후 본문 채우기. `hypothesis-discovery`가 `life_signal` trigger 포함하도록 일반화. weekly 가설 리뷰 카드 본문에 seed_kind 표시. 검증 매트릭 수 증가에 따른 BH-FDR 그룹 정의
+
+### 19. 본인 1명 패턴 발견 시스템 — Phase 6 (LLM 자율 매트릭 + 승인 게이트)
+
+> TODO(`/build`): 구현 후 본문 채우기. 월간 LLM 슬롯이 매트릭 후보 생성, 월 cap 5개. Slack `/insight metric-approve` 명령어 + Block Kit 승인 카드 (`metric-approval-cards.ts`). 승인 시 status='active' 전환. 거절 시 status='rejected'
+
+### 20. 본인 1명 패턴 발견 시스템 — Phase 7 (Bayesian update)
+
+> TODO(`/build`): 구현 후 본문 채우기. `src/shared/bayesian-posterior.ts` 헬퍼(\~100줄), Beta-Binomial 사후 갱신, posterior_p UPDATE. 가설 카드에 frequentist p값 + Bayesian posterior 병기. beta inverse CDF 라이브러리 선택
+
+### 21. 본인 1명 패턴 발견 시스템 — Phase 8 (인사이트 카드 UI + 마스터 close)
+
+> TODO(`/build`): 구현 후 본문 채우기. `#insight` 채널 패턴 발견 카드 (Block Kit). `life_signal` 패턴(요일 효과 등)도 같은 카드에서 출력. 마스터 회고 + 운영 1\~3개월 후 follow-up 이슈 7건 일괄 등록 (SPRT, Change Point Detection, informed prior, 카테고리 가중치 자동 튜닝, 가설 자동 제거, 매트릭 자동 비활성화, 웹 대시보드 승인 페이지)
+
+설계 결정 배경: [design-notebook personal-pattern-discovery](../design-notebook/personal-pattern-discovery.md)
+
 ## 파일 구조
 
 ```

--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -11,6 +11,19 @@
 
 ---
 
+## 2026-05-27: 프로액티브 인사이트 v2 close + 본인 1명 패턴 발견 시스템 신규 마스터 (#393 close, #434 open)
+
+마스터 #393 (사주 검증 시스템) close + 마스터 #434 (본인 1명 패턴 발견 시스템) open. 정체성 재정의 — 사주 단일 검증 → 사주 + 라이프 통념 통합 가설-검증 파이프라인.
+
+- **마스터 #393 누적**: Phase 1\~4 머지 완료 (\~13일). SQL 결정론 11종, LLM 자율 슬롯 + outcome 검증, 사주 60갑자 일일 매칭, 가설-검증 정량 파이프라인(Fisher + BH-FDR)
+- **마스터 #434 setup**: 5어휘 데이터 모델 분리(시드 → 매트릭 → 매칭 → 가설 → 검증), target-type 일반화(`life_signal` 추가), 매트릭 단위 카운터 + view derive, Beta-Binomial Bayesian posterior 도입, LLM 자율 매트릭 승인 게이트. 8-Phase 흐름 설계
+- **분리 트랙 유지**: Phase 5 (#408, 월운 매칭) — 검증 사이클 길이 차이로 본격 진입 보류 정책 계승. 운영 1\~3개월 누적 후 본격 인터뷰
+- **헌장 계승 + 확장**: v2 헌장 4개(LLM 텍스트 의존 최소화 / 결정론↔자율 분리 / outcome 검증 / 신뢰 비용 분리) 그대로 + 마스터 #434 자체 헌장 5개 추가(n=1 single-case design / 5어휘 분리 / target-type 일반화 / 승인 게이트 / Bayesian + frequentist 병기)
+
+설계 판단 → [ADR-0022](adr/0022-target-type-generalization.md), [ADR-0023](adr/0023-metric-unit-counter-and-summary-view.md), [ADR-0024](adr/0024-bayesian-posterior-update.md), [ADR-0025](adr/0025-llm-metric-approval-gate.md). 마스터 서사 → [design-notebook/personal-pattern-discovery.md](design-notebook/personal-pattern-discovery.md). v2 close 서사 → [design-notebook/insight-engine-v2.md](design-notebook/insight-engine-v2.md#마스터-close-2026-05-27).
+
+---
+
 ## 2026-05-26: 사주 풀이 시스템 책임 분리 + 주간 사주 회고 v2 (#421, PR #422·#423)
 
 사주 풀이 routine과 v2 매칭 시스템 사이의 데이터 흐름을 정리.


### PR DESCRIPTION
## 관련 이슈

Closes #393

마스터 #434 (본인 1명 패턴 발견 시스템) setup. #434는 Phase 1~8 누적 머지 후 마스터 close 예정.

## 변경 내용

문서 산출물 4개 분리 커밋:

1. **ADR-0022~0025** — 마스터 #434 핵심 결정 4건
   - 0022: target_type 일반화 (saju 6종 + life_signal 신설, seed_kind 컬럼)
   - 0023: metric 단위 hit/miss/inconclusive 카운터 + saju_signal_summary view derive
   - 0024: Beta-Binomial Bayesian posterior 컬럼 (frequentist와 병행)
   - 0025: LLM 매트릭 승인 게이트 (status/source + 자연어 description)

2. **design-notebook 2건**
   - `insight-engine-v2.md` — 마스터 close 섹션 추가 (정체성 진화, Phase 1~4 누적 결과, Phase 5 별도 트랙 유지)
   - `personal-pattern-discovery.md` (NEW) — 마스터 #434 서사. 자체 헌장 5개 + 8-Phase 골격 + 부록 A 5어휘 빠른 참조

3. **domains/insight.md** — Phase 1~8 골격 섹션 추가 (TODO 마커, 본문은 각 phase /build가 채움)

4. **project-history.md** — 2026-05-27 마일스톤 추가

## 코드 변경

없음. 문서만 변경.

## 다음 단계

본 PR 머지 후 별도 이슈/브랜치 (`feature/<phase1-issue>-schema-generalization`)에서 Phase 1 (스키마 일반화) 구현. 계획서: `.claude/plans/434-phase-1-schema.md`

## 코드 리뷰 결과

- [x] 보안 감사 통과 (문서만 변경, 민감 정보 없음)
- [x] 컨벤션 점검 완료 (ADR 포맷, design-notebook 구조)
- [x] 도메인 문서 골격 누락 방지 검증 (sections 14~21)

## 테스트

문서 변경이라 별도 테스트 없음. CI lint 통과 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)