### PR TITLE
feat(insight): #434 Phase 5 — 가설 발견·검증 파이프라인 target-type 확장 대응

### DIFF
--- a/docs/design-notebook/personal-pattern-discovery.md
+++ b/docs/design-notebook/personal-pattern-discovery.md
@@ -516,7 +516,65 @@ ADR-0023이 결정한 매트릭 단위 카운터 source of truth를 실제 코�
 
 ---
 
-## Phase 5\~8 (TODO: 각 Phase 진입 시 섹션 누적)
+## Phase 5: 가설 발견·검증 파이프라인 target-type 확장 대응 (2026-05-28)
+
+- 이슈: [#454](https://github.com/hyewon3938/slack-ai-agents/issues/454)
+- 관련 ADR: 새 ADR 없음. [ADR-0019](../adr/0019-saju-hypothesis-verification-pipeline.md) 위 실행. [ADR-0026](../adr/0026-pattern-prefix-rename.md)·[ADR-0029](../adr/0029-life-signal-trigger-aux-standard.md) 기반
+- 관련 계획서: `.claude/plans/454-phase-5-discovery-cards.md`
+- 상태: 설계 완료, 구현 대기
+
+### 결정 요약
+
+Phase 4까지 매칭 cron이 saju 175 + life_signal 38 = 213개 시드의 `trigger_activated`를 누적하기 시작했고, `hypothesis-discovery.ts`는 ADR-0019 단계에서 시드 ID 기반 type-agnostic으로 작성됐기에 데이터 흐름은 이미 일반화 완료 상태. 본 phase는 코드 흐름이 아닌 **운영 가시성 + cap 분리 + 동작 검증**에 집중.
+
+남은 작업 3건:
+
+1. **카드 출처 표시** — `buildCandidateCard`·`buildWeeklyReviewBlocks`가 saju/life_signal 출처를 prefix(`[사주]` / `[생활]`)로 표시. 텍스트 prefix 선택(이모지 충돌 회피, 컨벤션 안전)
+2. **신규 가설 후보 cap 분리** — `slice(0, 5)` 단일 cap → `pattern_kind`별 분리 cap (saju 최대 5 + life_signal 최대 5, 발견된 만큼만)
+3. **DISCOVERY 임계치 유지** — `q<0.2`, `p<0.1`, `ratio≥1.3`, `n≥5` 그대로. BH-FDR이 조합 N으로 자동 보정(`q = p × N / rank` 산식)하므로 N이 13배 늘면 같은 p에 대해 q도 13배 더 엄격. 임의값 박지 않기 헌장 정합
+
+새 ADR 작성 불필요 — UI 표시·cap 분리는 되돌리기 쉽고 ADR-0019 위 운영 결정.
+
+### 핵심 변경
+
+- `src/agents/insight/hypothesis-discovery.ts` — `ActiveSignal`·`CandidateHypothesis`에 `patternKind: 'saju' | 'life_signal'` 필드 추가, `loadActiveSignals` SQL에 `pattern_kind` SELECT
+- `src/agents/insight/hypothesis-cards.ts` — `KIND_LABEL` 상수 + `buildCandidateCard` header prefix + `buildWeeklyReviewBlocks`의 cap 분리(saju/life_signal 각각 5개) + 신규 후보 섹션 헤더에 `사주 N / 생활 M` 카운트 + `ActiveHypothesisRow`에 `patternKind`
+- `src/cron/weekly-hypothesis-review.ts` — `loadSignalNames` → `loadSignalMeta` (pattern_kind 동반 SELECT), `ActiveHypothesisRow` 빌드 시 `patternKind` 채움
+- 신규 vitest — `hypothesis-cards.test.ts`(prefix·cap 분리·카운트 헤더·0건 처리)
+
+### 의사결정 분기점
+
+1. **임계치 재조정 vs 유지** — A 유지 선택. BH-FDR 자동 보정 충분 + 헌장 정합 + 분리 통제(임계치는 신뢰도용, cap은 노출용 책임 분리). B 안(q<0.1) C 안(n≥7)은 운영 데이터 없이 추측해 박는 추가 임의값
+2. **prefix 어휘** — `[사주]` / `[생활]` 텍스트 선택. 이모지 prefix는 본 프로젝트 에이전트 말투 톤(이모지 금지)과 충돌, 텍스트 prefix는 안전 + 카드 라벨링 컨벤션 자연
+3. **cap 분리 방식** — 종류별 5개씩 분리 (saju 5 + life_signal 5). 발견된 만큼만 노출 — 0건이면 안 나옴. 단일 cap(5) 시 saju 임상 가설 강해 life_signal 가려질 위험 회피
+4. **새 ADR 작성 여부** — 불필요. UI 표시·cap 분리는 되돌리기 쉽고, 임계치 유지는 ADR-0019 결정 그대로
+5. **discovery 코드 변경 범위** — `CandidateHypothesis`에 `patternKind` 필드 1개만 추가, 통계 알고리즘은 변경 없음. 검증 부담 ↓
+
+### 사용자 임상 데이터
+
+본 phase는 데이터 모델·통계 신규 도입 없음. Phase 3에서 박힌 life_signal 시드 38개의 description(요일 효과·수면 ≤ N시간·streak 등 사용자 임상 단서)이 카드 노출에서 그대로 활용됨.
+
+### 포기한 안 / 미룬 항목
+
+- **임계치 조이기** (q<0.1·n≥7 등) — 헌장 "임의값 박지 않기" 위배. 운영 1~3개월 누적 후 데이터 보고 재조정. 마스터 close 시 follow-up 이슈 일괄 등록
+- **outcome enum 확장** (life_signal/metric 카운터를 outcome으로) — 본 phase scope 외. 데이터 모델 확장 + 통계 의미 확장이라 별도 phase 후보. 현재는 `diary_meta_tags` 22개만 outcome
+- **cap 늘리기** (5→8 또는 10) — 단순 확장은 사용자 검토 부담만 증가. 분리 cap(5+5)으로 두 카테고리 노출 보장
+- **카드 디자인 별도 섹션 분리** — saju 후보 / 생활 후보 두 section header로 묶는 안. prefix만으로 충분히 시각 구분, 디자인 부담 ↑
+- **이모지 prefix** — 에이전트 말투 톤(이모지 금지)과 충돌 회피
+
+### 미해결 / 가설
+
+- **첫 주 후보 노출량** — saju 175 + life_signal 38 × enum 22 = 4,686 조합 BH-FDR 보정 후 임계치 통과 후보가 몇 개 나올지 사전 예측 불가. 0개일 가능성도 있고 30개일 가능성도 있음. 운영 첫 주 결과 보고 follow-up 판단
+- **active 가설 prefix 일관성** — 현재 active 가설은 ADR-0019 시점에 등록된 사주 시드 기반. life_signal 시드의 첫 active 가설은 본 phase 머지 후 후보 → 등록 사이클을 통해야 발생. 첫 사례 발생 시 카드 표시 검증
+- **behavior_baseline kind 11개의 discovery 부담** — 매칭 cron 5초 한도 점검은 Phase 4 미해결 사항으로 표시. discovery는 setup 모드(lookbackDays=90)에서 가장 부담. 운영 데이터 보고 분리 cron 검토
+
+### 회고 (TODO: `/build` 구현 후 보강)
+
+> 회고는 PR 머지 후 추가. 운영 첫 주 결과(saju/life_signal 후보 비율, 노이즈 정도, 카드 가독성)도 같이 보강.
+
+---
+
+## Phase 6\~8 (TODO: 각 Phase 진입 시 섹션 누적)
 
 > 각 Phase 진입 시 `/design`이 본 문서에 해당 Phase 섹션을 추가한다. 템플릿: 결정 요약 / 의사결정 분기점 / 포기한 안 / 회고.
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -1124,9 +1124,64 @@ import 일괄 갱신(15+ 파일): 8 life-signal-evaluator + 6 evaluator test + `
 - [ADR-0024](../adr/0024-beta-binomial-bayesian-posterior.md) (Beta-Binomial posterior) — `posterior_alpha/beta/p` 산식
 - [ADR-0026](../adr/0026-pattern-prefix-rename.md) (pattern_* prefix) — 파일명까지 확장
 
-### 19. 본인 1명 패턴 발견 시스템 — Phase 5 (가설 발견·검증 업데이트)
+### 19. 본인 1명 패턴 발견 시스템 — Phase 5 (가설 발견·검증 파이프라인 target-type 확장 대응)
 
-> TODO(`/build`): 구현 후 본문 채우기. `hypothesis-discovery`가 `life_signal` trigger 포함하도록 일반화. weekly 가설 리뷰 카드 본문에 `pattern_kind` 표시. 검증 매트릭 수 증가에 따른 BH-FDR 그룹 정의.
+> 이슈: [#454](https://github.com/hyewon3938/slack-ai-agents/issues/454) · 계획서: `.claude/plans/454-phase-5-discovery-cards.md` · 관련 design-notebook: [personal-pattern-discovery.md](../design-notebook/personal-pattern-discovery.md)
+>
+> 한 줄 요약: ADR-0019 위 운영 결정 — UI 가시성(prefix)·노출 cap(종류별 분리)·동작 검증. discovery 통계 알고리즘(Fisher + BH-FDR)·임계치(`q<0.2`·`p<0.1`·`ratio≥1.3`·`n≥5`)는 변경 없음.
+
+#### 변경 파일
+
+- `src/agents/insight/hypothesis-discovery.ts` — `ActiveSignal`·`CandidateHypothesis`에 `patternKind: 'saju' | 'life_signal'` 필드 추가. `loadActiveSignals` SQL이 `pattern_kind` SELECT.
+- `src/agents/insight/hypothesis-cards.ts` — `KIND_LABEL` 상수, `buildCandidateCard` header에 prefix(`[사주]` / `[생활]`), `buildWeeklyReviewBlocks` 후보 노출을 종류별 cap 5+5로 분리, 신규 후보 섹션 헤더에 종류별 카운트 표기, `ActiveHypothesisRow`에 `patternKind` + active row 라인에도 prefix.
+- `src/cron/weekly-hypothesis-review.ts` — `loadSignalNames` → `loadSignalMeta` 전환, `pattern_kind`까지 함께 적재하여 `ActiveHypothesisRow.patternKind` 채움.
+- `src/agents/insight/__tests__/hypothesis-cards.test.ts` (신규) — prefix·종류별 cap·카운트 헤더·0건 처리·active row prefix 검증.
+- `src/agents/insight/__tests__/hypothesis-discovery.test.ts` (신규) — saju + life_signal 섞어 입력 시 두 후보 모두 `patternKind` 채워지는지 검증.
+
+#### 카드 표시 어휘
+
+| `pattern_kind` | prefix | 의도 |
+|---|---|---|
+| `saju` | `[사주]` | 사주 시드 (175개, Phase 1\~2 확정) |
+| `life_signal` | `[생활]` | 생활 시드 (38개, Phase 3에서 도입) |
+
+이모지 prefix(🌙/🏃 등) 후보가 있었으나, Slack iOS/macOS 간 이모지 렌더링 차이로 정렬이 깨지는 경우가 있어 텍스트 prefix 채택.
+
+#### cap 분리 정책
+
+신규 가설 후보는 `pattern_kind`별로 **각각 최대 5건**까지 노출 (합 최대 10건, 발견된 만큼만):
+
+```typescript
+const CANDIDATE_CAP_PER_KIND = 5;
+const sajuCands = candidates
+  .filter((c) => c.patternKind === 'saju')
+  .slice(0, CANDIDATE_CAP_PER_KIND);
+const lifeCands = candidates
+  .filter((c) => c.patternKind === 'life_signal')
+  .slice(0, CANDIDATE_CAP_PER_KIND);
+```
+
+배경: Phase 4까지 단일 `slice(0, 5)`였으나, 조합 풀이 352→4,686(13배) 늘면서 통계가 강한 saju 후보가 cap을 점유해 life_signal이 carbon-copy 가려지는 위험이 있었음. 종류별 cap으로 두 카테고리 모두 가시성 보장.
+
+신규 후보 섹션 헤더에 종류별 카운트 표기:
+
+```
+*신규 후보 (사주 3 / 생활 1)* — 등록할 거 골라
+```
+
+#### DISCOVERY 임계치 유지 결정 근거
+
+`q<0.2`·`p<0.1`·`ratio≥1.3`·`n≥5` 그대로. BH-FDR 보정 산식 `q_i = (p_i × N) / rank_i`에서 조합 수 N이 13배 늘면 q도 자동으로 그만큼 보수적으로 보정됨. 본 마스터 자체 헌장 5번 "임의값 박지 않기" 준수 — 운영 1\~3개월 누적 후 데이터 기반 재조정 후보 (마스터 close 시 follow-up 부록 E에 합류).
+
+#### 운영 검증
+
+머지 후 첫 월요일 08:00 KST 자동 발사 시점에 `#insight` 채널 카드 관측:
+
+- 두 카테고리(`[사주]` / `[생활]`) prefix가 카드 header에 모두 노출되는지
+- 신규 후보 섹션 헤더에 `사주 N / 생활 M` 카운트가 정확히 표기되는지
+- life_signal 후보가 종류별 cap 분리 덕분에 카드에 살아남는지 (Phase 4까지 단일 cap에서는 saju 강 후보에 가려졌던 케이스)
+
+운영 검증 결과는 design-notebook Phase 5 "회고" 섹션에 추가.
 
 ### 20. 본인 1명 패턴 발견 시스템 — Phase 6 (LLM 자율 매트릭 + 승인 게이트)
 

--- a/src/agents/insight/__tests__/hypothesis-cards.test.ts
+++ b/src/agents/insight/__tests__/hypothesis-cards.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import type { KnownBlock, SectionBlock } from '@slack/types';
+import {
+  buildCandidateCard,
+  buildWeeklyReviewBlocks,
+  type ActiveHypothesisRow,
+} from '../hypothesis-cards.js';
+import type { CandidateHypothesis } from '../hypothesis-discovery.js';
+import type { Hypothesis, HypothesisStat } from '../../../shared/pattern-hypothesis.js';
+
+const makeCandidate = (
+  signalId: number,
+  name: string,
+  patternKind: 'saju' | 'life_signal',
+): CandidateHypothesis => ({
+  triggerSpec: { type: 'seed', signalId },
+  signalName: name,
+  patternKind,
+  enumTarget: 'mood_high',
+  nTriggerDays: 8,
+  nTotalDays: 28,
+  rateTrigger: 0.5,
+  rateBaseline: 0.2,
+  rateRatio: 2.5,
+  rawP: 0.04,
+  fdrQ: 0.15,
+});
+
+const makeStat = (hypothesisId: number): HypothesisStat => ({
+  hypothesisId,
+  weekStart: '2026-05-25',
+  nTriggerDays: 4,
+  nTotalDays: 7,
+  rateTrigger: 0.5,
+  rateBaseline: 0.2,
+  rateRatio: 2.5,
+  rawP: 0.04,
+  fdrQ: 0.15,
+});
+
+const makeHypothesis = (id: number, signalId: number): Hypothesis => ({
+  id,
+  userId: 1,
+  triggerSpec: { type: 'seed', signalId },
+  enumTarget: 'mood_high',
+  status: 'active',
+  source: 'discovery',
+  registeredAt: new Date('2026-05-01T00:00:00Z'),
+  confirmedAt: null,
+  rejectedAt: null,
+  archivedAt: null,
+  notes: null,
+});
+
+const sectionTexts = (blocks: KnownBlock[]): string[] =>
+  blocks
+    .filter((b): b is SectionBlock => b.type === 'section')
+    .map((b) => {
+      const text = b.text;
+      if (text && 'text' in text && typeof text.text === 'string') return text.text;
+      return '';
+    });
+
+describe('buildCandidateCard — patternKind prefix', () => {
+  it('saju 시드는 [사주] prefix를 header에 포함', () => {
+    const blocks = buildCandidateCard(makeCandidate(1, '갑목일주', 'saju'));
+    const texts = sectionTexts(blocks);
+    expect(texts.length).toBeGreaterThan(0);
+    expect(texts[0]).toMatch(/^\[사주\] \*갑목일주\*/);
+  });
+
+  it('life_signal 시드는 [생활] prefix를 header에 포함', () => {
+    const blocks = buildCandidateCard(makeCandidate(2, '저녁 운동', 'life_signal'));
+    const texts = sectionTexts(blocks);
+    expect(texts[0]).toMatch(/^\[생활\] \*저녁 운동\*/);
+  });
+});
+
+describe('buildWeeklyReviewBlocks — cap per kind', () => {
+  it('saju 6 + life_signal 7 → 종류별 5건씩만 노출 (최대 10건)', () => {
+    const candidates: CandidateHypothesis[] = [
+      ...Array.from({ length: 6 }, (_, i) => makeCandidate(100 + i, `사주${i}`, 'saju')),
+      ...Array.from({ length: 7 }, (_, i) => makeCandidate(200 + i, `생활${i}`, 'life_signal')),
+    ];
+    const blocks = buildWeeklyReviewBlocks([], candidates, '2026-05-25');
+    const texts = sectionTexts(blocks);
+
+    const sajuCards = texts.filter((t) => /^\[사주\]/.test(t));
+    const lifeCards = texts.filter((t) => /^\[생활\]/.test(t));
+    expect(sajuCards.length).toBe(5);
+    expect(lifeCards.length).toBe(5);
+  });
+
+  it('신규 후보 섹션 헤더에 종류별 카운트 표기', () => {
+    const candidates: CandidateHypothesis[] = [
+      makeCandidate(1, '사주A', 'saju'),
+      makeCandidate(2, '사주B', 'saju'),
+      makeCandidate(3, '생활A', 'life_signal'),
+    ];
+    const blocks = buildWeeklyReviewBlocks([], candidates, '2026-05-25');
+    const headerSection = sectionTexts(blocks).find((t) => /^\*신규 후보/.test(t));
+    expect(headerSection).toBeDefined();
+    expect(headerSection).toContain('사주 2');
+    expect(headerSection).toContain('생활 1');
+  });
+
+  it('한쪽이 비어 있어도 header에 0 카운트로 표기', () => {
+    const candidates: CandidateHypothesis[] = [
+      makeCandidate(1, '사주A', 'saju'),
+      makeCandidate(2, '사주B', 'saju'),
+    ];
+    const blocks = buildWeeklyReviewBlocks([], candidates, '2026-05-25');
+    const headerSection = sectionTexts(blocks).find((t) => /^\*신규 후보/.test(t));
+    expect(headerSection).toContain('사주 2');
+    expect(headerSection).toContain('생활 0');
+  });
+
+  it('candidates가 0건이면 신규 후보 섹션 자체가 추가되지 않음', () => {
+    const blocks = buildWeeklyReviewBlocks([], [], '2026-05-25');
+    const headerSection = sectionTexts(blocks).find((t) => /^\*신규 후보/.test(t));
+    expect(headerSection).toBeUndefined();
+  });
+});
+
+describe('buildWeeklyReviewBlocks — active 가설 prefix', () => {
+  it('active row에도 patternKind 따라 [사주] / [생활] prefix가 붙는다', () => {
+    const active: ActiveHypothesisRow[] = [
+      {
+        hypothesis: makeHypothesis(10, 100),
+        signalName: '사주가설',
+        patternKind: 'saju',
+        latest: makeStat(10),
+        prev: null,
+      },
+      {
+        hypothesis: makeHypothesis(11, 101),
+        signalName: '생활가설',
+        patternKind: 'life_signal',
+        latest: makeStat(11),
+        prev: null,
+      },
+    ];
+    const blocks = buildWeeklyReviewBlocks(active, [], '2026-05-25');
+    const activeSection = sectionTexts(blocks).find((t) => t.includes('active 가설'));
+    expect(activeSection).toBeDefined();
+    expect(activeSection).toMatch(/\[사주\] \*사주가설\*/);
+    expect(activeSection).toMatch(/\[생활\] \*생활가설\*/);
+  });
+});

--- a/src/agents/insight/__tests__/hypothesis-discovery.test.ts
+++ b/src/agents/insight/__tests__/hypothesis-discovery.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+interface QueryResult<T> {
+  rows: T[];
+}
+
+type QueryArgs = readonly unknown[];
+
+interface FixtureSignal {
+  id: number;
+  name: string;
+  pattern_kind: 'saju' | 'life_signal';
+}
+
+interface FixtureTriggerRow {
+  pattern_id: number;
+  date: string;
+}
+
+interface FixtureEnumRow {
+  tag: string;
+  date: string;
+}
+
+interface Fixture {
+  signals: FixtureSignal[];
+  triggerRows: FixtureTriggerRow[];
+  enumRows: FixtureEnumRow[];
+  totalDays: number;
+}
+
+let fixture: Fixture = {
+  signals: [],
+  triggerRows: [],
+  enumRows: [],
+  totalDays: 0,
+};
+
+vi.mock('../../../shared/db.js', () => ({
+  query: vi.fn(async (sql: string, _params?: QueryArgs): Promise<QueryResult<unknown>> => {
+    if (/FROM pattern_catalog\b/i.test(sql) && /\bactive = true\b/i.test(sql)) {
+      return { rows: fixture.signals };
+    }
+    if (/FROM pattern_matches\b/i.test(sql)) {
+      return { rows: fixture.triggerRows };
+    }
+    if (/FROM diary_meta_tags\b/i.test(sql)) {
+      return { rows: fixture.enumRows };
+    }
+    if (/DATE\(\$2\) - DATE\(\$1\)/.test(sql)) {
+      return { rows: [{ days: String(fixture.totalDays) }] };
+    }
+    if (/FROM pattern_hypotheses\b/i.test(sql)) {
+      return { rows: [] };
+    }
+    throw new Error(`[fixture] unexpected SQL: ${sql.slice(0, 80)}`);
+  }),
+}));
+
+const { discoverCandidates } = await import('../hypothesis-discovery.js');
+
+const isoDate = (offsetDays: number): string => {
+  const base = new Date('2026-05-01T00:00:00Z');
+  base.setUTCDate(base.getUTCDate() + offsetDays);
+  return base.toISOString().slice(0, 10);
+};
+
+describe('discoverCandidates — patternKind 전파', () => {
+  beforeEach(() => {
+    fixture = {
+      signals: [],
+      triggerRows: [],
+      enumRows: [],
+      totalDays: 0,
+    };
+  });
+
+  it('saju + life_signal 시드가 섞여 있으면 결과 후보에 둘 다 patternKind가 채워진다', async () => {
+    fixture.totalDays = 28;
+    fixture.signals = [
+      { id: 1, name: '갑목일주', pattern_kind: 'saju' },
+      { id: 2, name: '저녁 운동', pattern_kind: 'life_signal' },
+    ];
+    // saju: 8 trigger days, 그중 7일에 enum 발현 → trigger rate 7/8, baseline (1/20)
+    // life_signal: 8 trigger days, 그중 6일에 enum 발현 → trigger rate 6/8, baseline (2/20)
+    const sajuTriggerDays = Array.from({ length: 8 }, (_, i) => isoDate(i));
+    const lifeTriggerDays = Array.from({ length: 8 }, (_, i) => isoDate(i + 10));
+    for (const d of sajuTriggerDays) {
+      fixture.triggerRows.push({ pattern_id: 1, date: d });
+    }
+    for (const d of lifeTriggerDays) {
+      fixture.triggerRows.push({ pattern_id: 2, date: d });
+    }
+    // saju enum 발현: trigger 8일 중 7일 + baseline 20일 중 1일
+    const sajuEnumOnTrigger = sajuTriggerDays.slice(0, 7);
+    const sajuEnumOnBaseline = [isoDate(20)];
+    // life_signal enum 발현: trigger 8일 중 6일 + baseline 20일 중 2일
+    const lifeEnumOnTrigger = lifeTriggerDays.slice(0, 6);
+    const lifeEnumOnBaseline = [isoDate(22), isoDate(23)];
+    // 같은 enum_target 한 종류만 발현(테스트 단순화) — energy_high
+    for (const d of [...sajuEnumOnTrigger, ...sajuEnumOnBaseline]) {
+      fixture.enumRows.push({ tag: 'mood_high', date: d });
+    }
+    for (const d of [...lifeEnumOnTrigger, ...lifeEnumOnBaseline]) {
+      // saju가 발현시킨 날과 겹칠 수 있지만 enum dedup은 set에서 자동 처리
+      fixture.enumRows.push({ tag: 'peaceful', date: d });
+    }
+
+    const candidates = await discoverCandidates(1, { mode: 'setup', lookbackDays: 28 });
+
+    expect(candidates.length).toBeGreaterThan(0);
+    const sajuCand = candidates.find((c) => c.signalName === '갑목일주');
+    const lifeCand = candidates.find((c) => c.signalName === '저녁 운동');
+    expect(sajuCand?.patternKind).toBe('saju');
+    expect(lifeCand?.patternKind).toBe('life_signal');
+  });
+
+  it('signals 빈 배열이면 후보도 빈 배열', async () => {
+    fixture.totalDays = 28;
+    const candidates = await discoverCandidates(1, { mode: 'setup', lookbackDays: 28 });
+    expect(candidates).toEqual([]);
+  });
+});

--- a/src/agents/insight/hypothesis-cards.ts
+++ b/src/agents/insight/hypothesis-cards.ts
@@ -12,6 +12,13 @@ import type { Hypothesis, HypothesisStat, TriggerSpec } from '../../shared/patte
 export const HYPOTHESIS_REGISTER_ACTION_ID = 'hypothesis_register';
 export const HYPOTHESIS_DISMISS_ACTION_ID = 'hypothesis_dismiss';
 
+const KIND_LABEL: Record<'saju' | 'life_signal', string> = {
+  saju: '[사주]',
+  life_signal: '[생활]',
+};
+
+const CANDIDATE_CAP_PER_KIND = 5;
+
 /** Slack action value 직렬화 — JSON 한도(2000자) 안전 */
 export interface HypothesisActionPayload {
   triggerSpec: TriggerSpec;
@@ -62,7 +69,8 @@ export const buildCandidateCard = (cand: CandidateHypothesis): KnownBlock[] => {
     triggerSpec: cand.triggerSpec,
     enumTarget: cand.enumTarget,
   });
-  const header = `*${cand.signalName}* → \`${cand.enumTarget}\``;
+  const kindLabel = KIND_LABEL[cand.patternKind];
+  const header = `${kindLabel} *${cand.signalName}* → \`${cand.enumTarget}\``;
   const detail =
     `발현일 n=${cand.nTriggerDays} · trigger ${formatPercent(cand.rateTrigger)} ` +
     `vs baseline ${formatPercent(cand.rateBaseline)} ` +
@@ -98,6 +106,7 @@ export const buildCandidateCard = (cand: CandidateHypothesis): KnownBlock[] => {
 export interface ActiveHypothesisRow {
   hypothesis: Hypothesis;
   signalName: string;
+  patternKind: 'saju' | 'life_signal';
   latest: HypothesisStat;
   prev: HypothesisStat | null;
 }
@@ -129,8 +138,9 @@ export const buildWeeklyReviewBlocks = (
       const prev = row.prev;
       const trigArrow = arrow(row.latest.rateTrigger, prev?.rateTrigger ?? null);
       const qArrow = arrow(row.latest.fdrQ, prev?.fdrQ ?? null);
+      const kindLabel = KIND_LABEL[row.patternKind];
       return (
-        `• *${row.signalName}* → \`${row.hypothesis.enumTarget}\` — ` +
+        `• ${kindLabel} *${row.signalName}* → \`${row.hypothesis.enumTarget}\` — ` +
         `n=${row.latest.nTriggerDays} ` +
         `trig ${formatPercent(row.latest.rateTrigger)} ${trigArrow} ` +
         `ratio ${formatRatio(row.latest.rateRatio)}x ` +
@@ -143,18 +153,24 @@ export const buildWeeklyReviewBlocks = (
     });
   }
 
-  if (candidates.length > 0) {
+  const sajuCands = candidates
+    .filter((c) => c.patternKind === 'saju')
+    .slice(0, CANDIDATE_CAP_PER_KIND);
+  const lifeCands = candidates
+    .filter((c) => c.patternKind === 'life_signal')
+    .slice(0, CANDIDATE_CAP_PER_KIND);
+
+  if (sajuCands.length + lifeCands.length > 0) {
     blocks.push({ type: 'divider' });
     blocks.push({
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*신규 후보 (${candidates.length}건)* — 등록할 거 골라`,
+        text: `*신규 후보 (사주 ${sajuCands.length} / 생활 ${lifeCands.length})* — 등록할 거 골라`,
       },
     });
-    for (const cand of candidates.slice(0, 5)) {
-      blocks.push(...buildCandidateCard(cand));
-    }
+    for (const cand of sajuCands) blocks.push(...buildCandidateCard(cand));
+    for (const cand of lifeCands) blocks.push(...buildCandidateCard(cand));
   }
 
   return blocks;

--- a/src/agents/insight/hypothesis-discovery.ts
+++ b/src/agents/insight/hypothesis-discovery.ts
@@ -18,6 +18,7 @@ export type DiscoveryMode =
 export interface CandidateHypothesis {
   triggerSpec: TriggerSpec;
   signalName: string;
+  patternKind: 'saju' | 'life_signal';
   enumTarget: DiaryMetaTag;
   nTriggerDays: number;
   nTotalDays: number;
@@ -36,16 +37,17 @@ const DISCOVERY_MIN_RATE_RATIO = 1.3;
 interface ActiveSignal {
   id: number;
   name: string;
+  patternKind: 'saju' | 'life_signal';
 }
 
 const loadActiveSignals = async (userId: number): Promise<ActiveSignal[]> => {
-  const res = await query<{ id: number; name: string }>(
-    `SELECT id, name FROM pattern_catalog
+  const res = await query<{ id: number; name: string; pattern_kind: 'saju' | 'life_signal' }>(
+    `SELECT id, name, pattern_kind FROM pattern_catalog
        WHERE user_id = $1 AND active = true
        ORDER BY id`,
     [userId],
   );
-  return res.rows;
+  return res.rows.map((r) => ({ id: r.id, name: r.name, patternKind: r.pattern_kind }));
 };
 
 const loadRegisteredCombos = async (userId: number): Promise<Set<string>> => {
@@ -220,6 +222,7 @@ export const discoverCandidates = async (
     candidates.push({
       triggerSpec: { type: 'seed', signalId: raw.signal.id },
       signalName: raw.signal.name,
+      patternKind: raw.signal.patternKind,
       enumTarget: raw.enumTarget,
       nTriggerDays: raw.triggerDays,
       nTotalDays: raw.totalDays,

--- a/src/cron/weekly-hypothesis-review.ts
+++ b/src/cron/weekly-hypothesis-review.ts
@@ -37,13 +37,18 @@ export const previousMondayISO = (todayIso: string): string => {
   return addDays(todayIso, -(daysSinceMonday + 7));
 };
 
-const loadSignalNames = async (signalIds: number[]): Promise<Map<number, string>> => {
+interface SignalMeta {
+  name: string;
+  patternKind: 'saju' | 'life_signal';
+}
+
+const loadSignalMeta = async (signalIds: number[]): Promise<Map<number, SignalMeta>> => {
   if (signalIds.length === 0) return new Map();
-  const res = await query<{ id: number; name: string }>(
-    `SELECT id, name FROM pattern_catalog WHERE id = ANY($1::int[])`,
+  const res = await query<{ id: number; name: string; pattern_kind: 'saju' | 'life_signal' }>(
+    `SELECT id, name, pattern_kind FROM pattern_catalog WHERE id = ANY($1::int[])`,
     [signalIds],
   );
-  return new Map(res.rows.map((r) => [r.id, r.name]));
+  return new Map(res.rows.map((r) => [r.id, { name: r.name, patternKind: r.pattern_kind }]));
 };
 
 const loadPrevStat = async (
@@ -115,7 +120,7 @@ const processUser = async (
       ...active.map((h) => h.triggerSpec.signalId),
     ]),
   );
-  const signalNameMap = await loadSignalNames(signalIds);
+  const signalMetaMap = await loadSignalMeta(signalIds);
 
   const statByHypothesisId = new Map(stats.map((s) => [s.hypothesisId, s]));
   const rows: ActiveHypothesisRow[] = [];
@@ -123,9 +128,11 @@ const processUser = async (
     const latest = statByHypothesisId.get(h.id);
     if (!latest) continue;
     const prev = await loadPrevStat(h.id, weekStart);
+    const meta = signalMetaMap.get(h.triggerSpec.signalId);
     rows.push({
       hypothesis: h,
-      signalName: signalNameMap.get(h.triggerSpec.signalId) ?? `signal#${h.triggerSpec.signalId}`,
+      signalName: meta?.name ?? `signal#${h.triggerSpec.signalId}`,
+      patternKind: meta?.patternKind ?? 'saju',
       latest,
       prev,
     });


### PR DESCRIPTION
## 관련 이슈
Closes #454

## 변경 내용
- `CandidateHypothesis`·`ActiveSignal`·`ActiveHypothesisRow`에 `patternKind: 'saju' | 'life_signal'` 필드 추가
- 카드 header에 `[사주]` / `[생활]` prefix (`KIND_LABEL` 상수 도입, 이모지 충돌 회피)
- 신규 가설 후보 cap을 종류별로 분리 — saju 5 + life_signal 5 (발견된 만큼만 노출)
- 신규 후보 섹션 헤더에 `사주 N / 생활 M` 카운트 표기
- `loadSignalNames` → `loadSignalMeta` 전환 (`pattern_kind` 동반 SELECT)
- DISCOVERY 임계치(`q<0.2`·`p<0.1`·`ratio≥1.3`·`n≥5`)는 유지 — BH-FDR 자동 보정(조합 N 13배 증가 자동 흡수), 임의값 박지 않기 헌장 준수
- vitest 신규: `hypothesis-cards.test.ts` (prefix·종류별 cap·카운트 헤더·0건 처리·active row prefix)
- vitest 신규: `hypothesis-discovery.test.ts` (saju + life_signal 시드 섞어 입력 시 `patternKind` 전파)
- 도메인 문서 `docs/domains/insight.md` Section 19 본문 채우기
- `docs/design-notebook/personal-pattern-discovery.md` Phase 5 섹션 추가

## ADR
신규 ADR 없음. [ADR-0019](../docs/adr/0019-saju-hypothesis-verification-pipeline.md) 위 운영 결정 — UI 표시·cap 분리는 되돌리기 쉽고, 임계치 유지는 ADR-0019 결정 그대로.

## 코드 리뷰 결과
- [x] 보안 감사 통과 — 크리덴셜 없음, SQL parameterized, 민감 정보 없음
- [x] 타입 안전성 확인 — `yarn tsc --noEmit` 통과
- [x] 컨벤션 점검 완료 — `yarn lint` 0 errors, 새 warning 없음
- [x] 코드 품질 확인 — 단일 책임 유지(discovery/cards/cron 분리), `any` 없음

## 테스트
- [x] vitest 570/570 통과 (insight 12개 신규 포함)
- [x] prefix 검증: `[사주]` / `[생활]` 두 카테고리
- [x] cap 분리 검증: saju 6 + life_signal 7 입력 → saju 5 + life_signal 5만 노출
- [x] 카운트 헤더 검증: `사주 N / 생활 M` 정확 표기
- [x] 0건 처리: candidates 0건이면 신규 후보 섹션 자체가 안 뜸
- [x] active 가설 prefix: `[사주]` / `[생활]` row 라인에도 표시
- [ ] 운영 검증 (머지 후 다음 월요일 08:00 KST `#insight` 채널 자동 발사 관측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)