### PR TITLE
feat(insight): 사주 시드 풀세트 + evidence-only no_metric (마스터 #434 Phase 2)

### DIFF
--- a/db/migrations/069_pattern_matches_no_metric.sql
+++ b/db/migrations/069_pattern_matches_no_metric.sql
@@ -1,0 +1,37 @@
+-- 069: pattern_matches.matched NULL 허용 + verify_status 'no_metric' 추가
+-- 마스터 #434 Phase 2.
+-- ADR-0027 (LLM 비동기 routine 통일) — Phase 6 LLM 매트릭 제안 슬롯이 사용할
+-- evidence-only 풀셋 시드(매트릭 없음) 운영을 위해 채점 스킵 경로 추가.
+--
+-- 변경:
+--   1) pattern_matches.matched NOT NULL → NULL 허용
+--      (매트릭 없는 시드는 trigger만 평가, hit/miss 채점 보류)
+--   2) verify_status CHECK constraint에 'no_metric' 추가
+--      ('pending','hit','miss','inconclusive','no_metric')
+--   3) idx_pattern_matches_no_metric 부분 인덱스
+--      Phase 6 LLM 매트릭 제안 슬롯이 'no_metric' 행을 user_id+date로 빠르게 SELECT
+
+BEGIN;
+
+-- 1) matched 컬럼 NULL 허용
+ALTER TABLE pattern_matches
+  ALTER COLUMN matched DROP NOT NULL;
+
+-- 2) verify_status enum 확장
+ALTER TABLE pattern_matches
+  DROP CONSTRAINT IF EXISTS saju_daily_matches_verify_status_check;
+ALTER TABLE pattern_matches
+  DROP CONSTRAINT IF EXISTS pattern_matches_verify_status_check;
+ALTER TABLE pattern_matches
+  ADD CONSTRAINT pattern_matches_verify_status_check
+    CHECK (verify_status IN ('pending','hit','miss','inconclusive','no_metric'));
+
+-- 3) no_metric 행 부분 인덱스 — Phase 6 evidence 풀 SELECT 가속
+CREATE INDEX IF NOT EXISTS idx_pattern_matches_no_metric
+  ON pattern_matches (user_id, date)
+  WHERE verify_status = 'no_metric';
+
+COMMENT ON COLUMN pattern_matches.matched IS
+  'NULL(매트릭 없음, verify_status=no_metric) / true(hit) / false(miss). ADR-0027 Phase 2 evidence-only 운영.';
+
+COMMIT;

--- a/db/migrations/070_saju_seed_pool.sql
+++ b/db/migrations/070_saju_seed_pool.sql
@@ -1,0 +1,1154 @@
+-- 070: 마스터 #434 Phase 2 — 사주 시드 풀세트 161개 INSERT
+-- 자동 생성: scripts/generate-saju-seed-pool.ts
+-- 풀셋은 매트릭 없이 등록 (evidence-only). pattern_matches.matched=NULL,
+-- verify_status='no_metric'. 60+일 evidence 누적 → Phase 6 LLM 매트릭 제안 슬롯
+-- 가설 후보 풀로 활용 (ADR-0027).
+--
+-- 본인 컨텍스트 (user_id=1): 일간 경금 / 일지 술토 / 본명 갑경경경 자술술술
+-- 자수 십신 정정: 자 = 상관 (사용자 임상, 식신 X)
+
+BEGIN;
+
+-- ── 1) STEM 풀셋 (신규 2개: 을 정재, 신 겁재) ──
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM stems_master WHERE name='을';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_을_천간', '정재', $desc$을목 천간 발현일 — 정재(안정적 재물 관리, 계획적 소비, 꾸준한 일정 진행)$desc$, 'stem', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM stems_master WHERE name='신';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_신_천간', '겁재', $desc$신금 천간 발현일 — 겁재(경쟁심·과시·이성 관심)$desc$, 'stem', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+-- ── 2) BRANCH 풀셋 단일 (신규 9개: 자, 축, 인, 묘, 진, 사, 미, 신, 유) ──
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='자';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_자_지지', '상관', $desc$자수 지지 발현일 — 상관(충동적 식사·배달·과식, 다 뒤집어 엎기·전면 개편, 관성 충돌)$desc$, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='축';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_축_지지', '정인', $desc$축토 지지 발현일 — 정인(차분한 휴식·내면 안정·잔잔한 회복)$desc$, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='인';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_인_지지', '편재', $desc$인목 지지 발현일 — 편재(새로운 시작·역동, 재물 활성)$desc$, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='묘';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_묘_지지', '정재', $desc$묘목 지지 발현일 — 정재(꾸준한 노력·계획적 진행)$desc$, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='진';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_진_지지', '편인', $desc$진토 지지 발현일 — 편인(침묵·내면 침잠·과거 기억, 본인 일지 술 충 동반 가능성)$desc$, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='사';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_사_지지', '편관', $desc$사화 지지 발현일 — 편관(추진·도전 + 신체 증상: 대상포진·피부 트러블·탈진. 사술원진/오행 쏠림 동반 시 강화 — 분리 검증 필요)$desc$, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='미';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_미_지지', '정인', $desc$미토 지지 발현일 — 정인(부드러운 휴식·따뜻한 분위기)$desc$, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='신';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_신_지지', '비견', $desc$신금 지지 발현일 — 비견(자기 동질감·동기 영역, 비견 충돌 가능)$desc$, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='유';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_유_지지', '겁재', $desc$유금 지지 발현일 — 겁재(경쟁·과시·이성 관심)$desc$, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+-- ── 3) GANJI 풀셋 (신규 60개 — 60갑자 콤보) ──
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '갑' AND b.name = '자';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_갑자', NULL, $desc$갑자 60갑자일 — 갑(편재) + 자(상관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '을' AND b.name = '축';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_을축', NULL, $desc$을축 60갑자일 — 을(정재) + 축(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '병' AND b.name = '인';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_병인', NULL, $desc$병인 60갑자일 — 병(편관) + 인(편재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '정' AND b.name = '묘';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_정묘', NULL, $desc$정묘 60갑자일 — 정(정관) + 묘(정재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '무' AND b.name = '진';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_무진', NULL, $desc$무진 60갑자일 — 무(편인) + 진(편인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '기' AND b.name = '사';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_기사', NULL, $desc$기사 60갑자일 — 기(정인) + 사(편관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '경' AND b.name = '오';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_경오', NULL, $desc$경오 60갑자일 — 경(비견) + 오(정관) 콤보 — 본인 일간 비화$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '신' AND b.name = '미';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_신미', NULL, $desc$신미 60갑자일 — 신(겁재) + 미(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '임' AND b.name = '신';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_임신', NULL, $desc$임신 60갑자일 — 임(식신) + 신(비견) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '계' AND b.name = '유';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_계유', NULL, $desc$계유 60갑자일 — 계(상관) + 유(겁재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '갑' AND b.name = '술';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_갑술', NULL, $desc$갑술 60갑자일 — 갑(편재) + 술(편인) 콤보 — 본인 일지 비화$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '을' AND b.name = '해';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_을해', NULL, $desc$을해 60갑자일 — 을(정재) + 해(식신) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '병' AND b.name = '자';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_병자', NULL, $desc$병자 60갑자일 — 병(편관) + 자(상관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '정' AND b.name = '축';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_정축', NULL, $desc$정축 60갑자일 — 정(정관) + 축(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '무' AND b.name = '인';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_무인', NULL, $desc$무인 60갑자일 — 무(편인) + 인(편재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '기' AND b.name = '묘';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_기묘', NULL, $desc$기묘 60갑자일 — 기(정인) + 묘(정재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '경' AND b.name = '진';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_경진', NULL, $desc$경진 60갑자일 — 경(비견) + 진(편인) 콤보 — 본인 일간 비화$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '신' AND b.name = '사';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_신사', NULL, $desc$신사 60갑자일 — 신(겁재) + 사(편관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '임' AND b.name = '오';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_임오', NULL, $desc$임오 60갑자일 — 임(식신) + 오(정관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '계' AND b.name = '미';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_계미', NULL, $desc$계미 60갑자일 — 계(상관) + 미(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '갑' AND b.name = '신';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_갑신', NULL, $desc$갑신 60갑자일 — 갑(편재) + 신(비견) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '을' AND b.name = '유';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_을유', NULL, $desc$을유 60갑자일 — 을(정재) + 유(겁재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '병' AND b.name = '술';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_병술', NULL, $desc$병술 60갑자일 — 병(편관) + 술(편인) 콤보 — 본인 일지 비화$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '정' AND b.name = '해';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_정해', NULL, $desc$정해 60갑자일 — 정(정관) + 해(식신) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '무' AND b.name = '자';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_무자', NULL, $desc$무자 60갑자일 — 무(편인) + 자(상관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '기' AND b.name = '축';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_기축', NULL, $desc$기축 60갑자일 — 기(정인) + 축(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '경' AND b.name = '인';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_경인', NULL, $desc$경인 60갑자일 — 경(비견) + 인(편재) 콤보 — 본인 일간 비화$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '신' AND b.name = '묘';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_신묘', NULL, $desc$신묘 60갑자일 — 신(겁재) + 묘(정재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '임' AND b.name = '진';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_임진', NULL, $desc$임진 60갑자일 — 임(식신) + 진(편인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '계' AND b.name = '사';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_계사', NULL, $desc$계사 60갑자일 — 계(상관) + 사(편관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '갑' AND b.name = '오';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_갑오', NULL, $desc$갑오 60갑자일 — 갑(편재) + 오(정관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '을' AND b.name = '미';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_을미', NULL, $desc$을미 60갑자일 — 을(정재) + 미(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '병' AND b.name = '신';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_병신', NULL, $desc$병신 60갑자일 — 병(편관) + 신(비견) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '정' AND b.name = '유';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_정유', NULL, $desc$정유 60갑자일 — 정(정관) + 유(겁재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '무' AND b.name = '술';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_무술', NULL, $desc$무술 60갑자일 — 무(편인) + 술(편인) 콤보 — 본인 일지 비화$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '기' AND b.name = '해';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_기해', NULL, $desc$기해 60갑자일 — 기(정인) + 해(식신) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '경' AND b.name = '자';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_경자', NULL, $desc$경자 60갑자일 — 경(비견) + 자(상관) 콤보 — 본인 일간 비화$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '신' AND b.name = '축';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_신축', NULL, $desc$신축 60갑자일 — 신(겁재) + 축(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '임' AND b.name = '인';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_임인', NULL, $desc$임인 60갑자일 — 임(식신) + 인(편재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '계' AND b.name = '묘';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_계묘', NULL, $desc$계묘 60갑자일 — 계(상관) + 묘(정재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '갑' AND b.name = '진';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_갑진', NULL, $desc$갑진 60갑자일 — 갑(편재) + 진(편인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '을' AND b.name = '사';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_을사', NULL, $desc$을사 60갑자일 — 을(정재) + 사(편관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '병' AND b.name = '오';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_병오', NULL, $desc$병오 60갑자일 — 병(편관) + 오(정관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '정' AND b.name = '미';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_정미', NULL, $desc$정미 60갑자일 — 정(정관) + 미(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '무' AND b.name = '신';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_무신', NULL, $desc$무신 60갑자일 — 무(편인) + 신(비견) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '기' AND b.name = '유';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_기유', NULL, $desc$기유 60갑자일 — 기(정인) + 유(겁재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '경' AND b.name = '술';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_경술', NULL, $desc$경술 60갑자일 — 경(비견) + 술(편인) 콤보 — 본인 일주와 동일$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '신' AND b.name = '해';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_신해', NULL, $desc$신해 60갑자일 — 신(겁재) + 해(식신) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '임' AND b.name = '자';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_임자', NULL, $desc$임자 60갑자일 — 임(식신) + 자(상관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '계' AND b.name = '축';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_계축', NULL, $desc$계축 60갑자일 — 계(상관) + 축(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '갑' AND b.name = '인';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_갑인', NULL, $desc$갑인 60갑자일 — 갑(편재) + 인(편재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '을' AND b.name = '묘';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_을묘', NULL, $desc$을묘 60갑자일 — 을(정재) + 묘(정재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '병' AND b.name = '진';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_병진', NULL, $desc$병진 60갑자일 — 병(편관) + 진(편인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '정' AND b.name = '사';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_정사', NULL, $desc$정사 60갑자일 — 정(정관) + 사(편관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '무' AND b.name = '오';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_무오', NULL, $desc$무오 60갑자일 — 무(편인) + 오(정관) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '기' AND b.name = '미';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_기미', NULL, $desc$기미 60갑자일 — 기(정인) + 미(정인) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '경' AND b.name = '신';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_경신', NULL, $desc$경신 60갑자일 — 경(비견) + 신(비견) 콤보 — 본인 일간 비화$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '신' AND b.name = '유';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_신유', NULL, $desc$신유 60갑자일 — 신(겁재) + 유(겁재) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '임' AND b.name = '술';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_임술', NULL, $desc$임술 60갑자일 — 임(식신) + 술(편인) 콤보 — 본인 일지 비화$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '계' AND b.name = '해';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_계해', NULL, $desc$계해 60갑자일 — 계(상관) + 해(식신) 콤보$desc$, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+-- ── 4) ELEMENT_DENSITY 풀셋 (신규 9개 — 토_과다는 S5 보존) ──
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_목_과다', NULL, $desc$목 오행 과다일 (10자 중 3+) — 재다신약(편재·정재 폭주, 일간 약화)$desc$, 'element_density', NULL, '{"element":"목","min_count":3}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_화_과다', NULL, $desc$화 오행 과다일 (10자 중 3+) — 화극금(본인 일간 경금 피해, 신체적 피로·발열·피부 트러블)$desc$, 'element_density', NULL, '{"element":"화","min_count":3}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_금_과다', NULL, $desc$금 오행 과다일 (10자 중 3+) — 비견·겁재 폭주, 자기주장·고집$desc$, 'element_density', NULL, '{"element":"금","min_count":3}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_수_과다', NULL, $desc$수 오행 과다일 (10자 중 3+) — 식상 폭주, 식사·창작·말 많음$desc$, 'element_density', NULL, '{"element":"수","min_count":3}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_목_부재', NULL, $desc$목 오행 부재일 (10자 중 0) — 편재·정재 결핍, 동력 부족$desc$, 'element_density', NULL, '{"element":"목","max_count":0}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_화_부재', NULL, $desc$화 오행 부재일 (10자 중 0) — 관성 결핍, 책임 회피 경향$desc$, 'element_density', NULL, '{"element":"화","max_count":0}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_토_부재', NULL, $desc$토 오행 부재일 (10자 중 0) — 인성 결핍, 의지처 부족$desc$, 'element_density', NULL, '{"element":"토","max_count":0}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_금_부재', NULL, $desc$금 오행 부재일 (10자 중 0) — 일간 동기 결핍, 자신감 저하$desc$, 'element_density', NULL, '{"element":"금","max_count":0}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_수_부재', NULL, $desc$수 오행 부재일 (10자 중 0) — 식상 결핍, 표현·먹기 저하$desc$, 'element_density', NULL, '{"element":"수","max_count":0}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+-- ── 5) SIBIUNSUNG 풀셋 (신규 11개 — S6 사·묘 통합에 포함된 묘 제외) ──
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_장생', NULL, $desc$장생일 — 새로운 시작·기획·신선한 에너지$desc$, 'sibiunsung', NULL, '{"states":["장생"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_목욕', NULL, $desc$목욕일 — 변화·정리·기분 전환$desc$, 'sibiunsung', NULL, '{"states":["목욕"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_관대', NULL, $desc$관대일 — 성숙·책임감 강화$desc$, 'sibiunsung', NULL, '{"states":["관대"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_건록', NULL, $desc$건록일 — 활력·열정·업무 폭주·운동 잘됨$desc$, 'sibiunsung', NULL, '{"states":["건록"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_제왕', NULL, $desc$제왕일 — 최고 활력·자기 주장 강화$desc$, 'sibiunsung', NULL, '{"states":["제왕"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_쇠', NULL, $desc$쇠일 — 활력 저하·정리 단계$desc$, 'sibiunsung', NULL, '{"states":["쇠"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_병', NULL, $desc$병일 — 컨디션 저하·신체 증상 주의$desc$, 'sibiunsung', NULL, '{"states":["병"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_사', NULL, $desc$사일 — 단절 + 체력 저하·몸 무거움·지침$desc$, 'sibiunsung', NULL, '{"states":["사"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_절', NULL, $desc$절일 — 단절·새 출발 직전 침잠$desc$, 'sibiunsung', NULL, '{"states":["절"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_태', NULL, $desc$태일 — 잠재·내부 성장 단계$desc$, 'sibiunsung', NULL, '{"states":["태"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_양', NULL, $desc$양일 — 부드러운 회복·따뜻함$desc$, 'sibiunsung', NULL, '{"states":["양"]}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+-- ── 6) RELATION 풀셋 (신규 70개) ──
+-- 지지 관계 (61개) — branch_relations LOOP, 기존 N3(진술충)/S2(사술원진) 제외
+DO $$
+DECLARE rel RECORD;
+  desc_text TEXT;
+  aux_json JSONB;
+  name_text TEXT;
+  ba_sipsin TEXT;
+  bb_sipsin TEXT;
+  natal_member TEXT;
+  is_existing BOOLEAN;
+BEGIN
+  FOR rel IN
+    SELECT br.relation_type, ba.name AS ba_name, bb.name AS bb_name
+      FROM branch_relations br
+      JOIN branches_master ba ON ba.id = br.branch_a_id
+      JOIN branches_master bb ON bb.id = br.branch_b_id
+      ORDER BY br.id
+  LOOP
+    -- 기존 시드 제외 (진-술 충, 사-술 원진)
+    is_existing := (rel.ba_name = '진' AND rel.bb_name = '술' AND rel.relation_type = '충')
+                OR (rel.ba_name = '술' AND rel.bb_name = '진' AND rel.relation_type = '충')
+                OR (rel.ba_name = '사' AND rel.bb_name = '술' AND rel.relation_type = '원진')
+                OR (rel.ba_name = '술' AND rel.bb_name = '사' AND rel.relation_type = '원진');
+    IF is_existing THEN
+      CONTINUE;
+    END IF;
+
+    name_text := 'pool_' || rel.relation_type || '_' || rel.ba_name || rel.bb_name;
+    desc_text := '지지 ' || rel.relation_type || ' 발현일 — ' || rel.ba_name || '·' || rel.bb_name;
+
+    -- 본인 일지(술) 또는 본명 지지(자/술)와 관련된 관계는 추가 단서
+    IF rel.ba_name = '술' OR rel.bb_name = '술' THEN
+      desc_text := desc_text || ' (본인 일지 ' || rel.relation_type || ', 자기 영역 흔들림)';
+    ELSIF rel.ba_name = '자' OR rel.bb_name = '자' THEN
+      desc_text := desc_text || ' (본인 본명 자 ' || rel.relation_type || ')';
+    END IF;
+
+    aux_json := jsonb_build_object(
+      'type', 'branch_' || rel.relation_type,
+      'members', jsonb_build_array(rel.ba_name, rel.bb_name)
+    );
+
+    INSERT INTO pattern_catalog
+      (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, name_text, NULL, desc_text, 'relation', NULL, aux_json, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+  END LOOP;
+END $$;
+
+-- 천간 관계 (11개) — stem_relations LOOP
+DO $$
+DECLARE rel RECORD;
+  desc_text TEXT;
+  aux_json JSONB;
+  name_text TEXT;
+BEGIN
+  FOR rel IN
+    SELECT sr.relation_type, sa.name AS sa_name, sb.name AS sb_name
+      FROM stem_relations sr
+      JOIN stems_master sa ON sa.id = sr.stem_a_id
+      JOIN stems_master sb ON sb.id = sr.stem_b_id
+      ORDER BY sr.id
+  LOOP
+    name_text := 'pool_' || rel.relation_type || '_' || rel.sa_name || rel.sb_name;
+    desc_text := '천간 ' || rel.relation_type || ' 발현일 — ' || rel.sa_name || '·' || rel.sb_name;
+
+    -- 본인 본명 천간(갑/경)과 관련된 관계는 추가 단서
+    IF rel.sa_name = '경' OR rel.sb_name = '경' THEN
+      desc_text := desc_text || ' (본인 일간 ' || rel.relation_type || ')';
+    ELSIF rel.sa_name = '갑' OR rel.sb_name = '갑' THEN
+      desc_text := desc_text || ' (본인 본명 갑 ' || rel.relation_type || ')';
+    END IF;
+
+    aux_json := jsonb_build_object(
+      'type', 'stem_' || rel.relation_type,
+      'members', jsonb_build_array(rel.sa_name, rel.sb_name)
+    );
+
+    INSERT INTO pattern_catalog
+      (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, name_text, NULL, desc_text, 'relation', NULL, aux_json, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+  END LOOP;
+END $$;
+
+COMMIT;
+

--- a/docs/adr/0027-llm-async-routine-unification.md
+++ b/docs/adr/0027-llm-async-routine-unification.md
@@ -1,0 +1,95 @@
+# 0027. LLM 비동기 작업 Claude 앱 routines 기반 통일
+
+- Status: Accepted
+- Date: 2026-05-28
+- Related: #434, #437, PR TBD
+- Tags: process, llm, infra, ops
+
+## Context
+
+이 프로젝트에는 LLM 호출이 들어가는 비실시간(스케줄러 기반) 작업이 다수 존재한다. 마스터 #421 (사주 풀이 책임 분리) 진행 중 `weekly-saju-review-v2`를 **Claude 앱의 routines 기능 기반**으로 운영하는 패턴을 도입했고, 이후 신규/기존 LLM 비동기 작업이 두 가지 운영 패턴으로 공존하게 되었다.
+
+| 패턴 | 위치 | 비용 | 현재 작업 |
+|------|------|------|-----------|
+| Node.js cron (`node-cron`) | 봇 서버 (Oracle VM Docker) | Claude API 키 호출(=종량) | morning/night insight, weekly-report, weekly-llm-insight, monthly-llm-insight, diary-meta-extract |
+| Claude 앱 routines | 사용자 Claude 앱 (구독료에 포함된 Opus) | 구독료 잠금(추가 종량 X) | weekly-saju-review-v2 |
+
+문제:
+
+- 신규 LLM 비동기 작업 진입 시(예: 마스터 #434 Phase 6 LLM 매트릭 제안 슬롯) **어느 쪽으로 운영해야 하는지 일관된 기준 없음**
+- 두 패턴이 임의로 섞이면 SKILL.md 위치(repo 외부) ↔ 코드(repo) 분기점이 흐려져 운영 부담
+- 사용자 명시: "실시간 답변이 아닌 건 무조건 routines" (2026-05-28 마스터 #434 Phase 2 인터뷰)
+
+## Decision
+
+**LLM 호출 들어가는 비실시간 작업은 모두 Claude 앱 routines로 운영**한다. 결정론 cron(LLM 호출 없는 SQL/평가 작업)은 Node.js cron을 유지한다.
+
+분류 기준:
+
+| 작업 유형 | 운영 방식 | 예 |
+|-----------|-----------|----|
+| LLM 호출 있는 비실시간 작업 | **Claude 앱 routines** | morning/night insight, weekly-report, weekly-llm, monthly-llm, diary-meta-extract, weekly-saju-review-v2, 마스터 #434 Phase 6 매트릭 제안 |
+| 결정론 SQL/평가 (LLM 호출 없음) | Node.js cron 유지 | daily-saju-matching, verify-llm-insights, weekly-hypothesis-review, 마스터 #434 Phase 4 매칭 cron 확장 |
+| Slack 실시간 응답 (fast path / 자연어 대화) | 봇 서버 (현재 유지) | fast path 명령어, 자연어 대화 응답 |
+
+신규 LLM 비동기 작업 등록 절차:
+
+1. `mcp__scheduled-tasks__create_scheduled_task`로 routine 생성
+2. SKILL.md를 `~/.claude/scheduled-tasks/<task_id>/SKILL.md`에 작성 (repo 외부, git 비추적)
+3. `weekly-saju-review-v2`의 운영 패턴 그대로 적용 — model selector 사용자 직접 지정 (`opus` 명시), 결과는 `mcp__slack__slack_post_message`로 채널에 발송
+
+## Alternatives considered
+
+### A. 전체 Node.js cron 유지
+
+- 장점: 단일 운영 환경, 봇 서버 한 곳에 모든 스케줄 집중, 코드 가시성 ↑
+- 단점: Claude 앱 구독료에 포함된 Opus 사용량을 활용 불가 → 종량 API 키 호출이 누적됨. 구독료 잠금된 비용 vs 종량 누적의 트레이드오프에서 후자가 불리
+- 기각 이유: 비용 효율 + 사용자가 이미 구독 중인 Claude 앱 자원을 사용하는 게 자연스러움. 마스터 #421이 이미 routine 패턴 도입
+
+### B. 모든 비동기 작업 routine (결정론 포함)
+
+- 장점: 단일 운영 패턴, 분기 없음
+- 단점: 결정론 작업도 routine 호출 시 LLM 컨텍스트 로드가 일어남 → 토큰 낭비 + 단순 SQL 평가에 LLM 개입할 이유 없음. 결정론은 안정적 + 빠른 cron이 적합
+- 기각 이유: LLM 호출 없는 작업까지 routine으로 묶는 건 본질에 안 맞음
+
+### C. LLM 호출 비동기만 routine (선택)
+
+- 장점: LLM 호출 = 구독료 활용 + 결정론 = Node.js cron 유지로 분기 본질에 맞음. 비용/성능/단순성 균형
+- 단점: 운영 패턴이 2종 공존 → 신규 작업 진입 시 분류 판단 필요 (하지만 분류 기준이 명확하므로 부담 작음)
+
+## Consequences
+
+### 장점
+
+- LLM 호출 비용을 Claude 앱 구독료에 잠금 — 종량 API 키 누적 회피
+- 결정론 작업은 봇 서버에서 빠르게 처리(LLM 컨텍스트 로드 없음)
+- 신규 LLM 비동기 작업 등록 시 운영 패턴이 명확 — `weekly-saju-review-v2` 1건이 운영 검증 끝낸 상태(2026-06-01 첫 발송 예정)
+
+### 단점 / 제약
+
+- SKILL.md가 `~/.claude/scheduled-tasks/<id>/SKILL.md`에 있어 repo 외부 → 변경 이력이 git에 안 남음. 운영 노트는 design-notebook이나 도메인 문서에서 별도 기록 필요
+- 운영 패턴 2종 분기 — 결정론 ↔ LLM 비동기 경계가 모호한 작업이 나오면 case-by-case 판단 (분류 기준 표가 가이드)
+- routine 실패 시 fallback 경로 별도 — Slack DM 알림 or 다음 실행에서 누락 보완 패턴 설계 필요
+
+### 후속 작업
+
+기존 6건 LLM cron의 routine 이관 (follow-up 이슈로 분리):
+
+- [ ] morning 인사이트 routine 이관 (`life-cron.ts` 09:05 부분)
+- [ ] night 인사이트 routine 이관 (`life-cron.ts` 23:55 부분)
+- [ ] weekly-report routine 이관 (월요일 09:00)
+- [ ] weekly-llm-insight routine 이관 (월요일 09:30)
+- [ ] monthly-llm-insight routine 이관 (매월 1일 09:30)
+- [ ] diary-meta-extract routine 이관 (매일 23:55-05:30)
+
+이관 시점: 마스터 #434 Phase 2 PR 머지 후 점진. 각 이슈에 본 ADR link + `weekly-saju-review-v2` 마이그레이션 패턴 참조.
+
+마스터 #434 Phase 6 (LLM 매트릭 제안 슬롯)은 신규 작업이므로 처음부터 routine으로 등록.
+
+---
+
+**참고 자료**
+
+- 마스터 #421 PR #423 — `weekly-saju-review-v2` routine 패턴 첫 도입
+- [ADR-0016](0016-llm-autonomous-slot-outcome-verification.md) — LLM 자율 발견 슬롯 (Node.js cron 기반, 이관 follow-up 대상)
+- [ADR-0025](0025-llm-metric-approval-gate.md) — LLM 매트릭 승인 게이트 (Phase 6 routine 진입 정책의 직접 컨텍스트)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -133,6 +133,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0024](0024-bayesian-posterior-update.md) | Beta-Binomial Bayesian posterior 도입 — frequentist 검증과 병기 | Accepted | 2026-05-27 | data, statistics, insight |
 | [0025](0025-llm-metric-approval-gate.md) | LLM 자율 매트릭 승인 게이트 — `description NOT NULL` + Slack inline button | Accepted | 2026-05-27 | data, llm, ux |
 | [0026](0026-pattern-prefix-rename.md) | `pattern_*` prefix 전면 rename — saju_signal_* 잔존 결정 폐기 | Accepted | 2026-05-27 | data, insight, architecture, refactor |
+| [0027](0027-llm-async-routine-unification.md) | LLM 비동기 작업 Claude 앱 routines 기반 통일 | Accepted | 2026-05-28 | process, llm, infra, ops |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/personal-pattern-discovery.md
+++ b/docs/design-notebook/personal-pattern-discovery.md
@@ -70,7 +70,7 @@ LLM 매트릭은 월 최대 N개 cap(예: 5개)으로 슬롯 폭주 방지. 매�
 - [ ] **Phase 3**: `life_signal` 시드 풀 셋 — 요일(월\~일 7) / 주말(2) / 월말(1) / 월초(1) / 계절(4) 등 1차 셋. 결정론 매트릭으로 작성
 - [ ] **Phase 4**: 매칭 cron + view 정비 — 매칭 cron이 `trigger_target_type='life_signal'`도 처리하도록 확장. `pattern_summary` view 본문 작성
 - [ ] **Phase 5**: 가설 발견·검증 업데이트 — `hypothesis-discovery`가 `life_signal` trigger를 포함하도록 일반화. weekly 가설 리뷰 카드 본문에 출처(`pattern_kind`) 표시
-- [ ] **Phase 6**: LLM 자율 매트릭 + 승인 게이트 — 월간 LLM 슬롯이 매트릭 후보를 생성, Slack 승인 UI(`/insight metric-approve` + Block Kit inline button). 활성화된 매트릭만 매칭 cron 진입
+- [ ] **Phase 6**: LLM 자율 매트릭 + 승인 게이트 — 월간 LLM 슬롯이 매트릭 후보를 생성, Slack 승인 UI(`/insight metric-approve` + Block Kit inline button). 활성화된 매트릭만 매칭 cron 진입. **운영은 Claude 앱 routines 기반** ([ADR-0027](../adr/0027-llm-async-routine-unification.md))
 - [ ] **Phase 7**: Bayesian update 도입 — `posterior_p` 컬럼 채움. Beta-Binomial 사후 갱신 헬퍼(\~100줄). 가설 카드에 frequentist p값 + Bayesian posterior 병기
 - [ ] **Phase 8**: 인사이트 카드 UI + 마스터 close — `#insight` 채널 패턴 발견 카드(Block Kit). `life_signal` 패턴(요일 효과 등)도 같은 카드에서 출력. 마스터 회고 + 운영 1\~3개월 시점 follow-up 이슈 7건 일괄 등록
 
@@ -202,7 +202,74 @@ LLM 매트릭은 월 최대 N개 cap(예: 5개)으로 슬롯 폭주 방지. 매�
 
 ---
 
-## Phase 2\~8 (TODO: 각 Phase 진입 시 섹션 누적)
+## Phase 2: 사주 시드 풀세트 + 빈 매트릭 evidence-only (2026-05-28)
+
+- 이슈: [#437](https://github.com/hyewon3938/slack-ai-agents/issues/437)
+- 관련 ADR: [ADR-0023](../adr/0023-metric-unit-counter-and-summary-view.md), [ADR-0025](../adr/0025-llm-metric-approval-gate.md), **[ADR-0027](../adr/0027-llm-async-routine-unification.md) 신설**
+- 관련 계획서: `.claude/plans/434-phase-2-seed-pool.md`
+- 상태: 설계 완료, 구현 대기
+
+### 결정 요약
+
+사주 6종 풀세트 161개 신규 시드를 `pattern_catalog`에 박는다. 풀셋 단일 시드는 **매트릭 없이** 등록되며, 매일 09:00 매칭 cron이 trigger만 평가 + `pattern_matches.evidence` JSONB 누적. `matched=NULL` + `verify_status='no_metric'`로 hit/miss 채점 스킵. 60+일 evidence 누적 후 Phase 6 LLM 매트릭 제안 슬롯의 가설 후보 풀로 활용.
+
+| 종류 | 마스터 카운트 | 기존 시드 | 신규 시드 | 합계 |
+|---|---|---|---|---|
+| stem | 10 | 8 | 2 | 10 |
+| branch | 12 | 3 + 1 통합 | 9 | 13 (단일 12 + 통합 1) |
+| ganji | 60 | 0 | 60 | 60 |
+| element_density | 10 | 1 | 9 | 10 |
+| sibiunsung | 12 | 1 | 11 | 12 |
+| relation | 72 | 2 | 70 | 72 |
+| **합계** | **176** | **16** | **161** | **177** |
+
+신규 시드 이름은 `pool_<대상>_<카테고리>` 패턴 (예: `pool_갑_천간`, `pool_자_지지`, `pool_충_진술`). 기존 16개 시드는 이름 보존(운영 자산 우선). 통합 시드(N4_축미 / S6_사지묘지 / S2_사화_사술원진)와 풀셋 단일 시드 둘 다 유지 — 데이터 풍부도 우선, 단일 시드가 분리 검증을 제공.
+
+### 핵심 변경
+
+- **`pattern_matches.matched` NOT NULL → NULL 허용** (Migration 069)
+- **`verify_status` enum에 `'no_metric'` 추가** (Migration 069)
+- **시드 풀세트 INSERT** (Migration 070 + `scripts/generate-saju-seed-pool.ts`)
+- **`src/shared/saju-match.ts`** — 빈 매트릭 시드는 `matched=null`, recordDailyMatches가 `verify_status='no_metric'`로 INSERT, verifyDailyMatches는 자연스럽게 스킵
+- **ADR-0027 신설** — LLM 비동기 작업은 모두 Claude 앱 routines로 통일. Phase 6 매트릭 제안 슬롯은 처음부터 routine으로 등록. 기존 6건 LLM cron은 follow-up 이슈로 점진 이관
+
+### 의사결정 분기점
+
+1. **풀셋 범위** — 사주 6종 only (life_signal은 Phase 3) — life_signal과 책임 분리
+2. **시드 vs 매트릭** — 시드 풀셋 + 매트릭은 선별 + 빈 매트릭 evidence-only — 사용자 명시 ("매트릭은 전부 채우지 않아도 돼, 시드는 모두 등록")
+3. **통합 시드 처리** — 기존 통합 + 풀셋 단일 둘 다 유지 — 데이터 풍부도 우선
+4. **LLM 비동기 작업 운영** — Claude 앱 routines 통일 (ADR-0027) — 사용자 명시 "실시간 답변이 아닌 건 무조건 routines" → "LLM 호출 있는 비실시간 작업" 해석
+5. **Element density 판정 기준** — 본인 8자 + 일진 2자 = 10자 기준 3+ — 명리학적 정합성 + 운 반영
+6. **Relation 시드 trigger 표현** — `trigger_target_id=NULL` + `trigger_aux` JSONB (관계 명세) — relation은 단일 소속 아니므로 JSONB가 자연
+7. **description 형식** — `<대상> 발현일 — <십신>(<해석>)` 패턴 + 사용자 임상 데이터 — ADR-0025 `description NOT NULL`과 자연스러움
+
+### 사용자 임상 데이터 반영 (description에 박힘)
+
+- **자수 (지지) — 상관** (사용자 임상 정정, 식신 X) — 충동적 식사/배달/과식, 다 뒤집어 엎기·전면 개편, 관성 충돌
+- **갑목 (천간) — 편재** — 충동 지출·투자 명목 지출 주의, 일정 폭주·대청소·다 떠오름 (일을 많이 벌이는 경향)
+- **사화 (지지) — 편관** — 추진·도전 + 신체 증상(대상포진·피부 트러블·탈진). 사술원진/오행 쏠림 동반 시 강화 — 분리 검증 필요
+- **편인 (자기 일지 술토 / 진토 / 무토)** — 깊은 몰입, 철학적 사고, 영화·책 깊게 봄
+- **진술충** — 본인 일지 충, 자기 영역 흔들림, **과거 기억 문득문득 떠오름** ⚠️
+- **사술원진** — 본인 일지 원진, **부모님/전남친에 대한 원망 발현** 가능 ⚠️
+- **화 과다 (10자 중 3+)** — 화극금(본인 일간 경금 피해, 신체적 피로·발열·피부 트러블)
+- **목 과다 (10자 중 3+)** — 재다신약(편재·정재 폭주, 일간 약화)
+- **사 / 묘 (십이운성)** — 단절·체력 저하·몸 무거움·지침
+- **건록 / 제왕 (십이운성)** — 활력·열정·업무 폭주·운동 잘됨
+
+위 단서는 Phase 6 LLM이 evidence 60+일 보고 매트릭을 제안할 때 가설 hint로 활용. 단순 단일 시드(예: 사화) vs 복합 조건(사화 + 사술원진 / 사화 + 오행 쏠림)의 차별화는 Phase 6 자동 발견 후보.
+
+### 포기한 안 / 미룬 항목
+
+- **기존 16개 시드 이름 통일 마이그레이션** (`S1_갑목_편재_천간` → `pool_갑_천간`) — 운영 자산 보존 우선
+- **풀셋 + 매트릭 자동 매핑** — Phase 6 LLM이 evidence 보고 제안. 자동 매핑은 가설 공간 폭주
+- **사화 단독 vs 사술원진 vs 오행 쏠림 차별화** — description hint로 박아두고 Phase 6 자동 발견
+- **축토 정인 vs 미토 정인 차이** — Phase 6 자동 발견 후보
+
+### 회고 (TODO: `/build` 후 보강)
+
+---
+
+## Phase 3\~8 (TODO: 각 Phase 진입 시 섹션 누적)
 
 > 각 Phase 진입 시 `/design`이 본 문서에 해당 Phase 섹션을 추가한다. 템플릿: 결정 요약 / 의사결정 분기점 / 포기한 안 / 회고.
 

--- a/docs/design-notebook/personal-pattern-discovery.md
+++ b/docs/design-notebook/personal-pattern-discovery.md
@@ -265,7 +265,13 @@ LLM 매트릭은 월 최대 N개 cap(예: 5개)으로 슬롯 폭주 방지. 매�
 - **사화 단독 vs 사술원진 vs 오행 쏠림 차별화** — description hint로 박아두고 Phase 6 자동 발견
 - **축토 정인 vs 미토 정인 차이** — Phase 6 자동 발견 후보
 
-### 회고 (TODO: `/build` 후 보강)
+### 회고
+
+- **TypeScript 타입 변경의 파급 효과** — `SeedMatchResult.matched: boolean → boolean | null` 변경이 `compactMatchedLine`의 `filter((r) => r.matched)`에 자연스럽게 흡수됨 (null도 falsy). 명시적 분기를 추가하지 않고도 의도(evidence-only seed는 Slack 노출 안 함)가 표현됨 — 타입 시스템이 의도를 강제하는 좋은 사례
+- **migration 070 생성 전략** — 161개 시드 SQL을 직접 손으로 쓰지 않고 TypeScript 스크립트가 stdout으로 생성. 십신 매핑·description·기존 시드 제외 규칙을 코드로 표현해 휴먼 에러 차단. 다만 `EXISTING_RELATIONS` 상수가 정의됐지만 사용되지 않음(LOOP 내부 하드코딩으로 대체) — 다음 phase에서 일회성 스크립트 정리 시 제거 가능
+- **테스트 커버리지 trade-off** — `matchAllSeedsForDay`의 `matched=null` 분기를 직접 단위 테스트하려면 `getDayPillar`/`loadActiveSeeds`/`buildNameIdMap` 등을 새로 mocking해야 함. 3줄 ternary의 테스트 가치 < mocking 부담이라 판단, 대신 `evaluateTrigger`의 새 `relation {type, members}` 포맷을 5건 추가. 가설 후보 풀로 사용되는 trigger 평가가 더 중요한 검증 대상
+- **사용자 임상 단서 description 박기** — 명리학적 십신만 적는 게 아니라 사용자 본인이 실제로 관측한 단서(예: "진술충 → 과거 기억 문득문득 떠오름")를 description에 박음. Phase 6 LLM이 evidence 60+일 보고 매트릭 제안할 때 가설 hint로 활용 — 자료가 LLM의 가설 공간을 좁히는 역할
+- **ADR-0027 신설의 trigger** — Phase 2 인터뷰 중 Phase 6 LLM 매트릭 제안 슬롯을 어떻게 운영할지 분기점에서 발생. 사용자 명시 "실시간 답변이 아닌 건 무조건 routines" → 신규 ADR로 분리. 기존 Node.js cron 6건은 follow-up 이슈로 점진 이관 — 운영 패턴 통일이라 PR과 별도 트랙으로 분리하는 게 맞음
 
 ---
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -750,9 +750,95 @@ GROUP BY c.id;
 
 설계 결정 배경: [ADR-0022](../adr/0022-target-type-generalization.md) (Superseded by 0026), [ADR-0023](../adr/0023-metric-unit-counter-and-summary-view.md), [ADR-0024](../adr/0024-bayesian-posterior-update.md), [ADR-0025](../adr/0025-llm-metric-approval-gate.md), [ADR-0026](../adr/0026-pattern-prefix-rename.md)
 
-### 15. 본인 1명 패턴 발견 시스템 — Phase 2 (사주 시드 풀 셋)
+### 15. 본인 1명 패턴 발견 시스템 — Phase 2 (사주 시드 풀세트 + 빈 매트릭 evidence-only)
 
-> TODO(`/build`): 구현 후 본문 채우기. Phase 3에서 작성된 사주 시드 카탈로그 풀(전체) 검토 + 누락 보완 (s1 일부만 작성된 상태에서 풀 셋으로). 누락 시드 식별 방법, 추가 시드 목록, 매트릭 description 작성. `pattern_catalog`·`pattern_metrics` 어휘 기준.
+#### 시드 풀세트 카운트
+
+사주 6종 풀세트 161개 신규 시드를 `pattern_catalog`에 박는다. 풀셋 단일 시드는 매트릭 없이 등록되며, 매일 매칭 cron이 trigger만 평가하고 `pattern_matches.evidence` JSONB만 누적한다.
+
+| 종류 | 마스터 카운트 | 기존 시드 | 신규 시드 | 합계 |
+|------|------|------|------|------|
+| stem | 10 | 8 | 2 | 10 |
+| branch | 12 | 3 + 1 통합 | 9 | 13 (단일 12 + 통합 1) |
+| ganji | 60 | 0 | 60 | 60 |
+| element_density | 10 | 1 | 9 | 10 |
+| sibiunsung | 12 | 1 | 11 | 12 |
+| relation | 72 | 2 | 70 | 72 |
+| **합계** | **176** | **16** | **161** | **177** |
+
+신규 시드 이름은 `pool_<대상>_<카테고리>` 패턴 (예: `pool_갑_천간`, `pool_자_지지`, `pool_충_진술`). 기존 16개 시드는 이름 보존(운영 자산 우선). 통합 시드와 풀셋 단일 시드 둘 다 유지 — 데이터 풍부도 우선.
+
+#### 데이터 모델 변경
+
+| 마이그레이션 | 내용 |
+|------|------|
+| `069_pattern_matches_no_metric.sql` | `pattern_matches.matched` NOT NULL → NULL 허용. `verify_status` CHECK 재정의 (`'no_metric'` 추가). 부분 인덱스 `idx_pattern_matches_no_metric ON pattern_matches (user_id, date) WHERE verify_status='no_metric'` |
+| `070_saju_seed_pool.sql` | 신규 161개 시드 INSERT (`pattern_catalog`) + 같은 ID `pattern_metrics` row 생성. `ON CONFLICT DO NOTHING` (멱등). 풀셋 시드는 `pattern_metrics`에 row가 없으므로 evidence-only로 동작 |
+
+마이그레이션 070은 직접 SQL을 손으로 쓰지 않고 `scripts/generate-saju-seed-pool.ts`가 stdout으로 생성한 SQL을 파일로 저장한 형태. 십신 매핑·description·기존 시드 제외 규칙을 모두 TypeScript 코드로 표현해 휴먼 에러 차단.
+
+#### Evidence-only 흐름 (`src/shared/saju-match.ts`)
+
+매칭 결과 인터페이스 확장:
+
+```typescript
+export interface SeedMatchResult {
+  seed: SajuSeedWithMetrics;
+  triggerActivated: boolean;
+  metricEvaluations: MetricEvaluation[];
+  matched: boolean | null;       // 매트릭 없으면 null
+  isEvidenceOnly: boolean;       // seed.metrics.length === 0
+}
+```
+
+매칭 cron 분기:
+
+```
+matched        = isEvidenceOnly ? null : triggerActivated && passed
+verify_status  = isEvidenceOnly ? 'no_metric' : 'pending'
+```
+
+`verifyDailyMatches`는 `verify_status='pending'` 행만 평가하므로 `no_metric` 행은 자연 스킵. 누적된 `evidence` JSONB는 Phase 6 LLM 매트릭 제안 슬롯의 가설 후보 풀로 사용.
+
+#### 시드별 trigger 표현
+
+| 종류 | trigger_target_type | trigger_target | trigger_aux |
+|------|------|------|------|
+| stem | `stem` | 천간 1자 | — |
+| branch | `branch` | 지지 1자 | — |
+| ganji | `ganji` | 갑자 1조 | — |
+| element_density | `element_density` | NULL | `{"element": "화", "mode": "over"}` 또는 `"lack"` (10자 기준 3+/0) |
+| sibiunsung | `sibiunsung` | NULL | `{"name": "장생"}` 등 |
+| relation | `relation` | NULL | `{"type": "branch_clash", "members": ["진", "술"]}` 등 (`branch_*` / `stem_*` prefix) |
+
+기존 `relation` 시드는 `{"day_branch": ..., "natal_branches": [...], "relation_types": [...]}` 포맷도 유지 (regression 방지). `evaluateTrigger`에서 새 `{type, members}` 포맷을 먼저 처리하고 폴백.
+
+#### 사용자 임상 단서를 description에 박기
+
+description 형식: `<대상> 발현일 — <십신>(<해석 + 사용자 임상 단서>)`. 사용자가 실제로 그날 어떤 패턴이 나타났는지 임상적으로 관측한 단서를 시드 description에 직접 박아 Phase 6 LLM 매트릭 제안 시 가설 hint로 활용. 십신 매핑 정정도 함께 반영 — **자수(지지) = 상관** (식신 X, 사용자 임상 정정). 60갑자 자수 ganji 시드(갑자/병자/무자/경자/임자)에도 동일 적용.
+
+상세 단서 목록: [design-notebook Phase 2 — 사용자 임상 데이터 반영](../design-notebook/personal-pattern-discovery.md#사용자-임상-데이터-반영-description에-박힘).
+
+#### Phase 6 연결
+
+60+일 evidence JSONB 누적 → Phase 6 LLM 매트릭 제안 슬롯이 가설 후보 풀로 활용. Phase 6 운영 형태는 **Claude 앱 routines 기반** ([ADR-0027](../adr/0027-llm-async-routine-unification.md)) — 기존 Node.js cron이 LLM API를 호출하던 비실시간 작업 6건도 routines로 점진 이관.
+
+#### 파일 구조
+
+```
+scripts/
+  generate-saju-seed-pool.ts   # SQL 생성기 (TypeScript, stdout)
+
+db/migrations/
+  069_pattern_matches_no_metric.sql
+  070_saju_seed_pool.sql       # 생성기 출력 (1154줄, 161 시드)
+
+src/shared/
+  saju-match.ts                # SeedMatchResult.matched: boolean | null
+                               # evaluateTrigger('relation') 새 {type, members} 포맷 분기
+```
+
+설계 결정 배경: [ADR-0023](../adr/0023-metric-unit-counter-and-summary-view.md), [ADR-0025](../adr/0025-llm-metric-approval-gate.md), [ADR-0027](../adr/0027-llm-async-routine-unification.md), [design-notebook Phase 2](../design-notebook/personal-pattern-discovery.md#phase-2-사주-시드-풀세트--빈-매트릭-evidence-only-2026-05-28)
 
 ### 16. 본인 1명 패턴 발견 시스템 — Phase 3 (life_signal 시드 풀 셋)
 
@@ -768,7 +854,7 @@ GROUP BY c.id;
 
 ### 19. 본인 1명 패턴 발견 시스템 — Phase 6 (LLM 자율 매트릭 + 승인 게이트)
 
-> TODO(`/build`): 구현 후 본문 채우기. 월간 LLM 슬롯이 매트릭 후보 생성, 월 cap 5개. Slack `/insight metric-approve` 명령어 + Block Kit 승인 카드 (`metric-approval-cards.ts`). 승인 시 `pattern_metrics.status = 'active'` 전환. 거절 시 `'rejected'`.
+> TODO(`/build`): 구현 후 본문 채우기. 월간 LLM 슬롯이 매트릭 후보 생성, 월 cap 5개. **운영은 Claude 앱 routines 기반** ([ADR-0027](../adr/0027-llm-async-routine-unification.md)) — Phase 2에서 누적된 60+일 evidence JSONB(`pattern_matches.evidence`, `verify_status='no_metric'` 행)를 가설 후보 풀로 사용. Slack `/insight metric-approve` 명령어 + Block Kit 승인 카드 (`metric-approval-cards.ts`). 승인 시 `pattern_metrics.status = 'active'` 전환. 거절 시 `'rejected'`.
 
 ### 20. 본인 1명 패턴 발견 시스템 — Phase 7 (Bayesian update)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,7 +28,7 @@
 - 일기 자동 저장 (`diary_entries`)
 - 삶의 테마 관리 (`life_themes`, 자동 진화)
 - 사주 패턴 누적 (`saju_patterns`, 28일 롤링 — 갱신 routine 2026-05-26 비활성화, 누적분만 시스템 프롬프트에 활용)
-- 사주 일일 매칭 시드 카탈로그 (`pattern_catalog`, Phase 3 — 결정론 매칭, 마스터 #434 Phase 1 rename per ADR-0026)
+- 사주 일일 매칭 시드 카탈로그 (`pattern_catalog`, Phase 3 — 결정론 매칭, 마스터 #434 Phase 1 rename per ADR-0026, 마스터 #434 Phase 2에서 6종 풀세트 161개 신규 시드 추가)
 - 일기 LLM enum 16종 추출 (`diary_meta_tags`, Phase 3)
 - 주간 사주 회고 카드 (`weekly-saju-review-v2`, 매주 월요일 08:00 KST `#insight` — 마스터 #421)
 - 상세: [docs/domains/insight.md](./domains/insight.md)
@@ -68,6 +68,7 @@
 - 일기 LLM enum 16종 자동 추출(허용 enum 외 출력 폐기) → `diary_meta_tags` 적재
 - 약한 시드(누적 \~10건 + hit rate < 30%) 주간 알림 → 사용자 명령어로 active 토글
 - 슬랙 조회/토글: `사주 시드 보기` / `사주 시드 모두 보기` / `사주 시드 끄기 #N` / `사주 시드 켜기 #N`
+- 풀셋 시드(매트릭 없음, 마스터 #434 Phase 2): trigger만 평가하고 `pattern_matches.matched=NULL` + `verify_status='no_metric'`로 evidence-only 누적. 60+일 후 LLM 매트릭 제안 슬롯(Phase 6)이 가설 후보 풀로 사용
 - 결정 기록: [ADR-0017](./adr/0017-saju-ganji-master-normalization.md)
 
 ### Slack fast path 명령어

--- a/scripts/generate-saju-seed-pool.ts
+++ b/scripts/generate-saju-seed-pool.ts
@@ -1,0 +1,349 @@
+/**
+ * 일회성: 마스터 #434 Phase 2 — user_id=1 사주 시드 풀세트 161개 SQL 생성.
+ * 결과를 db/migrations/070_saju_seed_pool.sql로 출력.
+ *
+ * 실행:
+ *   npx tsx scripts/generate-saju-seed-pool.ts > db/migrations/070_saju_seed_pool.sql
+ *
+ * 본인 사주 컨텍스트 (user_id=1):
+ *   일간 경금(庚) / 일지 술토(戌) / 본명 갑경경경 + 자술술술
+ *
+ * 십신 매핑 (경금 기준):
+ *   천간: 갑(편재) 을(정재) 병(편관) 정(정관) 무(편인) 기(정인) 경(비견) 신(겁재) 임(식신) 계(상관)
+ *   지지: 본기 천간 십신 매핑. 자 = 상관 (사용자 임상 정정, 식신 X)
+ *
+ * 풀셋 카운트 (신규 161):
+ *   stem 2 (을, 신 — 나머지 8개는 기존 S1/S3/S4/S7/S8/N1/N6/N8)
+ *   branch 9 (자, 축, 인, 묘, 진, 사, 미, 신, 유 — 해/술/오는 기존 N2/N5/N7)
+ *   ganji 60 (전부 신규)
+ *   element_density 9 (5오행 × 과다(3+)/부재(0) 10 - S5_토_과다 = 9)
+ *   sibiunsung 11 (12운성 - S6에 포함된 묘 = 11)
+ *   relation 70 (지지 61 + 천간 11 - N3 진술충 - S2 사술원진 = 70)
+ *
+ * 풀셋 시드는 매트릭 없이 등록 (evidence-only) — pattern_matches.matched=NULL,
+ * verify_status='no_metric'. 60+일 evidence 누적 후 Phase 6 LLM 매트릭 제안 슬롯
+ * 가설 후보 풀로 활용.
+ */
+
+const dq = (s: string): string => `$desc$${s}$desc$`;
+
+// 본인 일간 기준 천간 십신 매핑
+const STEM_SIPSIN: Record<string, string> = {
+  갑: '편재',
+  을: '정재',
+  병: '편관',
+  정: '정관',
+  무: '편인',
+  기: '정인',
+  경: '비견',
+  신: '겁재',
+  임: '식신',
+  계: '상관',
+};
+
+// 본인 일간 기준 지지 십신 매핑 (사용자 임상 — 자=상관 정정)
+const BRANCH_SIPSIN: Record<string, string> = {
+  자: '상관',
+  축: '정인',
+  인: '편재',
+  묘: '정재',
+  진: '편인',
+  사: '편관',
+  오: '정관',
+  미: '정인',
+  신: '비견',
+  유: '겁재',
+  술: '편인',
+  해: '식신',
+};
+
+// 본인 일지 + 본명 컨텍스트
+const NATAL_DAY_BRANCH = '술';
+const NATAL_DAY_STEM = '경';
+const NATAL_BRANCHES = ['자', '술', '술', '술'];
+const NATAL_STEMS = ['갑', '경', '경', '경'];
+
+// 천간 description (사용자 임상 반영)
+const STEM_DESC: Record<string, string> = {
+  갑: '갑목 천간 발현일 — 편재(재물 활성, 충동 지출·투자 명목 지출 주의, 일을 많이 벌이는 경향: 일정 폭주·대청소·다 떠오름)',
+  을: '을목 천간 발현일 — 정재(안정적 재물 관리, 계획적 소비, 꾸준한 일정 진행)',
+  병: '병화 천간 발현일 — 편관(양화 편관, 외부 압박·도전 증가, 추진력)',
+  정: '정화 천간 발현일 — 정관(책임·이직·세금·공식 일정 처리)',
+  무: '무토 천간 발현일 — 편인(분석·영화·깊은 사유, 본인 일지 술토와 동기 자기 일치)',
+  기: '기토 천간 발현일 — 정인(낮잠·휴식·평온·따뜻한 안정)',
+  경: '경금 천간 발현일 — 비견(자신감·완료율 상승, 본인 일간 비화, 자기 동일성 강화)',
+  신: '신금 천간 발현일 — 겁재(경쟁심·과시·이성 관심)',
+  임: '임수 천간 발현일 — 식신(요리·창작·대화·먹기 활성)',
+  계: '계수 천간 발현일 — 상관(배달·루틴 저하·일정 미루기·관성 충돌)',
+};
+
+// 지지 description (사용자 임상 반영)
+const BRANCH_DESC: Record<string, string> = {
+  자: '자수 지지 발현일 — 상관(충동적 식사·배달·과식, 다 뒤집어 엎기·전면 개편, 관성 충돌)',
+  축: '축토 지지 발현일 — 정인(차분한 휴식·내면 안정·잔잔한 회복)',
+  인: '인목 지지 발현일 — 편재(새로운 시작·역동, 재물 활성)',
+  묘: '묘목 지지 발현일 — 정재(꾸준한 노력·계획적 진행)',
+  진: '진토 지지 발현일 — 편인(침묵·내면 침잠·과거 기억, 본인 일지 술 충 동반 가능성)',
+  사: '사화 지지 발현일 — 편관(추진·도전 + 신체 증상: 대상포진·피부 트러블·탈진. 사술원진/오행 쏠림 동반 시 강화 — 분리 검증 필요)',
+  오: '오화 지지 발현일 — 정관(공식 일정·세금·이직 처리)',
+  미: '미토 지지 발현일 — 정인(부드러운 휴식·따뜻한 분위기)',
+  신: '신금 지지 발현일 — 비견(자기 동질감·동기 영역, 비견 충돌 가능)',
+  유: '유금 지지 발현일 — 겁재(경쟁·과시·이성 관심)',
+  술: '술토 지지 발현일 — 편인(본인 일지 비화, 깊은 몰입·철학적 사고·영화·책 깊게 봄)',
+  해: '해수 지지 발현일 — 식신(요리·창작 활성)',
+};
+
+// element_density 풀셋 description
+const ELEMENT_OVER_DESC: Record<string, string> = {
+  목: '목 오행 과다일 (10자 중 3+) — 재다신약(편재·정재 폭주, 일간 약화)',
+  화: '화 오행 과다일 (10자 중 3+) — 화극금(본인 일간 경금 피해, 신체적 피로·발열·피부 트러블)',
+  금: '금 오행 과다일 (10자 중 3+) — 비견·겁재 폭주, 자기주장·고집',
+  수: '수 오행 과다일 (10자 중 3+) — 식상 폭주, 식사·창작·말 많음',
+};
+const ELEMENT_LACK_DESC: Record<string, string> = {
+  목: '목 오행 부재일 (10자 중 0) — 편재·정재 결핍, 동력 부족',
+  화: '화 오행 부재일 (10자 중 0) — 관성 결핍, 책임 회피 경향',
+  토: '토 오행 부재일 (10자 중 0) — 인성 결핍, 의지처 부족',
+  금: '금 오행 부재일 (10자 중 0) — 일간 동기 결핍, 자신감 저하',
+  수: '수 오행 부재일 (10자 중 0) — 식상 결핍, 표현·먹기 저하',
+};
+
+// sibiunsung 12운성 description
+const SIBIUNSUNG_DESC: Record<string, string> = {
+  장생: '장생일 — 새로운 시작·기획·신선한 에너지',
+  목욕: '목욕일 — 변화·정리·기분 전환',
+  관대: '관대일 — 성숙·책임감 강화',
+  건록: '건록일 — 활력·열정·업무 폭주·운동 잘됨',
+  제왕: '제왕일 — 최고 활력·자기 주장 강화',
+  쇠: '쇠일 — 활력 저하·정리 단계',
+  병: '병일 — 컨디션 저하·신체 증상 주의',
+  사: '사일 — 단절 + 체력 저하·몸 무거움·지침',
+  절: '절일 — 단절·새 출발 직전 침잠',
+  태: '태일 — 잠재·내부 성장 단계',
+  양: '양일 — 부드러운 회복·따뜻함',
+};
+
+const STEMS_ORDER = ['갑', '을', '병', '정', '무', '기', '경', '신', '임', '계'];
+const BRANCHES_ORDER = ['자', '축', '인', '묘', '진', '사', '오', '미', '신', '유', '술', '해'];
+
+// 60갑자 — 갑자/을축/병인/정묘/.../계해 — 천간(10) 순회하며 지지(12)와 cyclic 매칭
+const ganjiList = (): Array<{ stem: string; branch: string }> => {
+  const result: Array<{ stem: string; branch: string }> = [];
+  const branchesByCycle = ['자', '축', '인', '묘', '진', '사', '오', '미', '신', '유', '술', '해'];
+  for (let i = 0; i < 60; i++) {
+    result.push({ stem: STEMS_ORDER[i % 10], branch: branchesByCycle[i % 12] });
+  }
+  return result;
+};
+
+// 기존 시드 이름 (충돌 방지 + 제외 처리)
+const EXISTING_STEMS = new Set(['갑', '계', '기', '경', '무', '임', '정', '병']);
+const EXISTING_BRANCHES = new Set(['해', '술', '오']);
+const EXISTING_RELATIONS = new Set(['branch_relations|진|술|충', 'branch_relations|사|술|원진']);
+
+// SQL 출력
+const out: string[] = [];
+out.push('-- 070: 마스터 #434 Phase 2 — 사주 시드 풀세트 161개 INSERT');
+out.push('-- 자동 생성: scripts/generate-saju-seed-pool.ts');
+out.push('-- 풀셋은 매트릭 없이 등록 (evidence-only). pattern_matches.matched=NULL,');
+out.push("-- verify_status='no_metric'. 60+일 evidence 누적 → Phase 6 LLM 매트릭 제안 슬롯");
+out.push('-- 가설 후보 풀로 활용 (ADR-0027).');
+out.push('--');
+out.push('-- 본인 컨텍스트 (user_id=1): 일간 경금 / 일지 술토 / 본명 갑경경경 자술술술');
+out.push('-- 자수 십신 정정: 자 = 상관 (사용자 임상, 식신 X)');
+out.push('');
+out.push('BEGIN;');
+out.push('');
+
+// ── 1) STEM 풀셋 (신규 2개: 을, 신) ───────────────────────
+out.push('-- ── 1) STEM 풀셋 (신규 2개: 을 정재, 신 겁재) ──');
+for (const stem of STEMS_ORDER) {
+  if (EXISTING_STEMS.has(stem)) continue;
+  const sipsin = STEM_SIPSIN[stem];
+  const desc = STEM_DESC[stem];
+  out.push('DO $$');
+  out.push('DECLARE t_id INTEGER;');
+  out.push('BEGIN');
+  out.push(`  SELECT id INTO t_id FROM stems_master WHERE name='${stem}';`);
+  out.push(`  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_${stem}_천간', '${sipsin}', ${dq(desc)}, 'stem', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;`);
+  out.push('END $$;');
+  out.push('');
+}
+
+// ── 2) BRANCH 풀셋 단일 (신규 9개) ─────────────────────────
+out.push('-- ── 2) BRANCH 풀셋 단일 (신규 9개: 자, 축, 인, 묘, 진, 사, 미, 신, 유) ──');
+for (const branch of BRANCHES_ORDER) {
+  if (EXISTING_BRANCHES.has(branch)) continue;
+  const sipsin = BRANCH_SIPSIN[branch];
+  const desc = BRANCH_DESC[branch];
+  out.push('DO $$');
+  out.push('DECLARE t_id INTEGER;');
+  out.push('BEGIN');
+  out.push(`  SELECT id INTO t_id FROM branches_master WHERE name='${branch}';`);
+  out.push(`  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_${branch}_지지', '${sipsin}', ${dq(desc)}, 'branch', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;`);
+  out.push('END $$;');
+  out.push('');
+}
+
+// ── 3) GANJI 풀셋 (신규 60개) ───────────────────────────
+out.push('-- ── 3) GANJI 풀셋 (신규 60개 — 60갑자 콤보) ──');
+for (const { stem, branch } of ganjiList()) {
+  const stemSipsin = STEM_SIPSIN[stem];
+  const branchSipsin = BRANCH_SIPSIN[branch];
+  const isNatalDayJu = stem === NATAL_DAY_STEM && branch === NATAL_DAY_BRANCH;
+  const isNatalBranchHwa = branch === NATAL_DAY_BRANCH;
+  const isNatalStemHwa = stem === NATAL_DAY_STEM;
+  let note = '';
+  if (isNatalDayJu) note = ' — 본인 일주와 동일';
+  else if (isNatalBranchHwa) note = ' — 본인 일지 비화';
+  else if (isNatalStemHwa) note = ' — 본인 일간 비화';
+  const desc = `${stem}${branch} 60갑자일 — ${stem}(${stemSipsin}) + ${branch}(${branchSipsin}) 콤보${note}`;
+  out.push('DO $$');
+  out.push('DECLARE t_id INTEGER;');
+  out.push('BEGIN');
+  out.push(`  SELECT g.id INTO t_id
+    FROM ganji_master g
+    JOIN stems_master s ON s.id = g.stem_id
+    JOIN branches_master b ON b.id = g.branch_id
+    WHERE s.name = '${stem}' AND b.name = '${branch}';`);
+  out.push(`  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, 'pool_${stem}${branch}', NULL, ${dq(desc)}, 'ganji', t_id, NULL, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;`);
+  out.push('END $$;');
+  out.push('');
+}
+
+// ── 4) ELEMENT_DENSITY 풀셋 (신규 9개) ──────────────────
+out.push('-- ── 4) ELEMENT_DENSITY 풀셋 (신규 9개 — 토_과다는 S5 보존) ──');
+for (const element of ['목', '화', '금', '수']) {
+  const desc = ELEMENT_OVER_DESC[element];
+  const auxJson = JSON.stringify({ element, min_count: 3 });
+  out.push(`INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_${element}_과다', NULL, ${dq(desc)}, 'element_density', NULL, '${auxJson}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;`);
+  out.push('');
+}
+for (const element of ['목', '화', '토', '금', '수']) {
+  const desc = ELEMENT_LACK_DESC[element];
+  const auxJson = JSON.stringify({ element, max_count: 0 });
+  out.push(`INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_${element}_부재', NULL, ${dq(desc)}, 'element_density', NULL, '${auxJson}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;`);
+  out.push('');
+}
+
+// ── 5) SIBIUNSUNG 풀셋 (신규 11개 — S6에 포함된 묘 제외) ─────────
+out.push('-- ── 5) SIBIUNSUNG 풀셋 (신규 11개 — S6 사·묘 통합에 포함된 묘 제외) ──');
+for (const state of Object.keys(SIBIUNSUNG_DESC)) {
+  if (state === '묘') continue;
+  const desc = SIBIUNSUNG_DESC[state];
+  const auxJson = JSON.stringify({ states: [state] });
+  out.push(`INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+  VALUES (1, 'pool_${state}', NULL, ${dq(desc)}, 'sibiunsung', NULL, '${auxJson}'::jsonb, 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;`);
+  out.push('');
+}
+
+// ── 6) RELATION 풀셋 (신규 70개 — 지지 61 + 천간 11, 기존 N3/S2 제외) ──
+out.push('-- ── 6) RELATION 풀셋 (신규 70개) ──');
+out.push('-- 지지 관계 (61개) — branch_relations LOOP, 기존 N3(진술충)/S2(사술원진) 제외');
+out.push(`DO $$
+DECLARE rel RECORD;
+  desc_text TEXT;
+  aux_json JSONB;
+  name_text TEXT;
+  ba_sipsin TEXT;
+  bb_sipsin TEXT;
+  natal_member TEXT;
+  is_existing BOOLEAN;
+BEGIN
+  FOR rel IN
+    SELECT br.relation_type, ba.name AS ba_name, bb.name AS bb_name
+      FROM branch_relations br
+      JOIN branches_master ba ON ba.id = br.branch_a_id
+      JOIN branches_master bb ON bb.id = br.branch_b_id
+      ORDER BY br.id
+  LOOP
+    -- 기존 시드 제외 (진-술 충, 사-술 원진)
+    is_existing := (rel.ba_name = '진' AND rel.bb_name = '술' AND rel.relation_type = '충')
+                OR (rel.ba_name = '술' AND rel.bb_name = '진' AND rel.relation_type = '충')
+                OR (rel.ba_name = '사' AND rel.bb_name = '술' AND rel.relation_type = '원진')
+                OR (rel.ba_name = '술' AND rel.bb_name = '사' AND rel.relation_type = '원진');
+    IF is_existing THEN
+      CONTINUE;
+    END IF;
+
+    name_text := 'pool_' || rel.relation_type || '_' || rel.ba_name || rel.bb_name;
+    desc_text := '지지 ' || rel.relation_type || ' 발현일 — ' || rel.ba_name || '·' || rel.bb_name;
+
+    -- 본인 일지(술) 또는 본명 지지(자/술)와 관련된 관계는 추가 단서
+    IF rel.ba_name = '술' OR rel.bb_name = '술' THEN
+      desc_text := desc_text || ' (본인 일지 ' || rel.relation_type || ', 자기 영역 흔들림)';
+    ELSIF rel.ba_name = '자' OR rel.bb_name = '자' THEN
+      desc_text := desc_text || ' (본인 본명 자 ' || rel.relation_type || ')';
+    END IF;
+
+    aux_json := jsonb_build_object(
+      'type', 'branch_' || rel.relation_type,
+      'members', jsonb_build_array(rel.ba_name, rel.bb_name)
+    );
+
+    INSERT INTO pattern_catalog
+      (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, name_text, NULL, desc_text, 'relation', NULL, aux_json, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+  END LOOP;
+END $$;`);
+out.push('');
+
+out.push('-- 천간 관계 (11개) — stem_relations LOOP');
+out.push(`DO $$
+DECLARE rel RECORD;
+  desc_text TEXT;
+  aux_json JSONB;
+  name_text TEXT;
+BEGIN
+  FOR rel IN
+    SELECT sr.relation_type, sa.name AS sa_name, sb.name AS sb_name
+      FROM stem_relations sr
+      JOIN stems_master sa ON sa.id = sr.stem_a_id
+      JOIN stems_master sb ON sb.id = sr.stem_b_id
+      ORDER BY sr.id
+  LOOP
+    name_text := 'pool_' || rel.relation_type || '_' || rel.sa_name || rel.sb_name;
+    desc_text := '천간 ' || rel.relation_type || ' 발현일 — ' || rel.sa_name || '·' || rel.sb_name;
+
+    -- 본인 본명 천간(갑/경)과 관련된 관계는 추가 단서
+    IF rel.sa_name = '경' OR rel.sb_name = '경' THEN
+      desc_text := desc_text || ' (본인 일간 ' || rel.relation_type || ')';
+    ELSIF rel.sa_name = '갑' OR rel.sb_name = '갑' THEN
+      desc_text := desc_text || ' (본인 본명 갑 ' || rel.relation_type || ')';
+    END IF;
+
+    aux_json := jsonb_build_object(
+      'type', 'stem_' || rel.relation_type,
+      'members', jsonb_build_array(rel.sa_name, rel.sb_name)
+    );
+
+    INSERT INTO pattern_catalog
+      (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux, pattern_kind, source, active)
+    VALUES (1, name_text, NULL, desc_text, 'relation', NULL, aux_json, 'saju', 'seed', true)
+    ON CONFLICT (user_id, name) DO NOTHING;
+  END LOOP;
+END $$;`);
+out.push('');
+
+out.push('COMMIT;');
+out.push('');
+
+console.log(out.join('\n'));

--- a/src/shared/__tests__/saju-match.test.ts
+++ b/src/shared/__tests__/saju-match.test.ts
@@ -272,6 +272,85 @@ describe('evaluateTrigger - relation', () => {
     const ctx = baseCtx({ dayBranch: '사' });
     expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
   });
+
+  // ── 풀셋 형태 (마스터 #434 Phase 2): {type, members} ──
+
+  it('풀셋 branch_충 — 본명 멤버 있고 일운이 반대 멤버면 true', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'relation',
+      trigger_aux: { type: 'branch_충', members: ['자', '오'] },
+    });
+    // 본명 자 있음, 일운 오 → trigger
+    const ctx = baseCtx({
+      dayBranch: '오',
+      natal: {
+        stems: ['갑', '경', '경', '경'],
+        branches: ['자', '술', '술', '술'],
+        dayMaster: '경',
+      },
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
+  });
+
+  it('풀셋 branch_충 — 본명 + 일운 양방향 평가, 반대도 true', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'relation',
+      trigger_aux: { type: 'branch_충', members: ['자', '오'] },
+    });
+    // 본명 오 있음, 일운 자 → trigger (양방향)
+    const ctx = baseCtx({
+      dayBranch: '자',
+      natal: {
+        stems: ['갑', '경', '경', '경'],
+        branches: ['오', '술', '술', '술'],
+        dayMaster: '경',
+      },
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
+  });
+
+  it('풀셋 branch_충 — 본명에 양쪽 멤버 모두 없으면 false', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'relation',
+      trigger_aux: { type: 'branch_충', members: ['자', '오'] },
+    });
+    const ctx = baseCtx({
+      dayBranch: '자',
+      natal: {
+        stems: ['갑', '경', '경', '경'],
+        branches: ['신', '술', '술', '술'], // 자/오 둘 다 없음
+        dayMaster: '경',
+      },
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
+  });
+
+  it('풀셋 stem_합 — 본명 천간 + 일운 천간 양방향 평가', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'relation',
+      trigger_aux: { type: 'stem_합', members: ['을', '경'] },
+    });
+    // 본명 경 있음, 일운 을 → trigger
+    const ctx = baseCtx({
+      dayStem: '을',
+      dayBranch: '술',
+      natal: {
+        stems: ['갑', '경', '경', '경'],
+        branches: ['자', '술', '술', '술'],
+        dayMaster: '경',
+      },
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
+  });
+
+  it('풀셋 type prefix 알 수 없으면 false', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'relation',
+      trigger_aux: { type: 'unknown_x', members: ['자', '오'] },
+    });
+    const ctx = baseCtx({ dayBranch: '오' });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
+  });
 });
 
 // ─── evaluateTrigger: sibiunsung ──────────────────────────
@@ -408,6 +487,7 @@ describe('compactMatchedLine', () => {
       passed: true,
     })),
     matched,
+    isEvidenceOnly: false,
   });
 
   it('matched 시드 없으면 null', () => {

--- a/src/shared/saju-match.ts
+++ b/src/shared/saju-match.ts
@@ -74,7 +74,10 @@ export interface SeedMatchResult {
   seed: SajuSeedWithMetrics;
   triggerActivated: boolean;
   metricEvaluations: MetricEvaluation[];
-  matched: boolean;
+  /** 매트릭 평가 결과. 매트릭 없는 풀셋 시드(evidence-only)는 null. */
+  matched: boolean | null;
+  /** 풀셋 evidence-only 시드 여부. true면 verify_status='no_metric'로 INSERT. */
+  isEvidenceOnly: boolean;
 }
 
 // ─── 본명 / 일운 컨텍스트 ────────────────────────────────
@@ -294,6 +297,26 @@ export const evaluateTrigger = async (
     }
 
     case 'relation': {
+      // 풀셋 형태 (마스터 #434 Phase 2): {type, members} — 양 멤버 자동 양방향 평가
+      // type='branch_<관계명>' 또는 'stem_<관계명>', members=['<a>', '<b>']
+      const typeAux = aux['type'];
+      const membersAux = aux['members'];
+      if (typeof typeAux === 'string' && isStringArray(membersAux) && membersAux.length === 2) {
+        const [a, b] = membersAux;
+        if (typeAux.startsWith('branch_')) {
+          if (ctx.natal.branches.includes(a as Jiji) && ctx.dayBranch === b) return true;
+          if (ctx.natal.branches.includes(b as Jiji) && ctx.dayBranch === a) return true;
+          return false;
+        }
+        if (typeAux.startsWith('stem_')) {
+          if (ctx.natal.stems.includes(a as Cheongan) && ctx.dayStem === b) return true;
+          if (ctx.natal.stems.includes(b as Cheongan) && ctx.dayStem === a) return true;
+          return false;
+        }
+        return false;
+      }
+
+      // 기존 형태 (N3 진술충, S2 사술원진): day_branch + natal_branches + relation_types
       const dayBranchName = typeof aux['day_branch'] === 'string' ? aux['day_branch'] : null;
       const natalBranches = aux['natal_branches'];
       const relationTypes = aux['relation_types'];
@@ -449,8 +472,13 @@ export const matchAllSeedsForDay = async (
       }
     }
 
-    const matched = triggerActivated && metricEvaluations.some((e) => e.passed);
-    results.push({ seed, triggerActivated, metricEvaluations, matched });
+    // 풀셋 evidence-only 시드(매트릭 없음)는 채점 스킵 — matched=null
+    // 마스터 #434 Phase 2: 60+일 evidence 누적 후 Phase 6 LLM 매트릭 제안 슬롯이 활용
+    const isEvidenceOnly = seed.metrics.length === 0;
+    const matched = isEvidenceOnly
+      ? null
+      : triggerActivated && metricEvaluations.some((e) => e.passed);
+    results.push({ seed, triggerActivated, metricEvaluations, matched, isEvidenceOnly });
   }
   return results;
 };
@@ -471,15 +499,25 @@ export const recordDailyMatches = async (
         },
       ]),
     );
+    const verifyStatus = r.isEvidenceOnly ? 'no_metric' : 'pending';
     await query(
       `INSERT INTO pattern_matches
          (user_id, date, pattern_id, trigger_activated, metric_values, matched, verify_status)
-       VALUES ($1, $2, $3, $4, $5::jsonb, $6, 'pending')
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)
        ON CONFLICT (user_id, date, pattern_id) DO UPDATE
          SET trigger_activated = EXCLUDED.trigger_activated,
              metric_values = EXCLUDED.metric_values,
-             matched = EXCLUDED.matched`,
-      [userId, date, r.seed.id, r.triggerActivated, JSON.stringify(metricValues), r.matched],
+             matched = EXCLUDED.matched,
+             verify_status = EXCLUDED.verify_status`,
+      [
+        userId,
+        date,
+        r.seed.id,
+        r.triggerActivated,
+        JSON.stringify(metricValues),
+        r.matched,
+        verifyStatus,
+      ],
     );
   }
 };


### PR DESCRIPTION
## 관련 이슈
Closes #437

## 변경 내용

### 데이터 모델 (Migration 069, 070)
- `pattern_matches.matched` NOT NULL → NULL 허용
- `verify_status` CHECK constraint에 `'no_metric'` 추가
- `idx_pattern_matches_no_metric (user_id, date)` 부분 인덱스
- 사주 6종 풀세트 161개 신규 시드 INSERT (stem 2 + branch 9 + ganji 60 + element_density 9 + sibiunsung 11 + relation 70)

### 매칭 엔진 (`src/shared/saju-match.ts`)
- `SeedMatchResult.matched: boolean → boolean | null` (매트릭 없는 풀셋 시드는 null)
- `isEvidenceOnly` 플래그 추가
- `recordDailyMatches` — evidence-only는 `verify_status='no_metric'`로 INSERT
- `evaluateTrigger('relation')` 풀셋 `{type, members}` 포맷 분기 추가 — 양 멤버 자동 양방향 평가. 기존 `{day_branch, natal_branches, relation_types}` 포맷은 폴백 유지

### 문서
- **ADR-0027** — LLM 비동기 작업 Claude 앱 routines 기반 통일. 결정론 cron은 Node.js 유지. Phase 6 매트릭 제안 슬롯은 처음부터 routine으로 등록
- design-notebook Phase 2 섹션 + 사용자 임상 데이터 (자수=상관 정정, 진술충/사술원진/화 과다/목 과다 등)
- 도메인 문서 Section 15 본문 채움
- features.md 풀셋 시드 + evidence-only 흐름 명시

### 시드 풀세트 카운트

| 종류 | 마스터 | 기존 | 신규 | 합계 |
|------|------|------|------|------|
| stem | 10 | 8 | 2 | 10 |
| branch | 12 | 3+1 통합 | 9 | 13 |
| ganji | 60 | 0 | 60 | 60 |
| element_density | 10 | 1 | 9 | 10 |
| sibiunsung | 12 | 1 | 11 | 12 |
| relation | 72 | 2 | 70 | 72 |
| **합계** | **176** | **16** | **161** | **177** |

## 코드 리뷰 결과

- [x] 보안 감사 통과 — 새 SQL 모두 parametrized, secrets 없음, 신규 정보 노출 없음
- [x] 타입 안전성 확인 — `npx tsc --noEmit` 클린
- [x] 컨벤션 점검 완료 — kebab-case 파일명, camelCase 함수, named export, any 미사용
- [x] 코드 품질 확인 — type guard로 trigger_aux JSONB 검증, 에러 처리 graceful

## 테스트

- [x] vitest 전체 통과 (492 tests / 28 files)
- [x] `evaluateTrigger` relation 풀셋 포맷 5건 추가:
  - branch_충 본명 a + 일운 b → true
  - branch_충 양방향 (a/b 위치 교환) → true
  - branch_충 본명에 양쪽 멤버 모두 없음 → false
  - stem_합 양방향
  - unknown type prefix → false
- [x] `npx tsc --noEmit` 통과

## ADR-0027 후속 작업 (이슈 등록 완료)

기존 6건 LLM cron의 routine 이관 — weekly-saju-review-v2 첫 실행(2026-06-01) 결과 확인 후 점진 진입:

- [ ] #439 — morning 인사이트 routine 이관 (`life-cron.ts` 09:05)
- [ ] #440 — night 인사이트 routine 이관 (`life-cron.ts` 23:55)
- [ ] #441 — weekly-report routine 이관 (월요일 09:00)
- [ ] #442 — weekly-llm-insight routine 이관 (월요일 09:30)
- [ ] #443 — monthly-llm-insight routine 이관 (매월 1일 09:30)
- [ ] #444 — diary-meta-extract routine 이관 (매일 23:55–05:30)

각 이슈 본문에 본 ADR link + `weekly-saju-review-v2` 마이그레이션 패턴(PR #423) 참조.

## 다음 Phase

- Phase 3 — `life_signal` 시드 풀 셋 (요일 7 + 주말 1 + 평일 1 + 월말/월초 + 계절 4)
- Phase 6 — LLM 매트릭 제안 슬롯 (60+일 evidence JSONB 누적 후, Claude 앱 routine으로 진입)