### PR TITLE
feat(insight): Phase 2.5 — 운 레벨 차원 + 풀셋 임계치 + 분포 분석 cron (마스터 #434)

### DIFF
--- a/db/migrations/071_pattern_signals_pillar_level.sql
+++ b/db/migrations/071_pattern_signals_pillar_level.sql
@@ -1,0 +1,189 @@
+-- 071: 마스터 #434 Phase 2.5 — 사주 시드 운 레벨 차원 도입 + 14개 신규 시드
+-- ADR-0028: 운 레벨 + 풀셋 임계치 + 임의값 배제
+--
+-- 변경:
+--   1) pattern_catalog.pillar_level 컬럼 추가 (사주 시드 전용)
+--   2) Phase 2 사주 시드 161개 backfill: pillar_level='ilun' (기존 시드는 일운 발현)
+--   3) trigger_target_type CHECK에 'cumulative_pillar_count' 추가
+--   4) pattern_metrics.domain CHECK에 'expense_category_present' 추가 (cross-domain)
+--   5) 14개 신규 시드 INSERT (편재 9 + 화 오행 5)
+--      - 편재 천간(갑) 일운·월운 2개
+--      - 편재 지지(인) 일운·월운 2개
+--      - 편재 누적 N=1..5 (sipsin 기준) 5개
+--      - 화 오행 누적 N=1..5 (element 기준) 5개 + 각 시드에 매트릭 2개 (OR 매칭)
+--
+-- 임의 임계치·가중치는 박지 않음. 풀셋(N=1..5)으로 데이터가 결정 (ADR-0028).
+-- 자동 분포 cron(월요일 09:15 KST)이 데이터 누적 후 임계치 추출 트리거 노출.
+
+BEGIN;
+
+-- 1) pillar_level 컬럼 (사주 시드 전용, life_signal/null은 미적용)
+ALTER TABLE pattern_catalog
+  ADD COLUMN pillar_level VARCHAR(20)
+  CHECK (
+    pillar_level IS NULL OR pillar_level IN ('wonguk', 'daeun', 'seun', 'wolun', 'ilun', 'cumulative')
+  );
+
+COMMENT ON COLUMN pattern_catalog.pillar_level IS
+  '사주 시드 발현 운 레벨 (wonguk/daeun/seun/wolun/ilun/cumulative). life_signal/null은 미적용. ADR-0028';
+
+-- 2) Phase 2 사주 시드 backfill: 모두 ilun 차원으로 설정
+UPDATE pattern_catalog
+  SET pillar_level = 'ilun'
+  WHERE pattern_kind = 'saju' AND source = 'seed' AND pillar_level IS NULL;
+
+-- 3) trigger_target_type CHECK 확장 — 'cumulative_pillar_count' 추가
+ALTER TABLE pattern_catalog
+  DROP CONSTRAINT pattern_catalog_trigger_target_type_check;
+ALTER TABLE pattern_catalog
+  ADD CONSTRAINT pattern_catalog_trigger_target_type_check
+  CHECK (trigger_target_type IN (
+    'stem', 'branch', 'ganji', 'element_density', 'sibiunsung', 'relation',
+    'cumulative_pillar_count',  -- Phase 2.5 신규
+    'life_signal'
+  ));
+
+-- 4) pattern_metrics.domain CHECK 확장 — 'expense_category_present' 추가
+-- cross-domain 메트릭 식별자 (사주 trigger × 다른 도메인 발현 카운트)
+-- saju_signal_metrics → pattern_metrics rename으로 인해 기존 제약명 두 경우 모두 처리
+ALTER TABLE pattern_metrics
+  DROP CONSTRAINT IF EXISTS saju_signal_metrics_domain_check;
+ALTER TABLE pattern_metrics
+  DROP CONSTRAINT IF EXISTS pattern_metrics_domain_check;
+ALTER TABLE pattern_metrics
+  ADD CONSTRAINT pattern_metrics_domain_check
+  CHECK (domain IN (
+    'schedule', 'routine', 'sleep', 'expense', 'diary_meta', 'audit',
+    'expense_category_present'  -- Phase 2.5 신규
+  ));
+
+-- 5) 인덱스 — 분포 cron의 GROUP BY pillar_level 가속
+CREATE INDEX IF NOT EXISTS idx_pattern_catalog_pillar_level
+  ON pattern_catalog (pillar_level) WHERE pattern_kind = 'saju';
+
+-- ── 6) 14개 신규 시드 INSERT ──────────────────────────────────────
+
+-- 6-1) 편재 천간(갑) — 일운·월운 2개
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM stems_master WHERE name='갑';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux,
+     pillar_level, pattern_kind, source, active)
+  VALUES
+    (1, 'pool_편재_갑_천간_일운', '편재',
+     $d$갑목 천간 일운 — 편재 (천간 발현 체감 vs 지지 비교용)$d$,
+     'stem', t_id, NULL, 'ilun', 'saju', 'seed', true),
+    (1, 'pool_편재_갑_천간_월운', '편재',
+     $d$갑목 천간 월운 — 편재 (한 달 단위 발현 가설)$d$,
+     'stem', t_id, NULL, 'wolun', 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+-- 6-2) 편재 지지(인) — 일운·월운 2개
+DO $$
+DECLARE t_id INTEGER;
+BEGIN
+  SELECT id INTO t_id FROM branches_master WHERE name='인';
+  INSERT INTO pattern_catalog
+    (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux,
+     pillar_level, pattern_kind, source, active)
+  VALUES
+    (1, 'pool_편재_인_지지_일운', '편재',
+     $d$인목 지지 일운 — 편재 (지지 발현 체감, 천간 비교)$d$,
+     'branch', t_id, NULL, 'ilun', 'saju', 'seed', true),
+    (1, 'pool_편재_인_지지_월운', '편재',
+     $d$인목 지지 월운 — 편재 (저변 기운 한 달 단위)$d$,
+     'branch', t_id, NULL, 'wolun', 'saju', 'seed', true)
+  ON CONFLICT (user_id, name) DO NOTHING;
+END $$;
+
+-- 6-3) 편재 누적 N=1..5 — 5개 (sipsin 기준, 5개 운 레벨 중 발현 수)
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux,
+   pillar_level, pattern_kind, source, active)
+VALUES
+  (1, 'pool_편재_누적_N1', '편재',
+   '편재 누적 1개 이상 (5개 운 레벨 중) — 풀셋 임계치 (ADR-0028)',
+   'cumulative_pillar_count', NULL, '{"sipsin":"편재","count_min":1}'::jsonb,
+   'cumulative', 'saju', 'seed', true),
+  (1, 'pool_편재_누적_N2', '편재',
+   '편재 누적 2개 이상 — 풀셋 임계치',
+   'cumulative_pillar_count', NULL, '{"sipsin":"편재","count_min":2}'::jsonb,
+   'cumulative', 'saju', 'seed', true),
+  (1, 'pool_편재_누적_N3', '편재',
+   '편재 누적 3개 이상 — 풀셋 임계치',
+   'cumulative_pillar_count', NULL, '{"sipsin":"편재","count_min":3}'::jsonb,
+   'cumulative', 'saju', 'seed', true),
+  (1, 'pool_편재_누적_N4', '편재',
+   '편재 누적 4개 이상 — 풀셋 임계치',
+   'cumulative_pillar_count', NULL, '{"sipsin":"편재","count_min":4}'::jsonb,
+   'cumulative', 'saju', 'seed', true),
+  (1, 'pool_편재_누적_N5', '편재',
+   '편재 누적 5개 (전 레벨) — 풀셋 임계치',
+   'cumulative_pillar_count', NULL, '{"sipsin":"편재","count_min":5}'::jsonb,
+   'cumulative', 'saju', 'seed', true)
+ON CONFLICT (user_id, name) DO NOTHING;
+
+-- 6-4) 화 오행 누적 N=1..5 — 5개 (element 기준)
+INSERT INTO pattern_catalog
+  (user_id, name, sipsin, description, trigger_target_type, trigger_target_id, trigger_aux,
+   pillar_level, pattern_kind, source, active)
+VALUES
+  (1, 'pool_화_오행_누적_N1', NULL,
+   '화 오행 누적 1개 이상 (5개 운 레벨 중) — 화극금 건강 가설 (ADR-0028 풀셋 임계치)',
+   'cumulative_pillar_count', NULL, '{"element":"화","count_min":1}'::jsonb,
+   'cumulative', 'saju', 'seed', true),
+  (1, 'pool_화_오행_누적_N2', NULL,
+   '화 오행 누적 2개 이상 — 풀셋 임계치',
+   'cumulative_pillar_count', NULL, '{"element":"화","count_min":2}'::jsonb,
+   'cumulative', 'saju', 'seed', true),
+  (1, 'pool_화_오행_누적_N3', NULL,
+   '화 오행 누적 3개 이상 — 풀셋 임계치',
+   'cumulative_pillar_count', NULL, '{"element":"화","count_min":3}'::jsonb,
+   'cumulative', 'saju', 'seed', true),
+  (1, 'pool_화_오행_누적_N4', NULL,
+   '화 오행 누적 4개 이상 — 풀셋 임계치',
+   'cumulative_pillar_count', NULL, '{"element":"화","count_min":4}'::jsonb,
+   'cumulative', 'saju', 'seed', true),
+  (1, 'pool_화_오행_누적_N5', NULL,
+   '화 오행 누적 5개 (전 레벨) — 풀셋 임계치',
+   'cumulative_pillar_count', NULL, '{"element":"화","count_min":5}'::jsonb,
+   'cumulative', 'saju', 'seed', true)
+ON CONFLICT (user_id, name) DO NOTHING;
+
+-- 6-5) 화 오행 누적 시드 매트릭 (각 시드에 2개씩 OR 매칭)
+-- 매트릭 둘 중 하나만 hit이어도 시드 hit (saju-match.ts metricEvaluations.some 로직)
+DO $$
+DECLARE seed_id INTEGER;
+BEGIN
+  FOR seed_id IN
+    SELECT id FROM pattern_catalog
+    WHERE name LIKE 'pool_화_오행_누적_N%' AND user_id = 1
+  LOOP
+    INSERT INTO pattern_metrics
+      (pattern_id, metric_name, expected_metric_sql, expected_direction, expected_threshold,
+       domain, description, status, window_days)
+    VALUES
+      (seed_id, 'diary_health_complaint',
+       $sql$SELECT COUNT(*) FROM diary_meta_tags WHERE user_id=$1 AND date=$2 AND tag='health_complaint'$sql$,
+       'flag_present', 1, 'diary_meta',
+       '당일 일기에 건강 불편 호소 enum 발현 — 화극금 건강 가설',
+       'active', 1),
+      (seed_id, 'expense_의료건강',
+       $sql$SELECT COUNT(*) FROM expenses WHERE user_id=$1 AND date=$2 AND type='expense' AND category='의료/건강'$sql$,
+       'flag_present', 1, 'expense_category_present',
+       '당일 의료/건강 카테고리 지출 발생 — cross-domain 검증',
+       'active', 1)
+    ON CONFLICT (pattern_id, metric_name) DO NOTHING;
+  END LOOP;
+END $$;
+
+-- ── 7) cron 슬롯 시드 ─────────────────────────────────────
+-- 매일 09:15 발송이지만 cron 본체가 월요일 외 return — weeklyHypothesisReview와 동일 패턴.
+INSERT INTO notification_settings (slot_name, time_value, label, active)
+  VALUES ('pillarLevelDistributionReview', '09:15', '운 레벨 분포 분석', true)
+  ON CONFLICT (slot_name) DO NOTHING;
+
+COMMIT;

--- a/docs/adr/0028-pillar-level-and-threshold-pool.md
+++ b/docs/adr/0028-pillar-level-and-threshold-pool.md
@@ -1,0 +1,133 @@
+# 0028. 사주 시드 운 레벨 차원 도입 + 풀셋 임계치 철학 + 임의값 배제
+
+- Status: Accepted
+- Date: 2026-05-28
+- Related: #445, 마스터 #434 Phase 2.5
+- Tags: data, insight, architecture, process
+
+## Context
+
+마스터 #434 Phase 2(풀세트 시드 카탈로그)를 PR #438로 머지한 직후, Phase 2의 시드들이 다음 한계를 가짐이 드러났다:
+
+1. **운 레벨 무차원**: 같은 십성 기운이라도 일운에 들어올 때와 월운·세운·대운에 들어올 때 체감이 다를 수 있는데, Phase 2 시드는 일운 발현 한 종류만 다룬다.
+2. **천간 vs 지지 동등 가정**: 같은 십성도 천간(드러난 기운)과 지지(저변 기운)로 들어올 때 체감이 다를 가능성이 있으나 Phase 2는 별도 비교 시드가 없다.
+3. **누적 효과 무차원**: 한 오행이 5개 운 레벨(원국+대운+세운+월운+일운) 중 여러 곳에 동시에 출현할 때 체감이 강해진다는 임상 단서가 있으나 평가 메커니즘이 없다. `element_density` trigger는 원국 비중 single-shot.
+4. **임의 임계치·가중치 박지 않음 원칙 충돌**: 누적 효과를 표현하려면 "오행 N개 이상 누적" 같은 임계치가 필요한데, 이 값을 미리 임의로 정하면 v2 헌장 ④(신뢰 비용 분리 — 결정론은 명시 임계치, 자율은 4안전장치) 정신을 위반한다.
+5. **지출 카테고리 미연결**: 사주 → 일기 enum 메트릭은 있으나, 사주 → 지출 카테고리 발생 여부 검증 경로가 없다. 화 오행 과다 → `의료/건강` 카테고리 지출 발생 같은 cross-domain 가설을 검증할 길이 닫혀 있음.
+
+이 다섯 한계를 풀려면 한 번에 3개의 설계 결정을 묶어야 한다. 분리 ADR로 쪼개면 결정 사이의 종속성(예: 운 레벨을 도입했더니 누적 카운트가 필요해졌고, 누적 카운트를 도입하려면 임계치가 필요해져서 풀셋 철학 확장이 필요해짐)이 사라진다.
+
+## Decision
+
+**다음 3개 결정을 하나의 ADR로 묶는다.**
+
+### (a) 운 레벨 차원 도입 — `pattern_signals.pillar_level` 컬럼
+
+모든 사주 trigger seed에 `pillar_level VARCHAR(20)` 컬럼을 부여한다. enum: `'wonguk' | 'daeun' | 'seun' | 'wolun' | 'ilun' | 'cumulative'`.
+
+- `'ilun'`: 일운 발현 (Phase 2 시드 161개 기본값 — 마이그레이션 071에서 backfill)
+- `'wolun'`, `'seun'`, `'daeun'`: 각 변동 운 레벨 발현
+- `'wonguk'`: 원국 발현 (사용자 사주 상수)
+- `'cumulative'`: 5개 운 레벨 누적 발현 카운트 trigger (아래 (b)와 결합)
+
+평가 로직(`saju-match.ts:evaluateTrigger`)은 `pillar_level`에 따라 `ctx.daily_pillar` / `ctx.monthly_pillar` / `ctx.yearly_pillar` / `ctx.major_pillar` / `ctx.natal_pillar` 중 어디서 매칭할지 분기한다.
+
+### (b) 풀셋 임계치 철학 — `cumulative_pillar_count` trigger
+
+5개 운 레벨에 같은 오행 또는 같은 십성이 몇 번 출현하는지 카운트하는 새 trigger type을 도입한다. `trigger_aux`에 `{ element?: '목'|'화'|'토'|'금'|'수', sipsin?: 정관|..., count_min: N }` 저장.
+
+**임의 임계치 박지 않는다.** N=1, 2, 3, 4, 5를 **모두 별도 시드로 등록**한다. 어느 N이 본인에게 의미가 있는지는 hit rate 데이터가 결정한다.
+
+이는 Phase 2의 풀셋 시드 철학("어떤 갑자가 본인에게 의미 있는지 모르므로 60갑자 풀셋 전체를 시드로 등록")을 **임계치 차원으로 확장**한 것이다. 동일 정신: "선험적으로 정할 수 없는 값은 풀셋으로 모두 등록 후 데이터가 추출하게."
+
+신규 시드 14개:
+- 편재 9개: (a) 일운·월운 천간 편재(2) + (b) 일운·월운 지지 편재(2) + (c) 천간 편재 누적 N=1..5 풀셋(5)
+- 화 오행 5개: 누적 N=1..5 풀셋(5)
+
+천간 vs 지지 비교는 `pillar_level='ilun'/'wolun'` × `trigger_target_type='stem'/'branch'` 조합으로 자연스럽게 충돌 없이 매칭된다.
+
+### (c) 임의 가중치 배제 — 자동 분포 분석 cron으로 데이터 추출 자동화
+
+"운 레벨별 가중치"는 **임의로 박지 않는다**. 대신 매주 월요일 09:15 KST에 `pillar-level-distribution-review` cron이 돈다:
+
+```sql
+-- 운 레벨별 시드 hit rate 분포 + 누적 카운트 N별 hit rate 분포
+SELECT pillar_level, COUNT(*) FILTER (WHERE matched=true) * 1.0 / NULLIF(COUNT(*), 0) AS hit_rate
+FROM pattern_catalog c
+JOIN pattern_matches m USING (signal_id)
+WHERE m.created_at >= NOW() - INTERVAL '90 days'
+GROUP BY pillar_level;
+```
+
+결과는 결정론 SQL 한 줄 메시지로 `#insight` 채널 발송 ([ADR-0027](0027-llm-async-routine-unification.md) 분류: 결정론 SQL → Node.js cron). LLM 해석 없음.
+
+데이터가 60\~90일 누적된 시점에 **임계치 학습**과 **운 레벨 가중치 적용**을 별도 후속 phase(번호 TBD)로 진행한다. 자동화 cron 자체가 "지금 임계치 학습할 만한가" 시점을 사용자에게 노출하므로 별도 follow-up 이슈가 필요 없다.
+
+## Alternatives considered
+
+### A. 운 레벨 차원 분리 ADR (3개 ADR로 쪼개기)
+
+- 장점: 각 결정의 독립성 명시
+- 단점: 결정 사이 종속성이 사라져 6개월 뒤 "왜 이런 시드 구조?"를 추적하려면 3개 ADR을 모두 읽어야 함
+- 기각 이유: 3개 결정이 **하나의 일관된 설계 정신(임의값 박지 않기 + 풀셋으로 데이터가 결정하게)**에서 나온 것임. 분리하면 정신이 흩어진다.
+
+### B. 운 레벨을 `trigger_aux`에 묻기
+
+- 장점: 스키마 변경 없이 JSONB 한 줄로 표현 가능
+- 단점: (1) 인덱스 못 침, (2) `WHERE pillar_level='ilun'` 분포 쿼리가 무거워짐, (3) Phase 2 시드 backfill이 까다로움
+- 기각 이유: `pillar_level`은 **모든 사주 시드가 갖는 1차 차원**. JSONB가 아니라 컬럼이 맞다.
+
+### C. 누적 카운트를 `element_density` 확장으로 처리
+
+- 장점: 새 trigger type 안 만들어도 됨
+- 단점: (1) `element_density`는 원국 비중 single-shot. 누적은 5개 운 레벨 합산. 의미가 다름. (2) 십성 누적은 `element_density`로 표현 불가
+- 기각 이유: 새 trigger type `cumulative_pillar_count`가 자연스러움. 누적은 첫 1급 개념이지 부산물이 아님.
+
+### D. 임의 가중치 박기 (예: 일운 1.0, 월운 0.5, 세운 0.3, 대운 0.1)
+
+- 장점: 즉시 작동
+- 단점: v2 헌장 ④ 위반. 사용자 본인 데이터 누적 없이 "어디서 들은 값" 박는 게 본 마스터 #434 정신(본인 1명 통계, n=1)과 정면 충돌
+- 기각 이유: 직접 거절됨 — "미리 임의의 값을 넣어두는 건 좀 별로임" (2026-05-28 인터뷰)
+
+### E. 풀셋 임계치 (선택한 안)
+
+- 장점: 풀셋 철학 일관성(Phase 2 정신 확장) + 임의값 배제 + 데이터가 자연스럽게 의미 있는 N 추출
+- 단점: 시드 개수가 늘어남(14개). 매칭 cron 부하 약간 증가
+- 한계: 시드 개수 증가는 v2 헌장 ②(결정론 ↔ LLM 자율 역할 분리) 정신상 결정론 쪽이 늘어나는 거라 큰 문제 아님.
+
+## Consequences
+
+### 장점
+
+1. **임상 가설 충실히 검증**: 천간 vs 지지, 운 레벨 차원, 누적 효과 — 3가지 임상 단서를 데이터로 검증 가능
+2. **임의값 박지 않는 원칙 확장**: 풀셋 철학이 갑자 차원(Phase 2)에서 임계치 차원(Phase 2.5)으로 일반화됨. 다른 마스터에도 적용 가능한 사고 패턴
+3. **자동화로 임계치 학습 노출**: 사용자가 별도 follow-up 이슈를 관리할 필요 없음. cron 발송 자체가 "이제 임계치 추출할 만한가" 트리거가 됨
+4. **cross-domain 메트릭 경로 확보**: `expense_category_present` 메트릭으로 사주 → 지출 카테고리 가설(예: 화 과다 → 의료/건강 지출) 검증 가능
+5. **인덱스로 분포 쿼리 빠름**: `pillar_level`이 컬럼이라 분포 cron이 가볍게 돌아감
+
+### 단점 / 제약
+
+1. **시드 수 증가**: 161개 → 175개 (8.7% 증가). 매칭 cron 평가 비용 약간 증가 (현재 측정 안 함, 운영 1\~3개월 후 회고)
+2. **누적 카운트 평가 시점**: `cumulative_pillar_count` trigger 평가에 `cumulative_pillar_count(natal, daeun, seun, wolun, ilun)` 함수 한 번 더 호출. 일일 매칭 cron 1회만 도므로 무시 가능
+3. **임의값 결정의 시점 분리**: "데이터로 임계치 추출"이 미래 후속 phase로 미뤄짐. 60\~90일간은 분포만 누적
+4. **`pillar_level='cumulative'` semantic**: pillar_level 자체가 "어느 운 레벨에서 평가하는가"인데 cumulative는 5개 모두를 본다 — 약간의 의미 충돌. 그러나 enum 분기상 `cumulative`만 별도 처리로 가독성 유지
+
+### 후속 작업
+
+- [ ] Phase 2.5 마이그레이션 071 작성 (`pillar_level` 컬럼 + Phase 2 161개 backfill = `'ilun'`)
+- [ ] `saju-match.ts:evaluateTrigger` — `pillar_level` 분기 + `cumulative_pillar_count` 케이스
+- [ ] `saju-calendar.ts` — `computeCumulativePillarCount` 함수 (원국+대운+세운+월운+일운)
+- [ ] `pattern_metrics`에 `expense_category_present` enum 추가
+- [ ] `pillar-level-distribution-review` cron — Monday 09:15 KST, 결정론 SQL
+- [ ] 14개 신규 시드 SQL (편재 9 + 화 오행 5)
+- [ ] 운영 60\~90일 후 후속 phase 진입 시점 검토 (cron 메시지가 트리거)
+
+---
+
+**참고 자료**
+
+- [v2 헌장 ④ 신뢰 비용 분리](../../.claude/projects/-Users-ihyewon-slack-ai-agents/memory/project_insight_v2_core_principles.md)
+- [#434 자체 헌장 ①·②](../design-notebook/personal-pattern-discovery.md#핵심-원칙--자체-헌장-변경-불가-변경-시-adr)
+- [ADR-0017 사주 60갑자 마스터 정규화](0017-saju-ganji-master-normalization.md) — `element_density` / `sibiunsung` trigger 도입
+- [ADR-0026 pattern_* prefix rename](0026-pattern-prefix-rename.md) — 본 ADR의 컬럼이 그 위에서 동작
+- [ADR-0027 LLM 비동기 작업 routines 통일](0027-llm-async-routine-unification.md) — 본 ADR의 자동 분포 cron은 결정론 SQL이므로 Node.js cron 잔존

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -134,6 +134,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0025](0025-llm-metric-approval-gate.md) | LLM 자율 매트릭 승인 게이트 — `description NOT NULL` + Slack inline button | Accepted | 2026-05-27 | data, llm, ux |
 | [0026](0026-pattern-prefix-rename.md) | `pattern_*` prefix 전면 rename — saju_signal_* 잔존 결정 폐기 | Accepted | 2026-05-27 | data, insight, architecture, refactor |
 | [0027](0027-llm-async-routine-unification.md) | LLM 비동기 작업 Claude 앱 routines 기반 통일 | Accepted | 2026-05-28 | process, llm, infra, ops |
+| [0028](0028-pillar-level-and-threshold-pool.md) | 사주 시드 운 레벨 차원 도입 + 풀셋 임계치 철학 + 임의값 배제 | Accepted | 2026-05-28 | data, insight, architecture, process |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/personal-pattern-discovery.md
+++ b/docs/design-notebook/personal-pattern-discovery.md
@@ -65,8 +65,9 @@ LLM 매트릭은 월 최대 N개 cap(예: 5개)으로 슬롯 폭주 방지. 매�
 
 > Phase 사이에 1주 운영 검증을 두지 않는다. 짧은 PR 검증(코드 리뷰 + 테스트 + setup 모드 단위 검증)으로 대체. 통계 누적 검증은 마스터 종료 후 운영 1\~3개월 누적 시점에 [부록 E](#부록-e-운영-1-3개월-후-도입-검토-기능-7건) 7건과 함께 회고.
 
-- [ ] **Phase 1**: 스키마 일반화 + `pattern_*` rename — 테이블·컬럼 rename (`saju_signal_*` → `pattern_*`, ADR-0026), `trigger_target_type` CHECK constraint 확장(`life_signal` 추가), `pattern_metrics`에 `description TEXT NOT NULL` + `window_days INTEGER` + `hit_count/miss_count/inconclusive_count` + `status` 컬럼, `posterior_alpha/beta/p` 예약, `pattern_summary` view 신설, `saju_influence_summary` view body 재정의 (운영 자산 보존)
-- [ ] **Phase 2**: 사주 시드 풀 셋 — Phase 3에서 작성된 시드를 카탈로그 풀(전체) 검토 + 누락 보완 (s1 일부만 작성된 상태였음)
+- [x] **Phase 1**: 스키마 일반화 + `pattern_*` rename — 테이블·컬럼 rename (`saju_signal_*` → `pattern_*`, ADR-0026), `trigger_target_type` CHECK constraint 확장(`life_signal` 추가), `pattern_metrics`에 `description TEXT NOT NULL` + `window_days INTEGER` + `hit_count/miss_count/inconclusive_count` + `status` 컬럼, `posterior_alpha/beta/p` 예약, `pattern_summary` view 신설, `saju_influence_summary` view body 재정의 (운영 자산 보존)
+- [x] **Phase 2**: 사주 시드 풀 셋 — Phase 3에서 작성된 시드를 카탈로그 풀(전체) 검토 + 누락 보완 (s1 일부만 작성된 상태였음)
+- [x] **Phase 2.5**: 사주 시드 운 레벨 차원 도입 + 자동 분포 분석 cron — `pillar_level` 컬럼(원국/대운/세운/월운/일운/cumulative), `cumulative_pillar_count` trigger(N=1..5 풀셋), `expense_category_present` 메트릭, `pillar-level-distribution-review` cron (월요일 09:15 KST). 14개 신규 시드(편재 9 + 화 오행 5). [ADR-0028](../adr/0028-pillar-level-and-threshold-pool.md)
 - [ ] **Phase 3**: `life_signal` 시드 풀 셋 — 요일(월\~일 7) / 주말(2) / 월말(1) / 월초(1) / 계절(4) 등 1차 셋. 결정론 매트릭으로 작성
 - [ ] **Phase 4**: 매칭 cron + view 정비 — 매칭 cron이 `trigger_target_type='life_signal'`도 처리하도록 확장. `pattern_summary` view 본문 작성
 - [ ] **Phase 5**: 가설 발견·검증 업데이트 — `hypothesis-discovery`가 `life_signal` trigger를 포함하도록 일반화. weekly 가설 리뷰 카드 본문에 출처(`pattern_kind`) 표시
@@ -272,6 +273,105 @@ LLM 매트릭은 월 최대 N개 cap(예: 5개)으로 슬롯 폭주 방지. 매�
 - **테스트 커버리지 trade-off** — `matchAllSeedsForDay`의 `matched=null` 분기를 직접 단위 테스트하려면 `getDayPillar`/`loadActiveSeeds`/`buildNameIdMap` 등을 새로 mocking해야 함. 3줄 ternary의 테스트 가치 < mocking 부담이라 판단, 대신 `evaluateTrigger`의 새 `relation {type, members}` 포맷을 5건 추가. 가설 후보 풀로 사용되는 trigger 평가가 더 중요한 검증 대상
 - **사용자 임상 단서 description 박기** — 명리학적 십신만 적는 게 아니라 사용자 본인이 실제로 관측한 단서(예: "진술충 → 과거 기억 문득문득 떠오름")를 description에 박음. Phase 6 LLM이 evidence 60+일 보고 매트릭 제안할 때 가설 hint로 활용 — 자료가 LLM의 가설 공간을 좁히는 역할
 - **ADR-0027 신설의 trigger** — Phase 2 인터뷰 중 Phase 6 LLM 매트릭 제안 슬롯을 어떻게 운영할지 분기점에서 발생. 사용자 명시 "실시간 답변이 아닌 건 무조건 routines" → 신규 ADR로 분리. 기존 Node.js cron 6건은 follow-up 이슈로 점진 이관 — 운영 패턴 통일이라 PR과 별도 트랙으로 분리하는 게 맞음
+
+---
+
+## Phase 2.5: 사주 시드 운 레벨 차원 도입 + 자동 분포 분석 cron (2026-05-28)
+
+> [#445](https://github.com/hyewon3938/slack-ai-agents/issues/445), [ADR-0028](../adr/0028-pillar-level-and-threshold-pool.md)
+
+### 도입 동기 (임상 단서)
+
+Phase 2 풀세트 시드 161개를 머지한 직후, 다음 세 단서가 명료해졌다:
+
+1. **천간 vs 지지 체감 차이**: 같은 십성이라도 천간(드러난 기운)으로 들어올 때와 지지(저변 기운)로 들어올 때 행동 패턴이 다를 가능성 — 사용자 임상
+2. **운 레벨 차원 부재**: 일운 발현만 추적하면 월운·세운·대운에 같은 십성이 들어왔을 때 효과를 못 잡음
+3. **누적 효과**: 한 오행이 5개 운 레벨(원국·대운·세운·월운·일운) 중 여러 곳에 동시 출현할 때 체감이 강해진다는 임상 단서 (예: 화 오행이 3개 이상 운 레벨에 누적되면 건강 이슈 발생)
+
+Phase 2 시드는 모두 일운 single-shot 평가라 이 단서들을 정량 검증할 수 없었다.
+
+### 결정 요약
+
+**3개 결정을 ADR-0028로 묶음** (분리하면 결정 사이 종속성 사라짐).
+
+#### (a) `pillar_level` 컬럼 도입
+
+```sql
+ALTER TABLE pattern_catalog ADD COLUMN pillar_level VARCHAR(20)
+  CHECK (pillar_level IN ('wonguk', 'daeun', 'seun', 'wolun', 'ilun', 'cumulative'));
+
+-- Phase 2 161개 시드를 'ilun'으로 backfill
+UPDATE pattern_catalog SET pillar_level = 'ilun'
+WHERE pattern_kind = 'saju' AND source = 'seed' AND pillar_level IS NULL;
+```
+
+`saju-match.ts:evaluateTrigger`는 `pillar_level`에 따라 `ctx.daily_pillar` / `ctx.monthly_pillar` / `ctx.yearly_pillar` / `ctx.major_pillar` / `ctx.natal_pillar` 중 어디서 매칭할지 분기.
+
+#### (b) `cumulative_pillar_count` trigger + 풀셋 임계치
+
+새 trigger type. `trigger_aux = { element?, sipsin?, count_min: N }`. 5개 운 레벨에서 같은 오행/십성이 N번 이상 출현하면 hit.
+
+**임계치 N을 임의로 박지 않는다.** N=1, 2, 3, 4, 5를 **모두 별도 시드**로 등록. 풀셋 철학(Phase 2 갑자 차원)을 **임계치 차원으로 확장**.
+
+14개 신규 시드:
+
+| # | 시드명 | 운 레벨 | trigger | 임상 가설 |
+|---|--------|--------|---------|----------|
+| 1 | `pool_편재_갑_천간_일운` | ilun | stem=갑 | 천간 편재 일운 → 일 많이 벌이는 경향 |
+| 2 | `pool_편재_갑_천간_월운` | wolun | stem=갑 | 천간 편재 월운 → 한 달 단위 일 폭주 |
+| 3 | `pool_편재_인_지지_일운` | ilun | branch=인 | 지지 편재 일운 → 천간과 체감 비교 |
+| 4 | `pool_편재_인_지지_월운` | wolun | branch=인 | 지지 편재 월운 |
+| 5\~9 | `pool_편재_천간_누적_N1` \~ `N5` | cumulative | stem 십성=편재, count_min=N | 천간 편재 누적 N개 운 레벨 |
+| 10\~14 | `pool_화_오행_누적_N1` \~ `N5` | cumulative | element=화, count_min=N | 화 오행 누적 N개 → 건강 이슈 |
+
+#### (c) 자동 분포 분석 cron — 임의 가중치 배제
+
+`pillar-level-distribution-review` cron — 매주 월요일 09:15 KST. 결정론 SQL([ADR-0027](../adr/0027-llm-async-routine-unification.md) 분류: 결정론 → Node.js cron).
+
+```sql
+-- 운 레벨별 hit rate 분포 + 누적 카운트 N별 hit rate 분포
+-- 90일 윈도우, evidence-only 매칭 제외
+```
+
+`#insight` 채널에 한 줄 메시지 발송. LLM 해석 없음. 60\~90일 누적 시점에 임계치 학습과 운 레벨 가중치 적용을 **별도 후속 phase**(번호 TBD)로 진행. 자동화 cron 자체가 사용자에게 "지금 임계치 학습할 만한가" 트리거 역할 → 별도 follow-up 이슈 불필요.
+
+### 의사결정 분기점
+
+1. **임의값 박지 않기 원칙 (사용자 명시)**: "미리 임의의 값을 넣어두는 건 좀 별로임" — 운 레벨 가중치(일운 1.0, 월운 0.5 등) 박는 안 즉시 기각. 풀셋 임계치로 우회 결정
+2. **천간 vs 지지 비교는 별도 시드** — `pillar_level='ilun'/'wolun'` × `trigger_target_type='stem'/'branch'` 조합으로 자연스럽게 분리. 한 시드 안에 두 차원 섞지 않음
+3. **누적 카운트 trigger 도입 위치** — `element_density` 확장 안과 새 `cumulative_pillar_count` trigger 안 중 선택. element_density는 원국 single-shot이라 의미 다름 → 새 trigger 분리
+4. **자동화 cron의 LLM 여부** — ADR-0027에 따라 결정론 SQL이므로 Node.js cron 잔존 결정. LLM 해석 도입 시 routines로 이관
+5. **운 레벨 가중치 적용 시점** — 즉시 박지 않고 **60\~90일 데이터 누적 후 후속 phase**. 어느 phase 번호인지 미정 (Phase 8 마무리 시점에 부록 E와 함께 결정)
+6. **scheduled-check 이슈 등록 여부** — 처음에는 60\~90일 후 점검용 이슈 등록 계획이었으나, 자동화 cron 자체가 트리거되므로 사용자 명시 "자동화 해두면 이슈에 박아둘 필요 없지 않아?" → 이슈 등록 항목 제거
+
+### 핵심 변경
+
+- 마이그레이션 071: `pattern_signals.pillar_level` 컬럼 + CHECK + index + Phase 2 161개 backfill = `'ilun'`
+- `trigger_target_type` enum 확장: `'cumulative_pillar_count'` 추가
+- `pattern_metrics.source_type` enum 확장: `'expense_category_present'` 추가 (cross-domain 메트릭)
+- `saju-match.ts:evaluateTrigger`: `pillar_level` 분기 + `cumulative_pillar_count` 케이스 + `evaluateMetric`의 `expense_category_present` 케이스 + OR 매칭 (한 시드 → 여러 매트릭 후보 중 하나라도 hit이면 hit)
+- `saju-calendar.ts`: `computeCumulativePillarCount(natal, daeun, seun, wolun, ilun)` 함수 — 오행/십성 카운트만 (누적 비중 아님)
+- `src/cron/pillar-level-distribution-review.ts`: 신규 cron (Monday 09:15 KST, 결정론 SQL)
+- `index.ts`: cron 등록
+- 14개 신규 시드 SQL
+
+### 사용자 임상 데이터 반영 (description에 박힘)
+
+- "천간 편재 = 일을 많이 벌이는 경향" — 일간 庚金 기준 천간 甲에 해당
+- "지지 편재 ≠ 천간 편재 체감" — 같은 십성이라도 체감 다름 (정량 검증 가설)
+- "화 오행 누적 → 건강 이슈" — 화극금 체질, `health_complaint` 일기 enum + `의료/건강` 지출 카테고리로 cross-domain 검증
+
+### 포기한 안 / 미룬 항목
+
+- **운 레벨 가중치 박기** — 임의값 배제 원칙 위반. 풀셋 임계치로 우회
+- **임계치 자동 추출 시점 이슈 등록** — 자동화 cron으로 대체
+- **세운·대운 LLM 회고 해석** — 이미 마스터 #421로 이관됨 (Phase 2와 동일 결정)
+- **천간 정관·정인 등 다른 십성도 같은 구조로 분화** — 편재만 1차 도입. 운영 검증 후 다른 십성 동일 패턴 복제 가능 (후속 phase)
+- **`pillar_level='wonguk'` 시드** — 원국은 본인 사주 상수(천간 편재 항상 ON, 지지 편재 항상 OFF). 변동 가능한 일운·월운만 1차 도입. 원국 영향 검증은 누적 카운트 trigger가 대신함
+
+### 회고 (TODO: `/build` 구현 후 보강)
+
+> 회고는 PR 머지 후 추가.
 
 ---
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -840,27 +840,166 @@ src/shared/
 
 설계 결정 배경: [ADR-0023](../adr/0023-metric-unit-counter-and-summary-view.md), [ADR-0025](../adr/0025-llm-metric-approval-gate.md), [ADR-0027](../adr/0027-llm-async-routine-unification.md), [design-notebook Phase 2](../design-notebook/personal-pattern-discovery.md#phase-2-사주-시드-풀세트--빈-매트릭-evidence-only-2026-05-28)
 
-### 16. 본인 1명 패턴 발견 시스템 — Phase 3 (life_signal 시드 풀 셋)
+### 16. 본인 1명 패턴 발견 시스템 — Phase 2.5 (운 레벨 차원 + 풀셋 임계치 + 자동 분포 분석 cron)
+
+Phase 2의 사주 시드는 모두 일운(日運) 단위로만 발현되어 "월운/세운/대운 단위로도 같은 패턴이 나타나는가?" 라는 질문을 데이터로 답할 수 없었다. Phase 2.5는 시드의 발현 운 레벨을 데이터 모델 차원으로 끌어올리고, 임의 임계치를 박는 대신 풀셋(N=1..5) 형태로 누적 카운트 자체를 시드화한다. 어느 N 임계치가 의미 있는지는 누적된 데이터가 결정 ([ADR-0028](../adr/0028-pillar-level-and-threshold-pool.md)).
+
+#### 데이터 모델 변경
+
+| 마이그레이션 | 내용 |
+|------|------|
+| `071_pattern_signals_pillar_level.sql` | `pattern_catalog.pillar_level VARCHAR(20)` 추가 (CHECK enum 6값) + Phase 2 사주 시드 161개 backfill (`pillar_level='ilun'`) + `trigger_target_type` CHECK에 `cumulative_pillar_count` 추가 + `pattern_metrics.domain` CHECK에 `expense_category_present` 추가 + 부분 인덱스 + 신규 14 시드 + cron 슬롯 시드 |
+
+`pattern_catalog.pillar_level` enum:
+
+| 값 | 의미 |
+|------|------|
+| `wonguk` | 원국(natal) — Phase 2.5 1차에서는 직접 매칭 시드 없음. cumulative 카운트에는 포함 |
+| `daeun` | 대운 (10년 단위, `saju_profiles.daewun_list`에서 추출) |
+| `seun` | 세운 (해당 연도 year pillar) |
+| `wolun` | 월운 (해당 월 month pillar) |
+| `ilun` | 일운 (해당 일 day pillar) — Phase 2 시드 161개 기본값 |
+| `cumulative` | 5개 운 레벨 누적 카운트 시드 (별도 trigger type) |
+
+`life_signal` 및 `pillar_level IS NULL`은 미적용 (Phase 3 이후 life_signal 시드는 본 차원과 무관).
+
+#### `cumulative_pillar_count` trigger type
+
+5개 운 레벨(원국/대운/세운/월운/일운) 중 오행 또는 십성이 발현된 레벨 수를 세서 `count_min` 임계치와 비교. 발현 정의는 "해당 레벨의 천간 또는 지지 1자라도 해당 오행/십성에 해당하면 +1".
+
+| trigger_aux | 의미 |
+|------|------|
+| `{"element": "화", "count_min": 3}` | 화 오행이 5개 레벨 중 3개 이상에서 발현 |
+| `{"sipsin": "편재", "count_min": 2}` | 편재가 5개 레벨 중 2개 이상에서 발현 |
+
+원국 레벨은 4주(年月日時) 중 하나라도 해당하면 카운트 +1. 대운이 미적용 구간(생년 이전 또는 daewun_list 비어있음)이면 해당 레벨은 0으로 처리. 풀셋 임계치 — N=1..5를 각각 별도 시드로 등록해 데이터가 임계치를 결정.
+
+#### `expense_category_present` 메트릭 domain
+
+지출 카테고리 발현 여부를 cross-domain 메트릭으로 식별. 본 phase에서는 화 오행 누적 시드의 보조 메트릭(`expense_의료건강` — 화극금 건강 가설 검증)으로 사용. `pattern_metrics.expected_direction='flag_present'` + `expected_threshold=1`.
+
+#### 14개 신규 시드 카탈로그
+
+| 카테고리 | 시드 수 | 이름 패턴 | trigger_target_type | pillar_level |
+|------|------|------|------|------|
+| 편재 천간(갑) | 2 | `pool_편재_갑_천간_<일운\|월운>` | `stem` | `ilun` / `wolun` |
+| 편재 지지(인) | 2 | `pool_편재_인_지지_<일운\|월운>` | `branch` | `ilun` / `wolun` |
+| 편재 누적 N=1..5 | 5 | `pool_편재_누적_N<1..5>` | `cumulative_pillar_count` | `cumulative` |
+| 화 오행 누적 N=1..5 | 5 | `pool_화_오행_누적_N<1..5>` | `cumulative_pillar_count` | `cumulative` |
+
+화 오행 누적 시드 5개는 각각 2개 메트릭 (OR 매칭):
+- `diary_health_complaint` (`diary_meta_tags.tag='health_complaint'`, domain=`diary_meta`)
+- `expense_의료건강` (`expenses.category='의료/건강'`, domain=`expense_category_present`)
+
+매트릭 둘 중 하나만 hit이어도 시드 hit — `saju-match.ts`의 `metricEvaluations.some((e) => e.passed)`가 기존부터 OR 동작.
+
+편재 9개 시드는 매트릭 없는 evidence-only (Phase 2 풀셋과 동일).
+
+#### `saju-match.ts` 운 레벨 분기
+
+`evaluateTrigger`의 `stem` / `branch` 케이스가 `pickPillarByLevel(seed.pillar_level, ctx)`로 평가 대상 pillar를 선택:
+
+```typescript
+const pickPillarByLevel = (level: PillarLevel | null, ctx: DailyContext): Pillar | null => {
+  switch (level) {
+    case null: case 'ilun': return ctx.ilun;
+    case 'wolun': return ctx.wolun;
+    case 'seun': return ctx.seun;
+    case 'daeun': return ctx.daeun;  // 미적용 구간이면 null → trigger false
+    case 'wonguk': case 'cumulative': return null;  // 직접 매칭 불가
+  }
+};
+```
+
+`cumulative_pillar_count` 케이스는 별도 `evaluateCumulativePillarCount(seed, ctx)`로 분기. `DailyContext`에 `ilun`/`wolun`/`seun`/`daeun` 필드 추가, `NatalContext`에 `pillars`/`birthDate`/`daewunList` 추가.
+
+#### `saju-calendar.ts:computeCumulativePillarCount`
+
+```typescript
+export const computeCumulativePillarCount = (
+  dayMaster: Cheongan,
+  pillars: PillarSet,
+): CumulativeCount => { ... }
+```
+
+5개 레벨 각각에 대해 천간/지지 → 오행/십성 변환 후, 레벨 내 발현 집합을 만들어 누적. 같은 레벨 내 중복은 1회만 카운트(`Set`). 원국은 4주 통합(`pillars.wonguk: readonly Pillar[]`), 그 외는 1주씩.
+
+#### `pillar-level-distribution-review` cron (월요일 09:15 KST)
+
+`pattern_matches` 90일 윈도우의 `pillar_level`별 hit-rate 분포 + `cumulative_pillar_count` trigger의 N=1..5 분포를 한 줄로 압축해 `#insight` 채널에 발송. 결정론 SQL만 사용 — LLM 호출 없음([ADR-0027](../adr/0027-llm-async-routine-unification.md) 준수).
+
+- `getKSTDayOfWeek() !== 1`이면 즉시 return (다른 요일에도 09:15에 트리거되지만 본체가 스킵 — `weeklyHypothesisReview`와 동일 패턴).
+- 양쪽 분포 모두 빈 결과면 `buildMessage` → null → 발송 스킵 (`데이터 부족` 로그만).
+- `verify_status='no_metric'` 행은 hit-rate 분포에서 제외 (evidence-only 시드의 채점은 무의미).
+- 멀티유저: `queryAllUserMappings()` 순회 + 유저별 channel fallback.
+
+```
+📊 운 레벨 분포 (90일 윈도우)
+- ilun: 120건, hit 18.5%
+- wolun: 40건, hit 8.0%
+...
+🔢 누적 카운트 분포 (오행/십성 × N=1..5)
+- 화 오행 N=1: 70건, hit 12
+- 화 오행 N=2: 25건, hit 6
+- 편재 N=3: 4건, hit 0
+...
+```
+
+자동으로 "어느 N이 의미 있는 임계치인가?"의 판단 단서를 노출. 사용자가 분포를 보고 Phase 6 LLM 매트릭 제안 슬롯에 임계치 hint를 줄 수 있도록.
+
+#### 크론 시각
+
+| 시각 | 슬롯 | 의도 | 산출물 |
+|------|------|------|------|
+| 09:15 (월요일만) | `pillarLevelDistributionReview` | 운 레벨별·누적별 hit-rate 분포 노출 | `#insight` 채널 한 줄 압축 메시지 |
+
+`weeklyReport`(09:00 월요일) / `weeklyHypothesisReview`(08:00 월요일)와 시간대 겹치지 않게 분리.
+
+#### 파일 구조
+
+```
+db/migrations/
+  071_pattern_signals_pillar_level.sql  # 컬럼·CHECK·backfill·14 시드·cron 슬롯
+
+src/shared/
+  saju-calendar.ts                       # +computeCumulativePillarCount, +getDaeunPillar, +makePillar
+                                         # +types: Element, PillarSet, CumulativeCount
+  saju-match.ts                          # +pickPillarByLevel, +evaluateCumulativePillarCount
+                                         # +DailyContext.{ilun,wolun,seun,daeun}
+                                         # +NatalContext.{pillars,birthDate,daewunList}
+
+src/cron/
+  pillar-level-distribution-review.ts    # 월요일 09:15 KST 결정론 분포 cron
+  life-cron.ts                           # SLOT_TASKS에 pillarLevelDistributionReview 등록
+```
+
+#### 다음 phase 연결
+
+본 phase에서 추가된 `pillar_level` 차원은 Phase 3 이후 `life_signal` 시드에서는 미적용 (`pillar_level IS NULL` 유지). Phase 5 가설 검증·BH-FDR 그룹은 `pillar_level`도 그룹화 키로 활용 가능 (예: "월운 기준으로만 confirmed된 가설 그룹"). 자동 분포 cron은 Phase 6 LLM 매트릭 제안 슬롯의 임계치 hint 입력으로 사용.
+
+설계 결정 배경: [ADR-0028](../adr/0028-pillar-level-and-threshold-pool.md), [design-notebook Phase 2.5](../design-notebook/personal-pattern-discovery.md#phase-25-운-레벨-차원-도입--자동-분포-분석-cron-2026-05-28)
+
+### 17. 본인 1명 패턴 발견 시스템 — Phase 3 (life_signal 시드 풀 셋)
 
 > TODO(`/build`): 구현 후 본문 채우기. `life_signal` 시드 1차 셋(14\~20개 — 요일 7 + 주말 1 + 평일 1 + 월말 1 + 월초 1 + 계절 4 + 기타). 각 시드의 매트릭(SQL + window_days + description). 결정론 매트릭으로 작성 (`pattern_metrics.source = 'deterministic'`).
 
-### 17. 본인 1명 패턴 발견 시스템 — Phase 4 (매칭 cron + view 정비)
+### 18. 본인 1명 패턴 발견 시스템 — Phase 4 (매칭 cron + view 정비)
 
 > TODO(`/build`): 구현 후 본문 채우기. 매칭 cron이 `trigger_target_type='life_signal'`도 처리하도록 확장 (필요 시 파일명 변경 검토 — `daily-saju-matching` → `daily-pattern-matching`). `pattern_summary` view 본문 작성 + 사용 예시. 매칭 시 `pattern_metrics`의 hit/miss/inconclusive UPDATE 로직 (catalog 카운트는 backfill 후 미사용).
 
-### 18. 본인 1명 패턴 발견 시스템 — Phase 5 (가설 발견·검증 업데이트)
+### 19. 본인 1명 패턴 발견 시스템 — Phase 5 (가설 발견·검증 업데이트)
 
 > TODO(`/build`): 구현 후 본문 채우기. `hypothesis-discovery`가 `life_signal` trigger 포함하도록 일반화. weekly 가설 리뷰 카드 본문에 `pattern_kind` 표시. 검증 매트릭 수 증가에 따른 BH-FDR 그룹 정의.
 
-### 19. 본인 1명 패턴 발견 시스템 — Phase 6 (LLM 자율 매트릭 + 승인 게이트)
+### 20. 본인 1명 패턴 발견 시스템 — Phase 6 (LLM 자율 매트릭 + 승인 게이트)
 
 > TODO(`/build`): 구현 후 본문 채우기. 월간 LLM 슬롯이 매트릭 후보 생성, 월 cap 5개. **운영은 Claude 앱 routines 기반** ([ADR-0027](../adr/0027-llm-async-routine-unification.md)) — Phase 2에서 누적된 60+일 evidence JSONB(`pattern_matches.evidence`, `verify_status='no_metric'` 행)를 가설 후보 풀로 사용. Slack `/insight metric-approve` 명령어 + Block Kit 승인 카드 (`metric-approval-cards.ts`). 승인 시 `pattern_metrics.status = 'active'` 전환. 거절 시 `'rejected'`.
 
-### 20. 본인 1명 패턴 발견 시스템 — Phase 7 (Bayesian update)
+### 21. 본인 1명 패턴 발견 시스템 — Phase 7 (Bayesian update)
 
 > TODO(`/build`): 구현 후 본문 채우기. `src/shared/bayesian-posterior.ts` 헬퍼(\~100줄), Beta-Binomial 사후 갱신, `pattern_metrics.posterior_p` UPDATE. 가설 카드에 frequentist p값 + Bayesian posterior 병기. beta inverse CDF 라이브러리 선택.
 
-### 21. 본인 1명 패턴 발견 시스템 — Phase 8 (인사이트 카드 UI + 마스터 close)
+### 22. 본인 1명 패턴 발견 시스템 — Phase 8 (인사이트 카드 UI + 마스터 close)
 
 > TODO(`/build`): 구현 후 본문 채우기. `#insight` 채널 패턴 발견 카드 (Block Kit). `life_signal` 패턴(요일 효과 등)도 같은 카드에서 출력. 마스터 회고 + 운영 1\~3개월 후 follow-up 이슈 7건 일괄 등록 (SPRT, Change Point Detection, informed prior, 카테고리 가중치 자동 튜닝, 가설 자동 제거, 매트릭 자동 비활성화, 웹 대시보드 승인 페이지).
 
@@ -887,9 +1026,10 @@ src/shared/
 └── saju-hypothesis.ts             # Phase 4 통계 (Fisher + BH-FDR + lifecycle)
 
 src/cron/
-├── daily-saju-matching.ts         # 09:00 사주 일일 매칭 + confirmed 가설 슬롯 (Phase 3/4)
-├── diary-meta-extract.ts          # 일기 → enum 태그 추출 cron (Phase 3, Opus)
-└── weekly-hypothesis-review.ts    # 월 08:00 주간 가설 리포트 (Phase 4)
+├── daily-saju-matching.ts                 # 09:00 사주 일일 매칭 + confirmed 가설 슬롯 (Phase 3/4)
+├── diary-meta-extract.ts                  # 일기 → enum 태그 추출 cron (Phase 3, Opus)
+├── weekly-hypothesis-review.ts            # 월 08:00 주간 가설 리포트 (Phase 4)
+└── pillar-level-distribution-review.ts    # 월 09:15 운 레벨 분포 분석 (Phase 2.5)
 
 scripts/
 ├── saju-hypothesis-backtest.ts    # Phase 4 임계치 튜닝 CLI
@@ -902,4 +1042,13 @@ db/migrations/  (마스터 #434 Phase 1 — 2026-05-27)
 ├── 066_pattern_metric_backfill.sql              # description placeholder + 카운터 이전 + Bayesian α/β/p 초기화
 ├── 067_pattern_summary_view.sql                 # seed-level 집계 view 신설
 └── 068_saju_influence_summary_rebuild.sql       # view body 재정의 (이름·컬럼 contract 보존)
+
+db/migrations/  (마스터 #434 Phase 2 — 2026-05-28)
+├── 069_pattern_matches_no_metric.sql            # matched NULL 허용 + verify_status='no_metric'
+└── 070_saju_seed_pool.sql                       # 사주 시드 풀셋 161개 INSERT
+
+db/migrations/  (마스터 #434 Phase 2.5 — 2026-05-28)
+└── 071_pattern_signals_pillar_level.sql         # pillar_level 컬럼 + cumulative_pillar_count trigger
+                                                 # + expense_category_present 메트릭 + 14 신규 시드
+                                                 # + pillarLevelDistributionReview 슬롯
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,7 +28,7 @@
 - 일기 자동 저장 (`diary_entries`)
 - 삶의 테마 관리 (`life_themes`, 자동 진화)
 - 사주 패턴 누적 (`saju_patterns`, 28일 롤링 — 갱신 routine 2026-05-26 비활성화, 누적분만 시스템 프롬프트에 활용)
-- 사주 일일 매칭 시드 카탈로그 (`pattern_catalog`, Phase 3 — 결정론 매칭, 마스터 #434 Phase 1 rename per ADR-0026, 마스터 #434 Phase 2에서 6종 풀세트 161개 신규 시드 추가)
+- 사주 일일 매칭 시드 카탈로그 (`pattern_catalog`, Phase 3 — 결정론 매칭, 마스터 #434 Phase 1 rename per ADR-0026, 마스터 #434 Phase 2에서 6종 풀세트 161개 신규 시드 추가, Phase 2.5에서 `pillar_level` 차원 + `cumulative_pillar_count` trigger + 14 신규 시드 추가)
 - 일기 LLM enum 16종 추출 (`diary_meta_tags`, Phase 3)
 - 주간 사주 회고 카드 (`weekly-saju-review-v2`, 매주 월요일 08:00 KST `#insight` — 마스터 #421)
 - 상세: [docs/domains/insight.md](./domains/insight.md)
@@ -69,7 +69,8 @@
 - 약한 시드(누적 \~10건 + hit rate < 30%) 주간 알림 → 사용자 명령어로 active 토글
 - 슬랙 조회/토글: `사주 시드 보기` / `사주 시드 모두 보기` / `사주 시드 끄기 #N` / `사주 시드 켜기 #N`
 - 풀셋 시드(매트릭 없음, 마스터 #434 Phase 2): trigger만 평가하고 `pattern_matches.matched=NULL` + `verify_status='no_metric'`로 evidence-only 누적. 60+일 후 LLM 매트릭 제안 슬롯(Phase 6)이 가설 후보 풀로 사용
-- 결정 기록: [ADR-0017](./adr/0017-saju-ganji-master-normalization.md)
+- 운 레벨 차원(마스터 #434 Phase 2.5): 시드별 `pillar_level`(원국/대운/세운/월운/일운/누적) 차원 도입 + `cumulative_pillar_count` trigger(N=1..5 풀셋 임계치) + 화 오행 누적 시드 OR 매칭(`diary_meta` + `expense_category_present`). 월요일 09:15 자동 분포 분석 cron이 hit-rate 분포 노출
+- 결정 기록: [ADR-0017](./adr/0017-saju-ganji-master-normalization.md), [ADR-0028](./adr/0028-pillar-level-and-threshold-pool.md)
 
 ### Slack fast path 명령어
 
@@ -102,6 +103,7 @@
 | 09:05 | 오늘 일정 + 낮 루틴 체크리스트 + 어제 리뷰 + morning 인사이트 |
 | 09:10 | LLM 자율 발견 outcome 검증 (대기열 50건) |
 | 월요일 09:00 | 주간 인사이트 리포트 (Block Kit) |
+| 월요일 09:15 | 운 레벨 분포 분석 — `pillar_level`별·누적 N=1..5 hit-rate 분포 (`#insight`, Phase 2.5) |
 | 월요일 09:30 | 주간 LLM 자율 발견 슬롯 (Block Kit) |
 | 매월 1일 09:30 | 월간 LLM 자율 발견 슬롯 (Block Kit) |
 | 23:55 | 하루 종합 리뷰 + 밤 루틴 + 마무리 잔소리 + night 인사이트 |
@@ -134,6 +136,7 @@
 ## 마스터 단위 진행 중 작업
 
 - **프로액티브 인사이트 v2** ([#393](https://github.com/hyewon3938/slack-ai-agents/issues/393)) — Phase 1\~4 머지 완료 (Phase 4 = 가설-검증 정량 파이프라인, 2026-05-22 PR [#415](https://github.com/hyewon3938/slack-ai-agents/pull/415)). Phase 5([#408](https://github.com/hyewon3938/slack-ai-agents/issues/408)) 월운·세운·대운 확장은 Phase 4 운영 1\~3개월 데이터 누적 후 진입 예정. 흐름: [design-notebook](./design-notebook/insight-engine-v2.md)
+- **본인 1명 패턴 발견 시스템** ([#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)) — Phase 1(스키마 rename, ADR-0022\~0026) / Phase 2(사주 시드 풀셋 161개 + evidence-only) / Phase 2.5(운 레벨 차원 + 풀셋 임계치 + 분포 분석 cron, ADR-0028) 머지 완료. Phase 3 이후는 life_signal 시드 풀 셋 + 매칭 cron 일반화 + LLM 매트릭 승인 게이트 + Bayesian update + UI. 흐름: [design-notebook](./design-notebook/personal-pattern-discovery.md)
 
 ## 문서 지도
 

--- a/src/cron/__tests__/pillar-level-distribution-review.test.ts
+++ b/src/cron/__tests__/pillar-level-distribution-review.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMessage,
+  type PillarRow,
+  type CumulativeRow,
+} from '../pillar-level-distribution-review.js';
+
+// ── buildMessage: 분포 압축 ─────────────────────────────
+
+describe('buildMessage', () => {
+  it('양쪽 모두 빈 결과면 null (발송 스킵)', () => {
+    expect(buildMessage([], [])).toBeNull();
+  });
+
+  it('pillar 분포만 있어도 메시지 생성', () => {
+    const rows: PillarRow[] = [
+      { pillar_level: 'ilun', matches: '120', hits: '24', hit_rate_pct: '20.0' },
+      { pillar_level: 'wolun', matches: '80', hits: '8', hit_rate_pct: '10.0' },
+    ];
+    const out = buildMessage(rows, []);
+    expect(out).toContain('운 레벨 분포');
+    expect(out).toContain('ilun: 120건, hit 20.0%');
+    expect(out).toContain('wolun: 80건, hit 10.0%');
+    expect(out).not.toContain('누적 카운트');
+  });
+
+  it('누적 분포만 있어도 메시지 생성', () => {
+    const cum: CumulativeRow[] = [
+      { count_min: 2, element: '화', sipsin: null, matches: '14', hits: '7' },
+      { count_min: 3, element: null, sipsin: '편재', matches: '5', hits: '1' },
+    ];
+    const out = buildMessage([], cum);
+    expect(out).toContain('운 레벨 분포'); // 헤더는 항상 노출 (빈 분포라도)
+    expect(out).toContain('누적 카운트 분포');
+    expect(out).toContain('화 오행 N=2: 14건');
+    expect(out).toContain('편재 N=3: 5건');
+  });
+
+  it('hit_rate_pct가 null이면 "-" 표시', () => {
+    const rows: PillarRow[] = [
+      { pillar_level: 'wonguk', matches: '0', hits: '0', hit_rate_pct: null },
+    ];
+    const out = buildMessage(rows, []);
+    expect(out).toContain('wonguk: 0건, hit -%');
+  });
+
+  it('pillar_level이 null이면 (unknown) 표시', () => {
+    const rows: PillarRow[] = [
+      { pillar_level: null, matches: '3', hits: '1', hit_rate_pct: '33.3' },
+    ];
+    const out = buildMessage(rows, []);
+    expect(out).toContain('(unknown)');
+  });
+
+  it('count_min이 null인 누적 행도 안전하게 출력', () => {
+    const cum: CumulativeRow[] = [
+      { count_min: null, element: '화', sipsin: null, matches: '2', hits: '0' },
+    ];
+    const out = buildMessage([], cum);
+    expect(out).toContain('N=?');
+  });
+
+  it('양쪽 분포 모두 있으면 두 섹션 모두 포함', () => {
+    const rows: PillarRow[] = [
+      { pillar_level: 'ilun', matches: '50', hits: '5', hit_rate_pct: '10.0' },
+    ];
+    const cum: CumulativeRow[] = [
+      { count_min: 1, element: '화', sipsin: null, matches: '20', hits: '6' },
+    ];
+    const out = buildMessage(rows, cum);
+    expect(out).toContain('운 레벨 분포');
+    expect(out).toContain('누적 카운트 분포');
+    expect(out).toContain('ilun');
+    expect(out).toContain('화 오행 N=1');
+  });
+});

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -53,6 +53,7 @@ import { verifyLlmInsightsTask } from './verify-llm-insights.js';
 import { dailySajuMatchingTask } from './daily-saju-matching.js';
 import { diaryMetaExtractTask } from './diary-meta-extract.js';
 import { weeklyHypothesisReviewTask } from './weekly-hypothesis-review.js';
+import { pillarLevelDistributionReviewTask } from './pillar-level-distribution-review.js';
 import { buildLifeContext } from '../shared/life-context.js';
 import { publishHomeView } from '../agents/life/home.js';
 
@@ -660,6 +661,7 @@ const SLOT_TASKS: Record<string, CronTaskFn> = {
   dailySajuMatching: dailySajuMatchingTask,
   diaryMetaExtract: diaryMetaExtractTask,
   weeklyHypothesisReview: weeklyHypothesisReviewTask,
+  pillarLevelDistributionReview: pillarLevelDistributionReviewTask,
 };
 
 // ─── CronScheduler 클래스 ───────────────────────────────

--- a/src/cron/pillar-level-distribution-review.ts
+++ b/src/cron/pillar-level-distribution-review.ts
@@ -1,0 +1,136 @@
+/**
+ * 운 레벨 분포 분석 cron — 월요일 09:15 KST.
+ * 마스터 #434 Phase 2.5 (ADR-0027 결정론 SQL + ADR-0028 풀셋 임계치).
+ *
+ * 흐름:
+ *   1) 90일 윈도우의 pattern_matches를 pillar_level별 hit-rate 분포 집계
+ *   2) cumulative_pillar_count trigger의 N=1..5 분포 집계
+ *   3) 데이터 부족 시 (양쪽 모두 0건) 발송 스킵
+ *   4) insight 채널에 한 줄 압축 메시지 발송
+ *
+ * 임의 임계치 안 박음. 분포만 그대로 노출 → 사용자가 임계치 학습 시점 판단.
+ */
+
+import type { App } from '@slack/bolt';
+import { query } from '../shared/db.js';
+import { getKSTDayOfWeek } from '../shared/kst.js';
+import { postToChannel } from '../shared/slack.js';
+import { queryAllUserMappings, DEFAULT_USER_ID } from '../shared/user-resolver.js';
+import type { LifeCronConfig } from './life-cron.js';
+
+export interface PillarRow {
+  pillar_level: string | null;
+  matches: string;
+  hits: string;
+  hit_rate_pct: string | null;
+}
+
+export interface CumulativeRow {
+  count_min: number | null;
+  element: string | null;
+  sipsin: string | null;
+  matches: string;
+  hits: string;
+}
+
+const SQL_PILLAR_DISTRIBUTION = `
+  SELECT
+    c.pillar_level,
+    COUNT(m.id)::TEXT AS matches,
+    SUM(CASE WHEN m.matched = true THEN 1 ELSE 0 END)::TEXT AS hits,
+    ROUND(
+      100.0 * SUM(CASE WHEN m.matched = true THEN 1 ELSE 0 END)
+      / NULLIF(COUNT(m.id) FILTER (WHERE m.matched IS NOT NULL), 0),
+      1
+    )::TEXT AS hit_rate_pct
+  FROM pattern_catalog c
+  JOIN pattern_matches m ON m.pattern_id = c.id
+  WHERE c.pattern_kind = 'saju'
+    AND c.user_id = $1
+    AND m.created_at >= NOW() - INTERVAL '90 days'
+    AND m.verify_status != 'no_metric'
+  GROUP BY c.pillar_level
+  ORDER BY hit_rate_pct DESC NULLS LAST
+`;
+
+const SQL_CUMULATIVE_DISTRIBUTION = `
+  SELECT
+    (c.trigger_aux->>'count_min')::INT AS count_min,
+    c.trigger_aux->>'element' AS element,
+    c.trigger_aux->>'sipsin' AS sipsin,
+    COUNT(m.id)::TEXT AS matches,
+    SUM(CASE WHEN m.matched = true THEN 1 ELSE 0 END)::TEXT AS hits
+  FROM pattern_catalog c
+  JOIN pattern_matches m ON m.pattern_id = c.id
+  WHERE c.trigger_target_type = 'cumulative_pillar_count'
+    AND c.user_id = $1
+    AND m.created_at >= NOW() - INTERVAL '90 days'
+    AND m.matched IS NOT NULL
+  GROUP BY count_min, element, sipsin
+  ORDER BY element, sipsin, count_min
+`;
+
+export const buildMessage = (pillarRows: PillarRow[], cumRows: CumulativeRow[]): string | null => {
+  if (pillarRows.length === 0 && cumRows.length === 0) return null;
+
+  const lines: string[] = ['📊 운 레벨 분포 (90일 윈도우)'];
+  for (const row of pillarRows) {
+    const level = row.pillar_level ?? '(unknown)';
+    const rate = row.hit_rate_pct ?? '-';
+    lines.push(`- ${level}: ${row.matches}건, hit ${rate}%`);
+  }
+  if (cumRows.length > 0) {
+    lines.push('', '🔢 누적 카운트 분포 (오행/십성 × N=1..5)');
+    for (const row of cumRows) {
+      const key = row.element ? `${row.element} 오행` : (row.sipsin ?? '?');
+      const n = row.count_min ?? '?';
+      lines.push(`- ${key} N=${n}: ${row.matches}건, hit ${row.hits}`);
+    }
+  }
+  return lines.join('\n');
+};
+
+const processUser = async (app: App, userId: number, channelId: string): Promise<void> => {
+  const [pillarRes, cumRes] = await Promise.all([
+    query<PillarRow>(SQL_PILLAR_DISTRIBUTION, [userId]),
+    query<CumulativeRow>(SQL_CUMULATIVE_DISTRIBUTION, [userId]),
+  ]);
+
+  const message = buildMessage(pillarRes.rows, cumRes.rows);
+  if (!message) {
+    console.warn(`[Pillar Distribution] user=${userId} 데이터 부족 — 발송 스킵`);
+    return;
+  }
+
+  await postToChannel(app.client, channelId, message);
+};
+
+/**
+ * 본체 — life-cron SLOT_TASKS에서 호출.
+ * 등록 시각은 09:15이지만 월요일만 실행 (weeklyHypothesisReview 패턴 동일).
+ */
+export const pillarLevelDistributionReviewTask = async (
+  app: App,
+  config: LifeCronConfig,
+): Promise<void> => {
+  if (getKSTDayOfWeek() !== 1) return;
+  const mappings = await queryAllUserMappings();
+  const insightFallback = process.env['INSIGHT_CHANNEL_ID'] ?? config.channelId;
+
+  if (mappings.length === 0) {
+    if (!insightFallback) return;
+    await processUser(app, DEFAULT_USER_ID, insightFallback);
+    return;
+  }
+
+  for (const mapping of mappings) {
+    const channelId = mapping.insightChannelId ?? insightFallback;
+    if (!channelId) continue;
+    try {
+      await processUser(app, mapping.userId, channelId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[Pillar Distribution] user=${mapping.userId} 처리 실패: ${msg}`);
+    }
+  }
+};

--- a/src/shared/__tests__/saju-match.test.ts
+++ b/src/shared/__tests__/saju-match.test.ts
@@ -34,9 +34,17 @@ import {
   __resetCacheForTest,
   type SajuSeedWithMetrics,
   type DailyContext,
+  type NatalContext,
   type SeedMatchResult,
   type SajuMetric,
 } from '../saju-match.js';
+import {
+  getMonthPillar,
+  getYearPillar,
+  makePillar,
+  type Cheongan,
+  type Jiji,
+} from '../saju-calendar.js';
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -94,6 +102,7 @@ const baseSeed = (overrides: Partial<SajuSeedWithMetrics> = {}): SajuSeedWithMet
   trigger_target_type: 'stem',
   trigger_target_id: null,
   trigger_aux: null,
+  pillar_level: null,
   active: true,
   source: 'seed',
   hit_count: 0,
@@ -103,17 +112,44 @@ const baseSeed = (overrides: Partial<SajuSeedWithMetrics> = {}): SajuSeedWithMet
   ...overrides,
 });
 
-const baseCtx = (overrides: Partial<DailyContext> = {}): DailyContext => ({
-  date: '2026-05-17',
-  dayStem: '경',
-  dayBranch: '술',
-  natal: {
-    stems: ['갑', '경', '경', '경'],
-    branches: ['자', '술', '술', '술'],
-    dayMaster: '경',
-  },
-  ...overrides,
+/** stems/branches/dayMaster만 받아서 NatalContext 완성 (Phase 2.5 신규 필드 자동 채움) */
+export const buildNatal = (partial: {
+  stems: Cheongan[];
+  branches: Jiji[];
+  dayMaster: Cheongan;
+}): NatalContext => ({
+  stems: partial.stems,
+  branches: partial.branches,
+  dayMaster: partial.dayMaster,
+  pillars: partial.stems.map((s, i) => makePillar(s, partial.branches[i])),
+  birthDate: null,
+  daewunList: [],
 });
+
+const baseCtx = (
+  overrides: Partial<Omit<DailyContext, 'natal'>> & { natal?: NatalContext } = {},
+): DailyContext => {
+  const date = overrides.date ?? '2026-05-17';
+  const dayStem = overrides.dayStem ?? '경';
+  const dayBranch = overrides.dayBranch ?? '술';
+  const ilun = overrides.ilun ?? makePillar(dayStem, dayBranch);
+  return {
+    date,
+    dayStem,
+    dayBranch,
+    natal:
+      overrides.natal ??
+      buildNatal({
+        stems: ['갑', '경', '경', '경'],
+        branches: ['자', '술', '술', '술'],
+        dayMaster: '경',
+      }),
+    ilun,
+    wolun: overrides.wolun ?? getMonthPillar(date),
+    seun: overrides.seun ?? getYearPillar(date),
+    daeun: overrides.daeun ?? null,
+  };
+};
 
 // ─── evaluateTrigger: stem ────────────────────────────────
 
@@ -255,11 +291,11 @@ describe('evaluateTrigger - relation', () => {
     });
     const ctx = baseCtx({
       dayBranch: '사',
-      natal: {
+      natal: buildNatal({
         stems: ['갑', '경', '경', '경'],
         branches: ['자', '축', '신', '유'], // 진 없음
         dayMaster: '경',
-      },
+      }),
     });
     expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
   });
@@ -283,11 +319,11 @@ describe('evaluateTrigger - relation', () => {
     // 본명 자 있음, 일운 오 → trigger
     const ctx = baseCtx({
       dayBranch: '오',
-      natal: {
+      natal: buildNatal({
         stems: ['갑', '경', '경', '경'],
         branches: ['자', '술', '술', '술'],
         dayMaster: '경',
-      },
+      }),
     });
     expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
   });
@@ -300,11 +336,11 @@ describe('evaluateTrigger - relation', () => {
     // 본명 오 있음, 일운 자 → trigger (양방향)
     const ctx = baseCtx({
       dayBranch: '자',
-      natal: {
+      natal: buildNatal({
         stems: ['갑', '경', '경', '경'],
         branches: ['오', '술', '술', '술'],
         dayMaster: '경',
-      },
+      }),
     });
     expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
   });
@@ -316,11 +352,11 @@ describe('evaluateTrigger - relation', () => {
     });
     const ctx = baseCtx({
       dayBranch: '자',
-      natal: {
+      natal: buildNatal({
         stems: ['갑', '경', '경', '경'],
         branches: ['신', '술', '술', '술'], // 자/오 둘 다 없음
         dayMaster: '경',
-      },
+      }),
     });
     expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
   });
@@ -334,11 +370,11 @@ describe('evaluateTrigger - relation', () => {
     const ctx = baseCtx({
       dayStem: '을',
       dayBranch: '술',
-      natal: {
+      natal: buildNatal({
         stems: ['갑', '경', '경', '경'],
         branches: ['자', '술', '술', '술'],
         dayMaster: '경',
-      },
+      }),
     });
     expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
   });
@@ -521,5 +557,192 @@ describe('compactMatchedLine', () => {
     const results = [buildResult('S5_토_과다', null, true, 3)];
     const line = compactMatchedLine(ctx, results);
     expect(line).toContain('S5_토_과다');
+  });
+});
+
+// ─── Phase 2.5: pillar_level (운 레벨) 분기 ────────────────
+
+describe('evaluateTrigger - pillar_level (Phase 2.5)', () => {
+  it('pillar_level=wolun + stem trigger — 월운 천간이 target과 일치하면 true', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'stem',
+      trigger_target_id: 1, // 갑
+      pillar_level: 'wolun',
+    });
+    const ctx = baseCtx({
+      dayStem: '경', // ilun.cheongan=경
+      wolun: makePillar('갑', '인'), // wolun.cheongan=갑 → trigger
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
+  });
+
+  it('pillar_level=wolun + stem trigger — 일운만 일치하고 월운 미일치면 false', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'stem',
+      trigger_target_id: 7, // 경
+      pillar_level: 'wolun',
+    });
+    const ctx = baseCtx({
+      dayStem: '경', // ilun.cheongan=경 (target과 같지만 무시)
+      wolun: makePillar('갑', '인'), // wolun.cheongan=갑 → 미일치
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
+  });
+
+  it('pillar_level=seun + branch trigger — 세운 지지 일치 시 true', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'branch',
+      trigger_target_id: 3, // 인
+      pillar_level: 'seun',
+    });
+    const ctx = baseCtx({
+      dayBranch: '술',
+      seun: makePillar('병', '인'), // seun.jiji=인 → trigger
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
+  });
+
+  it('pillar_level=daeun + stem trigger — 대운 적용 시 true', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'stem',
+      trigger_target_id: 1, // 갑
+      pillar_level: 'daeun',
+    });
+    const ctx = baseCtx({
+      dayStem: '경',
+      daeun: makePillar('갑', '인'), // daeun.cheongan=갑 → trigger
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
+  });
+
+  it('pillar_level=daeun + daeun=null이면 false (미적용 구간)', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'stem',
+      trigger_target_id: 7, // 경
+      pillar_level: 'daeun',
+    });
+    const ctx = baseCtx({
+      dayStem: '경',
+      daeun: null, // 대운 미시작 / 미등록
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
+  });
+
+  it('pillar_level=wonguk이면 stem/branch trigger는 false (직접 매칭 불가)', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'stem',
+      trigger_target_id: 7, // 경
+      pillar_level: 'wonguk',
+    });
+    const ctx = baseCtx({ dayStem: '경' });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
+  });
+
+  it('pillar_level=null이면 일운 기준 (기존 동작 유지)', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'stem',
+      trigger_target_id: 7, // 경
+      pillar_level: null,
+    });
+    const ctx = baseCtx({ dayStem: '경' });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
+  });
+});
+
+// ─── Phase 2.5: cumulative_pillar_count ────────────────────
+
+describe('evaluateTrigger - cumulative_pillar_count (Phase 2.5)', () => {
+  it('element 화 count_min=2 — 본명(병/정)에 화 + 월운 화 천간이면 true', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'cumulative_pillar_count',
+      trigger_aux: { element: '화', count_min: 2 },
+      pillar_level: 'cumulative',
+    });
+    // 본명에 정(화)/오(화) 있음 → wonguk 화 +1
+    // wolun.cheongan=병(화) → wolun 화 +1
+    // 합계 2 ≥ 2 → true
+    const ctx = baseCtx({
+      natal: buildNatal({
+        stems: ['정', '경', '경', '경'],
+        branches: ['오', '술', '술', '술'],
+        dayMaster: '경',
+      }),
+      wolun: makePillar('병', '자'),
+      seun: makePillar('갑', '술'), // 화 없음
+      ilun: makePillar('경', '술'), // 화 없음
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
+  });
+
+  it('element 화 count_min=3 — 화가 2개 레벨에만 있으면 false', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'cumulative_pillar_count',
+      trigger_aux: { element: '화', count_min: 3 },
+      pillar_level: 'cumulative',
+    });
+    const ctx = baseCtx({
+      natal: buildNatal({
+        stems: ['정', '경', '경', '경'],
+        branches: ['오', '술', '술', '술'],
+        dayMaster: '경',
+      }),
+      wolun: makePillar('병', '자'),
+      seun: makePillar('갑', '술'),
+      ilun: makePillar('경', '술'),
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
+  });
+
+  it('sipsin 편재 count_min=2 — 일간 경 기준 갑(편재)이 본명+일운에서 발현', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'cumulative_pillar_count',
+      trigger_aux: { sipsin: '편재', count_min: 2 },
+      pillar_level: 'cumulative',
+    });
+    // 일간 경 기준 편재 = 갑(천간) / 인(지지)
+    // 본명 stems에 갑 → wonguk +1
+    // ilun.cheongan=갑 → ilun +1
+    // 합계 2 ≥ 2 → true
+    const ctx = baseCtx({
+      natal: buildNatal({
+        stems: ['갑', '경', '경', '경'],
+        branches: ['자', '술', '술', '술'],
+        dayMaster: '경',
+      }),
+      ilun: makePillar('갑', '술'),
+      wolun: makePillar('경', '자'),
+      seun: makePillar('경', '자'),
+    });
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(true);
+  });
+
+  it('count_min<=0이면 false', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'cumulative_pillar_count',
+      trigger_aux: { element: '화', count_min: 0 },
+      pillar_level: 'cumulative',
+    });
+    const ctx = baseCtx();
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
+  });
+
+  it('aux에 element/sipsin 둘 다 없으면 false', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'cumulative_pillar_count',
+      trigger_aux: { count_min: 1 },
+      pillar_level: 'cumulative',
+    });
+    const ctx = baseCtx();
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
+  });
+
+  it('element 값이 오행이 아니면 false', async () => {
+    const seed = baseSeed({
+      trigger_target_type: 'cumulative_pillar_count',
+      trigger_aux: { element: '잘못된오행', count_min: 1 },
+      pillar_level: 'cumulative',
+    });
+    const ctx = baseCtx();
+    expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
   });
 });

--- a/src/shared/saju-calendar.ts
+++ b/src/shared/saju-calendar.ts
@@ -97,6 +97,34 @@ export interface DailyFortuneData {
   };
 }
 
+// ─── Phase 2.5: 운 레벨 + 누적 카운트 ────────────────────
+
+export type Element = '목' | '화' | '토' | '금' | '수';
+
+/** 5개 운 레벨의 pillar 집합 (원국 4 + 대운/세운/월운/일운 각 1) */
+export interface PillarSet {
+  /** 원국 4주 (year/month/day/hour 순) */
+  wonguk: readonly Pillar[];
+  /** 대운 1주 (대운 적용 구간 외 또는 미정의 시 null) */
+  daeun: Pillar | null;
+  /** 세운 1주 (= target date의 year pillar) */
+  seun: Pillar;
+  /** 월운 1주 (= target date의 month pillar) */
+  wolun: Pillar;
+  /** 일운 1주 (= target date의 day pillar) */
+  ilun: Pillar;
+}
+
+/**
+ * 5개 운 레벨에서 오행/십성 발현 카운트.
+ * 각 레벨에서 해당 오행/십성이 1회 이상 나타나면 그 레벨을 1로 카운트.
+ * 결과 범위: 0\~5 (대운 미적용 시 0\~4).
+ */
+export interface CumulativeCount {
+  element: Record<Element, number>;
+  sipsin: Record<string, number>;
+}
+
 // ─── 상수: 천간/지지 ────────────────────────────────────
 
 const CHEONGAN_LIST: readonly Cheongan[] = [
@@ -802,6 +830,127 @@ export const calculateFortuneRange = (
     results.push(calculateDailyFortune(dateStr, dayMaster, wonkukStems, wonkukBranches));
   }
   return results;
+};
+
+// ─── Phase 2.5: 오행/Pillar 유틸 + 대운 추출 + 누적 카운트 ──
+
+const ELEMENT_LIST: readonly Element[] = ['목', '화', '토', '금', '수'];
+
+/** 천간 → 오행 */
+export const getElementByCheongan = (c: Cheongan): Element =>
+  ELEMENT_LIST[CHEONGAN_ELEMENT[cheonganIndex(c)]];
+
+/** 지지 → 오행 (본기 천간 기준) */
+export const getElementByJiji = (j: Jiji): Element =>
+  ELEMENT_LIST[CHEONGAN_ELEMENT[JIJI_BONGI[jijiIndex(j)]]];
+
+/**
+ * 천간 + 지지 → Pillar.
+ * 음양 mismatch(유효한 60갑자 조합 아님)는 index=-1로 표기, 객체는 정상 반환.
+ * (테스트 fixture·임의 stem+branch 조합 허용용. 프로덕션 데이터는 항상 유효 갑자.)
+ */
+export const makePillar = (cheongan: Cheongan, jiji: Jiji): Pillar => {
+  const cIdx = cheonganIndex(cheongan);
+  const jIdx = jijiIndex(jiji);
+  if (cIdx < 0) throw new Error(`알 수 없는 천간: ${cheongan}`);
+  if (jIdx < 0) throw new Error(`알 수 없는 지지: ${jiji}`);
+  let index = -1;
+  for (let i = 0; i < 60; i++) {
+    if (i % 10 === cIdx && i % 12 === jIdx) {
+      index = i;
+      break;
+    }
+  }
+  return {
+    index,
+    hanja: `${CHEONGAN_HANJA[cIdx]}${JIJI_HANJA[jIdx]}`,
+    hangul: `${CHEONGAN_LIST[cIdx]}${JIJI_LIST[jIdx]}`,
+    cheongan,
+    jiji,
+  };
+};
+
+/** '병인' 같은 한글 2자 간지 문자열 → Pillar */
+export const parsePillarString = (s: string): Pillar => {
+  if (s.length !== 2) throw new Error(`잘못된 pillar 문자열: ${s}`);
+  return makePillar(s.charAt(0) as Cheongan, s.charAt(1) as Jiji);
+};
+
+/** 만 나이 계산 (생일 미도래 시 -1) */
+const calcAge = (birthDate: string, targetDate: string): number => {
+  const birth = parseDate(birthDate);
+  const target = parseDate(targetDate);
+  let age = target.getFullYear() - birth.getFullYear();
+  const bm = birth.getMonth();
+  const bd = birth.getDate();
+  const tm = target.getMonth();
+  const td = target.getDate();
+  if (tm < bm || (tm === bm && td < bd)) age -= 1;
+  return age;
+};
+
+/**
+ * daewun_list에서 targetDate 시점 활성 대운 추출.
+ * daewun_list는 `[{age, pillar}, ...]` 형식 (saju_profiles 컬럼).
+ * birthDate 기준 만 나이가 첫 entry보다 어리면 null (대운 미시작).
+ * 그 외에는 age <= entry.age인 가장 큰 entry의 pillar 반환.
+ *
+ * @param birthDate YYYY-MM-DD
+ * @param daewunList saju_profiles.daewun_list (오름차순 age 가정)
+ * @param targetDate YYYY-MM-DD
+ */
+export const getDaeunPillar = (
+  birthDate: string,
+  daewunList: ReadonlyArray<{ age: number; pillar: string }>,
+  targetDate: string,
+): Pillar | null => {
+  if (daewunList.length === 0) return null;
+  const age = calcAge(birthDate, targetDate);
+  const sorted = [...daewunList].sort((a, b) => a.age - b.age);
+  if (age < sorted[0].age) return null;
+  let active = sorted[0];
+  for (const entry of sorted) {
+    if (entry.age <= age) active = entry;
+    else break;
+  }
+  return parsePillarString(active.pillar);
+};
+
+/**
+ * 5개 운 레벨에서 오행/십성 발현 카운트.
+ * 각 레벨에서 해당 오행/십성이 1회 이상 나타나면 그 레벨을 1로 카운트.
+ * 가중치 없음. 풀셋 임계치 N=1..5 시드용 (ADR-0028).
+ */
+export const computeCumulativePillarCount = (
+  dayMaster: Cheongan,
+  pillars: PillarSet,
+): CumulativeCount => {
+  const levels: ReadonlyArray<readonly Pillar[]> = [
+    pillars.wonguk,
+    pillars.daeun ? [pillars.daeun] : [],
+    [pillars.seun],
+    [pillars.wolun],
+    [pillars.ilun],
+  ];
+
+  const elementCount: Record<Element, number> = { 목: 0, 화: 0, 토: 0, 금: 0, 수: 0 };
+  const sipsinCount: Record<string, number> = {};
+
+  for (const level of levels) {
+    if (level.length === 0) continue;
+    const presentElements = new Set<Element>();
+    const presentSipsins = new Set<Sipsung>();
+    for (const p of level) {
+      presentElements.add(getElementByCheongan(p.cheongan));
+      presentElements.add(getElementByJiji(p.jiji));
+      presentSipsins.add(getSipsung(dayMaster, p.cheongan));
+      presentSipsins.add(getJijiSipsung(dayMaster, p.jiji));
+    }
+    for (const e of presentElements) elementCount[e]++;
+    for (const s of presentSipsins) sipsinCount[s] = (sipsinCount[s] ?? 0) + 1;
+  }
+
+  return { element: elementCount, sipsin: sipsinCount };
 };
 
 // ─── CLI 모드 ───────────────────────────────────────────

--- a/src/shared/saju-match.ts
+++ b/src/shared/saju-match.ts
@@ -11,11 +11,25 @@
  */
 
 import { query, queryWithClient } from './db.js';
-import { getDayPillar, type Cheongan, type Jiji } from './saju-calendar.js';
+import {
+  computeCumulativePillarCount,
+  getDayPillar,
+  getDaeunPillar,
+  getMonthPillar,
+  getYearPillar,
+  makePillar,
+  type Cheongan,
+  type Element,
+  type Jiji,
+  type Pillar,
+  type PillarSet,
+} from './saju-calendar.js';
 import { addDays } from './kst.js';
 
 const METRIC_TIMEOUT_MS = 5_000;
 const BASELINE_WINDOW_DAYS = 28;
+
+export type PillarLevel = 'wonguk' | 'daeun' | 'seun' | 'wolun' | 'ilun' | 'cumulative';
 
 export interface SajuSeed {
   id: number;
@@ -23,9 +37,18 @@ export interface SajuSeed {
   name: string;
   sipsin: string | null;
   description: string | null;
-  trigger_target_type: 'stem' | 'branch' | 'ganji' | 'element_density' | 'sibiunsung' | 'relation';
+  trigger_target_type:
+    | 'stem'
+    | 'branch'
+    | 'ganji'
+    | 'element_density'
+    | 'sibiunsung'
+    | 'relation'
+    | 'cumulative_pillar_count';
   trigger_target_id: number | null;
   trigger_aux: Record<string, unknown> | null;
+  /** 사주 시드 발현 운 레벨. life_signal/null은 미적용 (마스터 #434 Phase 2.5). */
+  pillar_level: PillarLevel | null;
   active: boolean;
   source: 'seed' | 'llm_promoted';
   hit_count: number;
@@ -40,7 +63,14 @@ export interface SajuMetric {
   expected_metric_sql: string;
   expected_direction: 'above_avg' | 'below_avg' | 'above_abs' | 'below_abs' | 'flag_present';
   expected_threshold: number | null;
-  domain: 'schedule' | 'routine' | 'sleep' | 'expense' | 'diary_meta' | 'audit';
+  domain:
+    | 'schedule'
+    | 'routine'
+    | 'sleep'
+    | 'expense'
+    | 'diary_meta'
+    | 'audit'
+    | 'expense_category_present';
 }
 
 export interface SajuSeedWithMetrics extends SajuSeed {
@@ -51,6 +81,12 @@ export interface NatalContext {
   stems: Cheongan[];
   branches: Jiji[];
   dayMaster: Cheongan;
+  /** 원국 4주 (year/month/day/hour 순) — Phase 2.5 cumulative trigger용 */
+  pillars: Pillar[];
+  /** 생년월일 (YYYY-MM-DD) — 대운 추출용. 미등록 시 null */
+  birthDate: string | null;
+  /** saju_profiles.daewun_list — 대운 추출용 */
+  daewunList: ReadonlyArray<{ age: number; pillar: string }>;
 }
 
 export interface DailyContext {
@@ -58,6 +94,14 @@ export interface DailyContext {
   dayStem: Cheongan;
   dayBranch: Jiji;
   natal: NatalContext;
+  /** 일운 Pillar (= {cheongan: dayStem, jiji: dayBranch}) — Phase 2.5 */
+  ilun: Pillar;
+  /** 월운 Pillar — Phase 2.5 */
+  wolun: Pillar;
+  /** 세운 Pillar (= year pillar of target date) — Phase 2.5 */
+  seun: Pillar;
+  /** 대운 Pillar (적용 구간 외 또는 미등록 시 null) — Phase 2.5 */
+  daeun: Pillar | null;
 }
 
 export interface MetricEvaluation {
@@ -87,23 +131,49 @@ interface SajuProfileRow {
   year_pillar: string;
   month_pillar: string;
   hour_pillar: string;
+  birth_date: string | null;
+  daewun_list: unknown;
 }
+
+interface DaewunEntry {
+  age: number;
+  pillar: string;
+}
+
+const isDaewunEntryArray = (value: unknown): value is DaewunEntry[] => {
+  if (!Array.isArray(value)) return false;
+  return value.every(
+    (v) =>
+      typeof v === 'object' &&
+      v !== null &&
+      typeof (v as Record<string, unknown>).age === 'number' &&
+      typeof (v as Record<string, unknown>).pillar === 'string',
+  );
+};
 
 export const loadNatalContext = async (userId: number): Promise<NatalContext | null> => {
   const result = await query<SajuProfileRow>(
-    'SELECT day_pillar, year_pillar, month_pillar, hour_pillar FROM saju_profiles WHERE user_id = $1',
+    `SELECT day_pillar, year_pillar, month_pillar, hour_pillar,
+            birth_date::text AS birth_date, daewun_list
+       FROM saju_profiles WHERE user_id = $1`,
     [userId],
   );
   const row = result.rows[0];
   if (!row) return null;
 
-  const pillars = [row.year_pillar, row.month_pillar, row.day_pillar, row.hour_pillar];
-  const stems = pillars.map((p) => p.charAt(0)) as Cheongan[];
-  const branches = pillars.map((p) => p.charAt(1)) as Jiji[];
+  const pillarStrs = [row.year_pillar, row.month_pillar, row.day_pillar, row.hour_pillar];
+  const stems = pillarStrs.map((p) => p.charAt(0)) as Cheongan[];
+  const branches = pillarStrs.map((p) => p.charAt(1)) as Jiji[];
+  const pillars = pillarStrs.map((p) => makePillar(p.charAt(0) as Cheongan, p.charAt(1) as Jiji));
+  const daewunList = isDaewunEntryArray(row.daewun_list) ? row.daewun_list : [];
+
   return {
     stems,
     branches,
     dayMaster: row.day_pillar.charAt(0) as Cheongan,
+    pillars,
+    birthDate: row.birth_date,
+    daewunList,
   };
 };
 
@@ -113,12 +183,19 @@ export const getDailyContext = async (
 ): Promise<DailyContext | null> => {
   const natal = await loadNatalContext(userId);
   if (!natal) return null;
-  const pillar = getDayPillar(date);
+  const ilun = getDayPillar(date);
+  const wolun = getMonthPillar(date);
+  const seun = getYearPillar(date);
+  const daeun = natal.birthDate ? getDaeunPillar(natal.birthDate, natal.daewunList, date) : null;
   return {
     date,
-    dayStem: pillar.cheongan,
-    dayBranch: pillar.jiji,
+    dayStem: ilun.cheongan,
+    dayBranch: ilun.jiji,
     natal,
+    ilun,
+    wolun,
+    seun,
+    daeun,
   };
 };
 
@@ -130,7 +207,7 @@ type MetricRow = SajuMetric;
 export const loadActiveSeeds = async (userId: number): Promise<SajuSeedWithMetrics[]> => {
   const seeds = await query<SeedRow>(
     `SELECT id, user_id, name, sipsin, description,
-            trigger_target_type, trigger_target_id, trigger_aux,
+            trigger_target_type, trigger_target_id, trigger_aux, pillar_level,
             active, source, hit_count, miss_count, inconclusive_count
        FROM pattern_catalog
       WHERE user_id = $1 AND active = true
@@ -242,6 +319,64 @@ const getNumberField = (obj: Record<string, unknown>, key: string): number | nul
   return null;
 };
 
+/**
+ * pillar_level에 따라 평가 대상 pillar 선택 (Phase 2.5).
+ * - null / 'ilun' → 일운 (= ctx.ilun, 기존 dayStem/dayBranch 동등)
+ * - 'wolun' / 'seun' / 'daeun' → 해당 운 pillar
+ * - 'wonguk' / 'cumulative' → null (직접 매칭 불가 — wonguk은 Phase 2.5 1차에서 시드 없음, cumulative는 별도 trigger)
+ * - 'daeun'이 미적용 구간이면 null (대운 미시작 사용자 / 데이터 누락)
+ */
+const pickPillarByLevel = (level: PillarLevel | null, ctx: DailyContext): Pillar | null => {
+  switch (level) {
+    case null:
+    case 'ilun':
+      return ctx.ilun;
+    case 'wolun':
+      return ctx.wolun;
+    case 'seun':
+      return ctx.seun;
+    case 'daeun':
+      return ctx.daeun;
+    case 'wonguk':
+    case 'cumulative':
+      return null;
+  }
+};
+
+const VALID_ELEMENTS: readonly Element[] = ['목', '화', '토', '금', '수'];
+
+const isElement = (v: unknown): v is Element =>
+  typeof v === 'string' && (VALID_ELEMENTS as readonly string[]).includes(v);
+
+/**
+ * cumulative_pillar_count trigger 평가 (Phase 2.5).
+ * trigger_aux:
+ *   - { element: '화', count_min: 3 } — 화 오행이 5개 운 레벨 중 3개 이상에서 발현
+ *   - { sipsin: '편재', count_min: 2 } — 편재가 5개 운 레벨 중 2개 이상에서 발현
+ */
+const evaluateCumulativePillarCount = (seed: SajuSeed, ctx: DailyContext): boolean => {
+  const aux = seed.trigger_aux ?? {};
+  const countMin = getNumberField(aux as Record<string, unknown>, 'count_min');
+  if (countMin === null || countMin <= 0) return false;
+
+  const pillarSet: PillarSet = {
+    wonguk: ctx.natal.pillars,
+    daeun: ctx.daeun,
+    seun: ctx.seun,
+    wolun: ctx.wolun,
+    ilun: ctx.ilun,
+  };
+  const count = computeCumulativePillarCount(ctx.natal.dayMaster, pillarSet);
+
+  if (isElement(aux['element'])) {
+    return count.element[aux['element']] >= countMin;
+  }
+  if (typeof aux['sipsin'] === 'string') {
+    return (count.sipsin[aux['sipsin']] ?? 0) >= countMin;
+  }
+  return false;
+};
+
 export const evaluateTrigger = async (
   seed: SajuSeedWithMetrics,
   ctx: DailyContext,
@@ -249,19 +384,27 @@ export const evaluateTrigger = async (
   branchNameToId: Map<string, number>,
 ): Promise<boolean> => {
   const aux = seed.trigger_aux ?? {};
-  const dayStemId = stemNameToId.get(ctx.dayStem);
-  const dayBranchId = branchNameToId.get(ctx.dayBranch);
 
   switch (seed.trigger_target_type) {
-    case 'stem':
-      return seed.trigger_target_id !== null && seed.trigger_target_id === dayStemId;
+    case 'stem': {
+      const pillar = pickPillarByLevel(seed.pillar_level, ctx);
+      if (!pillar) return false;
+      const stemId = stemNameToId.get(pillar.cheongan);
+      return seed.trigger_target_id !== null && seed.trigger_target_id === stemId;
+    }
 
     case 'branch': {
-      if (seed.trigger_target_id !== null && seed.trigger_target_id === dayBranchId) return true;
+      const pillar = pickPillarByLevel(seed.pillar_level, ctx);
+      if (!pillar) return false;
+      const branchId = branchNameToId.get(pillar.jiji);
+      if (seed.trigger_target_id !== null && seed.trigger_target_id === branchId) return true;
       const orBranches = aux['or_branches'];
-      if (isStringArray(orBranches) && orBranches.includes(ctx.dayBranch)) return true;
+      if (isStringArray(orBranches) && orBranches.includes(pillar.jiji)) return true;
       return false;
     }
+
+    case 'cumulative_pillar_count':
+      return evaluateCumulativePillarCount(seed, ctx);
 
     case 'ganji': {
       // ganji_master.id 매칭 — 일운 stem+branch 조합의 ganji id


### PR DESCRIPTION
## 관련 이슈
Closes #445

마스터 #434 (본인 1명 패턴 발견 시스템) Phase 2.5 — Phase 2 사주 시드 풀세트 161개의 일운 단일 차원 한계를 운 레벨 5단계(원국/대운/세운/월운/일운) + 누적 카운트로 확장. 임의 임계치 대신 풀셋(N=1..5)으로 누적 카운트 자체를 시드화해 데이터가 임계치를 결정하게 만든다.

## 변경 내용

### 데이터 모델 (`db/migrations/071_pattern_signals_pillar_level.sql`)
- `pattern_catalog.pillar_level VARCHAR(20)` 컬럼 추가 (enum 6값)
- Phase 2 사주 시드 161개를 `pillar_level='ilun'`로 backfill
- `trigger_target_type` CHECK 확장: `cumulative_pillar_count` 추가
- `pattern_metrics.domain` CHECK 확장: `expense_category_present` 추가 (cross-domain)
- `pillar_level` 부분 인덱스 (분포 cron GROUP BY 가속)
- 14개 신규 시드 INSERT (편재 9 + 화 오행 5)
- `pillarLevelDistributionReview` cron 슬롯 시드

### 매칭 엔진 (`src/shared/saju-match.ts`)
- `pickPillarByLevel(level, ctx)` — 시드의 `pillar_level`에 따라 평가 대상 pillar 선택
- `evaluateCumulativePillarCount` — 5개 운 레벨 중 오행/십성이 발현된 레벨 수 ≥ N 평가
- `DailyContext.{ilun, wolun, seun, daeun}` 추가
- `NatalContext.{pillars, birthDate, daewunList}` 추가
- `daeun` 미적용 구간이면 false (대운 미시작 사용자 안전)

### 누적 카운트 헬퍼 (`src/shared/saju-calendar.ts`)
- `computeCumulativePillarCount(dayMaster, pillarSet)` — 레벨별 발현 집합 누적
- `getDaeunPillar(birthDate, daewunList, targetDate)` — 적용 구간 외 null
- `makePillar(cheongan, jiji)` — 60갑자 인덱스 계산 (tolerant)
- types: `Element`, `PillarSet`, `CumulativeCount`

### Cron (`src/cron/pillar-level-distribution-review.ts`)
- 월요일 09:15 KST — `weeklyHypothesisReview` 패턴 동일 (요일 외 즉시 return)
- 결정론 SQL 2개 (ADR-0027 준수, LLM 호출 0건)
- 90일 윈도우 + `verify_status != 'no_metric'` 필터
- 양쪽 분포 모두 빈 결과면 발송 스킵
- 멀티유저 루프 + 채널 fallback (insight 채널 → 환경변수 → config)

### 화 오행 누적 시드 OR 매칭
- 시드당 2 메트릭: `diary_health_complaint`(diary_meta) + `expense_의료건강`(expense_category_present)
- `metricEvaluations.some(e => e.passed)` 기존 OR 로직이 그대로 동작

### 문서
- ADR-0028 (운 레벨 + 풀셋 임계치 + 임의값 배제)
- design-notebook Phase 2.5 섹션 + 도입 동기·결정·포기한 안
- domains/insight.md Phase 2.5 본문 (TODO 마커 → 본문)
- features.md 카탈로그 + 크론 표 갱신

## 코드 리뷰 결과
- [x] 보안 감사 통과 — 파라미터화 SQL ($1 user_id), 외부 입력 없음, 민감정보 로깅 없음
- [x] 타입 안전성 — `any` 없음, `unknown` + 타입 가드 (isElement, isDaewunEntryArray)
- [x] 컨벤션 점검 — camelCase / PascalCase / UPPER_SNAKE_CASE 준수
- [x] 코드 품질 — `daeun` null 안전, 잘못된 enum 입력은 false로 폴백
- [x] 결정론 정책 — LLM 호출 0건 (ADR-0027 준수)

## 테스트
- [x] 전체 512 테스트 통과 (29 파일)
- [x] saju-match.ts Phase 2.5 분기 — `pillar_level=wolun/seun/daeun` 7건
- [x] cumulative_pillar_count — element/sipsin/count_min<=0/잘못된 enum 6건
- [x] cron `buildMessage` — 빈 결과/null 필드/양쪽 분포 7건
- [x] TypeScript strict 모드 통과