### PR TITLE
feat(insight): #434 Phase 4 — 매칭 cron 카운터 source 전환 + pattern-match rename

### DIFF
--- a/docs/design-notebook/personal-pattern-discovery.md
+++ b/docs/design-notebook/personal-pattern-discovery.md
@@ -68,8 +68,8 @@ LLM 매트릭은 월 최대 N개 cap(예: 5개)으로 슬롯 폭주 방지. 매�
 - [x] **Phase 1**: 스키마 일반화 + `pattern_*` rename — 테이블·컬럼 rename (`saju_signal_*` → `pattern_*`, ADR-0026), `trigger_target_type` CHECK constraint 확장(`life_signal` 추가), `pattern_metrics`에 `description TEXT NOT NULL` + `window_days INTEGER` + `hit_count/miss_count/inconclusive_count` + `status` 컬럼, `posterior_alpha/beta/p` 예약, `pattern_summary` view 신설, `saju_influence_summary` view body 재정의 (운영 자산 보존)
 - [x] **Phase 2**: 사주 시드 풀 셋 — Phase 3에서 작성된 시드를 카탈로그 풀(전체) 검토 + 누락 보완 (s1 일부만 작성된 상태였음)
 - [x] **Phase 2.5**: 사주 시드 운 레벨 차원 도입 + 자동 분포 분석 cron — `pillar_level` 컬럼(원국/대운/세운/월운/일운/cumulative), `cumulative_pillar_count` trigger(N=1..5 풀셋), `expense_category_present` 메트릭, `pillar-level-distribution-review` cron (월요일 09:15 KST). 14개 신규 시드(편재 9 + 화 오행 5). [ADR-0028](../adr/0028-pillar-level-and-threshold-pool.md)
-- [ ] **Phase 3**: `life_signal` 시드 풀 셋 — 요일(월\~일 7) / 주말(2) / 월말(1) / 월초(1) / 계절(4) 등 1차 셋. 결정론 매트릭으로 작성
-- [ ] **Phase 4**: 매칭 cron + view 정비 — 매칭 cron이 `trigger_target_type='life_signal'`도 처리하도록 확장. `pattern_summary` view 본문 작성
+- [x] **Phase 3**: `life_signal` 시드 풀 셋 + 매칭 cron 일반화 — 환경 결정론 + 임계치 풀셋 + 11종 결정론 패턴 승격 = 신규 38개 시드. `trigger_aux.kind` 7 kinds(weekday/weekday_group/month_position/season/calendar_event/threshold/behavior_baseline) discriminated union. [ADR-0029](../adr/0029-life-signal-trigger-aux-standard.md)
+- [ ] **Phase 4**: 매칭 cron 카운터 source of truth 전환 + pattern-match rename — verifyDailyMatches가 catalog 대신 `pattern_metrics` 카운터 + Bayesian posterior 산식 갱신. compactMatchedLine은 `pattern_summary` view 정렬. evidence-only 시드는 카운터 SKIP. 파일명 `saju-match.ts` → `pattern-match.ts`, `daily-saju-matching.ts` → `daily-pattern-matching.ts` (잔존 saju-* 파일은 후속 phase 진입 전 별도 PR)
 - [ ] **Phase 5**: 가설 발견·검증 업데이트 — `hypothesis-discovery`가 `life_signal` trigger를 포함하도록 일반화. weekly 가설 리뷰 카드 본문에 출처(`pattern_kind`) 표시
 - [ ] **Phase 6**: LLM 자율 매트릭 + 승인 게이트 — 월간 LLM 슬롯이 매트릭 후보를 생성, Slack 승인 UI(`/insight metric-approve` + Block Kit inline button). 활성화된 매트릭만 매칭 cron 진입. **운영은 Claude 앱 routines 기반** ([ADR-0027](../adr/0027-llm-async-routine-unification.md))
 - [ ] **Phase 7**: Bayesian update 도입 — `posterior_p` 컬럼 채움. Beta-Binomial 사후 갱신 헬퍼(\~100줄). 가설 카드에 frequentist p값 + Bayesian posterior 병기
@@ -456,7 +456,67 @@ WHERE pattern_kind = 'saju' AND source = 'seed' AND pillar_level IS NULL;
 
 ---
 
-## Phase 4\~8 (TODO: 각 Phase 진입 시 섹션 누적)
+## Phase 4: 매칭 cron 카운터 source of truth 전환 + pattern-match rename (2026-05-28)
+
+- 이슈: [#449](https://github.com/hyewon3938/slack-ai-agents/issues/449)
+- 관련 ADR: [ADR-0023](../adr/0023-metric-unit-counter-and-summary-view.md) (실행), [ADR-0024](../adr/0024-bayesian-posterior-update.md) (산식만), [ADR-0026](../adr/0026-pattern-prefix-rename.md) (파일명까지)
+- 관련 계획서: `.claude/plans/449-phase-4-metric-counter.md`
+- 상태: 설계 완료, 구현 대기
+
+### 결정 요약
+
+ADR-0023이 결정한 매트릭 단위 카운터 source of truth를 실제 코드로 실행한다. 현재는 Phase 1에서 신설된 `pattern_summary` view가 마스터 A 한 곳에서만 활용 중이고, `verifyDailyMatches`는 여전히 `pattern_catalog`의 deprecated 카운터를 UPDATE 중 — 즉 ADR-0023의 의도가 구현 단절 상태.
+
+본 phase로 4개 코드 경로가 전환된다:
+
+1. `verifyDailyMatches` — `pattern_metrics.hit_count/miss_count/inconclusive_count` + `last_matched_at` + Bayesian `posterior_alpha/beta/p` 동시 갱신. evidence-only 시드(matched IS NULL)는 status='inconclusive'만 박고 카운터 SKIP.
+2. `compactMatchedLine` — `seed.hit_count` 정렬을 `pattern_summary.total_hits`로 전환 (sync → async).
+3. `loadActiveSeeds` — catalog의 deprecated 카운터 컬럼 SELECT 제거.
+4. `matchAllSeedsForDay` — 시드 수·duration_ms 로그 (cron 부담 측정, 5초 한도 관측).
+
+추가로 ADR-0026의 prefix 통일성을 파일명까지 확장: `saju-match.ts` → `pattern-match.ts`, `daily-saju-matching.ts` → `daily-pattern-matching.ts`. 잔존 `saju-hypothesis.ts`·`saju-seed-fast-path.ts` 등은 Phase 5 진입 전 follow-up PR로 분리.
+
+### 핵심 변경
+
+- `src/shared/pattern-match.ts` (rename + verifyDailyMatches 매트릭 갱신 + compactMatchedLine async)
+- `src/shared/types.ts` — `PatternCatalog`의 hit/miss/inconclusive deprecated 표시 또는 optional
+- `src/cron/daily-pattern-matching.ts` (rename + `await compactMatchedLine`)
+- import 경로 일괄 갱신 (cron/agents/scripts)
+- 새 ADR 없음 — ADR-0023의 실행 단계
+
+### 의사결정 분기점
+
+1. **evidence-only 시드 카운터 처리** — 매트릭 0개면 카운터 자체 비대상 (verify_status='no_metric'만 박고 SKIP). 이중 source 방지 + Phase 2 패턴(`no_metric` enum) 자연 계승
+2. **정렬 기준** — `pattern_summary.total_hits` 사용. view derive 패턴 정착. aggregate_posterior_p는 Phase 7 운영 검증 전이라 미루고, 카운트 단순 정렬이 현 단계 적합
+3. **Bayesian posterior 갱신 시점** — Phase 4에서 같이 갱신 (산식 `alpha = 1+hit, beta = 1+miss`). counter source가 같은 위치에서 갱신되는 게 정합성 ↑. Phase 7은 UI/가설 카드 노출 + 임계치 정책으로 scope 축소
+4. **catalog deprecated 카운터** — 잔존 유지 + 코드 참조 완전 제거. Phase 8에서 DROP 검토 (단발 PR diff 최소화)
+5. **매칭 cron 부담 측정** — 본 PR에 포함 (간단한 시간 로그). 5초 한도 초과 시 follow-up 이슈로 인덱스/분리 cron 조치
+6. **파일명 rename 범위** — Phase 4는 `pattern-match.ts`·`daily-pattern-matching.ts` 두 쌍만. 나머지(`saju-hypothesis`·`saju-seed-fast-path`·`saju-hypothesis-backtest`)는 사용자 명시 "phase 5 진입 전 후속작업" — 별도 follow-up PR로 빼서 본 phase 의도 명확화
+
+### 포기한 안 / 미룬 항목
+
+- **pattern_summary view를 fast path `/insight pattern-summary` 명령어로 노출** — Phase 8 카드 UI와 중복, 사용자 임상 데이터 결정 기준 명확치 않음
+- **분포 분석 cron 신설(pillar-level cron 패턴 확장)** — Phase 6 LLM 슬롯 입력으로도 가능한 정보. PR 비대화 회피
+- **catalog 카운터 즉시 DROP** — backfill된 과거 값 손실 + view 정합성 검증 비용. Phase 8까지 marker로 잔존
+- **잔존 saju-* 파일 일괄 rename (saju-hypothesis 등)** — Phase 5 진입 전 별도 follow-up PR. 본 phase는 매칭 cron 중심으로 scope 한정
+- **시드 1:N 매트릭 분기 처리** — Phase 5+ 시드 1:N 매트릭이 실제 발생하는 시점에 metric_values JSONB로 매트릭별 outcome 기록 + verifyDailyMatches 분배 분기 추가
+
+### 미해결 / 가설
+
+- **매칭 cron 5초 한도** — Phase 2.5 + Phase 3 후 시드 213+개. behavior_baseline 11개가 SQL 부담 주축. 측정값에 따라 인덱스 최적화 또는 분리 cron 필요할 수 있음
+- **시드:매트릭 1:1 가정의 수명** — 현 운영 정확. Phase 6 LLM 매트릭이 동일 시드에 추가 매트릭을 붙이는 시점부터 분배 로직 필요
+
+### 회고
+
+- **catalog → metrics 카운터 전환은 4단계 deprecation 패턴이 정착되는 첫 사례**: Phase 1에서 backfill, 본 phase에서 reference 제거, Phase 8에서 DROP. 한 PR에서 다 하면 빌드 깨질 위험 있는 schema migration에서 이 패턴이 비용 대비 안전성 높음
+- **evidence-only (matched IS NULL) 분기는 Phase 2의 `no_metric` 패턴이 그대로 카운터에 살아남는 흐름** — Phase 2에서 enum + verify_status 분기를 미리 박아두지 않았으면 Phase 4 verifyDailyMatches가 evidence-only 시드를 잘못 hit/miss로 카운트할 뻔. phase 간 invariant 누적이 효과를 발휘한 케이스
+- **compactMatchedLine sync → async 전환은 PR 진단 가치가 높았다**: view SELECT 의존이 생기는 시점에 caller가 자동으로 await하는지 typecheck로 확인. `runDailyPatternMatchingDryRun` 한 곳만 caller라 변경 비용이 작았고 단일 PR로 완결됨
+- **파일명 rename은 의외로 import 일괄 갱신이 부담** — 8 evaluator + 6 test + life-cron + insights comment + 3 rename = 18 파일 동시 수정. SLOT_TASKS 키 `dailySajuMatching`만 DB 호환성을 위해 보존하는 비대칭이 발생 (DB 컬럼은 코드 rename을 쉽게 따라가지 못함을 재확인)
+- **Bayesian posterior를 Phase 4에 흡수한 결정은 정합성 ↑**: counter source가 같은 위치에서 갱신되니 Phase 7이 UI/임계치 정책에만 집중 가능. 다만 산식 검증 테스트(`posterior_alpha + 1.0` 형태)가 SQL 문자열 매칭으로만 가능해 vitest assertion이 조금 약함 — Phase 7에서 헬퍼로 추출하면서 단위 테스트 추가 예정
+
+---
+
+## Phase 5\~8 (TODO: 각 Phase 진입 시 섹션 누적)
 
 > 각 Phase 진입 시 `/design`이 본 문서에 해당 Phase 섹션을 추가한다. 템플릿: 결정 요약 / 의사결정 분기점 / 포기한 안 / 회고.
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -1068,9 +1068,61 @@ src/shared/
 - **Phase 5\~7**: 가설 발견·검증 파이프라인이 `pattern_kind` 무관하게 동작 (이미 일반화 완료)
 - **Phase 8**: `insights.ts` detect 함수 → 시드 evaluator로 일원화 (잔소리 시스템 통합)
 
-### 18. 본인 1명 패턴 발견 시스템 — Phase 4 (매칭 cron + view 정비)
+### 18. 본인 1명 패턴 발견 시스템 — Phase 4 (매칭 cron 카운터 source of truth 전환 + pattern-match rename)
 
-> TODO(`/build`): 구현 후 본문 채우기. 매칭 cron이 `trigger_target_type='life_signal'`도 처리하도록 확장 (필요 시 파일명 변경 검토 — `daily-saju-matching` → `daily-pattern-matching`). `pattern_summary` view 본문 작성 + 사용 예시. 매칭 시 `pattern_metrics`의 hit/miss/inconclusive UPDATE 로직 (catalog 카운트는 backfill 후 미사용).
+ADR-0023 실행 단계. Phase 1\~3에서 매칭 결과가 `pattern_catalog.hit_count/miss_count/inconclusive_count`에 누적되던 것을, **매트릭 단위 카운터(`pattern_metrics`) + Bayesian posterior**로 전환하고 시드 단위 합계는 `pattern_summary` view에서 derive하도록 정리. 잔존 catalog 카운터는 Phase 8에서 DROP.
+
+#### 변경된 데이터 흐름
+
+| 단계 | Phase 3 (Before) | Phase 4 (After) |
+|------|-----------------|-----------------|
+| `verifyDailyMatches` 카운터 대상 | `pattern_catalog.hit_count/miss_count` | `pattern_metrics.hit_count/miss_count/inconclusive_count` |
+| Bayesian 갱신 | (없음) | `posterior_alpha/beta/p` 동시 UPDATE — ADR-0024 산식 |
+| `last_matched_at` | (없음) | UPDATE마다 `NOW()` 기록 |
+| evidence-only(matched IS NULL) | inconclusive UPDATE만, 카운터는 catalog UPDATE | inconclusive UPDATE만, 매트릭 카운터 SKIP (no_metric 자연 계승) |
+| `compactMatchedLine` 정렬 키 | `seed.hit_count` (in-memory) | `pattern_summary.total_hits` (view SELECT) |
+| 함수 시그니처 | sync `(ctx, results) => string \| null` | **async** `(ctx, results) => Promise<string \| null>` |
+| 매칭 부담 로그 | (없음) | `console.warn('[pattern-match] user=… date=… seeds=… elapsed=…ms')` |
+
+#### Bayesian posterior 산식 (ADR-0024)
+
+```
+hit:  alpha' = alpha + 1, p' = (alpha + 1) / (alpha + beta + 1)
+miss: beta'  = beta + 1,  p' = alpha / (alpha + beta + 1)
+```
+
+`posterior_p` 초기값 0.5 (uniform prior `alpha=beta=1`). 매트릭이 hit/miss 누적될수록 `p`가 실측 비율로 수렴.
+
+#### evidence-only 시드 처리
+
+매트릭이 0개인 시드(Phase 2 `no_metric` 패턴)는 `matched IS NULL`로 기록된다. `verifyDailyMatches`는:
+
+1. `SELECT … WHERE trigger_activated = true AND matched IS NOT NULL` → hit/miss 카운터 UPDATE
+2. `SELECT … WHERE trigger_activated = false OR matched IS NULL` → `verify_status='inconclusive'`만 박음. matched IS NULL이면 매트릭 카운터 SKIP (그래야 evidence-only 시드가 카운터에 오염을 안 줌).
+
+#### 파일명 rename (ADR-0026 확장)
+
+| 이전 | 이후 |
+|------|------|
+| `src/shared/saju-match.ts` | `src/shared/pattern-match.ts` |
+| `src/cron/daily-saju-matching.ts` | `src/cron/daily-pattern-matching.ts` |
+| `src/shared/__tests__/saju-match.test.ts` | `src/shared/__tests__/pattern-match.test.ts` |
+
+import 일괄 갱신(15+ 파일): 8 life-signal-evaluator + 6 evaluator test + `insights.ts` comment + `life-cron.ts`. SLOT_TASKS 키 `dailySajuMatching`은 DB `notification_settings.slot_name` 호환성을 위해 보존(value만 `dailyPatternMatchingTask`로). 함수명도 `dailyPatternMatching*`로 일관 변경.
+
+잔존 `saju-hypothesis.ts`·`saju-seed-fast-path.ts`·`scripts/saju-hypothesis-backtest.ts`·`weekly-report.ts`의 catalog 카운터 SELECT는 Phase 5 follow-up PR로 분리.
+
+#### 후속 정리 항목
+
+- `saju-seed-fast-path.ts`의 catalog `hit_count/miss_count` 표시 → view `total_hits/total_misses` 전환
+- `weekly-report.ts`의 사주 시드 섹션 → view 기반 재구성
+- `pattern_catalog.hit_count/miss_count/inconclusive_count` 컬럼 DROP (Phase 8)
+
+#### 결정 기록
+
+- [ADR-0023](../adr/0023-metric-unit-counter-and-summary-view.md) (counter source of truth) — Phase 4가 실행 단계
+- [ADR-0024](../adr/0024-beta-binomial-bayesian-posterior.md) (Beta-Binomial posterior) — `posterior_alpha/beta/p` 산식
+- [ADR-0026](../adr/0026-pattern-prefix-rename.md) (pattern_* prefix) — 파일명까지 확장
 
 ### 19. 본인 1명 패턴 발견 시스템 — Phase 5 (가설 발견·검증 업데이트)
 

--- a/src/cron/daily-pattern-matching.ts
+++ b/src/cron/daily-pattern-matching.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 3 — 매일 09시 사주 일일 매칭 cron.
+ * Phase 3+4 — 매일 09시 패턴 일일 매칭 cron.
  * ADR-0017 + ADR-0026(pattern_* rename) 참조.
  *
  * 흐름:
@@ -15,14 +15,14 @@ import {
   verifyDailyMatches,
   compactMatchedLine,
   getDailyContext,
-} from '../shared/saju-match.js';
+} from '../shared/pattern-match.js';
 import { postToChannel } from '../shared/slack.js';
 import { getEffectiveTodayISO } from '../shared/kst.js';
 import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
 import { pickConfirmedHypothesisLines } from '../shared/insights.js';
 import type { LifeCronConfig } from './life-cron.js';
 
-export interface DailySajuMatchingResult {
+export interface DailyPatternMatchingResult {
   date: string;
   triggeredCount: number;
   matchedCount: number;
@@ -33,10 +33,10 @@ export interface DailySajuMatchingResult {
 /**
  * 매칭 평가만 수행 (Slack 전송 X). 테스트/디버깅용.
  */
-export const runDailySajuMatchingDryRun = async (
+export const runDailyPatternMatchingDryRun = async (
   userId: number,
   date: string,
-): Promise<DailySajuMatchingResult> => {
+): Promise<DailyPatternMatchingResult> => {
   const ctx = await getDailyContext(userId, date);
   if (!ctx) {
     return { date, triggeredCount: 0, matchedCount: 0, line: null, hypothesisLines: [] };
@@ -47,7 +47,7 @@ export const runDailySajuMatchingDryRun = async (
 
   const triggeredCount = results.filter((r) => r.triggerActivated).length;
   const matchedCount = results.filter((r) => r.matched).length;
-  const line = compactMatchedLine(ctx, results);
+  const line = await compactMatchedLine(ctx, results);
   const hypothesisLines = await pickConfirmedHypothesisLines(userId, date);
 
   return { date, triggeredCount, matchedCount, line, hypothesisLines };
@@ -56,7 +56,7 @@ export const runDailySajuMatchingDryRun = async (
 /**
  * 한 유저 매칭 처리 (Slack 전송 포함).
  */
-export const dailySajuMatchingForUser = async (
+export const dailyPatternMatchingForUser = async (
   app: App,
   userId: number,
   channelId: string,
@@ -66,20 +66,20 @@ export const dailySajuMatchingForUser = async (
     await verifyDailyMatches(userId);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[Saju Match] verify 실패 user=${userId}: ${msg}`);
+    console.error(`[Pattern Match] verify 실패 user=${userId}: ${msg}`);
   }
 
-  let result: DailySajuMatchingResult;
+  let result: DailyPatternMatchingResult;
   try {
-    result = await runDailySajuMatchingDryRun(userId, date);
+    result = await runDailyPatternMatchingDryRun(userId, date);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[Saju Match] 매칭 실패 user=${userId}: ${msg}`);
+    console.error(`[Pattern Match] 매칭 실패 user=${userId}: ${msg}`);
     return;
   }
 
   console.warn(
-    `[Saju Match] user=${userId} date=${date} triggered=${result.triggeredCount} matched=${result.matchedCount}`,
+    `[Pattern Match] user=${userId} date=${date} triggered=${result.triggeredCount} matched=${result.matchedCount}`,
   );
 
   if (result.line) {
@@ -87,7 +87,7 @@ export const dailySajuMatchingForUser = async (
       await postToChannel(app.client, channelId, result.line);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[Saju Match] Slack 전송 실패 user=${userId}: ${msg}`);
+      console.error(`[Pattern Match] Slack 전송 실패 user=${userId}: ${msg}`);
     }
   }
 
@@ -96,28 +96,28 @@ export const dailySajuMatchingForUser = async (
       await postToChannel(app.client, channelId, result.hypothesisLines.join('\n'));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[Saju Match] 가설 라인 전송 실패 user=${userId}: ${msg}`);
+      console.error(`[Pattern Match] 가설 라인 전송 실패 user=${userId}: ${msg}`);
     }
   }
 };
 
 /**
- * 사주 일일 매칭 cron 본체. SLOT_TASKS에서 호출.
+ * 패턴 일일 매칭 cron 본체. SLOT_TASKS에서 호출.
  * #life 채널로 전송 (life channel mapping 사용).
  */
-export const dailySajuMatchingTask = async (app: App, config: LifeCronConfig): Promise<void> => {
+export const dailyPatternMatchingTask = async (app: App, config: LifeCronConfig): Promise<void> => {
   const today = getEffectiveTodayISO();
   const mappings = await queryAllUserMappings();
 
   if (mappings.length === 0) {
     if (!config.channelId) return;
-    await dailySajuMatchingForUser(app, DEFAULT_USER_ID, config.channelId, today);
+    await dailyPatternMatchingForUser(app, DEFAULT_USER_ID, config.channelId, today);
     return;
   }
 
   for (const mapping of mappings) {
     const channelId = mapping.lifeChannelId ?? mapping.slackUserId;
     if (!channelId) continue;
-    await dailySajuMatchingForUser(app, mapping.userId, channelId, today);
+    await dailyPatternMatchingForUser(app, mapping.userId, channelId, today);
   }
 };

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -50,7 +50,7 @@ import { weeklyReportTask } from './weekly-report.js';
 import { weeklyLlmInsightTask } from './weekly-llm-insight.js';
 import { monthlyLlmInsightTask } from './monthly-llm-insight.js';
 import { verifyLlmInsightsTask } from './verify-llm-insights.js';
-import { dailySajuMatchingTask } from './daily-saju-matching.js';
+import { dailyPatternMatchingTask } from './daily-pattern-matching.js';
 import { diaryMetaExtractTask } from './diary-meta-extract.js';
 import { weeklyHypothesisReviewTask } from './weekly-hypothesis-review.js';
 import { pillarLevelDistributionReviewTask } from './pillar-level-distribution-review.js';
@@ -658,7 +658,7 @@ const SLOT_TASKS: Record<string, CronTaskFn> = {
   verifyLlmInsights: async () => {
     await verifyLlmInsightsTask();
   },
-  dailySajuMatching: dailySajuMatchingTask,
+  dailySajuMatching: dailyPatternMatchingTask,
   diaryMetaExtract: diaryMetaExtractTask,
   weeklyHypothesisReview: weeklyHypothesisReviewTask,
   pillarLevelDistributionReview: pillarLevelDistributionReviewTask,

--- a/src/shared/__tests__/pattern-match.test.ts
+++ b/src/shared/__tests__/pattern-match.test.ts
@@ -31,13 +31,14 @@ import {
   evaluateTrigger,
   evaluateMetric,
   compactMatchedLine,
+  verifyDailyMatches,
   __resetCacheForTest,
   type SajuSeedWithMetrics,
   type DailyContext,
   type NatalContext,
   type SeedMatchResult,
   type SajuMetric,
-} from '../saju-match.js';
+} from '../pattern-match.js';
 import {
   getMonthPillar,
   getYearPillar,
@@ -105,9 +106,6 @@ const baseSeed = (overrides: Partial<SajuSeedWithMetrics> = {}): SajuSeedWithMet
   pillar_level: null,
   active: true,
   source: 'seed',
-  hit_count: 0,
-  miss_count: 0,
-  inconclusive_count: 0,
   metrics: [],
   ...overrides,
 });
@@ -506,13 +504,13 @@ describe('compactMatchedLine', () => {
   const ctx = baseCtx({ dayStem: '경', dayBranch: '술' });
 
   const buildResult = (
+    id: number,
     name: string,
     sipsin: string | null,
     matched: boolean,
-    hitCount: number,
     passedDomains: string[] = ['schedule'],
   ): SeedMatchResult => ({
-    seed: baseSeed({ name, sipsin, hit_count: hitCount }),
+    seed: baseSeed({ id, name, sipsin }),
     triggerActivated: true,
     metricEvaluations: passedDomains.map((d) => ({
       metric_name: `${d}_x`,
@@ -527,37 +525,65 @@ describe('compactMatchedLine', () => {
     isEvidenceOnly: false,
   });
 
-  it('matched 시드 없으면 null', () => {
-    const results = [buildResult('S1', '편재', false, 5)];
-    expect(compactMatchedLine(ctx, results)).toBeNull();
+  /** pattern_summary view에서 pattern_id → total_hits 반환을 mock. */
+  const mockSummary = (hitsById: Record<number, number>): void => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('pattern_summary')) {
+        return Promise.resolve({
+          rows: Object.entries(hitsById).map(([id, hits]) => ({
+            pattern_id: Number(id),
+            total_hits: String(hits),
+          })),
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  };
+
+  it('matched 시드 없으면 null', async () => {
+    mockSummary({});
+    const results = [buildResult(1, 'S1', '편재', false)];
+    expect(await compactMatchedLine(ctx, results)).toBeNull();
   });
 
-  it('matched 시드 1개 — 일운 + 시드 한 줄 포맷', () => {
-    const results = [buildResult('S1_갑목_편재_천간', '편재', true, 5)];
-    const line = compactMatchedLine(ctx, results);
+  it('matched 시드 1개 — 일운 + 시드 한 줄 포맷', async () => {
+    mockSummary({ 1: 5 });
+    const results = [buildResult(1, 'S1_갑목_편재_천간', '편재', true)];
+    const line = await compactMatchedLine(ctx, results);
     expect(line).toContain('오늘 일운 경술');
     expect(line).toContain('편재');
     expect(line).toContain('schedule');
   });
 
-  it('최대 3개까지만 노출, hit_count 높은 순', () => {
+  it('최대 3개까지만 노출, pattern_summary.total_hits 높은 순', async () => {
+    mockSummary({ 1: 2, 2: 10, 3: 5, 4: 8 });
     const results = [
-      buildResult('S1', '편재', true, 2),
-      buildResult('S2', '식신', true, 10),
-      buildResult('S3', '정인', true, 5),
-      buildResult('S4', '비견', true, 8),
+      buildResult(1, 'S1', '편재', true),
+      buildResult(2, 'S2', '식신', true),
+      buildResult(3, 'S3', '정인', true),
+      buildResult(4, 'S4', '비견', true),
     ];
-    const line = compactMatchedLine(ctx, results);
-    expect(line).toContain('식신'); // hit_count 10 (1순위)
-    expect(line).toContain('비견'); // hit_count 8 (2순위)
-    expect(line).toContain('정인'); // hit_count 5 (3순위)
-    expect(line).not.toContain('편재'); // hit_count 2 → cap
+    const line = await compactMatchedLine(ctx, results);
+    expect(line).toContain('식신'); // total_hits 10 (1순위)
+    expect(line).toContain('비견'); // total_hits 8 (2순위)
+    expect(line).toContain('정인'); // total_hits 5 (3순위)
+    expect(line).not.toContain('편재'); // total_hits 2 → cap
   });
 
-  it('sipsin 없으면 name으로 대체', () => {
-    const results = [buildResult('S5_토_과다', null, true, 3)];
-    const line = compactMatchedLine(ctx, results);
+  it('sipsin 없으면 name으로 대체', async () => {
+    mockSummary({ 5: 3 });
+    const results = [buildResult(5, 'S5_토_과다', null, true)];
+    const line = await compactMatchedLine(ctx, results);
     expect(line).toContain('S5_토_과다');
+  });
+
+  it('pattern_summary에 행 없으면 total_hits=0으로 취급 (정렬 동률)', async () => {
+    mockSummary({}); // 빈 view 결과
+    const results = [buildResult(1, 'S1', '편재', true), buildResult(2, 'S2', '식신', true)];
+    const line = await compactMatchedLine(ctx, results);
+    // 둘 다 동률 — 입력 순서대로 유지되는지만 확인 (cap 3 미만)
+    expect(line).toContain('편재');
+    expect(line).toContain('식신');
   });
 });
 
@@ -795,5 +821,148 @@ describe('evaluateTrigger - life_signal', () => {
     });
     const ctx = baseCtx();
     expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
+  });
+});
+
+// ─── Phase 4: verifyDailyMatches (matched 카운터 + Bayesian posterior) ─────
+
+describe('verifyDailyMatches (Phase 4)', () => {
+  /**
+   * verifyDailyMatches 호출은 SELECT 2건 + UPDATE 다수 패턴.
+   * mockQuery에 순차적 응답을 등록하고 호출 인자를 검증.
+   */
+
+  it('hit 매칭은 pattern_metrics hit_count + posterior_alpha UPDATE', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes("verify_status = 'pending'") && sql.includes('trigger_activated = true')) {
+        return Promise.resolve({ rows: [{ id: 100, pattern_id: 7, matched: true }] });
+      }
+      if (sql.includes("verify_status = 'pending'") && sql.includes('OR matched IS NULL')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await verifyDailyMatches(1);
+
+    const calls = mockQuery.mock.calls;
+    // UPDATE pattern_matches verify_status='hit'
+    const matchUpdate = calls.find(
+      ([sql, params]) =>
+        typeof sql === 'string' &&
+        sql.includes('UPDATE pattern_matches') &&
+        sql.includes('verify_status') &&
+        Array.isArray(params) &&
+        params[0] === 'hit',
+    );
+    expect(matchUpdate).toBeDefined();
+
+    // UPDATE pattern_metrics hit_count + posterior_alpha
+    const metricUpdate = calls.find(
+      ([sql, params]) =>
+        typeof sql === 'string' &&
+        sql.includes('UPDATE pattern_metrics') &&
+        sql.includes('hit_count       = hit_count + 1') &&
+        sql.includes('posterior_alpha = posterior_alpha + 1.0') &&
+        Array.isArray(params) &&
+        params[0] === 7,
+    );
+    expect(metricUpdate).toBeDefined();
+  });
+
+  it('miss 매칭은 pattern_metrics miss_count + posterior_beta UPDATE', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes("verify_status = 'pending'") && sql.includes('trigger_activated = true')) {
+        return Promise.resolve({ rows: [{ id: 101, pattern_id: 8, matched: false }] });
+      }
+      if (sql.includes("verify_status = 'pending'") && sql.includes('OR matched IS NULL')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await verifyDailyMatches(1);
+
+    const calls = mockQuery.mock.calls;
+    const metricUpdate = calls.find(
+      ([sql, params]) =>
+        typeof sql === 'string' &&
+        sql.includes('UPDATE pattern_metrics') &&
+        sql.includes('miss_count      = miss_count + 1') &&
+        sql.includes('posterior_beta  = posterior_beta + 1.0') &&
+        Array.isArray(params) &&
+        params[0] === 8,
+    );
+    expect(metricUpdate).toBeDefined();
+  });
+
+  it('evidence-only (matched IS NULL)는 SELECT 1에서 제외되어 카운터 UPDATE 안 함', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes("verify_status = 'pending'") && sql.includes('trigger_activated = true')) {
+        // matched IS NOT NULL 필터로 인해 빈 결과
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("verify_status = 'pending'") && sql.includes('OR matched IS NULL')) {
+        // evidence-only 1건
+        return Promise.resolve({ rows: [{ id: 200, pattern_id: 9, matched: null }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await verifyDailyMatches(1);
+
+    const calls = mockQuery.mock.calls;
+    const metricUpdate = calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE pattern_metrics'),
+    );
+    expect(metricUpdate).toBeUndefined();
+
+    // verify_status='inconclusive' UPDATE는 실행되어야 함
+    const inconclusiveUpdate = calls.find(
+      ([sql, params]) =>
+        typeof sql === 'string' &&
+        sql.includes('UPDATE pattern_matches') &&
+        sql.includes("verify_status = 'inconclusive'") &&
+        Array.isArray(params) &&
+        params[0] === 200,
+    );
+    expect(inconclusiveUpdate).toBeDefined();
+  });
+
+  it('trigger_off (matched IS NOT NULL but trigger_activated=false)는 inconclusive_count UPDATE', async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes("verify_status = 'pending'") && sql.includes('trigger_activated = true')) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("verify_status = 'pending'") && sql.includes('OR matched IS NULL')) {
+        return Promise.resolve({ rows: [{ id: 300, pattern_id: 10, matched: false }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await verifyDailyMatches(1);
+
+    const calls = mockQuery.mock.calls;
+    const inconclusiveCounter = calls.find(
+      ([sql, params]) =>
+        typeof sql === 'string' &&
+        sql.includes('UPDATE pattern_metrics') &&
+        sql.includes('inconclusive_count = inconclusive_count + 1') &&
+        Array.isArray(params) &&
+        params[0] === 10,
+    );
+    expect(inconclusiveCounter).toBeDefined();
+  });
+
+  it('pending 없으면 UPDATE 호출 0회', async () => {
+    mockQuery.mockImplementation(() => Promise.resolve({ rows: [] }));
+    await verifyDailyMatches(1);
+
+    const updates = mockQuery.mock.calls.filter(
+      ([sql]) =>
+        typeof sql === 'string' &&
+        (sql.includes('UPDATE pattern_matches') || sql.includes('UPDATE pattern_metrics')),
+    );
+    expect(updates.length).toBe(0);
   });
 });

--- a/src/shared/insights.ts
+++ b/src/shared/insights.ts
@@ -750,7 +750,7 @@ interface ConfirmedHypothesisRow {
  * 오늘 trigger가 발현한 confirmed 가설들의 잔소리 라인 반환.
  * - confirmed 가설(pattern_hypotheses.status='confirmed') × 오늘 pattern_matches.trigger_activated=true 조인
  * - 가설별 최신 rate_ratio를 같이 보여줘 효과 크기 인지
- * - 빈 결과면 빈 배열 반환 → daily-saju-matching 측에서 분기
+ * - 빈 결과면 빈 배열 반환 → daily-pattern-matching 측에서 분기
  */
 export const pickConfirmedHypothesisLines = async (
   userId: number,

--- a/src/shared/life-signal-evaluators/__tests__/behavior-baseline.test.ts
+++ b/src/shared/life-signal-evaluators/__tests__/behavior-baseline.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../insights.js', () => ({
 }));
 
 import * as insights from '../../insights.js';
-import type { BehaviorBaselineAux, DailyContext } from '../../saju-match.js';
+import type { BehaviorBaselineAux, DailyContext } from '../../pattern-match.js';
 import { evaluateBehaviorBaseline } from '../behavior-baseline.js';
 
 const baseCtx = (date: string): DailyContext => ({ date, userId: 1 }) as unknown as DailyContext;

--- a/src/shared/life-signal-evaluators/__tests__/calendar-event.test.ts
+++ b/src/shared/life-signal-evaluators/__tests__/calendar-event.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEventAux, DailyContext } from '../../saju-match.js';
+import type { CalendarEventAux, DailyContext } from '../../pattern-match.js';
 import { evaluateCalendarEvent } from '../calendar-event.js';
 
 const baseCtx = (date: string): DailyContext => ({ date, userId: 1 }) as unknown as DailyContext;

--- a/src/shared/life-signal-evaluators/__tests__/month-position.test.ts
+++ b/src/shared/life-signal-evaluators/__tests__/month-position.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { DailyContext, MonthPositionAux } from '../../saju-match.js';
+import type { DailyContext, MonthPositionAux } from '../../pattern-match.js';
 import { evaluateMonthPosition } from '../month-position.js';
 
 const baseCtx = (date: string): DailyContext => ({ date, userId: 1 }) as unknown as DailyContext;

--- a/src/shared/life-signal-evaluators/__tests__/season.test.ts
+++ b/src/shared/life-signal-evaluators/__tests__/season.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { DailyContext, SeasonAux } from '../../saju-match.js';
+import type { DailyContext, SeasonAux } from '../../pattern-match.js';
 import { evaluateSeason } from '../season.js';
 
 const baseCtx = (date: string): DailyContext => ({ date, userId: 1 }) as unknown as DailyContext;

--- a/src/shared/life-signal-evaluators/__tests__/threshold.test.ts
+++ b/src/shared/life-signal-evaluators/__tests__/threshold.test.ts
@@ -6,7 +6,7 @@ vi.mock('../../db.js', () => ({
   query: (sql: string, params: unknown[]): unknown => mockQuery(sql, params),
 }));
 
-import type { DailyContext, ThresholdAux } from '../../saju-match.js';
+import type { DailyContext, ThresholdAux } from '../../pattern-match.js';
 import { evaluateThreshold } from '../threshold.js';
 
 const baseCtx = (date: string): DailyContext => ({ date, userId: 1 }) as unknown as DailyContext;

--- a/src/shared/life-signal-evaluators/__tests__/weekday.test.ts
+++ b/src/shared/life-signal-evaluators/__tests__/weekday.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { DailyContext, WeekdayAux, WeekdayGroupAux } from '../../saju-match.js';
+import type { DailyContext, WeekdayAux, WeekdayGroupAux } from '../../pattern-match.js';
 import { evaluateWeekday, evaluateWeekdayGroup } from '../weekday.js';
 
 const baseCtx = (date: string): DailyContext =>

--- a/src/shared/life-signal-evaluators/behavior-baseline.ts
+++ b/src/shared/life-signal-evaluators/behavior-baseline.ts
@@ -9,7 +9,7 @@
  * Phase 8에서 잔소리 시스템을 시드 evaluator로 일원화 (도메인 문서 §17 참조).
  */
 
-import type { BehaviorBaselineAux, BehaviorSignalName, DailyContext } from '../saju-match.js';
+import type { BehaviorBaselineAux, BehaviorSignalName, DailyContext } from '../pattern-match.js';
 import {
   detectCategorySkew,
   detectDrift,

--- a/src/shared/life-signal-evaluators/calendar-event.ts
+++ b/src/shared/life-signal-evaluators/calendar-event.ts
@@ -7,7 +7,7 @@
  *                (사용자 설정 UI는 follow-up — 현 단계는 시드 자체가 catalog에 없음)
  */
 
-import type { CalendarEventAux, DailyContext } from '../saju-match.js';
+import type { CalendarEventAux, DailyContext } from '../pattern-match.js';
 import { isKoreanHoliday } from './korean-holidays.js';
 
 export const evaluateCalendarEvent = async (

--- a/src/shared/life-signal-evaluators/index.ts
+++ b/src/shared/life-signal-evaluators/index.ts
@@ -5,10 +5,10 @@
  * kind: weekday / weekday_group / month_position / season / calendar_event / threshold / behavior_baseline
  *
  * 평가 결과는 boolean — true면 오늘 trigger 발현, false면 미발현.
- * 잘못된 aux는 saju-match.ts:isLifeSignalAux에서 걸러진 후 들어오므로 여기서는 예외 X.
+ * 잘못된 aux는 pattern-match.ts:isLifeSignalAux에서 걸러진 후 들어오므로 여기서는 예외 X.
  */
 
-import type { DailyContext, LifeSignalAux } from '../saju-match.js';
+import type { DailyContext, LifeSignalAux } from '../pattern-match.js';
 import { evaluateWeekday, evaluateWeekdayGroup } from './weekday.js';
 import { evaluateMonthPosition } from './month-position.js';
 import { evaluateSeason } from './season.js';

--- a/src/shared/life-signal-evaluators/month-position.ts
+++ b/src/shared/life-signal-evaluators/month-position.ts
@@ -6,7 +6,7 @@
  * position='mid':   start..end 범위 (기본 11..20)
  */
 
-import type { DailyContext, MonthPositionAux } from '../saju-match.js';
+import type { DailyContext, MonthPositionAux } from '../pattern-match.js';
 
 export const evaluateMonthPosition = async (
   aux: MonthPositionAux,

--- a/src/shared/life-signal-evaluators/season.ts
+++ b/src/shared/life-signal-evaluators/season.ts
@@ -9,7 +9,7 @@
  * 절기 기반 계절(입춘 등)이 아니라 양력 월 기반. Phase 4+에서 절기 기반 fine-grain 검토.
  */
 
-import type { DailyContext, SeasonAux } from '../saju-match.js';
+import type { DailyContext, SeasonAux } from '../pattern-match.js';
 
 const SEASON_MONTHS: Record<SeasonAux['season'], readonly number[]> = {
   spring: [3, 4, 5],

--- a/src/shared/life-signal-evaluators/threshold.ts
+++ b/src/shared/life-signal-evaluators/threshold.ts
@@ -9,7 +9,7 @@
  */
 
 import { query } from '../db.js';
-import type { DailyContext, ThresholdAux } from '../saju-match.js';
+import type { DailyContext, ThresholdAux } from '../pattern-match.js';
 
 interface SleepMinutesRow {
   minutes: string;

--- a/src/shared/life-signal-evaluators/weekday.ts
+++ b/src/shared/life-signal-evaluators/weekday.ts
@@ -3,7 +3,7 @@
  * 한국 시간(KST = UTC+9) 기준으로 요일 판정.
  */
 
-import type { DailyContext, WeekdayAux, WeekdayGroupAux } from '../saju-match.js';
+import type { DailyContext, WeekdayAux, WeekdayGroupAux } from '../pattern-match.js';
 
 const dowFromISO = (date: string): number => {
   // ctx.date는 'YYYY-MM-DD' (KST 캘린더 기준). 요일은 timezone과 무관 — y/m/d를 UTC로 해석해 getUTCDay.

--- a/src/shared/pattern-match.ts
+++ b/src/shared/pattern-match.ts
@@ -53,9 +53,6 @@ export interface SajuSeed {
   pillar_level: PillarLevel | null;
   active: boolean;
   source: 'seed' | 'llm_promoted';
-  hit_count: number;
-  miss_count: number;
-  inconclusive_count: number;
 }
 
 export interface SajuMetric {
@@ -346,7 +343,7 @@ export const loadActiveSeeds = async (userId: number): Promise<SajuSeedWithMetri
   const seeds = await query<SeedRow>(
     `SELECT id, user_id, name, sipsin, description,
             trigger_target_type, trigger_target_id, trigger_aux, pillar_level,
-            active, source, hit_count, miss_count, inconclusive_count
+            active, source
        FROM pattern_catalog
       WHERE user_id = $1 AND active = true
       ORDER BY id`,
@@ -730,6 +727,7 @@ export const matchAllSeedsForDay = async (
   userId: number,
   date: string,
 ): Promise<SeedMatchResult[]> => {
+  const t0 = Date.now();
   const ctx = await getDailyContext(userId, date);
   if (!ctx) return [];
   const seeds = await loadActiveSeeds(userId);
@@ -753,7 +751,7 @@ export const matchAllSeedsForDay = async (
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err);
           console.error(
-            `[saju-match] metric 평가 실패 seed=${seed.name} metric=${m.metric_name}: ${errMsg}`,
+            `[pattern-match] metric 평가 실패 seed=${seed.name} metric=${m.metric_name}: ${errMsg}`,
           );
         }
       }
@@ -767,6 +765,11 @@ export const matchAllSeedsForDay = async (
       : triggerActivated && metricEvaluations.some((e) => e.passed);
     results.push({ seed, triggerActivated, metricEvaluations, matched, isEvidenceOnly });
   }
+
+  const elapsedMs = Date.now() - t0;
+  console.warn(
+    `[pattern-match] user=${userId} date=${date} seeds=${seeds.length} elapsed=${elapsedMs}ms`,
+  );
   return results;
 };
 
@@ -812,56 +815,109 @@ export const recordDailyMatches = async (
 // ─── 검증 사이클 (다음날 verify_status 확정 + outcome 카운트 누적) ─────
 
 export const verifyDailyMatches = async (userId: number): Promise<void> => {
-  // 어제 trigger_activated=true 매칭의 pending → hit/miss 확정
-  // Phase 1: 카운터는 pattern_catalog(deprecated) 유지 — 매트릭 단위 이전은 Phase 4에서.
+  // 어제 trigger_activated=true + matched IS NOT NULL인 pending → hit/miss 확정 + pattern_metrics 카운터 UPDATE.
+  // ADR-0023: counter source of truth는 pattern_metrics. ADR-0024: posterior_alpha/beta Beta-Binomial.
   const pending = await query<{ id: number; pattern_id: number; matched: boolean | null }>(
     `SELECT id, pattern_id, matched
        FROM pattern_matches
       WHERE user_id = $1 AND verify_status = 'pending'
         AND date <= (CURRENT_DATE - INTERVAL '1 day')
-        AND trigger_activated = true`,
+        AND trigger_activated = true
+        AND matched IS NOT NULL`,
     [userId],
   );
 
   for (const row of pending.rows) {
     const outcome = row.matched ? 'hit' : 'miss';
     await query(`UPDATE pattern_matches SET verify_status = $1 WHERE id = $2`, [outcome, row.id]);
-    const counter = outcome === 'hit' ? 'hit_count' : 'miss_count';
-    await query(`UPDATE pattern_catalog SET ${counter} = ${counter} + 1 WHERE id = $1`, [
-      row.pattern_id,
-    ]);
+    if (outcome === 'hit') {
+      await query(
+        `UPDATE pattern_metrics
+            SET hit_count       = hit_count + 1,
+                last_matched_at = NOW(),
+                posterior_alpha = posterior_alpha + 1.0,
+                posterior_p     = (posterior_alpha + 1.0) /
+                                  (posterior_alpha + posterior_beta + 1.0)
+          WHERE pattern_id = $1 AND status = 'active'`,
+        [row.pattern_id],
+      );
+    } else {
+      await query(
+        `UPDATE pattern_metrics
+            SET miss_count      = miss_count + 1,
+                last_matched_at = NOW(),
+                posterior_beta  = posterior_beta + 1.0,
+                posterior_p     = posterior_alpha /
+                                  (posterior_alpha + posterior_beta + 1.0)
+          WHERE pattern_id = $1 AND status = 'active'`,
+        [row.pattern_id],
+      );
+    }
   }
 
-  // trigger_activated=false는 inconclusive 처리 (시드는 카운트하되 outcome에 영향 X)
-  await query(
-    `UPDATE pattern_matches
-        SET verify_status = 'inconclusive'
+  // trigger_activated=false 또는 matched IS NULL(evidence-only)은 inconclusive 처리.
+  // matched IS NOT NULL이지만 trigger_activated=false인 케이스만 매트릭 inconclusive_count++.
+  const inconclusiveRows = await query<{
+    id: number;
+    pattern_id: number;
+    matched: boolean | null;
+  }>(
+    `SELECT id, pattern_id, matched
+       FROM pattern_matches
       WHERE user_id = $1 AND verify_status = 'pending'
         AND date <= (CURRENT_DATE - INTERVAL '1 day')
-        AND trigger_activated = false`,
+        AND (trigger_activated = false OR matched IS NULL)`,
     [userId],
   );
+
+  for (const row of inconclusiveRows.rows) {
+    await query(`UPDATE pattern_matches SET verify_status = 'inconclusive' WHERE id = $1`, [
+      row.id,
+    ]);
+    if (row.matched !== null) {
+      await query(
+        `UPDATE pattern_metrics
+            SET inconclusive_count = inconclusive_count + 1,
+                last_matched_at    = NOW()
+          WHERE pattern_id = $1 AND status = 'active'`,
+        [row.pattern_id],
+      );
+    }
+  }
 };
 
 // ─── Slack 한 줄 압축 ────────────────────────────────────
 
 const MAX_LINE_SEEDS = 3;
 
-export const compactMatchedLine = (
+export const compactMatchedLine = async (
   ctx: DailyContext,
   results: SeedMatchResult[],
-): string | null => {
+): Promise<string | null> => {
   const matched = results.filter((r) => r.matched);
   if (matched.length === 0) return null;
 
-  // 우선순위: hit_count 높은 시드 = 검증된 시드 우선 (재현성 신뢰도)
-  matched.sort((a, b) => b.seed.hit_count - a.seed.hit_count);
+  // 우선순위: pattern_summary view의 total_hits 높은 시드 = 검증된 시드 우선 (재현성 신뢰도)
+  // ADR-0023: 시드 단위 합계는 view에서 derive (catalog 카운터 의존 제거).
+  const patternIds = matched.map((r) => r.seed.id);
+  const summary = await query<{ pattern_id: number; total_hits: string }>(
+    `SELECT pattern_id, total_hits
+       FROM pattern_summary
+      WHERE pattern_id = ANY($1)`,
+    [patternIds],
+  );
+  const hitsByPattern = new Map<number, number>();
+  for (const row of summary.rows) {
+    hitsByPattern.set(row.pattern_id, Number(row.total_hits));
+  }
+
+  matched.sort((a, b) => (hitsByPattern.get(b.seed.id) ?? 0) - (hitsByPattern.get(a.seed.id) ?? 0));
   const top = matched.slice(0, MAX_LINE_SEEDS);
 
   const labels = top.map((r) => {
     const passedDomains = new Set(r.metricEvaluations.filter((e) => e.passed).map((e) => e.domain));
-    const summary = Array.from(passedDomains).join('/');
-    return `${r.seed.sipsin ?? r.seed.name} (${summary})`;
+    const summaryText = Array.from(passedDomains).join('/');
+    return `${r.seed.sipsin ?? r.seed.name} (${summaryText})`;
   });
 
   return `오늘 일운 ${ctx.dayStem}${ctx.dayBranch} — ${labels.join(', ')}`;


### PR DESCRIPTION
## 관련 이슈
Closes #449

## 변경 내용

ADR-0023(매트릭 단위 카운터를 source of truth로) 실행 단계 + ADR-0026의 prefix 통일성을 파일명까지 확장.

### 코드 변경

- **`verifyDailyMatches`**: `pattern_catalog` deprecated 카운터 → `pattern_metrics.hit_count/miss_count/inconclusive_count` + `last_matched_at` UPDATE. Beta-Binomial Bayesian `posterior_alpha/beta/p` 동시 갱신 (ADR-0024 산식)
- **evidence-only(matched IS NULL)**: `verify_status='inconclusive'`만 박고 매트릭 카운터 SKIP (Phase 2 `no_metric` 패턴 자연 계승)
- **`compactMatchedLine`**: `seed.hit_count` → `pattern_summary.total_hits` view 정렬 (sync → async)
- **`loadActiveSeeds`**: catalog의 deprecated 카운터 SELECT 컬럼 제거 + `SajuSeed` 타입에서 hit/miss/inconclusive 필드 정리
- **`matchAllSeedsForDay`**: 시드 수·duration_ms 로그 추가 (5초 한도 관측)

### 파일명 rename (ADR-0026 확장)

| 이전 | 이후 |
|------|------|
| `src/shared/saju-match.ts` | `src/shared/pattern-match.ts` |
| `src/cron/daily-saju-matching.ts` | `src/cron/daily-pattern-matching.ts` |
| `src/shared/__tests__/saju-match.test.ts` | `src/shared/__tests__/pattern-match.test.ts` |

import 일괄 갱신: 8 life-signal-evaluator + 6 evaluator test + `life-cron` + `insights` comment. SLOT_TASKS 키 `dailySajuMatching`은 DB `notification_settings.slot_name` 호환성을 위해 보존(value만 `dailyPatternMatchingTask`로).

잔존 `saju-hypothesis.ts`·`saju-seed-fast-path.ts`·`scripts/saju-hypothesis-backtest.ts`·`weekly-report.ts`의 catalog 카운터 SELECT는 Phase 5 follow-up PR로 분리.

### 문서

- `docs/domains/insight.md` Section 18 본문 채움 (변경 흐름 표 + 산식 + evidence-only 분기 + rename 매핑)
- `docs/design-notebook/personal-pattern-discovery.md` Phase 4 회고 작성

## 코드 리뷰 결과

- [x] 보안 감사 통과 — 모든 SQL parameterized($1/$2), 로그에 PII/credential 없음, hardcoded secret 없음
- [x] 타입 안전성 확인 — discriminated union 유지, any 없음
- [x] 컨벤션 점검 완료 — kebab-case 파일명, camelCase 함수, named export
- [x] 코드 품질 확인 — evidence-only invariant 유지, 코멘트는 ADR 참조 + WHY만

## 테스트

- [x] 신규: `verifyDailyMatches` — hit/miss/evidence-only/trigger_off/empty 5케이스
- [x] `compactMatchedLine` — pattern_summary view mock 정렬 검증 (3+1 케이스)
- [x] `pattern-match.test.ts` 54 케이스 통과
- [x] 전체 vitest suite 561 케이스 통과
- [x] `tsc --noEmit` 통과

## 후속 작업

- Phase 5 follow-up PR: `saju-hypothesis.ts`·`saju-seed-fast-path.ts`·`scripts/saju-hypothesis-backtest.ts`·`weekly-report.ts` catalog 카운터 → view 전환
- Phase 8: `pattern_catalog.hit_count/miss_count/inconclusive_count` 컬럼 DROP