### PR TITLE
feat(insight): #434 Phase 6 — LLM 자율 매트릭 + 승인 게이트

### DIFF
--- a/db/migrations/073_pattern_metrics_rejected_at.sql
+++ b/db/migrations/073_pattern_metrics_rejected_at.sql
@@ -1,0 +1,13 @@
+-- 073: pattern_metrics에 rejected_at 컬럼 추가
+-- 마스터 #434 Phase 6.
+-- ADR-0030: LLM 매트릭 거절 시각. routine 재제안 시 LLM 입력에 노출하여 자율 판단 근거 제공.
+
+BEGIN;
+
+ALTER TABLE pattern_metrics
+  ADD COLUMN rejected_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN pattern_metrics.rejected_at IS
+  'LLM 매트릭 거절 시각. monthly-metric-suggest routine 재제안 시 LLM 입력에 노출 (ADR-0030)';
+
+COMMIT;

--- a/docs/adr/0030-llm-metric-suggest-input-and-cadence.md
+++ b/docs/adr/0030-llm-metric-suggest-input-and-cadence.md
@@ -1,0 +1,165 @@
+# 0030. LLM 매트릭 제안 슬롯 — 입력 풀 구성 + 거절 재제안 + 월간 cron
+
+- Status: Accepted
+- Date: 2026-05-28
+- Related: [#458](https://github.com/hyewon3938/slack-ai-agents/issues/458), 마스터 [#434](https://github.com/hyewon3938/slack-ai-agents/issues/434) Phase 6
+- Tags: llm, insight, ops
+
+## Context
+
+[ADR-0025](0025-llm-metric-approval-gate.md)는 LLM 자율 매트릭의 승인 게이트(`status='pending' → 'active'`, 월 cap 5, Slack inline button, `description NOT NULL`) 골격을 결정했다. [ADR-0027](0027-llm-async-routine-unification.md)은 LLM 비동기 작업이 Claude 앱 routines로 통일된다는 운영 패턴을 결정했다.
+
+본 ADR이 다루는 잔여 결정 3건:
+
+1. **LLM이 매트릭 후보를 만들 때 입력 데이터를 어떻게 구성하는가** — Phase 2에서 박은 161개 evidence-only 시드의 `pattern_matches.evidence` JSONB 60+일 누적이 본래 가설 풀 가정이었으나, 마스터 #434 Phase 2 머지일이 2026-05-28이라 본 phase 진입 시점 evidence 누적 = 0일. 입력 풀이 빈 상태에서도 의미있는 후보를 만들 수 있어야 함
+2. **거절된 매트릭의 재제안 정책** — 동일 (seed_id, outcome) 무한 반복 차단 + 새 근거 발견 시 재평가 가능성 보존을 어떻게 양립
+3. **routine 실행 빈도** — ADR-0025의 "월 cap 5"와 자연스럽게 호환되는 주기
+
+## Decision
+
+### (a) LLM 입력 풀 — 3 결합
+
+routine 컨텍스트에 다음 3종 데이터를 LLM에 노출. 본 데이터는 사용자 텍스트 원문(일기·schedule 제목 등)을 포함하지 않는다 (v2 헌장 ① 계승).
+
+| 입력 | 출처 | 의도 |
+|------|------|------|
+| **evidence JSONB 누적 요약** | `pattern_matches.evidence` WHERE `verify_status='no_metric'`, 최근 60일 | trigger 발현 시 같이 관측된 outcome 카운트 패턴 (누적 부족 단계에서는 자연 0건, 누적되면 자연 풍부) |
+| **시드 description** | `pattern_catalog.description` (Phase 2 시드 풀세트가 사용자 임상 단서 박아둠) | 가설 공간 좁히는 hint. "사화 발현일 → 신체 증상(대상포진·피부)" 등 사용자 본인이 관측한 패턴 |
+| **라이프 메트릭 표** | 최근 30일, schedule done/total, sleep_avg, routine streak, expense category count 등 메타데이터 (금액 X) | trigger와 outcome의 cross-domain 동조 패턴 발견 입력. v2 헌장 ① 준수 (메타데이터만) |
+
+LLM 프롬프트 지침에 다음 명시:
+
+- 근거 부족하면 부족하다고 말하고 0개 제안 가능 — cap 5는 max이지 무조건 5개 아님
+- SQL 본문은 evaluateMetric 가능한 패턴(SELECT 단일 쿼리 + outcome 카운트 평가)으로만
+- 매트릭 description은 자연어 + 사용자가 SQL 본문 검토 없이 의도 파악 가능한 수준
+
+### (b) 거절 재제안 — rejected 목록 LLM 노출 + 자율 판단
+
+routine 컨텍스트에 다음도 같이 노출:
+
+```sql
+SELECT pattern_id, description, proposed_at, rejected_at
+FROM pattern_metrics
+WHERE status = 'rejected'
+ORDER BY rejected_at DESC
+LIMIT 30;
+```
+
+LLM 프롬프트 지침:
+
+- "이미 거절된 (seed_id, outcome) 조합은 **새 근거**(누적 evidence 변화·다른 outcome·다른 window)가 있을 때만 재제안"
+- 재제안 시 description에 "이전 거절 사유와 다른 점" 명시 의무
+- 새 근거 없는 동일 조합 반복은 금지
+
+→ 영구 거절 vs 무제한 재제안의 절충. 무한 반복은 LLM 자율 판단 + 사용자 거절 게이트가 거름. 사용자 시각으로 봤을 때 "왜 또 이거?" 의문이 생기지 않게 LLM이 차이점을 설명해야 한다는 의무 부과.
+
+### (c) routine 실행 빈도
+
+**매월 1일 09:30 KST**.
+
+- ADR-0025의 "월 cap 5"와 자연 일치 (월 1회 실행 = 월 cap 자동 reset)
+- 기존 monthly-llm-insight cron과 동일 패턴 (운영 입증된 시간대)
+- routine 위치: `~/.claude/scheduled-tasks/monthly-metric-suggest/SKILL.md`
+- model: opus (구독료 잠금 — ADR-0027)
+
+routine 실행 흐름:
+
+1. 입력 데이터 3 결합 SELECT
+2. LLM (Opus) 매트릭 후보 0\~5개 생성
+3. 후보별로 `pattern_metrics` INSERT (`status='pending'`, `source='llm_autonomous'`, `proposed_at=NOW()`)
+4. 후보별 Block Kit 메시지 1건씩 `#insight` 채널에 발송 ([승인]/[거절] 버튼)
+5. 후보 0건이면 "X월 제안 없음" 메시지 1건
+
+승인/거절 인터랙션은 봇 서버 `src/agents/insight/actions.ts`가 받는다 (routine ≠ Slack interactivity endpoint).
+
+## Alternatives considered
+
+### A. evidence + 시드 description + 라이프 메트릭 표 (선택)
+
+- 장점:
+  - evidence 누적 부족 단계에서도 시드 description + 라이프 메트릭으로 의미있는 후보 생성 가능
+  - 누적될수록 evidence 풀이 자연 풍부 → 후보 품질 자동 향상 (인프라 변경 없이)
+  - 3 입력은 서로 독립적 신호 — LLM이 교차 검증 가능
+- 단점: 프롬프트 토큰 길어짐 + LLM이 라이프 메트릭 표를 잘못 해석하면 인과 가설 폭주 위험
+
+### B. evidence + 시드 description만
+
+- 장점: 입력 단순, 프롬프트 토큰 최소화
+- 단점: evidence 0일 단계에서 후보 생성 실질 불가. LLM이 "trigger X가 outcome Y와 함께 나타난다" 관찰을 못함
+- 기각 이유: 본 phase 진입 시점 evidence 누적 = 0일이라 이 안은 빈 cron이 됨
+
+### C. evidence + description + 메트릭 + active 가설 상태
+
+- 장점: 현재 active 가설의 hit/miss 추세도 LLM에 노출. "기존 가설이 검증되는 방향에서 더 세분한 매트릭 제안" 유도
+- 단점: 프롬프트 복잡·토큰 더 ↑. 가설 공간 더 좁아지지만 입력 복잡도 비용 vs 효용이 본 단계에 불명확
+- 기각 이유: 운영 누적 후 검토. 1차는 3 결합으로 시작
+
+→ **A (3 결합) 선택**.
+
+### 거절 재제안 정책 대안
+
+#### α. rejected 목록 노출 + LLM 자율 판단 (선택)
+
+- 장점: 영구 차단·임의 cool down 둘 다 피함. 새 근거 있으면 재평가 가능
+- 단점: LLM 판단 의존 — "새 근거"의 기준이 자율적이라 일관성 변동 가능
+
+#### β. rejected 목록 노출 + 90일 cool down
+
+- 장점: 명확한 규칙
+- 단점: 임의값 박기 (마스터 #434 헌장 "임의값 배제" 부분 위배)
+
+#### γ. rejected 목록 비노출 (동일 조합 반복 허용)
+
+- 장점: 구현 단순
+- 단점: 사용자가 매번 같은 거절 반복 → UX 저하
+- 기각 이유: 사용자 부담만 ↑
+
+### routine 빈도 대안
+
+#### x. 매월 1일 09:30 KST (선택)
+
+- 장점: 월 cap 5와 자연 호환, monthly-llm-insight 운영 패턴 계승
+- 단점: 가설 제안 주기가 길어 운영 누적 빠른 단계에 답답할 수 있음
+
+#### y. 매주 월요일 09:30 KST
+
+- 장점: 가설 제안 주기 빠름
+- 단점: 월 cap 5와 충돌 — 주 4\~5회 × cap 5 = 철소 처리 추가 복잡도
+- 기각 이유: ADR-0025 cap 정책과 자연 호환 안 됨
+
+#### z. evidence 누적 임계치 기반 자동 트리거
+
+- 장점: 데이터 충분할 때만 routine 실행
+- 단점: 메타 cron(daily check) 필요 + 임계치 자동 판단 임의값 박기. 1차 도입 이른 가능성
+- 기각 이유: 운영 누적 1\~3개월 후 follow-up 검토. 1차는 fixed monthly로 충분
+
+## Consequences
+
+### 장점
+
+- evidence 누적 0일 단계에서도 routine 첫 실행 가능 → 인프라 + 운영 검증 동시 진행
+- 입력 풀 3 결합이 본 phase에서 표준화 → 후속 LLM 매트릭 슬롯 확장(예: weekly 후보 슬롯 분리) 시 같은 표준 위에서 결정 가능
+- rejected 목록 LLM 노출 + 자율 판단으로 임의 cool down 없이 노이즈 차단
+- monthly cron = ADR-0025 cap과 자연 호환, monthly-llm-insight 운영 패턴 재사용
+
+### 단점 / 제약
+
+- LLM 프롬프트 토큰 ↑ — evidence 60일 + description 161개 + 메트릭 표. Opus 토큰 비용은 routine(Claude 앱 구독료 잠금)이라 종량 부담 없음 (ADR-0027 효용)
+- 첫 cron 발사가 빈약한 후보(0\~2개)가 될 가능성 ↑. 운영 누적될수록 자연 향상
+- LLM이 "새 근거" 판단이 일관되지 않으면 동일 거절 반복 가능. 운영 1\~3개월 후 정책 재검토
+- routine 실패 fallback 미정 — routine 실행 실패 시 알림 경로는 별도 ADR/follow-up
+
+### 후속 작업
+
+- [ ] Phase 6 PR: routine SKILL.md + metric-approval-cards.ts + actions.ts METRIC_APPROVE/REJECT + index.ts fast path 정규식 + 도메인 문서 본문 채우기
+- [ ] 첫 routine 발사 후(2026-07-01) 후보 품질 회고 — design-notebook Phase 6 회고 섹션
+- [ ] 운영 1\~3개월 누적 후 follow-up: rejected 재제안 정책 일관성 평가, 입력 풀 확장(active 가설 상태 노출) 검토, evidence 누적 임계치 자동 트리거 검토
+
+---
+
+**참고 자료**
+
+- [ADR-0025](0025-llm-metric-approval-gate.md) — 승인 게이트 골격
+- [ADR-0027](0027-llm-async-routine-unification.md) — routine 운영 통일
+- 마스터 #434 자체 헌장 ④ (결정론↔자율 + 승인 게이트): `docs/design-notebook/personal-pattern-discovery.md`
+- v2 헌장 ① (텍스트 원문 노출 금지): `.claude/projects/-Users-ihyewon-slack-ai-agents/memory/project_insight_v2_core_principles.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -136,6 +136,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0027](0027-llm-async-routine-unification.md) | LLM 비동기 작업 Claude 앱 routines 기반 통일 | Accepted | 2026-05-28 | process, llm, infra, ops |
 | [0028](0028-pillar-level-and-threshold-pool.md) | 사주 시드 운 레벨 차원 도입 + 풀셋 임계치 철학 + 임의값 배제 | Accepted | 2026-05-28 | data, insight, architecture, process |
 | [0029](0029-life-signal-trigger-aux-standard.md) | `life_signal` 단일 type 통합 + `trigger_aux.kind` 평가 명세 표준 | Accepted | 2026-05-28 | data, insight, architecture, schema |
+| [0030](0030-llm-metric-suggest-input-and-cadence.md) | LLM 매트릭 제안 슬롯 — 입력 풀 구성 + 거절 재제안 + 월간 cron | Accepted | 2026-05-28 | llm, insight, ops |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/personal-pattern-discovery.md
+++ b/docs/design-notebook/personal-pattern-discovery.md
@@ -580,7 +580,72 @@ Phase 4까지 매칭 cron이 saju 175 + life_signal 38 = 213개 시드의 `trigg
 
 ---
 
-## Phase 6\~8 (TODO: 각 Phase 진입 시 섹션 누적)
+## Phase 6: LLM 자율 매트릭 + 승인 게이트 (2026-05-28)
+
+- 이슈: [#458](https://github.com/hyewon3938/slack-ai-agents/issues/458)
+- 관련 ADR: [ADR-0025](../adr/0025-llm-metric-approval-gate.md) (승인 게이트 골격), [ADR-0027](../adr/0027-llm-async-routine-unification.md) (routine 통일), **[ADR-0030](../adr/0030-llm-metric-suggest-input-and-cadence.md) 신설** (LLM 입력 풀 + 거절 정책 + 월간 cron)
+- 관련 계획서: `.claude/plans/458-phase-6-llm-metric-gate.md`
+- 상태: 설계 완료, 구현 대기
+
+### 결정 요약
+
+ADR-0025가 골격(`status='pending'→'active'` 게이트, 월 cap 5, Slack inline button, `description NOT NULL`)을 결정했고 ADR-0027이 운영 패턴(Claude 앱 routines)을 결정한 상태. 본 phase는 잔여 운영 결정 3건을 ADR-0030으로 묶고 인프라 구현.
+
+5개 결정:
+
+1. **routine 빈도**: 매월 1일 09:30 KST, Claude 앱 routine 운영
+2. **LLM 입력 풀**: evidence-only 시드 evidence JSONB(60일) + 시드 description + 라이프 메트릭 표(30일 메타데이터, 금액 X) **3 결합**
+3. **카드 디자인**: 후보별 1메시지 (N개 메시지 연속 발송, hypothesis-card 패턴 계승)
+4. **거절 재제안**: rejected 목록 LLM에 노출 + LLM 자율 판단 (새 근거 명시 시만 재제안)
+5. **cap**: 월 최대 5개 (ADR-0025 계승)
+
+evidence 누적 부족 단계(첫 발사 2026-07-01 ≈ Phase 2 머지 후 1개월)에서도 시드 description hint(사용자 임상 단서) + 라이프 메트릭 표로 의미있는 후보 1\~3개 제안 가능 여부 운영 첫 회로 확인.
+
+### 핵심 변경
+
+- `src/agents/insight/metric-approval-cards.ts` 신설 — Block Kit 승인 카드 빌더 + action payload encode/decode (hypothesis-cards 패턴)
+- `src/agents/insight/actions.ts` — `METRIC_APPROVE_ACTION_ID`·`METRIC_REJECT_ACTION_ID` 핸들러 추가 (hypothesis register/dismiss 패턴 계승)
+- `src/agents/insight/index.ts` — `/insight metric-list` fast path 정규식 추가 (pending 목록 보기)
+- `~/.claude/scheduled-tasks/monthly-metric-suggest/SKILL.md` 신설 (repo 외부, weekly-saju-review-v2 패턴) — 입력 데이터 SELECT + Opus 호출 + INSERT + Slack 발송
+- ADR-0030 신설
+- domain `docs/domains/insight.md` Section 20 본문 채움
+
+### 의사결정 분기점
+
+1. **Phase 6 진입 범위** — A 인프라만 구현·routine 첫 실행 보류 / B Phase 7 먼저 / **C 입력 풀 보강 + 즉시 활성 (선택)** / D 마스터 close 1차. 사용자 명시: "보류하거나 나중에 하는 거 없이 완성하고 싶어. 그 다음부터는 운영하면서 자동으로". cap + 사용자 승인 게이트가 마지막 거름망 + 시드 description hint가 LLM 가설 공간 좁힘 → 즉시 활성 위험 작음
+2. **LLM 입력 풀** — **A 3 결합 (evidence + description + 메트릭 표) 선택** / B evidence + description만 / C A + active 가설 상태. evidence 누적 0일 단계에서도 후보 생성 가능 + 누적될수록 자동 향상. 토큰 비용은 routine(구독료 잠금)이라 부담 없음
+3. **카드 디자인** — **A 후보별 1메시지 (선택)** / B 한 메시지에 N 섹션. hypothesis-card 패턴 계승 + 후보별 독립 인터랙션 + 0건이면 "X월 제안 없음" 메시지 1건
+4. **routine 빈도** — **A 매월 1일 09:30 KST (선택)** / B 매주 월요일 / C evidence 임계치 기반. ADR-0025 월 cap 5와 자연 호환 + monthly-llm-insight 운영 패턴 계승. 임계치 기반은 임의값 박기 (헌장 위배)
+5. **거절 재제안 정책** — **α rejected 목록 LLM 노출 + 자율 판단 (선택)** / β 90일 cool down / γ 영구 거절 / δ 비노출. 사용자 명시: "거절해도 유의미한 데이터가 발견되면 계속 제안해도 되는 거 아니야?" — 영구 차단·임의 cool down 둘 다 피함. LLM 프롬프트에 "이전 거절 사유와 다른 점" 명시 의무 부과
+6. **새 ADR 작성 필요성** — **ADR-0030 신설 (선택)**. ADR-0025·0027은 골격, 본 phase 운영 결정 3건(입력 풀·거절·cron 빈도)은 영속 결정이라 ADR로 박는 게 후속 phase에서 변경 시 추적 가능
+
+### 사용자 임상 데이터
+
+본 phase는 LLM이 시드 description(Phase 2에서 박힌 임상 단서)을 입력으로 받는 구조. 신규 사용자 임상 단서 박지 않음. Phase 2의 사화·갑목·진술충·화 과다 등 description hint가 그대로 LLM 후보 생성에 활용됨.
+
+### 포기한 안 / 미룬 항목
+
+- **evidence 누적 충분(60+일) 후 진입** — 사용자 명시 보류 안 함. 누적 부족 단계에서도 description + 메트릭 표로 안전 장치 + 자율 판단으로 빈 cron 처리
+- **Phase 7 먼저 진입** — 헌장 위배는 아니나 사용자가 phase 순서 그대로 6→7→8 진행 선호
+- **90일 cool down** — 임의값 박기 (헌장 "임의값 배제" 위배)
+- **active 가설 상태 입력 추가** — 운영 누적 후 follow-up. 1차는 3 결합 표준화에 집중
+- **evidence 임계치 자동 트리거** — 1차 도입 이른 가능성. 운영 1\~3개월 후 follow-up
+- **LLM 매트릭 SQL 본문 사용자 검토** — ADR-0025 결정 계승. description만 노출, SQL 본문은 4안전장치(SELECT-only 등)로 통제
+- **routine 실패 fallback** — 본 phase scope 외. routine 실행 실패 알림 경로는 별도 follow-up
+
+### 미해결 / 가설
+
+- **첫 routine 발사 후보 품질** — 2026-07-01 첫 발사 시점에 evidence 누적이 약 30일. description + 메트릭 표만으로 1\~3개 의미있는 후보 생성 가능 여부 운영 첫 회로 검증. 0건이어도 routine 정상 작동 여부도 점검
+- **rejected 재제안 LLM 자율 판단 일관성** — "새 근거" 기준이 모델별·실행별 변동 가능. 운영 1\~3개월 후 일관성 평가 follow-up
+- **input 토큰 길이** — 시드 161개 description + 메트릭 표 30일 + evidence 60일. 토큰 한계 도달 가능성. routine SKILL.md 작성 시 토큰 관측치 누적 + 한계 도달 시 입력 압축 전략 필요
+
+### 회고 (TODO: `/build` 구현 후 보강 + 2026-07-01 첫 발사 후 보강)
+
+> 회고는 PR 머지 후 추가. 첫 발사 후 후보 품질·LLM 거절 재제안 일관성·routine 토큰 비용 관측도 같이 보강.
+
+---
+
+## Phase 7\~8 (TODO: 각 Phase 진입 시 섹션 누적)
 
 > 각 Phase 진입 시 `/design`이 본 문서에 해당 Phase 섹션을 추가한다. 템플릿: 결정 요약 / 의사결정 분기점 / 포기한 안 / 회고.
 

--- a/docs/design-notebook/personal-pattern-discovery.md
+++ b/docs/design-notebook/personal-pattern-discovery.md
@@ -639,9 +639,24 @@ evidence 누적 부족 단계(첫 발사 2026-07-01 ≈ Phase 2 머지 후 1개�
 - **rejected 재제안 LLM 자율 판단 일관성** — "새 근거" 기준이 모델별·실행별 변동 가능. 운영 1\~3개월 후 일관성 평가 follow-up
 - **input 토큰 길이** — 시드 161개 description + 메트릭 표 30일 + evidence 60일. 토큰 한계 도달 가능성. routine SKILL.md 작성 시 토큰 관측치 누적 + 한계 도달 시 입력 압축 전략 필요
 
-### 회고 (TODO: `/build` 구현 후 보강 + 2026-07-01 첫 발사 후 보강)
+### 회고 (구현 — 2026-05-29, 운영 첫 발사 회고는 2026-07-01 후 보강)
 
-> 회고는 PR 머지 후 추가. 첫 발사 후 후보 품질·LLM 거절 재제안 일관성·routine 토큰 비용 관측도 같이 보강.
+**인프라 골격 완성**:
+- `metric-approval-cards.ts` Block Kit 후보 카드 빌더 + payload encode/decode (12 단위 테스트)
+- `actions.ts` METRIC_APPROVE/REJECT 핸들러 — hypothesis 패턴 그대로 차용해서 일관성 유지. `WHERE user_id` 격리 + `WHERE status = 'pending'`로 이중 클릭/타 사용자 매트릭 접근 차단
+- `index.ts` `insight metric-list` fast path — 디버깅·놓친 카드 재확인 통로 (자유언어 추출 금지 헌장 준수)
+- Migration 073 `rejected_at` 컬럼 — `routine 거절 재제안 입력 풀의 4번째 결합 요소
+
+**routine 자동화 슬롯 완성**:
+- Claude 앱 routines 등록 (`monthly-metric-suggest`, `0 30 9 1 * *`, Opus 권장)
+- SKILL.md 본문에 v2 헌장 ① · 자체 헌장 ④ · ADR-0025 cap · ADR-0030 거절 재제안을 명시적으로 박아 routine 발사 시점에 헌장 cross-check 가능
+
+**첫 발사 운영 검증 대기 (2026-07-01)**:
+- 후보 품질 — evidence 누적 30일 + 시드 description 161개로 의미있는 후보 1\~3개 생성 가능한지
+- LLM 거절 재제안 자율 판단 일관성 — 같은 (seed_id, outcome) 조합에 새 근거 없을 때 LLM이 실제로 보류하는지
+- routine 토큰 비용 — 입력 풀 3 결합이 토큰 한계 도달하는지
+
+운영 첫 발사 후 본 섹션에 결과 추가 예정.
 
 ---
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -1185,7 +1185,90 @@ const lifeCands = candidates
 
 ### 20. 본인 1명 패턴 발견 시스템 — Phase 6 (LLM 자율 매트릭 + 승인 게이트)
 
-> TODO(`/build`): 구현 후 본문 채우기. 월간 LLM 슬롯이 매트릭 후보 생성, 월 cap 5개. **운영은 Claude 앱 routines 기반** ([ADR-0027](../adr/0027-llm-async-routine-unification.md)) — Phase 2에서 누적된 60+일 evidence JSONB(`pattern_matches.evidence`, `verify_status='no_metric'` 행)를 가설 후보 풀로 사용. Slack `/insight metric-approve` 명령어 + Block Kit 승인 카드 (`metric-approval-cards.ts`). 승인 시 `pattern_metrics.status = 'active'` 전환. 거절 시 `'rejected'`.
+Phase 1\~5에서 결정론 매트릭만 평가되던 구조 위에 **LLM이 매트릭 후보를 자율 제안하는 슬롯**을 도입. 새 매트릭은 `status='pending'`으로 INSERT되고 사용자가 Slack 승인/거절 버튼을 눌러야 매칭 cron이 평가에 반영. v2 헌장 ④ (승인 게이트) 진입점.
+
+#### 운영 형태
+
+| 항목 | 값 |
+|------|-----|
+| routine 위치 | `~/.claude/scheduled-tasks/monthly-metric-suggest/SKILL.md` (repo 외부, Claude 앱 routines 기반 — [ADR-0027](../adr/0027-llm-async-routine-unification.md)) |
+| cron 시각 | 매월 1일 09:30 KST (`30 9 1 * *`) |
+| 모델 | Opus 권장 (사용자가 Claude 앱 model selector에서 지정) |
+| 후보 cap | 월 최대 5개 ([ADR-0025](../adr/0025-llm-metric-approval-gate.md)) |
+| 발사 채널 | `#insight` |
+| idempotency | 같은 달에 `source='llm_autonomous'` INSERT 이력 있으면 즉시 종료 |
+
+#### LLM 입력 풀 (3 결합, [ADR-0030](../adr/0030-llm-metric-suggest-input-and-cadence.md))
+
+| 입력 | 출처 | 의도 |
+|------|------|------|
+| ① evidence JSONB 누적 | `pattern_matches`의 `verify_status='no_metric'` 행, 최근 60일 | Phase 2 evidence-only 시드에서 누적된 사용자 임상 단서 후보 |
+| ② 시드 description | `pattern_catalog.description IS NOT NULL` 행 | Phase 2에서 박힌 사용자 임상 가설 hint |
+| ③ 라이프 메트릭 표 | schedules / routine_records / sleeps / diary_meta_tags 30일 메타데이터 | 사용자 텍스트 원문 노출 없이 컨텍스트 제공 (헌장 ① 위 — 카운트·태그 enum·평균값만) |
+
+추가 입력: ④ rejected 매트릭 30건 + ⑤ active 매트릭 — LLM이 중복 제안 회피 + 거절 재제안 자율 판단에 활용.
+
+#### 거절 재제안 정책 (ADR-0030)
+
+- `status='rejected'` 매트릭 목록을 LLM 입력에 노출
+- LLM은 **새 근거**(누적 evidence 변화·다른 outcome·다른 window) 있을 때만 재제안
+- 재제안 시 `rejection_diff` 필드에 이전 거절 대비 차이점 명시 의무 — 카드 detail에 "재제안 사유: ..." 줄로 노출
+- 임의 N일 cool-down은 마스터 #434 헌장 "임의값 박지 않기" 위배라 채택 거부
+
+#### 데이터 모델
+
+`pattern_metrics` 테이블에 추가된 컬럼 (Phase 1 migration 065 + 본 phase migration 073):
+
+| 컬럼 | 타입 | 의도 |
+|------|------|------|
+| `status` | `TEXT CHECK(active/pending/rejected)` | LLM 자율 매트릭은 `pending`으로 시작 |
+| `source` | `TEXT CHECK(deterministic/llm_autonomous)` | 결정론 시드 vs LLM 자율 |
+| `description` | `TEXT NOT NULL` | 사용자가 SQL 본문 검토 없이 의도 파악 가능한 자연어 |
+| `proposed_at` | `TIMESTAMPTZ` | LLM 제안 시각 |
+| `approved_at` | `TIMESTAMPTZ` | 사용자 승인 시각 |
+| `rejected_at` | `TIMESTAMPTZ` | 사용자 거절 시각 (migration 073, 본 phase) |
+
+#### 인터랙션 흐름
+
+```
+[매월 1일 09:30 KST]
+        │
+        ▼
+[monthly-metric-suggest routine (Claude 앱)]
+        │ ① idempotency 체크 → ② 입력 풀 수집 → ③ Opus 호출 → ④ INSERT pending
+        ▼
+[#insight 채널에 후보별 1메시지 (Block Kit 승인 카드)]
+        │
+        ▼
+[사용자 클릭]
+        │
+        ├─ [승인] ─→ actions.ts:METRIC_APPROVE_ACTION_ID
+        │             → UPDATE status='active', approved_at=NOW()
+        │             → 매칭 cron 다음 회부터 평가 반영
+        │
+        └─ [거절] ─→ actions.ts:METRIC_REJECT_ACTION_ID
+                      → UPDATE status='rejected', rejected_at=NOW()
+                      → 다음 달 routine 입력 풀의 rejected 목록에 노출
+```
+
+#### fast path 명령어
+
+| 명령어 | 정규식 | 동작 |
+|--------|--------|------|
+| `insight metric-list` | `/^\/?insight\s+metric-list[.?!]?$/` | `status='pending'` 매트릭 후보 20건 목록 조회 (디버깅·놓친 카드 재확인) |
+
+자유 문장 부분추출 금지 헌장(`feedback_no_freeform_regex_extraction`) 준수 — 약속된 단일 명령어 매칭만.
+
+#### 보안
+
+- LLM `metric_sql`은 SELECT 단일 쿼리만 허용. INSERT/UPDATE/DELETE/DDL 키워드 발견 시 후보 폐기. 매칭 cron 실행 전에도 `verifyDailyMatches` 정규식 차단 (Phase 4).
+- 액션 핸들러는 `resolveBodyUserId(body)` 통해 Slack user ID → DB user_id 매핑. 다른 user의 매트릭은 UPDATE 안 됨 (`WHERE user_id = $2`).
+- routine은 DB Proxy API 경유 (Vercel→VM 직결 없음, [ADR-0004](../adr/0004-db-proxy-api.md))
+- 사용자 텍스트 원문(diary content, schedule title, routine name)은 LLM 입력에 미포함 — 메타데이터만 (v2 헌장 ①).
+
+#### 다음 phase 연결
+
+Phase 7 (Bayesian update)에서 active 매트릭의 `posterior_alpha/beta/p`가 매칭 cron 평가 결과로 갱신. Phase 8 (인사이트 카드 UI)에서 active 매트릭의 verified 결과를 사용자에게 노출하는 카드 통합.
 
 ### 21. 본인 1명 패턴 발견 시스템 — Phase 7 (Bayesian update)
 
@@ -1208,7 +1291,8 @@ src/agents/insight/
 ├── diary-fast-path.ts             # 일기 저장 + 자연스러운 응답
 ├── saju-seed-fast-path.ts         # 사주 시드 보기/끄기/켜기 (Phase 3)
 ├── hypothesis-discovery.ts        # Phase 4 자동 패턴 발견 (setup/recurring)
-└── hypothesis-cards.ts            # Phase 4 카드 빌더 + 액션 payload
+├── hypothesis-cards.ts            # Phase 4 카드 빌더 + 액션 payload
+└── metric-approval-cards.ts       # Phase 6 LLM 매트릭 후보 카드 + 승인/거절 payload
 
 src/shared/
 ├── saju-match.ts                  # Phase 3 매칭 엔진 (evaluateTrigger 6종 + evaluateMetric)
@@ -1243,4 +1327,10 @@ db/migrations/  (마스터 #434 Phase 2.5 — 2026-05-28)
 └── 071_pattern_signals_pillar_level.sql         # pillar_level 컬럼 + cumulative_pillar_count trigger
                                                  # + expense_category_present 메트릭 + 14 신규 시드
                                                  # + pillarLevelDistributionReview 슬롯
+
+db/migrations/  (마스터 #434 Phase 6 — 2026-05-29)
+└── 073_pattern_metrics_rejected_at.sql          # rejected_at TIMESTAMPTZ (ADR-0030 거절 재제안 입력)
+
+~/.claude/scheduled-tasks/  (Claude 앱 routines, repo 외부)
+└── monthly-metric-suggest/SKILL.md              # Phase 6 매월 1일 09:30 LLM 매트릭 후보 제안
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -136,7 +136,7 @@
 ## 마스터 단위 진행 중 작업
 
 - **프로액티브 인사이트 v2** ([#393](https://github.com/hyewon3938/slack-ai-agents/issues/393)) — Phase 1\~4 머지 완료 (Phase 4 = 가설-검증 정량 파이프라인, 2026-05-22 PR [#415](https://github.com/hyewon3938/slack-ai-agents/pull/415)). Phase 5([#408](https://github.com/hyewon3938/slack-ai-agents/issues/408)) 월운·세운·대운 확장은 Phase 4 운영 1\~3개월 데이터 누적 후 진입 예정. 흐름: [design-notebook](./design-notebook/insight-engine-v2.md)
-- **본인 1명 패턴 발견 시스템** ([#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)) — Phase 1(스키마 rename, ADR-0022\~0026) / Phase 2(사주 시드 풀셋 161개 + evidence-only) / Phase 2.5(운 레벨 차원 + 풀셋 임계치 + 분포 분석 cron, ADR-0028) 머지 완료. Phase 3 이후는 life_signal 시드 풀 셋 + 매칭 cron 일반화 + LLM 매트릭 승인 게이트 + Bayesian update + UI. 흐름: [design-notebook](./design-notebook/personal-pattern-discovery.md)
+- **본인 1명 패턴 발견 시스템** ([#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)) — Phase 1(스키마 rename, ADR-0022\~0026) / Phase 2(사주 시드 풀셋 161개 + evidence-only) / Phase 2.5(운 레벨 차원 + 풀셋 임계치 + 분포 분석 cron, ADR-0028) / Phase 3(life_signal 시드 풀 셋 + 매칭 cron 일반화) / Phase 4(매칭 cron 카운터 source 전환 + pattern-match rename) / Phase 5(가설 발견·검증 파이프라인 target-type 확장) / Phase 6(LLM 자율 매트릭 + 승인 게이트, ADR-0030) 머지 완료. 다음은 Bayesian update + UI. 흐름: [design-notebook](./design-notebook/personal-pattern-discovery.md)
 
 ## 문서 지도
 

--- a/src/agents/insight/__tests__/metric-approval-cards.test.ts
+++ b/src/agents/insight/__tests__/metric-approval-cards.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import type { KnownBlock, SectionBlock, ActionsBlock } from '@slack/types';
+import {
+  buildMetricCandidateCard,
+  buildNoSuggestionMessage,
+  encodeMetricActionPayload,
+  decodeMetricActionPayload,
+  METRIC_APPROVE_ACTION_ID,
+  METRIC_REJECT_ACTION_ID,
+  type MetricCandidateCardInput,
+} from '../metric-approval-cards.js';
+
+const makeCardInput = (
+  overrides: Partial<MetricCandidateCardInput> = {},
+): MetricCandidateCardInput => ({
+  metricId: 42,
+  seedName: 'pool_갑_천간_일운',
+  patternKind: 'saju',
+  description: '갑목 일운 → 일정 폭주',
+  windowDays: 7,
+  evaluationRule: '발현일 다음날 schedule count >= 3이면 hit',
+  evidenceCount: 12,
+  rejectionDiff: null,
+  ...overrides,
+});
+
+const sectionTexts = (blocks: KnownBlock[]): string[] =>
+  blocks
+    .filter((b): b is SectionBlock => b.type === 'section')
+    .map((b) => {
+      const text = b.text;
+      if (text && 'text' in text && typeof text.text === 'string') return text.text;
+      return '';
+    });
+
+const actionBlocks = (blocks: KnownBlock[]): ActionsBlock[] =>
+  blocks.filter((b): b is ActionsBlock => b.type === 'actions');
+
+describe('encodeMetricActionPayload ↔ decodeMetricActionPayload', () => {
+  it('정상 payload 라운드트립', () => {
+    const raw = encodeMetricActionPayload({ metricId: 123 });
+    expect(decodeMetricActionPayload(raw)).toEqual({ metricId: 123 });
+  });
+
+  it('잘못된 JSON 은 null 반환', () => {
+    expect(decodeMetricActionPayload('not-json')).toBeNull();
+  });
+
+  it('metricId가 number가 아니면 null 반환', () => {
+    expect(decodeMetricActionPayload(JSON.stringify({ metricId: 'abc' }))).toBeNull();
+    expect(decodeMetricActionPayload(JSON.stringify({}))).toBeNull();
+  });
+
+  it('NaN/Infinity는 null 반환', () => {
+    expect(decodeMetricActionPayload('{"metricId": null}')).toBeNull();
+  });
+});
+
+describe('buildMetricCandidateCard', () => {
+  it('saju 시드는 [사주] prefix를 header에 포함', () => {
+    const blocks = buildMetricCandidateCard(makeCardInput({ patternKind: 'saju' }));
+    const texts = sectionTexts(blocks);
+    expect(texts[0]).toMatch(/^\[사주\] \*pool_갑_천간_일운\* — 매트릭 제안/);
+  });
+
+  it('life_signal 시드는 [생활] prefix를 header에 포함', () => {
+    const blocks = buildMetricCandidateCard(
+      makeCardInput({ patternKind: 'life_signal', seedName: 'sleep_short' }),
+    );
+    const texts = sectionTexts(blocks);
+    expect(texts[0]).toMatch(/^\[생활\] \*sleep_short\* — 매트릭 제안/);
+  });
+
+  it('detail에 description / evaluationRule / window / evidenceCount 포함', () => {
+    const blocks = buildMetricCandidateCard(makeCardInput());
+    const texts = sectionTexts(blocks);
+    expect(texts[0]).toContain('갑목 일운 → 일정 폭주');
+    expect(texts[0]).toContain('평가 기준: 발현일 다음날 schedule count >= 3이면 hit');
+    expect(texts[0]).toContain('window: 최근 7일');
+    expect(texts[0]).toContain('evidence 누적 12일');
+  });
+
+  it('rejectionDiff null이면 재제안 사유 줄 없음', () => {
+    const blocks = buildMetricCandidateCard(makeCardInput({ rejectionDiff: null }));
+    const texts = sectionTexts(blocks);
+    expect(texts[0]).not.toContain('재제안 사유');
+  });
+
+  it('rejectionDiff 있으면 재제안 사유 줄 포함', () => {
+    const blocks = buildMetricCandidateCard(
+      makeCardInput({ rejectionDiff: 'window 7→14일 확장, evidence 누적 8건 추가' }),
+    );
+    const texts = sectionTexts(blocks);
+    expect(texts[0]).toContain('재제안 사유: window 7→14일 확장');
+  });
+
+  it('승인/거절 버튼 action_id 검증', () => {
+    const blocks = buildMetricCandidateCard(makeCardInput());
+    const actions = actionBlocks(blocks);
+    expect(actions.length).toBe(1);
+    const buttons = actions[0].elements;
+    expect(buttons.length).toBe(2);
+    expect(buttons[0]).toMatchObject({
+      type: 'button',
+      action_id: METRIC_APPROVE_ACTION_ID,
+      style: 'primary',
+    });
+    expect(buttons[1]).toMatchObject({
+      type: 'button',
+      action_id: METRIC_REJECT_ACTION_ID,
+    });
+  });
+
+  it('버튼 value에 metricId payload 직렬화 포함', () => {
+    const blocks = buildMetricCandidateCard(makeCardInput({ metricId: 999 }));
+    const actions = actionBlocks(blocks);
+    const button = actions[0].elements[0];
+    if (button.type !== 'button') throw new Error('Expected button');
+    const decoded = decodeMetricActionPayload(button.value ?? '');
+    expect(decoded).toEqual({ metricId: 999 });
+  });
+});
+
+describe('buildNoSuggestionMessage', () => {
+  it('yyyymm 포함된 section 1개 반환', () => {
+    const blocks = buildNoSuggestionMessage('2026-07');
+    expect(blocks.length).toBe(1);
+    const texts = sectionTexts(blocks);
+    expect(texts[0]).toContain('2026-07');
+    expect(texts[0]).toContain('매트릭 제안 없음');
+  });
+});

--- a/src/agents/insight/actions.ts
+++ b/src/agents/insight/actions.ts
@@ -1,7 +1,8 @@
 /**
- * Insight 에이전트 Slack 액션 핸들러 — ADR-0019 Phase 4.
+ * Insight 에이전트 Slack 액션 핸들러.
  *
- * 가설 후보 카드의 등록/패스 버튼 처리.
+ * - 가설 후보 카드 등록/패스 버튼 (ADR-0019 Phase 4)
+ * - LLM 매트릭 후보 카드 승인/거절 버튼 (ADR-0025·0030 Phase 6)
  */
 
 import type { App } from '@slack/bolt';
@@ -13,6 +14,11 @@ import {
   HYPOTHESIS_DISMISS_ACTION_ID,
   decodeActionPayload,
 } from './hypothesis-cards.js';
+import {
+  METRIC_APPROVE_ACTION_ID,
+  METRIC_REJECT_ACTION_ID,
+  decodeMetricActionPayload,
+} from './metric-approval-cards.js';
 
 const resolveBodyUserId = async (body: { user?: string | { id: string } }): Promise<number> => {
   const slackUserId = body.user ? (typeof body.user === 'string' ? body.user : body.user.id) : '';
@@ -79,6 +85,76 @@ export const registerInsightActions = (app: App): void => {
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       console.error(`[Insight Action] hypothesis_dismiss 오류: ${msg}`);
+    }
+  });
+
+  app.action(METRIC_APPROVE_ACTION_ID, async ({ ack, body, client }) => {
+    await ack();
+    const raw = extractRawValue(body);
+    if (!raw) return;
+    const payload = decodeMetricActionPayload(raw);
+    if (!payload) {
+      console.warn('[Insight Action] metric_approve: payload 디코딩 실패');
+      return;
+    }
+    try {
+      const userId = await resolveBodyUserId(body);
+      const res = await query<{ id: number; description: string }>(
+        `UPDATE pattern_metrics
+           SET status = 'active', approved_at = NOW()
+         WHERE id = $1 AND user_id = $2 AND status = 'pending'
+         RETURNING id, description`,
+        [payload.metricId, userId],
+      );
+      if (res.rows.length === 0) {
+        console.warn(
+          `[Insight Action] metric_approve: id=${payload.metricId} pending 아님 또는 권한 없음`,
+        );
+        return;
+      }
+      const row = res.rows[0];
+      const channelId = 'channel' in body && body.channel ? body.channel.id : undefined;
+      const messageTs = 'message' in body && body.message ? body.message.ts : undefined;
+      if (channelId && messageTs) {
+        await updateMessage(
+          client,
+          channelId,
+          messageTs,
+          `매트릭 승인 완료 — \`${row.description}\` 다음 매칭 cron부터 활성.`,
+          [],
+        );
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`[Insight Action] metric_approve 오류: ${msg}`);
+    }
+  });
+
+  app.action(METRIC_REJECT_ACTION_ID, async ({ ack, body, client }) => {
+    await ack();
+    const raw = extractRawValue(body);
+    if (!raw) return;
+    const payload = decodeMetricActionPayload(raw);
+    if (!payload) {
+      console.warn('[Insight Action] metric_reject: payload 디코딩 실패');
+      return;
+    }
+    try {
+      const userId = await resolveBodyUserId(body);
+      await query(
+        `UPDATE pattern_metrics
+           SET status = 'rejected', rejected_at = NOW()
+         WHERE id = $1 AND user_id = $2 AND status = 'pending'`,
+        [payload.metricId, userId],
+      );
+      const channelId = 'channel' in body && body.channel ? body.channel.id : undefined;
+      const messageTs = 'message' in body && body.message ? body.message.ts : undefined;
+      if (channelId && messageTs) {
+        await updateMessage(client, channelId, messageTs, `_매트릭 후보 거절._`, []);
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`[Insight Action] metric_reject 오류: ${msg}`);
     }
   });
 };

--- a/src/agents/insight/index.ts
+++ b/src/agents/insight/index.ts
@@ -1,7 +1,7 @@
 import type { AgentHandler } from '../../router.js';
 import type { LLMClient } from '../../shared/llm.js';
 import { sendMessage } from '../../shared/slack.js';
-import { queryOne } from '../../shared/db.js';
+import { query, queryOne } from '../../shared/db.js';
 import { getTodayISO, getEffectiveTodayISO, addDays } from '../../shared/kst.js';
 import { resolveUserId, DEFAULT_USER_ID } from '../../shared/user-resolver.js';
 import { saveDiaryEntry, pickDiaryConfirmation, naturalDelay } from './diary-fast-path.js';
@@ -22,6 +22,8 @@ const TOMORROW_FORTUNE_RE = /^내일\s*일운(\s*(보여줘|보여|알려줘|뭐
 const MAJOR_FORTUNE_RE = /^(내\s*)?대운(\s*(보여줘|보여|알려줘|뭐야))?[.?!]?$/;
 /** 오늘 일기 조회 */
 const TODAY_DIARY_RE = /^오늘\s*일기/;
+/** LLM 매트릭 pending 목록 조회 (ADR-0030 디버깅·놓친 카드 재확인용) */
+const METRIC_LIST_RE = /^\/?insight\s+metric-list[.?!]?$/;
 
 interface FortuneRow {
   date: string;
@@ -94,6 +96,42 @@ const tryFortuneFastPath = async (
   return true;
 };
 
+/** pending 매트릭 목록 조회 fast path (ADR-0030) */
+const showPendingMetrics = async (
+  say: Parameters<AgentHandler>[1],
+  userId: number,
+): Promise<void> => {
+  try {
+    const res = await query<{
+      id: number;
+      description: string;
+      proposed_at: string;
+      seed_name: string | null;
+    }>(
+      `SELECT pm.id, pm.description, pm.proposed_at,
+              (SELECT name FROM pattern_catalog WHERE id = pm.pattern_id) AS seed_name
+         FROM pattern_metrics pm
+        WHERE pm.user_id = $1 AND pm.status = 'pending'
+        ORDER BY pm.proposed_at DESC
+        LIMIT 20`,
+      [userId],
+    );
+    if (res.rows.length === 0) {
+      await sendMessage(say, '대기 중인 매트릭 후보가 없어.');
+      return;
+    }
+    const lines = res.rows.map((r) => {
+      const dateStr = r.proposed_at.slice(0, 10);
+      const seedPart = r.seed_name ? ` · ${r.seed_name}` : '';
+      return `#${r.id} ${r.description}${seedPart} (${dateStr})`;
+    });
+    await sendMessage(say, ['*pending 매트릭 후보*', ...lines].join('\n'));
+  } catch (error: unknown) {
+    console.error('[Insight Agent] metric-list 조회 오류:', error);
+    await sendMessage(say, '매트릭 목록 조회 중 오류가 발생했어.');
+  }
+};
+
 /** 오늘 일기 조회 fast path */
 const showTodayDiary = async (say: Parameters<AgentHandler>[1], userId: number): Promise<void> => {
   const today = getEffectiveTodayISO();
@@ -147,6 +185,12 @@ export const createInsightAgent = (_llmClient: LLMClient): AgentHandler => {
     // ── fast path: 오늘 일기 조회 ──
     if (TODAY_DIARY_RE.test(trimmed)) {
       await showTodayDiary(say, userId);
+      return;
+    }
+
+    // ── fast path: LLM 매트릭 pending 목록 (ADR-0030) ──
+    if (METRIC_LIST_RE.test(trimmed)) {
+      await showPendingMetrics(say, userId);
       return;
     }
 

--- a/src/agents/insight/metric-approval-cards.ts
+++ b/src/agents/insight/metric-approval-cards.ts
@@ -1,0 +1,98 @@
+/**
+ * LLM 자율 매트릭 후보 Block Kit 카드 빌더 — ADR-0025, ADR-0030.
+ *
+ * monthly-metric-suggest routine이 LLM 후보를 INSERT(`status='pending'`) 후
+ * 후보별 1메시지 발송. 사용자가 [승인]/[거절] 버튼 클릭 → actions.ts 처리.
+ */
+
+import type { KnownBlock } from '@slack/types';
+
+export const METRIC_APPROVE_ACTION_ID = 'metric_approve';
+export const METRIC_REJECT_ACTION_ID = 'metric_reject';
+
+const KIND_LABEL: Record<'saju' | 'life_signal', string> = {
+  saju: '[사주]',
+  life_signal: '[생활]',
+};
+
+export interface MetricApprovalPayload {
+  metricId: number;
+}
+
+export const encodeMetricActionPayload = (payload: MetricApprovalPayload): string =>
+  JSON.stringify(payload);
+
+export const decodeMetricActionPayload = (raw: string): MetricApprovalPayload | null => {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.metricId !== 'number' || !Number.isFinite(obj.metricId)) return null;
+    return { metricId: obj.metricId };
+  } catch {
+    return null;
+  }
+};
+
+export interface MetricCandidateCardInput {
+  metricId: number;
+  seedName: string;
+  patternKind: 'saju' | 'life_signal';
+  description: string;
+  windowDays: number;
+  /** LLM이 명시한 hit/miss 분류 기준 자연어 (예: "수면 ≤ 7시간이면 hit") */
+  evaluationRule: string;
+  /** evidence 누적 카운트 (참고용 표시) */
+  evidenceCount: number;
+  /** 재제안 시 LLM이 명시한 이전 거절 사유 대비 차이점. 신규 제안이면 null */
+  rejectionDiff: string | null;
+}
+
+export const buildMetricCandidateCard = (input: MetricCandidateCardInput): KnownBlock[] => {
+  const payload = encodeMetricActionPayload({ metricId: input.metricId });
+  const kindLabel = KIND_LABEL[input.patternKind];
+  const header = `${kindLabel} *${input.seedName}* — 매트릭 제안`;
+  const detailLines = [
+    `_${input.description}_`,
+    `평가 기준: ${input.evaluationRule}`,
+    `window: 최근 ${input.windowDays}일 · evidence 누적 ${input.evidenceCount}일`,
+  ];
+  if (input.rejectionDiff) {
+    detailLines.push(`재제안 사유: ${input.rejectionDiff}`);
+  }
+  return [
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: `${header}\n${detailLines.join('\n')}` },
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: '승인' },
+          style: 'primary',
+          action_id: METRIC_APPROVE_ACTION_ID,
+          value: payload,
+        },
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: '거절' },
+          action_id: METRIC_REJECT_ACTION_ID,
+          value: payload,
+        },
+      ],
+    },
+  ];
+};
+
+/** 후보 0건일 때 발사 메시지 */
+export const buildNoSuggestionMessage = (yyyymm: string): KnownBlock[] => [
+  {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `_${yyyymm} 매트릭 제안 없음. 다음 달 누적 데이터로 재시도._`,
+    },
+  },
+];


### PR DESCRIPTION
## 관련 이슈
Closes #458

## 변경 내용

마스터 #434 Phase 6 — LLM이 매트릭 후보를 자율 제안 + Slack 승인 게이트로 자동 활성화하는 인프라.

### 인프라

- `metric-approval-cards.ts`: Block Kit 후보 카드 빌더 + 승인/거절 payload (`metric_approve`/`metric_reject` action_id)
- `actions.ts`: 두 핸들러 — `pending → active/rejected` 전환. `WHERE user_id` 격리 + `WHERE status = 'pending'` 이중 클릭 방지
- `index.ts`: `insight metric-list` fast path — 대기 중인 후보 목록 조회
- `migration 073`: `pattern_metrics.rejected_at` 컬럼 추가 (다음 routine의 입력으로 노출)

### 자동화 슬롯

- `monthly-metric-suggest` routine (Claude 앱 routines, 매월 1일 09:30 KST):
  - 입력 풀 3 결합 — evidence JSONB(60일) + 시드 description + 라이프 메트릭(30일 메타데이터)
  - 후보 0\~5개 LLM 생성 → INSERT(`status='pending'`) → `#insight` 카드 발송
  - 거절 재제안: rejected 목록 LLM 노출 + 새 근거 있을 때만 재제안 + 차이점 명시 의무

### 결정 기록

- [ADR-0030](../docs/adr/0030-llm-metric-suggest-input-and-cadence.md) 신설: 입력 풀 구성 / 거절 정책 / 월간 cron 명문화
- [도메인 문서 Section 20](../docs/domains/insight.md) 본문
- [design-notebook Phase 6 섹션](../docs/design-notebook/personal-pattern-discovery.md)

## 코드 리뷰 결과

- [x] 보안 감사 — SQL parameterized + user_id 격리 + status 게이트 + payload validation
- [x] 헌장 ① (사용자 텍스트 원문 노출 금지) — routine 입력에 카운트·태그 enum·메타데이터만
- [x] 자유언어 추출 금지 헌장 — 단일 명령어(`insight metric-list`)만 매칭
- [x] 타입 안전성 — `any` 없음, payload decode 가드
- [x] 일관성 — hypothesis 핸들러 패턴 그대로 차용

## 테스트

- [x] `metric-approval-cards.test.ts` 12건 추가 (payload 라운드트립 + 카드 구조 + 0건 메시지)
- [x] `yarn test` 전 583건 통과
- [x] `yarn tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)