### PR TITLE
feat(insight): #434 Phase 7 — Bayesian posterior 헬퍼·카드 병기 + 시드 영향력 섹션

### DIFF
--- a/db/migrations/074_pattern_stats_posterior.sql
+++ b/db/migrations/074_pattern_stats_posterior.sql
@@ -1,0 +1,26 @@
+-- 074: pattern_stats 가설 단위 Bayesian posterior 추가
+-- 마스터 #434 Phase 7. ADR-0024 실행.
+--
+-- Phase 4(065)가 pattern_metrics에 매트릭 단위 posterior를 도입했고,
+-- 본 마이그레이션은 가설 단위(seed × enum_target) posterior를 pattern_stats에 추가한다.
+-- weekly-hypothesis-review cron이 stats UPSERT 시 누적 hit/miss로부터
+-- posterior_alpha/beta 재계산 (pattern_metrics와 동일하게 prior Beta(1,1)).
+--
+-- backfill 정책: 기존 row(Phase 4 이후 1주분만 누적)는 NULL 유지.
+-- 다음 weekly-hypothesis-review cron이 채움 — 1주 대기로 backfill SQL 생략.
+
+BEGIN;
+
+ALTER TABLE pattern_stats
+  ADD COLUMN IF NOT EXISTS posterior_alpha NUMERIC(8,2),
+  ADD COLUMN IF NOT EXISTS posterior_beta  NUMERIC(8,2),
+  ADD COLUMN IF NOT EXISTS posterior_p     NUMERIC(6,4);
+
+COMMENT ON COLUMN pattern_stats.posterior_alpha IS
+  '가설 단위 Beta-Binomial α (prior Beta(1,1) + 누적 hit). ADR-0024.';
+COMMENT ON COLUMN pattern_stats.posterior_beta IS
+  '가설 단위 Beta-Binomial β (prior Beta(1,1) + 누적 miss). ADR-0024.';
+COMMENT ON COLUMN pattern_stats.posterior_p IS
+  '사후 평균 = α / (α + β). NULL이면 아직 누적 갱신 전.';
+
+COMMIT;

--- a/docs/design-notebook/personal-pattern-discovery.md
+++ b/docs/design-notebook/personal-pattern-discovery.md
@@ -660,7 +660,126 @@ evidence 누적 부족 단계(첫 발사 2026-07-01 ≈ Phase 2 머지 후 1개�
 
 ---
 
-## Phase 7\~8 (TODO: 각 Phase 진입 시 섹션 누적)
+## Phase 7 — Bayesian posterior 헬퍼·카드 병기 + 시드 영향력 섹션 (2026-05-29 ~)
+
+> 이슈 [#460](https://github.com/hyewon3938/slack-ai-agents/issues/460) · 브랜치 `feature/460-phase-7-bayesian-display`
+>
+> ADR-0024 (Beta-Binomial Bayesian posterior) 실행 마무리. Phase 4가 매트릭 단위 posterior UPDATE를 흡수했으므로 본 phase는 **가설 단위 posterior 추가 + UI 표현 + 헬퍼 추출 + 시드 영향력 리포트**에 집중.
+
+### 핵심 원칙 cross-check (v2 + #434 헌장)
+
+- **v2 ①** "LLM 텍스트 의존 최소화" — posterior 산식은 결정론 SQL/TS. LLM 텍스트 X
+- **v2 ②** "결정론과 자율 영역의 역할 분리" — 본 phase는 결정론 (Phase 6의 LLM 자율과 무관)
+- **v2 ④** "신뢰 비용 분리" — Frequentist (p/q) + Bayesian (사후/CI) 병기로 누적 단계별 신뢰도 표현
+- **#434 ⑤** "임의값 박지 않기" — 사후·CI 정렬은 lower bound 자연 정렬. 사용자 노출용 임계치 없음 (`50%=우연, 80%↑=강함` 안내는 가이드 텍스트로만)
+
+→ 충돌 없음. 본 phase는 ADR-0024 실행 마무리.
+
+### 결정 요약
+
+1. **헬퍼 추출** — `src/shared/bayesian-posterior.ts`에 `updatePosterior` / `posteriorMean` / `credibleInterval` 추출. 매칭 cron SQL inline UPDATE는 atomicity 위해 유지, 헬퍼는 표시·테스트 전용
+2. **가설 stats Bayesian 갱신** — Migration 074로 `pattern_stats`에 `posterior_alpha`/`posterior_beta`/`posterior_p` 추가. `computeAndPersistWeeklyStats`에서 가설 단위 (seed × enum_target) Bayesian update
+3. **라이브러리 선택** — `@stdlib/stats-base-dists-beta-quantile` (Beta inverse CDF). scipy-like project의 단일 함수 패키지
+4. **가설 카드 표현** — 한 줄 병기: `… p=0.08 q=0.21 / 사후 0.62 [0.41, 0.81]`
+5. **시드 영향력 섹션 신설** — 주간 카드 상단에 `이번주 영향력 시드 top 5` 섹션. 사주/생활 혼합 정렬. credible interval lower bound 내림차순. **리포트 전용 (버튼 없음)**. 데이터 소스는 `pattern_summary.aggregate_posterior_p` + α/β
+6. **버튼 라벨 정리** — 가설 카드 `등록`→`승인`, `패스`→`반려`. 매트릭 카드 `거절`→`반려`. 동작은 그대로, 라벨만 통일
+
+### 의사결정 분기점
+
+#### A. 헬퍼 추출 vs SQL only
+
+- A1. SQL only 유지 (현행) — atomicity 좋으나 단위 테스트 약함. 사후 0.62 같은 표시도 다른 곳에서 다시 SQL 호출 필요
+- A2. **SQL inline 유지 + TS 헬퍼는 표시·테스트 전용 (선택)** — cron의 동시성 안정성 유지하면서 표시·검증은 헬퍼로 일원화. Phase 4 회고에서 식별한 "SQL 문자열 매칭 테스트 한계" 직접 해결
+- A3. SQL 다 들어내고 TS만 — atomicity 깨질 위험. cron 동시 실행 시 race 가능
+
+→ A2 채택. 매칭 cron은 SQL만 (cron 자체 락이 보장), 표시·통계 산출은 헬퍼로.
+
+#### B. 가설 단위 posterior 저장 위치
+
+- B1. **`pattern_stats`에 컬럼 추가 (선택)** — 가설 = (seed × enum_target) 단위. 매트릭 posterior(`pattern_metrics`)와 결이 같지만 의미가 다름. 가설 카드/시드 영향력 리포트가 직접 참조
+- B2. view 계산으로 산출 — SQL 표현식 복잡, 매번 재계산 비용
+- B3. pattern_metrics posterior만 사용 — 가설 단위와 매트릭 단위는 의미가 다름 (가설 = "갑일 → 수면 7h 미만"이라는 명제 자체, 매트릭 = 그 명제를 검증하는 SQL 인스턴스)
+
+→ B1. ADR-0024 후속 작업 체크박스 그대로 따름.
+
+#### C. 시드 영향력 표현 단위
+
+- C1. 가설 카드(매트릭 단위)에만 표현 — 시드 단위 인지 어려움
+- C2. **카드 위 별도 섹션 (선택)** — 시드 단위 영향력은 사용자 의사결정의 다른 축. 카드는 매트릭 승인, 섹션은 영향력 리포트
+- C3. 시드 카드도 만들기 — 가설은 매트릭 단위라는 헌장(가설 = seed × enum)이 흔들림. 시드 = 트리거이지 가설 아님
+
+→ C2. 사용자 멘탈 모델: "사술원진이 나한테 영향 크네"(리포트) vs "사술원진 → 수면 부족 가설 등록하자"(액션)
+
+#### D. 시드 영향력 정렬 기준
+
+- D1. 사후 평균 내림차순 — 단순. 그러나 N 적은 시드가 prior 영향으로 평균 높을 수 있음 → 표시상 노이즈
+- D2. **credible interval lower bound 내림차순 (선택)** — N 적으면 CI 넓어져 lower bound 자동 페널티. **헌장 ⑤ "임의값 박지 않기" 정합** (`검증 ≥ 5` 같은 컷오프 불필요)
+- D3. N≥5 컷오프 후 평균 정렬 — 임의값 박기
+
+→ D2.
+
+#### E. 시드 영향력 정렬 분리 vs 통합
+
+- E1. 사주 top 5 + 생활 top 5 분리
+- E2. **통합 top 5 (선택)** — 본인에게 강한 패턴이 무엇이든 한눈에. 데이터 누적 후 영역별 비교 필요해지면 분리 follow-up
+- E3. top 10 통합 — 카드 길어짐
+
+→ E2.
+
+#### F. 시드 영향력 항목 형식
+
+- F1. 시드 이름 + 통계만
+- F2. **시드 이름 + description 첫 N자 + 통계 (선택)** — 사용자가 "사화 편관 사술원진"만 봐선 의미 모름. description 한 줄로 맥락 부여
+- F3. 시드 이름 + description 전체 + 통계 — 카드 길어짐
+
+→ F2. description은 잘라서 표시 (기존 `metric-approval-cards`의 description 표시 패턴 차용)
+
+#### G. 안내문(범례) 위치
+
+- G1. **시드 영향력 섹션 아래에만 (선택)** — 처음 보는 사용자에게 사후·CI 의미 부여. 카드마다 반복 없이
+- G2. 카드마다 — 매주 같은 텍스트 노출 피로
+- G3. 안 넣기 — 사용자가 사후 0.62의 의미 추측해야 함
+
+→ G1. `_사후 = 본인 패턴일 확률 추정 (50%=우연, 80%↑=강함) · [] = 95% 신뢰 구간 (좁을수록 정확)_`
+
+#### H. dismiss(반려) 정책
+
+- H1. **현행 유지 (DB write 없음, 자동 재발현) (선택)** — `actions.ts:73-89` 그대로. 일주일 차에 반려해도 한 달 뒤 데이터 누적되면 다시 후보로 — 사용자 요청 그대로
+- H2. dismissed 기록 + cool down — 임의값 박기 (헌장 ⑤ 위배)
+
+→ H1.
+
+### 포기한 안
+
+- **`pattern_metrics.posterior_p`를 그대로 가설 카드에 표시** — 매트릭 단위 사후이지 가설 단위 사후 아님. 가설 = (seed × enum)이라 매트릭 7개의 hit/miss를 가설 단위로 누적해야 의미 있음
+- **시드 영향력 임계치(예: 검증 ≥ 5)** — 헌장 ⑤ "임의값 박지 않기" 위배. CI lower bound 정렬로 대체
+- **사주/생활 분리 top 5** — 1차는 통합. 데이터 누적 후 영역별 비교 필요해지면 follow-up
+- **credible interval 90% / 99% 옵션** — 1차는 95% 표준. confidence 노출 X (사용자 혼동 방지)
+- **카드마다 안내문 반복** — top 시드 섹션 아래 1회
+
+### 미해결 / 가설
+
+- **첫 운영 시 시드 영향력 top 5 품질** — 검증 누적이 약 1주~1개월 사이일 때 N 적은 시드들이 prior에 묶여 CI lower bound가 비슷할 가능성. CI 자체가 자연 페널티이지만 운영 첫 회 결과로 검증
+- **사주/생활 통합 정렬에서 영역 편향** — 한쪽이 항상 상위 점령할 가능성. 운영 1~3개월 후 영역별 비교 필요해지면 분리 follow-up
+- **Migration 074의 backfill** — 기존 pattern_stats row의 posterior_alpha/beta를 hit/miss로 backfill할지, NULL로 두고 다음 주 stats 계산부터 채울지 → 기존 row 적음 (Phase 4 머지 후 1주분만 누적). 다음 주 stats부터 채우는 게 단순
+
+### 회고 (구현 — 2026-05-29, 운영 첫 발사 회고는 2026-06-08 후 보강)
+
+- **헬퍼 추출 효과** — `bayesian-posterior.ts`(~60줄) + 단위 테스트 16개로 산식 검증이 코드 레벨에서 명료해졌다. Phase 4 회고에서 식별한 "SQL 문자열 매칭 테스트 한계" 해결. 매트릭 단위 inline SQL UPDATE는 그대로 보존해 atomicity 손해 0
+- **누적 hit/miss derive 선택** — `SUM((rate_trigger × n_trigger_days)::NUMERIC)`로 derive하니 별도 hit/miss 컬럼 추가 없이 누적 산식이 한 줄로 정리됨. 다만 `rate_trigger`가 부동소수점이라 `Math.round`로 정수 변환 — 첫 운영 시 round 오차 누적 여부 점검 필요
+- **`@stdlib/stats-base-dists-beta-quantile`** — npm install 28초, 의존성 ~20개. 단일 함수 사용이지만 stdlib 프로젝트의 numerical stability(scipy 등급)를 받음. 자체 Beta inverse CDF 구현(~50줄)보다 신뢰도 ↑
+- **버튼 라벨 정리 동기화** — 라벨 변경은 사용자 노출 텍스트만이라 action_id/value/handler 동작 그대로 — in-flight 카드 호환 유지. dismiss 정책 변경 없음 + DB write 없음 보존
+- **Migration 074 backfill 정책 검증** — 기존 pattern_stats row(Phase 4 머지 후 약 1주)가 NULL로 들어가지만, 다음 weekly cron이 자연 재계산. 사용자에게 노출되는 건 다음 발사부터라 backfill SQL 생략 결정 정합. 첫 발사 시 NULL 비율 확인
+- **시드 영향력 데이터 소스 분기** — `pattern_summary` view에 α/β sum 노출되어 있지 않아 별도 SELECT 추가. view 시그니처 보존 우선 결정이 정합. view 확장은 외부 의존도가 생긴 후에 별도 PR로
+- **Follow-up (운영 1\~3개월 후)**
+  - 시드 영향력 top 5의 첫 운영 결과 — N 적은 시드들의 CI lower bound 분포가 prior(50%) 근방에 몰리는지
+  - 사주/생활 통합 정렬에서 영역 편향 발생 여부
+  - `Math.round(rate_trigger × n_trigger_days)` round 오차 누적 점검 (수 주 누적 후 raw hit과 derived hit 비교)
+  - `aggregate_posterior_p` view 컬럼이 카드에 직접 노출되지 않는 사실 자체 — Phase 8 카드 UI에서 어떻게 활용할지
+
+---
+
+## Phase 8 (TODO: 진입 시 섹션 추가)
 
 > 각 Phase 진입 시 `/design`이 본 문서에 해당 Phase 섹션을 추가한다. 템플릿: 결정 요약 / 의사결정 분기점 / 포기한 안 / 회고.
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -1270,9 +1270,69 @@ Phase 1\~5에서 결정론 매트릭만 평가되던 구조 위에 **LLM이 매�
 
 Phase 7 (Bayesian update)에서 active 매트릭의 `posterior_alpha/beta/p`가 매칭 cron 평가 결과로 갱신. Phase 8 (인사이트 카드 UI)에서 active 매트릭의 verified 결과를 사용자에게 노출하는 카드 통합.
 
-### 21. 본인 1명 패턴 발견 시스템 — Phase 7 (Bayesian update)
+### 21. 본인 1명 패턴 발견 시스템 — Phase 7 (Bayesian posterior 헬퍼·카드 병기 + 시드 영향력 섹션)
 
-> TODO(`/build`): 구현 후 본문 채우기. `src/shared/bayesian-posterior.ts` 헬퍼(\~100줄), Beta-Binomial 사후 갱신, `pattern_metrics.posterior_p` UPDATE. 가설 카드에 frequentist p값 + Bayesian posterior 병기. beta inverse CDF 라이브러리 선택.
+**데이터 모델 (Migration 074)** — `pattern_stats`에 가설 단위 Beta-Binomial posterior 3컬럼 추가:
+
+| 컬럼 | 타입 | 의미 |
+|------|------|------|
+| `posterior_alpha` | NUMERIC(8,2) | prior Beta(1,1) + 누적 hit |
+| `posterior_beta`  | NUMERIC(8,2) | prior Beta(1,1) + 누적 miss |
+| `posterior_p`     | NUMERIC(6,4) | α / (α + β) |
+
+기존 row(Phase 4 이후 1주분만 누적)는 NULL. 다음 weekly cron이 자연스럽게 채움 — 별도 backfill SQL 생략.
+
+매트릭 단위 posterior(`pattern_metrics.posterior_alpha/beta/p`, Phase 4 도입)는 매칭 cron의 SQL inline UPDATE 그대로 유지(atomicity 보호). 가설 단위는 weekly UPSERT 흐름이 메모리 합산 → UPSERT 한 번이라 헬퍼로 산출.
+
+**헬퍼 (`src/shared/bayesian-posterior.ts`)**:
+
+| 함수 | 시그니처 | 용도 |
+|------|---------|------|
+| `updatePosterior(prior, 'hit'\|'miss')` | `BetaPosterior → BetaPosterior` | 단발 갱신(테스트·유닛 케이스) |
+| `posteriorMean(α, β)` | `→ number` | 사후 평균 |
+| `credibleInterval(α, β, conf=0.95)` | `→ {lower, upper}` | Beta inverse CDF로 신뢰구간 |
+| `cumulativePosteriorFromHitMiss(h, m)` | `→ {alpha:1+h, beta:1+m}` | 누적 hit/miss → posterior |
+
+라이브러리: `@stdlib/stats-base-dists-beta-quantile` (Beta inverse CDF 단일 함수).
+
+**누적 산식 (`computeAndPersistWeeklyStats`)** — 가설별:
+
+1. 이전 주들의 누적 hit/miss를 `pattern_stats`에서 SELECT (`SUM(rate_trigger × n_trigger_days)`로 derive)
+2. 이번 주 hit/miss는 메모리에서 derive
+3. `cumulativePosteriorFromHitMiss(priorHits + weekHits, priorMisses + weekMisses)` → α/β
+4. `posteriorMean` + `credibleInterval` → mean + CI
+5. UPSERT는 9컬럼 → 12컬럼 (α/β/p 추가)
+
+> hit를 별도 컬럼으로 추가하지 않고 `rate_trigger × n_trigger_days`로 derive하는 이유: 기존 row만으로 충분, 스키마 변경 최소.
+
+**UI 흐름**
+
+가설 카드(`buildCandidateCard`)는 frequentist(p/q)와 Bayesian(사후/CI)를 한 줄에 병기:
+
+```
+[사주] *갑목일주* → `mood_high`
+발현일 n=8 · trigger 50.0% vs baseline 20.0% · ratio 2.50x
+p=0.040 q=0.150 · 사후 50% [21%, 79%]
+```
+
+주간 리뷰 카드 상단에 **시드 영향력 top 5** 섹션 신설(사주·생활 통합, `pattern_summary` view + 매트릭 α/β 합산 query). 정렬 기준은 **95% credible interval lower bound 내림차순** — N 적으면 CI가 자동으로 넓어져 lower 페널티 발생(임의 컷오프 회피, #434 헌장 ⑤ 준수). 안내문: `_사후 = 본인 패턴일 확률 추정 (50%=우연, 80%↑=강함) · [] = 95% 신뢰 구간 (좁을수록 정확)_`
+
+**시드 영향력 데이터 소스**
+
+`pattern_summary` view에는 `aggregate_posterior_p`(평균)만 노출되어 있고 α/β는 view contract에 없다. credible interval은 α/β 모두 필요하므로 별도 query로 `SUM(posterior_alpha), SUM(posterior_beta)` 추가 SELECT — view 시그니처는 보존(외부 의존 자산 보호).
+
+**버튼 라벨 정리**
+
+| Phase | Before | After |
+|-------|--------|-------|
+| Phase 4 가설 카드 | `가설 등록` / `이번엔 패스` | `가설 승인` / `가설 반려` |
+| Phase 6 매트릭 카드 | `승인` / `거절` | `승인` / `반려` |
+
+action_id, value, handler 동작, DB SQL은 그대로 — 사용자 노출 텍스트만 변경. dismiss 시 DB write 없음(자동 재발현 정책 유지).
+
+**관련 결정**: [ADR-0024](../adr/0024-bayesian-posterior-update.md) (Beta-Binomial posterior 도입).
+
+이슈 [#460](https://github.com/hyewon3938/slack-ai-agents/issues/460) · ADR-0024 실행 마무리 (신규 ADR 없음).
 
 ### 22. 본인 1명 패턴 발견 시스템 — Phase 8 (인사이트 카드 UI + 마스터 close)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -136,7 +136,7 @@
 ## 마스터 단위 진행 중 작업
 
 - **프로액티브 인사이트 v2** ([#393](https://github.com/hyewon3938/slack-ai-agents/issues/393)) — Phase 1\~4 머지 완료 (Phase 4 = 가설-검증 정량 파이프라인, 2026-05-22 PR [#415](https://github.com/hyewon3938/slack-ai-agents/pull/415)). Phase 5([#408](https://github.com/hyewon3938/slack-ai-agents/issues/408)) 월운·세운·대운 확장은 Phase 4 운영 1\~3개월 데이터 누적 후 진입 예정. 흐름: [design-notebook](./design-notebook/insight-engine-v2.md)
-- **본인 1명 패턴 발견 시스템** ([#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)) — Phase 1(스키마 rename, ADR-0022\~0026) / Phase 2(사주 시드 풀셋 161개 + evidence-only) / Phase 2.5(운 레벨 차원 + 풀셋 임계치 + 분포 분석 cron, ADR-0028) / Phase 3(life_signal 시드 풀 셋 + 매칭 cron 일반화) / Phase 4(매칭 cron 카운터 source 전환 + pattern-match rename) / Phase 5(가설 발견·검증 파이프라인 target-type 확장) / Phase 6(LLM 자율 매트릭 + 승인 게이트, ADR-0030) 머지 완료. 다음은 Bayesian update + UI. 흐름: [design-notebook](./design-notebook/personal-pattern-discovery.md)
+- **본인 1명 패턴 발견 시스템** ([#434](https://github.com/hyewon3938/slack-ai-agents/issues/434)) — Phase 1(스키마 rename, ADR-0022\~0026) / Phase 2(사주 시드 풀셋 161개 + evidence-only) / Phase 2.5(운 레벨 차원 + 풀셋 임계치 + 분포 분석 cron, ADR-0028) / Phase 3(life_signal 시드 풀 셋 + 매칭 cron 일반화) / Phase 4(매칭 cron 카운터 source 전환 + pattern-match rename) / Phase 5(가설 발견·검증 파이프라인 target-type 확장) / Phase 6(LLM 자율 매트릭 + 승인 게이트, ADR-0030) / Phase 7(가설 단위 Beta-Binomial posterior + 카드 한 줄 병기 + 시드 영향력 top 5 섹션, ADR-0024 실행) 머지 완료. 다음은 인사이트 카드 UI. 흐름: [design-notebook](./design-notebook/personal-pattern-discovery.md)
 
 ## 문서 지도
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@slack/bolt": "^4.7.0",
+    "@stdlib/stats-base-dists-beta-quantile": "^0.2.3",
     "dotenv": "^17.3.1",
     "node-cron": "^4.2.1",
     "pg": "^8.20.0",

--- a/src/agents/insight/__tests__/hypothesis-cards.test.ts
+++ b/src/agents/insight/__tests__/hypothesis-cards.test.ts
@@ -24,6 +24,9 @@ const makeCandidate = (
   rateRatio: 2.5,
   rawP: 0.04,
   fdrQ: 0.15,
+  posteriorP: 0.5,
+  ciLower: 0.21,
+  ciUpper: 0.79,
 });
 
 const makeStat = (hypothesisId: number): HypothesisStat => ({
@@ -36,6 +39,11 @@ const makeStat = (hypothesisId: number): HypothesisStat => ({
   rateRatio: 2.5,
   rawP: 0.04,
   fdrQ: 0.15,
+  posteriorAlpha: 3,
+  posteriorBeta: 3,
+  posteriorP: 0.5,
+  ciLower: 0.18,
+  ciUpper: 0.82,
 });
 
 const makeHypothesis = (id: number, signalId: number): Hypothesis => ({
@@ -82,7 +90,7 @@ describe('buildWeeklyReviewBlocks — cap per kind', () => {
       ...Array.from({ length: 6 }, (_, i) => makeCandidate(100 + i, `사주${i}`, 'saju')),
       ...Array.from({ length: 7 }, (_, i) => makeCandidate(200 + i, `생활${i}`, 'life_signal')),
     ];
-    const blocks = buildWeeklyReviewBlocks([], candidates, '2026-05-25');
+    const blocks = buildWeeklyReviewBlocks([], candidates, '2026-05-25', []);
     const texts = sectionTexts(blocks);
 
     const sajuCards = texts.filter((t) => /^\[사주\]/.test(t));
@@ -97,7 +105,7 @@ describe('buildWeeklyReviewBlocks — cap per kind', () => {
       makeCandidate(2, '사주B', 'saju'),
       makeCandidate(3, '생활A', 'life_signal'),
     ];
-    const blocks = buildWeeklyReviewBlocks([], candidates, '2026-05-25');
+    const blocks = buildWeeklyReviewBlocks([], candidates, '2026-05-25', []);
     const headerSection = sectionTexts(blocks).find((t) => /^\*신규 후보/.test(t));
     expect(headerSection).toBeDefined();
     expect(headerSection).toContain('사주 2');
@@ -109,14 +117,14 @@ describe('buildWeeklyReviewBlocks — cap per kind', () => {
       makeCandidate(1, '사주A', 'saju'),
       makeCandidate(2, '사주B', 'saju'),
     ];
-    const blocks = buildWeeklyReviewBlocks([], candidates, '2026-05-25');
+    const blocks = buildWeeklyReviewBlocks([], candidates, '2026-05-25', []);
     const headerSection = sectionTexts(blocks).find((t) => /^\*신규 후보/.test(t));
     expect(headerSection).toContain('사주 2');
     expect(headerSection).toContain('생활 0');
   });
 
   it('candidates가 0건이면 신규 후보 섹션 자체가 추가되지 않음', () => {
-    const blocks = buildWeeklyReviewBlocks([], [], '2026-05-25');
+    const blocks = buildWeeklyReviewBlocks([], [], '2026-05-25', []);
     const headerSection = sectionTexts(blocks).find((t) => /^\*신규 후보/.test(t));
     expect(headerSection).toBeUndefined();
   });
@@ -140,7 +148,7 @@ describe('buildWeeklyReviewBlocks — active 가설 prefix', () => {
         prev: null,
       },
     ];
-    const blocks = buildWeeklyReviewBlocks(active, [], '2026-05-25');
+    const blocks = buildWeeklyReviewBlocks(active, [], '2026-05-25', []);
     const activeSection = sectionTexts(blocks).find((t) => t.includes('active 가설'));
     expect(activeSection).toBeDefined();
     expect(activeSection).toMatch(/\[사주\] \*사주가설\*/);

--- a/src/agents/insight/actions.ts
+++ b/src/agents/insight/actions.ts
@@ -80,7 +80,7 @@ export const registerInsightActions = (app: App): void => {
       const messageTs = 'message' in body && body.message ? body.message.ts : undefined;
       if (channelId && messageTs) {
         const label = payload?.enumTarget ?? '후보';
-        await updateMessage(client, channelId, messageTs, `_${label} 후보 패스함._`, []);
+        await updateMessage(client, channelId, messageTs, `_${label} 후보 반려함._`, []);
       }
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -150,7 +150,7 @@ export const registerInsightActions = (app: App): void => {
       const channelId = 'channel' in body && body.channel ? body.channel.id : undefined;
       const messageTs = 'message' in body && body.message ? body.message.ts : undefined;
       if (channelId && messageTs) {
-        await updateMessage(client, channelId, messageTs, `_매트릭 후보 거절._`, []);
+        await updateMessage(client, channelId, messageTs, `_매트릭 후보 반려._`, []);
       }
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/src/agents/insight/hypothesis-cards.ts
+++ b/src/agents/insight/hypothesis-cards.ts
@@ -1,8 +1,8 @@
 /**
- * 가설 Block Kit 카드 빌더 — ADR-0019 Phase 4.
+ * 가설 Block Kit 카드 빌더 — ADR-0019 Phase 4 + Phase 7 Bayesian 병기.
  *
- * - 후보 카드 (discovery → 등록/패스 액션)
- * - 주간 리뷰 묶음 (active 가설 stat 변화 + 신규 후보)
+ * - 후보 카드 (discovery → 승인/반려 액션)
+ * - 주간 리뷰 묶음 (시드 영향력 top 5 + active 가설 stat 변화 + 신규 후보)
  */
 
 import type { KnownBlock } from '@slack/types';
@@ -63,7 +63,10 @@ const formatRatio = (v: number): string => (Number.isFinite(v) ? v.toFixed(2) : 
 
 const formatPValue = (v: number): string => (Number.isFinite(v) ? v.toFixed(3) : '—');
 
-/** 단일 후보 카드 — 등록/패스 버튼 포함 */
+const formatPosterior = (v: number): string =>
+  Number.isFinite(v) ? `${(v * 100).toFixed(0)}%` : '—';
+
+/** 단일 후보 카드 — 승인/반려 버튼 포함 */
 export const buildCandidateCard = (cand: CandidateHypothesis): KnownBlock[] => {
   const payload = encodeActionPayload({
     triggerSpec: cand.triggerSpec,
@@ -71,30 +74,33 @@ export const buildCandidateCard = (cand: CandidateHypothesis): KnownBlock[] => {
   });
   const kindLabel = KIND_LABEL[cand.patternKind];
   const header = `${kindLabel} *${cand.signalName}* → \`${cand.enumTarget}\``;
-  const detail =
+  const freqLine =
     `발현일 n=${cand.nTriggerDays} · trigger ${formatPercent(cand.rateTrigger)} ` +
     `vs baseline ${formatPercent(cand.rateBaseline)} ` +
-    `· ratio ${formatRatio(cand.rateRatio)}x ` +
-    `· p=${formatPValue(cand.rawP)} q=${formatPValue(cand.fdrQ)}`;
+    `· ratio ${formatRatio(cand.rateRatio)}x`;
+  const bayesLine =
+    `p=${formatPValue(cand.rawP)} q=${formatPValue(cand.fdrQ)} · ` +
+    `사후 ${formatPosterior(cand.posteriorP)} ` +
+    `[${formatPosterior(cand.ciLower)}, ${formatPosterior(cand.ciUpper)}]`;
 
   return [
     {
       type: 'section',
-      text: { type: 'mrkdwn', text: `${header}\n${detail}` },
+      text: { type: 'mrkdwn', text: `${header}\n${freqLine}\n${bayesLine}` },
     },
     {
       type: 'actions',
       elements: [
         {
           type: 'button',
-          text: { type: 'plain_text', text: '가설 등록' },
+          text: { type: 'plain_text', text: '가설 승인' },
           style: 'primary',
           action_id: HYPOTHESIS_REGISTER_ACTION_ID,
           value: payload,
         },
         {
           type: 'button',
-          text: { type: 'plain_text', text: '이번엔 패스' },
+          text: { type: 'plain_text', text: '가설 반려' },
           action_id: HYPOTHESIS_DISMISS_ACTION_ID,
           value: payload,
         },
@@ -111,11 +117,57 @@ export interface ActiveHypothesisRow {
   prev: HypothesisStat | null;
 }
 
-/** 주간 리뷰 묶음 — active 가설 표 + 신규 후보 카드 */
+/** 시드 영향력 섹션 — 주간 리뷰 상단. credible interval lower bound 정렬. */
+export interface SeedInfluenceRow {
+  patternId: number;
+  patternKind: 'saju' | 'life_signal';
+  signalName: string;
+  description: string | null;
+  totalHits: number;
+  totalMisses: number;
+  posteriorP: number;
+  ciLower: number;
+  ciUpper: number;
+}
+
+const POSTERIOR_LEGEND =
+  '_사후 = 본인 패턴일 확률 추정 (50%=우연, 80%↑=강함) · [] = 95% 신뢰 구간 (좁을수록 정확)_';
+
+export const buildSeedInfluenceSection = (rows: SeedInfluenceRow[]): KnownBlock[] => {
+  if (rows.length === 0) return [];
+  const lines = rows.map((r) => {
+    const kindLabel = KIND_LABEL[r.patternKind];
+    const desc = (r.description ?? '').slice(0, 40);
+    const verifyCount = r.totalHits + r.totalMisses;
+    return (
+      `• ${kindLabel} *${r.signalName}* (검증 ${verifyCount}개)` +
+      (desc ? ` — ${desc}` : '') +
+      ` — 사후 ${formatPosterior(r.posteriorP)} ` +
+      `[${formatPosterior(r.ciLower)}, ${formatPosterior(r.ciUpper)}]`
+    );
+  });
+  return [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*이번 주 영향력 시드 top ${rows.length}*\n${lines.join('\n')}`,
+      },
+    },
+    {
+      type: 'context',
+      elements: [{ type: 'mrkdwn', text: POSTERIOR_LEGEND }],
+    },
+    { type: 'divider' },
+  ];
+};
+
+/** 주간 리뷰 묶음 — 시드 영향력 + active 가설 표 + 신규 후보 카드 */
 export const buildWeeklyReviewBlocks = (
   active: ActiveHypothesisRow[],
   candidates: CandidateHypothesis[],
   weekStart: string,
+  seedInfluence: SeedInfluenceRow[],
 ): KnownBlock[] => {
   const blocks: KnownBlock[] = [
     {
@@ -124,11 +176,13 @@ export const buildWeeklyReviewBlocks = (
     },
   ];
 
+  blocks.push(...buildSeedInfluenceSection(seedInfluence));
+
   if (active.length === 0) {
     const noActiveText =
       candidates.length === 0
         ? '_active 가설 없음 — 신규 후보도 아직 없어. 데이터 더 쌓이면 자동으로 떠올거야._'
-        : '_active 가설 없음 — 아래 후보에서 골라 등록해._';
+        : '_active 가설 없음 — 아래 후보에서 골라 승인해._';
     blocks.push({
       type: 'section',
       text: { type: 'mrkdwn', text: noActiveText },
@@ -139,13 +193,16 @@ export const buildWeeklyReviewBlocks = (
       const trigArrow = arrow(row.latest.rateTrigger, prev?.rateTrigger ?? null);
       const qArrow = arrow(row.latest.fdrQ, prev?.fdrQ ?? null);
       const kindLabel = KIND_LABEL[row.patternKind];
-      return (
+      const head =
         `• ${kindLabel} *${row.signalName}* → \`${row.hypothesis.enumTarget}\` — ` +
         `n=${row.latest.nTriggerDays} ` +
         `trig ${formatPercent(row.latest.rateTrigger)} ${trigArrow} ` +
         `ratio ${formatRatio(row.latest.rateRatio)}x ` +
-        `q=${formatPValue(row.latest.fdrQ)} ${qArrow}`
-      );
+        `q=${formatPValue(row.latest.fdrQ)} ${qArrow}`;
+      const post =
+        `   사후 ${formatPosterior(row.latest.posteriorP)} ` +
+        `[${formatPosterior(row.latest.ciLower)}, ${formatPosterior(row.latest.ciUpper)}]`;
+      return `${head}\n${post}`;
     });
     blocks.push({
       type: 'section',
@@ -166,7 +223,7 @@ export const buildWeeklyReviewBlocks = (
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*신규 후보 (사주 ${sajuCands.length} / 생활 ${lifeCands.length})* — 등록할 거 골라`,
+        text: `*신규 후보 (사주 ${sajuCands.length} / 생활 ${lifeCands.length})* — 승인할 거 골라`,
       },
     });
     for (const cand of sajuCands) blocks.push(...buildCandidateCard(cand));

--- a/src/agents/insight/hypothesis-discovery.ts
+++ b/src/agents/insight/hypothesis-discovery.ts
@@ -9,6 +9,11 @@
 
 import { query } from '../../shared/db.js';
 import { fisherExact, bhFdr, type TriggerSpec } from '../../shared/pattern-hypothesis.js';
+import {
+  cumulativePosteriorFromHitMiss,
+  posteriorMean,
+  credibleInterval,
+} from '../../shared/bayesian-posterior.js';
 import { DIARY_META_TAGS, type DiaryMetaTag } from '../../cron/diary-meta-extract.js';
 
 export type DiscoveryMode =
@@ -27,6 +32,10 @@ export interface CandidateHypothesis {
   rateRatio: number;
   rawP: number;
   fdrQ: number;
+  // Phase 7 — discovery 윈도우 hit/miss 기반 posterior (prior Beta(1,1))
+  posteriorP: number;
+  ciLower: number;
+  ciUpper: number;
 }
 
 const DISCOVERY_MIN_N = 5;
@@ -219,6 +228,11 @@ export const discoverCandidates = async (
     const rateRatio = rateBaseline > 0 ? rateTrigger / rateBaseline : 0;
     if (rateRatio < DISCOVERY_MIN_RATE_RATIO) continue;
 
+    const windowMisses = raw.triggerDays - raw.triggerHits;
+    const { alpha, beta } = cumulativePosteriorFromHitMiss(raw.triggerHits, windowMisses);
+    const posteriorP = posteriorMean(alpha, beta);
+    const { lower: ciLower, upper: ciUpper } = credibleInterval(alpha, beta);
+
     candidates.push({
       triggerSpec: { type: 'seed', signalId: raw.signal.id },
       signalName: raw.signal.name,
@@ -231,6 +245,9 @@ export const discoverCandidates = async (
       rateRatio,
       rawP: p,
       fdrQ: q,
+      posteriorP,
+      ciLower,
+      ciUpper,
     });
   }
 

--- a/src/agents/insight/metric-approval-cards.ts
+++ b/src/agents/insight/metric-approval-cards.ts
@@ -77,7 +77,7 @@ export const buildMetricCandidateCard = (input: MetricCandidateCardInput): Known
         },
         {
           type: 'button',
-          text: { type: 'plain_text', text: '거절' },
+          text: { type: 'plain_text', text: '반려' },
           action_id: METRIC_REJECT_ACTION_ID,
           value: payload,
         },

--- a/src/cron/weekly-hypothesis-review.ts
+++ b/src/cron/weekly-hypothesis-review.ts
@@ -22,12 +22,16 @@ import {
   loadActiveHypotheses,
   type HypothesisStat,
 } from '../shared/pattern-hypothesis.js';
+import { posteriorMean, credibleInterval } from '../shared/bayesian-posterior.js';
 import { discoverCandidates } from '../agents/insight/hypothesis-discovery.js';
 import {
   buildWeeklyReviewBlocks,
   type ActiveHypothesisRow,
+  type SeedInfluenceRow,
 } from '../agents/insight/hypothesis-cards.js';
 import type { LifeCronConfig } from './life-cron.js';
+
+const SEED_INFLUENCE_TOP_N = 5;
 
 /** 오늘이 월요일이라는 전제 — 전주 월요일(=7일 전) 반환 */
 export const previousMondayISO = (todayIso: string): string => {
@@ -65,11 +69,15 @@ const loadPrevStat = async (
     rate_ratio: string;
     raw_p: string;
     fdr_q: string;
+    posterior_alpha: string | null;
+    posterior_beta: string | null;
+    posterior_p: string | null;
   }>(
     `SELECT hypothesis_id, TO_CHAR(week_start, 'YYYY-MM-DD') AS week_start,
             n_trigger_days, n_total_days,
             rate_trigger::TEXT, rate_baseline::TEXT, rate_ratio::TEXT,
-            raw_p::TEXT, fdr_q::TEXT
+            raw_p::TEXT, fdr_q::TEXT,
+            posterior_alpha::TEXT, posterior_beta::TEXT, posterior_p::TEXT
        FROM pattern_stats
       WHERE hypothesis_id = $1 AND week_start < $2
       ORDER BY week_start DESC LIMIT 1`,
@@ -77,6 +85,9 @@ const loadPrevStat = async (
   );
   const row = res.rows[0];
   if (!row) return null;
+  const alpha = row.posterior_alpha === null ? NaN : Number(row.posterior_alpha);
+  const beta = row.posterior_beta === null ? NaN : Number(row.posterior_beta);
+  const { lower, upper } = credibleInterval(alpha, beta);
   return {
     hypothesisId: row.hypothesis_id,
     weekStart: row.week_start,
@@ -87,7 +98,80 @@ const loadPrevStat = async (
     rateRatio: Number(row.rate_ratio),
     rawP: Number(row.raw_p),
     fdrQ: Number(row.fdr_q),
+    posteriorAlpha: alpha,
+    posteriorBeta: beta,
+    posteriorP: row.posterior_p === null ? posteriorMean(alpha, beta) : Number(row.posterior_p),
+    ciLower: lower,
+    ciUpper: upper,
   };
+};
+
+/**
+ * 시드 영향력 top N (credible interval lower bound 정렬).
+ * pattern_summary view에서 시드 메타 + aggregate posterior 평균을 가져오고,
+ * α/β 합산은 view contract 보존을 위해 별도 query로 산출.
+ */
+const loadSeedInfluence = async (userId: number, topN: number): Promise<SeedInfluenceRow[]> => {
+  const summaryRes = await query<{
+    pattern_id: string;
+    pattern_kind: 'saju' | 'life_signal';
+    pattern_name: string;
+    pattern_description: string | null;
+    total_hits: string;
+    total_misses: string;
+  }>(
+    `SELECT pattern_id::TEXT, pattern_kind, pattern_name, pattern_description,
+            total_hits::TEXT, total_misses::TEXT
+       FROM pattern_summary
+      WHERE user_id = $1
+        AND active
+        AND aggregate_posterior_p IS NOT NULL`,
+    [userId],
+  );
+  if (summaryRes.rows.length === 0) return [];
+
+  const alphaBetaRes = await query<{
+    pattern_id: string;
+    sum_alpha: string | null;
+    sum_beta: string | null;
+  }>(
+    `SELECT pattern_id::TEXT,
+            SUM(posterior_alpha)::TEXT AS sum_alpha,
+            SUM(posterior_beta)::TEXT  AS sum_beta
+       FROM pattern_metrics
+      WHERE user_id = $1 AND status = 'active'
+      GROUP BY pattern_id`,
+    [userId],
+  );
+  const abMap = new Map<string, { alpha: number; beta: number }>();
+  for (const row of alphaBetaRes.rows) {
+    const alpha = row.sum_alpha === null ? NaN : Number(row.sum_alpha);
+    const beta = row.sum_beta === null ? NaN : Number(row.sum_beta);
+    abMap.set(row.pattern_id, { alpha, beta });
+  }
+
+  const rows: SeedInfluenceRow[] = [];
+  for (const r of summaryRes.rows) {
+    const ab = abMap.get(r.pattern_id);
+    if (!ab || !Number.isFinite(ab.alpha) || !Number.isFinite(ab.beta)) continue;
+    const mean = posteriorMean(ab.alpha, ab.beta);
+    const { lower, upper } = credibleInterval(ab.alpha, ab.beta);
+    if (!Number.isFinite(lower)) continue;
+    rows.push({
+      patternId: Number(r.pattern_id),
+      patternKind: r.pattern_kind,
+      signalName: r.pattern_name,
+      description: r.pattern_description,
+      totalHits: Math.max(0, Math.round(Number(r.total_hits))),
+      totalMisses: Math.max(0, Math.round(Number(r.total_misses))),
+      posteriorP: mean,
+      ciLower: lower,
+      ciUpper: upper,
+    });
+  }
+
+  rows.sort((a, b) => b.ciLower - a.ciLower);
+  return rows.slice(0, topN);
 };
 
 const processUser = async (
@@ -146,7 +230,15 @@ const processUser = async (
     console.error(`[Hypothesis Review] discover 실패 user=${userId}: ${msg}`);
   }
 
-  const blocks = buildWeeklyReviewBlocks(rows, candidates, weekStart);
+  let seedInfluence: SeedInfluenceRow[] = [];
+  try {
+    seedInfluence = await loadSeedInfluence(userId, SEED_INFLUENCE_TOP_N);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[Hypothesis Review] 시드 영향력 로드 실패 user=${userId}: ${msg}`);
+  }
+
+  const blocks = buildWeeklyReviewBlocks(rows, candidates, weekStart, seedInfluence);
   const fallback = `가설 주간 리포트 (${weekStart} ~) — active ${rows.length}건, 신규 후보 ${candidates.length}건`;
 
   try {

--- a/src/shared/__tests__/bayesian-posterior.test.ts
+++ b/src/shared/__tests__/bayesian-posterior.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  updatePosterior,
+  posteriorMean,
+  credibleInterval,
+  cumulativePosteriorFromHitMiss,
+} from '../bayesian-posterior.js';
+
+describe('updatePosterior', () => {
+  it('hit → α+1, β 그대로', () => {
+    expect(updatePosterior({ alpha: 1, beta: 1 }, 'hit')).toEqual({ alpha: 2, beta: 1 });
+  });
+
+  it('miss → α 그대로, β+1', () => {
+    expect(updatePosterior({ alpha: 1, beta: 1 }, 'miss')).toEqual({ alpha: 1, beta: 2 });
+  });
+
+  it('연속 hit 3회 → α=4', () => {
+    let p = { alpha: 1, beta: 1 };
+    p = updatePosterior(p, 'hit');
+    p = updatePosterior(p, 'hit');
+    p = updatePosterior(p, 'hit');
+    expect(p).toEqual({ alpha: 4, beta: 1 });
+  });
+});
+
+describe('posteriorMean', () => {
+  it('Beta(1,1) → 0.5 (uniform prior)', () => {
+    expect(posteriorMean(1, 1)).toBeCloseTo(0.5, 6);
+  });
+
+  it('Beta(2,1) → 2/3', () => {
+    expect(posteriorMean(2, 1)).toBeCloseTo(2 / 3, 6);
+  });
+
+  it('Beta(11,6) — 10 hit + 5 miss + prior → 11/17', () => {
+    expect(posteriorMean(11, 6)).toBeCloseTo(11 / 17, 6);
+  });
+
+  it('α+β=0 → NaN', () => {
+    expect(Number.isNaN(posteriorMean(0, 0))).toBe(true);
+  });
+
+  it('Infinity → NaN', () => {
+    expect(Number.isNaN(posteriorMean(Infinity, 1))).toBe(true);
+    expect(Number.isNaN(posteriorMean(1, Infinity))).toBe(true);
+  });
+});
+
+describe('credibleInterval', () => {
+  it('Beta(2,1) 95% CI — lower < mean < upper, mean=2/3', () => {
+    const { lower, upper } = credibleInterval(2, 1, 0.95);
+    expect(lower).toBeGreaterThan(0);
+    expect(upper).toBeLessThanOrEqual(1);
+    expect(lower).toBeLessThan(2 / 3);
+    expect(upper).toBeGreaterThan(2 / 3);
+  });
+
+  it('큰 N — Beta(51,11) 95% CI는 평균 근방으로 좁아짐', () => {
+    const mean = 51 / 62; // ≈ 0.823
+    const { lower, upper } = credibleInterval(51, 11, 0.95);
+    expect(upper - lower).toBeLessThan(0.25);
+    expect(lower).toBeLessThan(mean);
+    expect(upper).toBeGreaterThan(mean);
+  });
+
+  it('작은 N — Beta(2,2) 95% CI는 매우 넓음 (N 적을 때 자연 페널티)', () => {
+    const { lower, upper } = credibleInterval(2, 2, 0.95);
+    expect(upper - lower).toBeGreaterThan(0.7);
+  });
+
+  it('α≤0 또는 β≤0 → NaN', () => {
+    expect(Number.isNaN(credibleInterval(0, 1).lower)).toBe(true);
+    expect(Number.isNaN(credibleInterval(1, 0).upper)).toBe(true);
+    expect(Number.isNaN(credibleInterval(-1, 5).lower)).toBe(true);
+  });
+
+  it('비유효 conf → NaN', () => {
+    expect(Number.isNaN(credibleInterval(2, 1, 0).lower)).toBe(true);
+    expect(Number.isNaN(credibleInterval(2, 1, 1).upper)).toBe(true);
+    expect(Number.isNaN(credibleInterval(2, 1, NaN).lower)).toBe(true);
+  });
+});
+
+describe('cumulativePosteriorFromHitMiss', () => {
+  it('0/0 → Beta(1,1) (prior 그대로)', () => {
+    expect(cumulativePosteriorFromHitMiss(0, 0)).toEqual({ alpha: 1, beta: 1 });
+  });
+
+  it('10/5 → Beta(11,6)', () => {
+    expect(cumulativePosteriorFromHitMiss(10, 5)).toEqual({ alpha: 11, beta: 6 });
+  });
+
+  it('대용량 누적 — 일관성', () => {
+    const p = cumulativePosteriorFromHitMiss(200, 100);
+    expect(p.alpha).toBe(201);
+    expect(p.beta).toBe(101);
+    expect(posteriorMean(p.alpha, p.beta)).toBeCloseTo(201 / 302, 6);
+  });
+});

--- a/src/shared/bayesian-posterior.ts
+++ b/src/shared/bayesian-posterior.ts
@@ -1,0 +1,61 @@
+/**
+ * Beta-Binomial Bayesian posterior 헬퍼 — ADR-0024 실행 (마스터 #434 Phase 7).
+ *
+ * - prior Beta(1,1) (uniform) 가정
+ * - hit 1회 → α+1, miss 1회 → β+1
+ * - posterior mean = α / (α+β)
+ * - 95% credible interval = Beta inverse CDF (`@stdlib/stats-base-dists-beta-quantile`)
+ *
+ * 가설 단위 누적용으로 `cumulativePosteriorFromHitMiss` 사용.
+ * 매트릭 단위 SQL inline UPDATE는 매칭 cron에 그대로 유지(atomicity).
+ */
+
+import betaQuantile from '@stdlib/stats-base-dists-beta-quantile';
+
+export interface BetaPosterior {
+  alpha: number;
+  beta: number;
+}
+
+export const updatePosterior = (prior: BetaPosterior, outcome: 'hit' | 'miss'): BetaPosterior =>
+  outcome === 'hit'
+    ? { alpha: prior.alpha + 1, beta: prior.beta }
+    : { alpha: prior.alpha, beta: prior.beta + 1 };
+
+export const posteriorMean = (alpha: number, beta: number): number => {
+  if (!Number.isFinite(alpha) || !Number.isFinite(beta)) return NaN;
+  const denom = alpha + beta;
+  return denom > 0 ? alpha / denom : NaN;
+};
+
+export const credibleInterval = (
+  alpha: number,
+  beta: number,
+  conf = 0.95,
+): { lower: number; upper: number } => {
+  if (
+    !Number.isFinite(alpha) ||
+    !Number.isFinite(beta) ||
+    alpha <= 0 ||
+    beta <= 0 ||
+    !Number.isFinite(conf) ||
+    conf <= 0 ||
+    conf >= 1
+  ) {
+    return { lower: NaN, upper: NaN };
+  }
+  const tail = (1 - conf) / 2;
+  return {
+    lower: betaQuantile(tail, alpha, beta),
+    upper: betaQuantile(1 - tail, alpha, beta),
+  };
+};
+
+/** 누적 hit/miss → posterior (prior Beta(1,1) + 누적). */
+export const cumulativePosteriorFromHitMiss = (
+  totalHits: number,
+  totalMisses: number,
+): BetaPosterior => ({
+  alpha: 1 + totalHits,
+  beta: 1 + totalMisses,
+});

--- a/src/shared/pattern-hypothesis.ts
+++ b/src/shared/pattern-hypothesis.ts
@@ -8,6 +8,11 @@
  */
 
 import { query } from './db.js';
+import {
+  cumulativePosteriorFromHitMiss,
+  posteriorMean,
+  credibleInterval,
+} from './bayesian-posterior.js';
 
 // ─── 타입 정의 ───────────────────────────────────────────
 
@@ -39,6 +44,12 @@ export interface HypothesisStat {
   rateRatio: number;
   rawP: number;
   fdrQ: number;
+  // Phase 7 — Beta-Binomial 가설 단위 posterior (누적 hit/miss 기반, prior Beta(1,1))
+  posteriorAlpha: number;
+  posteriorBeta: number;
+  posteriorP: number;
+  ciLower: number;
+  ciUpper: number;
 }
 
 // ─── 통계 알고리즘 (pure 함수) ─────────────────────────
@@ -172,7 +183,12 @@ export const computeHypothesisStat = async (
   userId: number,
   hypothesis: Pick<Hypothesis, 'id' | 'triggerSpec' | 'enumTarget'>,
   weekStart: string,
-): Promise<Omit<HypothesisStat, 'fdrQ'>> => {
+): Promise<
+  Omit<
+    HypothesisStat,
+    'fdrQ' | 'posteriorAlpha' | 'posteriorBeta' | 'posteriorP' | 'ciLower' | 'ciUpper'
+  >
+> => {
   const baselineStart = shiftDate(weekStart, -BASELINE_LOOKBACK_DAYS + 7);
   const weekEnd = shiftDate(weekStart, 6);
   const window = await loadTriggerWindow(
@@ -236,26 +252,60 @@ export const computeAndPersistWeeklyStats = async (
   );
   const qValues = bhFdr(rawStats.map((s) => s.rawP));
 
-  const finalStats: HypothesisStat[] = rawStats.map((s, i) => ({
-    ...s,
-    fdrQ: qValues[i] ?? NaN,
-  }));
+  const finalStats: HypothesisStat[] = [];
+  for (let i = 0; i < rawStats.length; i++) {
+    const stat = rawStats[i];
+    if (!stat) continue;
+    const fdrQ = qValues[i] ?? NaN;
 
-  for (const stat of finalStats) {
+    // 가설 단위 누적 hit/miss: 이전 주들의 누적을 SELECT + 이번 주 derive 합산
+    const cumulativeRes = await query<{ total_hits: string; total_misses: string }>(
+      `SELECT
+         COALESCE(SUM((rate_trigger * n_trigger_days)::NUMERIC), 0)::TEXT AS total_hits,
+         COALESCE(SUM(n_trigger_days - (rate_trigger * n_trigger_days)::NUMERIC), 0)::TEXT AS total_misses
+       FROM pattern_stats
+       WHERE hypothesis_id = $1 AND week_start < $2`,
+      [stat.hypothesisId, stat.weekStart],
+    );
+    const priorHits = Math.max(0, Math.round(Number(cumulativeRes.rows[0]?.total_hits ?? 0)));
+    const priorMisses = Math.max(0, Math.round(Number(cumulativeRes.rows[0]?.total_misses ?? 0)));
+    const weekHits = Math.max(0, Math.round(stat.rateTrigger * stat.nTriggerDays));
+    const weekMisses = Math.max(0, stat.nTriggerDays - weekHits);
+    const { alpha, beta } = cumulativePosteriorFromHitMiss(
+      priorHits + weekHits,
+      priorMisses + weekMisses,
+    );
+    const posteriorP = posteriorMean(alpha, beta);
+    const { lower: ciLower, upper: ciUpper } = credibleInterval(alpha, beta);
+
+    finalStats.push({
+      ...stat,
+      fdrQ,
+      posteriorAlpha: alpha,
+      posteriorBeta: beta,
+      posteriorP,
+      ciLower,
+      ciUpper,
+    });
+
     await query(
       `INSERT INTO pattern_stats
          (hypothesis_id, week_start, n_trigger_days, n_total_days,
-          rate_trigger, rate_baseline, rate_ratio, raw_p, fdr_q)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+          rate_trigger, rate_baseline, rate_ratio, raw_p, fdr_q,
+          posterior_alpha, posterior_beta, posterior_p)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        ON CONFLICT (hypothesis_id, week_start) DO UPDATE SET
-         n_trigger_days = EXCLUDED.n_trigger_days,
-         n_total_days   = EXCLUDED.n_total_days,
-         rate_trigger   = EXCLUDED.rate_trigger,
-         rate_baseline  = EXCLUDED.rate_baseline,
-         rate_ratio     = EXCLUDED.rate_ratio,
-         raw_p          = EXCLUDED.raw_p,
-         fdr_q          = EXCLUDED.fdr_q,
-         computed_at    = NOW()`,
+         n_trigger_days  = EXCLUDED.n_trigger_days,
+         n_total_days    = EXCLUDED.n_total_days,
+         rate_trigger    = EXCLUDED.rate_trigger,
+         rate_baseline   = EXCLUDED.rate_baseline,
+         rate_ratio      = EXCLUDED.rate_ratio,
+         raw_p           = EXCLUDED.raw_p,
+         fdr_q           = EXCLUDED.fdr_q,
+         posterior_alpha = EXCLUDED.posterior_alpha,
+         posterior_beta  = EXCLUDED.posterior_beta,
+         posterior_p     = EXCLUDED.posterior_p,
+         computed_at     = NOW()`,
       [
         stat.hypothesisId,
         stat.weekStart,
@@ -265,7 +315,10 @@ export const computeAndPersistWeeklyStats = async (
         stat.rateBaseline,
         Number.isNaN(stat.rateRatio) ? 'NaN' : stat.rateRatio,
         Number.isNaN(stat.rawP) ? 'NaN' : stat.rawP,
-        Number.isNaN(stat.fdrQ) ? 'NaN' : stat.fdrQ,
+        Number.isNaN(fdrQ) ? 'NaN' : fdrQ,
+        alpha,
+        beta,
+        Number.isNaN(posteriorP) ? 'NaN' : posteriorP,
       ],
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,2052 @@
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
+"@stdlib/array-base-filled@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-base-filled/-/array-base-filled-0.2.3.tgz#b6b5d073ed4f5db5f9bed61f61c8c38f68189d80"
+  integrity sha512-+npZqPn297Gv+D6B/OUkDT/3JGFdrr31+d/SGTeCzm7JQ22tGCUDmixDXwqVp9fWwB+LbjrOWrXMKluUTLcNWg==
+
+"@stdlib/array-base-zeros@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-base-zeros/-/array-base-zeros-0.2.3.tgz#76fce10cf0c16ce31b12c3c6706b9f448df96a2f"
+  integrity sha512-C+eo5MFy37TR7BJ5EDK/5O83/x1n4pozCRj3fcL3ZrURTwUHq0nwRCVCmym/DrmZuxb7MM4xHyYto/suoQOm3A==
+  dependencies:
+    "@stdlib/array-base-filled" "^0.2.2"
+
+"@stdlib/array-float32@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-float32/-/array-float32-0.2.3.tgz#3fc614814be7688b9254d5ec36ac44caba5177f9"
+  integrity sha512-LxdKGrpsCehFDgU+nw7r3/NL+g8pe9zcDn/6fvNwiuy0AiunX/+c8lin9qUy/FEhrbU6aFXepFM2Ql/9YQD+TA==
+  dependencies:
+    "@stdlib/assert-has-float32array-support" "^0.2.3"
+
+"@stdlib/array-float64@^0.2.2", "@stdlib/array-float64@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-float64/-/array-float64-0.2.3.tgz#dac4624f8c006fcfa7db3ca355d22612416b484d"
+  integrity sha512-LtQOcxfE2zX5QnYfLNfptSV9q3JUGkOvGhvtO94iPXEvYTvJSEWLK7G97AJR9MK3rdL1+USjGQzUPiUd1/kAbw==
+  dependencies:
+    "@stdlib/assert-has-float64array-support" "^0.2.3"
+
+"@stdlib/array-uint16@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-uint16/-/array-uint16-0.2.3.tgz#5d2a92ecd6a19b2973c8a8ff0ae6201f043e1afb"
+  integrity sha512-ceDGvNGOxR2kUO30USUWL8ezKw+R6wBwQNJmPOfT1HJRmCxio+eRMBygmxoRmWwoj2pj8IHC/GlC3N2kSNN0Iw==
+  dependencies:
+    "@stdlib/assert-has-uint16array-support" "^0.2.3"
+
+"@stdlib/array-uint32@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-uint32/-/array-uint32-0.2.3.tgz#748ee8017eaf40e96044f349cbdf491540c10721"
+  integrity sha512-zZGjkJjPsgp3WyKOCICOGaJ3OoVyzwgyZgyEHl3wlEqfPhUPpVJGLhy9mFx8WIoTGHsCWHs1COWZfh88bL/pSA==
+  dependencies:
+    "@stdlib/assert-has-uint32array-support" "^0.2.3"
+
+"@stdlib/array-uint8@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-uint8/-/array-uint8-0.2.3.tgz#29119900b75e925b0621ae26260e85deec0596c6"
+  integrity sha512-+UVsdR94Qe1zXEbpE+rpXFxp/VB8+zGxH3d7RH2cUpy5eFeqcSQNvxaxfqZnbmqk2Gu5tJEv/ZBcTXkpeKH7HA==
+  dependencies:
+    "@stdlib/assert-has-uint8array-support" "^0.2.3"
+
+"@stdlib/assert-has-float32array-support@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-float32array-support/-/assert-has-float32array-support-0.2.3.tgz#68fd3f398544e3df7f2a6e01db5981aa7c0497c2"
+  integrity sha512-nNRO8I4dp3CtxFXCD901IBmVc+/otaFMr/Mx1jN956nkaXaL3GZR6p12IGgN535Nj3QILoKPmOG7gOjts+uQOA==
+  dependencies:
+    "@stdlib/assert-is-float32array" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+
+"@stdlib/assert-has-float64array-support@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-float64array-support/-/assert-has-float64array-support-0.2.3.tgz#38c25412f067fa25aee86dc94e5ca069b623a75b"
+  integrity sha512-BbHjShic68woFydK2s8ECn4uKM+Cr3lB6kBP+9wK7wkUGVzq4lo7n+Twt0cBbgwJOGLlQayJQOQAVVq/nu/wDg==
+  dependencies:
+    "@stdlib/assert-is-float64array" "^0.2.3"
+
+"@stdlib/assert-has-generator-support@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-generator-support/-/assert-has-generator-support-0.2.3.tgz#fcf17a8446e6e4f173a84af906aaec7d00d19657"
+  integrity sha512-wr4w9/ufSBHSj+x3WNGK2WdEA9u+itVeY2Tx6ExN7w5avBAFe5EF8/ndeta4iQd8Su6YKJCqCUXNVJ3Dq4gl5g==
+  dependencies:
+    "@stdlib/utils-eval" "^0.2.3"
+
+"@stdlib/assert-has-own-property@^0.2.2", "@stdlib/assert-has-own-property@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-own-property/-/assert-has-own-property-0.2.3.tgz#26026550742a77be84677a81d953a503983808c8"
+  integrity sha512-BnX1Lpvd9YaucQLokQrf7ppLwa3V+nTUQ9qoys5SloYhjwbYWtO61SJVT2JK+cfsCxUAx/HAh3dN1qTKxx1PIg==
+
+"@stdlib/assert-has-symbol-support@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-symbol-support/-/assert-has-symbol-support-0.2.3.tgz#cfbfc0a33087d573f9534ab575580dac49d27b88"
+  integrity sha512-yNsJnCb7HWye5xhZ/eRIpp28HwOVFF5gUCKeT1p4haoDJOn+3YEPYaXMn4mYK6kRN96tUhovlJQv9H/9jwnLpA==
+
+"@stdlib/assert-has-to-primitive-symbol-support@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-to-primitive-symbol-support/-/assert-has-to-primitive-symbol-support-0.1.1.tgz#0dcf9bbc7cecc819dd75f8c18343dbb82fc9a734"
+  integrity sha512-nobeU8aB76XlDtKCC4DZWRdWSbPCoOGOOwEuVoyJ058gNacR4lRPoCA/7cxAVl3UqqLwhX3E1MSOMxNTnMyTGA==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.3"
+    "@stdlib/symbol-ctor" "^0.2.3"
+
+"@stdlib/assert-has-tostringtag-support@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-tostringtag-support/-/assert-has-tostringtag-support-0.2.3.tgz#c450216f68ea9f270ce5eb3612088c9fb5b377c3"
+  integrity sha512-9sULfRKYneF/Mq6F96xqeQrf0a9wdJc1lNZf2wfs1EtRwQHQfx5+QlYl7hp3gWI/iid5M4Npme86T0413eaBfA==
+  dependencies:
+    "@stdlib/assert-has-symbol-support" "^0.2.3"
+
+"@stdlib/assert-has-uint16array-support@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-uint16array-support/-/assert-has-uint16array-support-0.2.3.tgz#d323b3921837dfc4790634c66083454628980798"
+  integrity sha512-7PjQTyXmpIczUz7Vx8c7BcdroJmMmQjyNQDF9a46Ya+nZxqH7g9jRsxmvzqVrSyXhkIyAbw1Ao2QyKocz+hZhg==
+  dependencies:
+    "@stdlib/assert-is-uint16array" "^0.2.2"
+    "@stdlib/constants-uint16-max" "^0.2.3"
+
+"@stdlib/assert-has-uint32array-support@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-uint32array-support/-/assert-has-uint32array-support-0.2.3.tgz#2a2fe967db14552dd6cb7acf94f6829561f7625e"
+  integrity sha512-xa/0yWs+fhp/yUZPD3/ZmQCXqv7haJGGJE75HBX9tw9CHgmqpgAihD4yGy982CtQaxEltH8icNOX8CQzZZS31w==
+  dependencies:
+    "@stdlib/assert-is-uint32array" "^0.2.2"
+    "@stdlib/constants-uint32-max" "^0.2.3"
+
+"@stdlib/assert-has-uint8array-support@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-uint8array-support/-/assert-has-uint8array-support-0.2.3.tgz#9134f8852147ab69b394a30a598919607ec00589"
+  integrity sha512-cgXcNtv5PS+LEV0tj8VOZ8WVjLJuvSzG0GolF+2M0u5le2hHk7BfKH9bqmrk0AzpipAEEdQgp4CGc/Mmji5s8g==
+  dependencies:
+    "@stdlib/assert-is-uint8array" "^0.2.2"
+    "@stdlib/constants-uint8-max" "^0.2.3"
+
+"@stdlib/assert-is-array@^0.2.2", "@stdlib/assert-is-array@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-array/-/assert-is-array-0.2.3.tgz#e231dd5988b52e1ad06fa2d494d5b8ee9e63da17"
+  integrity sha512-ayRsLGmssNO+8SR63tPP2+LZCxFVsSXtdN0ToSdm0kAOaGT4e0FoQus+AlFdhW5xWtvoxL8r5WKTVqJ514/rvQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-big-endian@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-big-endian/-/assert-is-big-endian-0.2.3.tgz#6b64e2feaf72dd9618ef44b1e8ef22ecc48da49f"
+  integrity sha512-+/X7ZcXFdboHIKDtxnx25fKmf9EhPRyp37qp9H9tUb0RnPT8SgmQKtYZxovp7EeBbESZOKSousg0jZKLbPqRAg==
+  dependencies:
+    "@stdlib/array-uint16" "^0.2.2"
+    "@stdlib/array-uint8" "^0.2.2"
+
+"@stdlib/assert-is-boolean@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-boolean/-/assert-is-boolean-0.2.3.tgz#0789c6be929977b4e59ffec49d0912aaccb05e40"
+  integrity sha512-36BETlRDrBeCOBLowW1/vqk9wD+OA3Wp9eQxFij/7icKiMDURH+Fiw2hfbhaZ3c3Y9uEN0rAdOT7AJlwWhXc7Q==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.2.3"
+    "@stdlib/boolean-ctor" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-buffer@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-buffer/-/assert-is-buffer-0.2.3.tgz#966b860b997f35dcd78af2c70b946407b35200e5"
+  integrity sha512-ppnL0sC5XHSk221AYjT4zD33TDB/XuSkhbbbr5sviTH5+88KAqy7SjFlvcpqpvB2BvEVzqRE1fgVso8SjGQD+A==
+  dependencies:
+    "@stdlib/assert-is-object-like" "^0.2.2"
+
+"@stdlib/assert-is-float32array@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-float32array/-/assert-is-float32array-0.2.3.tgz#c87eb6fc031cc19da406868285bc05aff623ffae"
+  integrity sha512-fHPem8taZPd1YoYIB1lqju9HEPDUuY/UFKG0/PquCZtA/g32TEyMM7tb/GCcDQuxno9jnH4+6r7CTfHaa9758w==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-float64array@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-float64array/-/assert-is-float64array-0.2.3.tgz#8ebb74975657f364087157248ec7c3594fa2e86b"
+  integrity sha512-GEuYmjWDT2PY530fIO4qBDr4xO9vYWTjyszkyma0RWKzyGBdCV6GYdMj8qO+W7bOVsqeuoYNTCNebOYfpgZbSQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-function@^0.2.2", "@stdlib/assert-is-function@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-function/-/assert-is-function-0.2.3.tgz#a72970ba919418e81e681db56d89f45ae9c91611"
+  integrity sha512-6EdSkdJ1KtILdGb84MhherNtitGgzHH+u6rs1gGj+294wg/9IzLYaaHDktJVRN/viD3XLEQjPGzSTq5x5DzPbQ==
+  dependencies:
+    "@stdlib/utils-type-of" "^0.2.2"
+
+"@stdlib/assert-is-little-endian@^0.2.2", "@stdlib/assert-is-little-endian@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-little-endian/-/assert-is-little-endian-0.2.3.tgz#c2ebfd5f9cff85cd137eefd6eca6c81f6389c794"
+  integrity sha512-TvKdQhKwrWf0rik5iiurlI1hpJru+bbYGByoSJ6SScTvZIgf54MTYEsWgVyoNqMw8AQFxOyDbMRee+je65ZbMA==
+  dependencies:
+    "@stdlib/array-uint16" "^0.2.2"
+    "@stdlib/array-uint8" "^0.2.2"
+
+"@stdlib/assert-is-number@^0.2.2", "@stdlib/assert-is-number@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-number/-/assert-is-number-0.2.3.tgz#51544706671466157ce07493c036f7ccaf5a3cbd"
+  integrity sha512-6i2RoG5TYn7mfKnPmvAA1Gdhn3PxvQegb2bh2pi5k/+xXgEHoubpqBSVxZBTZ70GIkPwNFJQDRWqwOwHet6enQ==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.2.3"
+    "@stdlib/number-ctor" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-object-like@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-object-like/-/assert-is-object-like-0.2.3.tgz#0230a766a038fbd7dea65a9d468ae578cf9bf268"
+  integrity sha512-K6G58h5euEVSEZvFZSHADoYL7sixNTRy+ezHl/I3byJpC9PJdvTO0XWYD0CT0yVXIaqmCYU2NsPpgGdcPLELFg==
+  dependencies:
+    "@stdlib/assert-tools-array-function" "^0.2.2"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+
+"@stdlib/assert-is-object@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-object/-/assert-is-object-0.2.3.tgz#c26bdd04ba4c83e567119a029a92ed8be8248a1a"
+  integrity sha512-H9NaVGuPl4qA3J4gDAzy+sHCkTImVycoNd7izPF63JuAlEO6KTdpVK7stQBXgcWf1pyRHem7ZTJCzht2UMLzcA==
+  dependencies:
+    "@stdlib/assert-is-array" "^0.2.3"
+
+"@stdlib/assert-is-plain-object@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-plain-object/-/assert-is-plain-object-0.2.3.tgz#3d5a2a88f9ec1cc723106257d3c1430ce9b79af8"
+  integrity sha512-MRdn9kuzC4Hf/2Z/911yZUso6s6f048Ck3dO1j9scHk9EKnU404XrC5NJHeZ9OaI/689Fs+JKDWyKyqyHYRV8A==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.3"
+    "@stdlib/assert-is-function" "^0.2.3"
+    "@stdlib/assert-is-object" "^0.2.2"
+    "@stdlib/utils-get-prototype-of" "^0.2.3"
+    "@stdlib/utils-native-class" "^0.2.3"
+
+"@stdlib/assert-is-regexp@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-regexp/-/assert-is-regexp-0.2.3.tgz#a94bf42da29f655b649bdcbf023741b8dcc9bbf2"
+  integrity sha512-+QlQMHrmSmF++7gK0Jjgy7W5aa91gAfpFWPyY4gUwkrSc+mY+JPPYW4peAf+v6dXABOgfKH/JOaFPSv227SSTQ==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.2.3"
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-string@^0.2.2", "@stdlib/assert-is-string@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-string/-/assert-is-string-0.2.3.tgz#1c3a4212ab321574020f6dae06d2e499c4f2236c"
+  integrity sha512-KC2sHwnIo775uEPRG7miERHb3DMABf37jS6o2bmcMHyME+gl+HC/bnqgwYTfgOsM0YOvYMSgA1HJo6iPDXdFrw==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-uint16array@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-uint16array/-/assert-is-uint16array-0.2.3.tgz#3379afd05e233fa6801dfb78a4219e9fa4111b10"
+  integrity sha512-gHnj9FpIpyiIgsDfA7exvfqqn91THgGJD6BAWqiBgQQccK++K5q3ARc31ysTBuIea1FqYfpy30vt2ZW46lIMcw==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-uint32array@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-uint32array/-/assert-is-uint32array-0.2.3.tgz#d874e5f6ca95eeea704bbb605ee46f6793735121"
+  integrity sha512-Jt9hp3iolCoQC6zC/yisTvxcuxhZ9jyiYwNzyEzgoY4GdV/WETuTpQKwTKbgQkJdUbcl/3VIQaVopEJSUaoV5w==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-uint8array@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-uint8array/-/assert-is-uint8array-0.2.3.tgz#563c70c9a4c5e67870c3e3f38d5908b472bfa739"
+  integrity sha512-a+CzS7ffk2D8oFsswqGJk3L8zpqcnzuB5rwolilRVQtrWjQT/s2ydv5b1HbMB2rEcT6h64rYJDNAITeetGmzBA==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-napi-equal-typedarray-types@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-napi-equal-typedarray-types/-/assert-napi-equal-typedarray-types-0.2.3.tgz#8bbec8707ec2648d5664b557fc7bc66e7e2de0d0"
+  integrity sha512-eBfODSc+zsPnsIXuO1cmWZ6AgGFXPpx0YEApBFzG6akllcPssYuOIJHuE9xBdgL2c8NAGKl91tMitlkmEulG8w==
+  dependencies:
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/assert-napi-equal-types@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-napi-equal-types/-/assert-napi-equal-types-0.2.3.tgz#2817829e95e4291223c6eb99d948bbcbdb18a550"
+  integrity sha512-JfESREBknrUOorPQp6y0vQicG5oSrzopRs2/Uas4tXRWRWe8J+WI60W/HTNAbfow03a5k30M9b7Vg81N6zf2mw==
+  dependencies:
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/assert-napi-is-type@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-napi-is-type/-/assert-napi-is-type-0.2.3.tgz#cc9f7627149ab0ff8400f9dd1ee2fa3261a0c6cf"
+  integrity sha512-EajA0tANjWepz0MVE0zZU45CXLA12/uuRpQ+680ZBfULsVc0plipSQfIMePBgHueJe9YMgyqm3r25RXzf98i7g==
+  dependencies:
+    "@stdlib/assert-napi-equal-types" "^0.2.2"
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/assert-napi-is-typedarray@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-napi-is-typedarray/-/assert-napi-is-typedarray-0.2.3.tgz#adef66186b1ab09563077bc3d99d27f29e029279"
+  integrity sha512-szTmOUQmxi7wi+sJjOpmqBeKdaTHXJAYaBAlrT4Lm8KPjIGr+RP2Fvi2CfFqQu4faekHEM/AXuKbujZnc/P7Xw==
+  dependencies:
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/assert-napi-status-ok@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-napi-status-ok/-/assert-napi-status-ok-0.2.3.tgz#b85cc8bb442ad98484754f08cb8195e4525e0275"
+  integrity sha512-rA+0Vo1ULn4uBHQ+FfagPAcikFT3W/t9I7HdP7SMjz71IZpkWyuxVFZi5MTv2+7hGMYA8be5FibLz20uzbZ9pA==
+
+"@stdlib/assert-tools-array-function@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-tools-array-function/-/assert-tools-array-function-0.2.3.tgz#ee56db5590f8e27d987fca39551b4bef6ea4b1ba"
+  integrity sha512-z2a2G6f9Exz/V0UfE00TLm1sp6W+pOdYltekRRgdEgFNPPP66WxaJfFLkXwqZv0X75U6TuQ0pp7tFq6Ac0lf5A==
+  dependencies:
+    "@stdlib/assert-is-array" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.3"
+    "@stdlib/string-format" "^0.2.3"
+
+"@stdlib/boolean-ctor@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/boolean-ctor/-/boolean-ctor-0.2.3.tgz#bcb19028736853a848c4dc773cd8168631e723a8"
+  integrity sha512-JmVu1SdJHYK5ubLl8nqi0gfYX5kAcSRRJYNQ7JuG8oU6WtkIMsC0ahQ8+3G673czRaQ7HGE+pL0IZiH/s8HSrQ==
+
+"@stdlib/complex-float32-ctor@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float32-ctor/-/complex-float32-ctor-0.1.1.tgz#c64f2d00018adf1392ba0c37a9f938cccf86faa5"
+  integrity sha512-P5aJ7kJ3VkOCvtwIipYH2t/vENK8XnwQGDChQiZAgkJadrF2dKYOXa8t1vWEsy/AMVujAjamHlCXQffhafYm8A==
+  dependencies:
+    "@stdlib/assert-is-number" "^0.2.3"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.3"
+    "@stdlib/number-float64-base-to-float32" "^0.2.2"
+    "@stdlib/string-format" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+    "@stdlib/utils-define-read-only-property" "^0.2.3"
+
+"@stdlib/complex-float32-reim@^0.1.3":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float32-reim/-/complex-float32-reim-0.1.4.tgz#a23653d83c6f0bb1da62785a9b4134c8b7cea4a3"
+  integrity sha512-PXnims1rRAVGARrpoeiwxkYcThjCoXv3iLhUhz8oyulcHteGkJuBAmhnrLANfkh2ro+bFlk6lC9znLt13SOM2g==
+  dependencies:
+    "@stdlib/array-float32" "^0.2.3"
+    "@stdlib/complex-float32-ctor" "^0.1.0"
+
+"@stdlib/complex-float64-ctor@^0.1.1", "@stdlib/complex-float64-ctor@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float64-ctor/-/complex-float64-ctor-0.1.2.tgz#0f94e3af159b0a6843ffdabeeb7fcaeb2a6ce9ff"
+  integrity sha512-xCVE2Lv1/I7A/2mDloT3hDCpA9NP9XOqZKpyKhg3D/9D/vJnh1rnn9CK8+xzVfRborsyQbJF7OI+Ijc3szDI1A==
+  dependencies:
+    "@stdlib/assert-is-number" "^0.2.2"
+    "@stdlib/complex-float32-ctor" "^0.1.0"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.3"
+    "@stdlib/string-format" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+    "@stdlib/utils-define-read-only-property" "^0.2.3"
+
+"@stdlib/complex-float64-reim@^0.1.3":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float64-reim/-/complex-float64-reim-0.1.4.tgz#7527defb93bc42230a1807979334842e2041e84d"
+  integrity sha512-5IxS+GqkVezTGh57Gp7pIyAHS+obDqUpq5y7KpAjrH0s6gp6oN/m+tmPh7K6Yz8yX+7FLVn5b9lZxY1otBBEJQ==
+  dependencies:
+    "@stdlib/array-float64" "^0.2.3"
+    "@stdlib/complex-float64-ctor" "^0.1.2"
+
+"@stdlib/constants-float16-eps@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float16-eps/-/constants-float16-eps-0.2.3.tgz#dfb485c21fda9d4fb14a22e680700eabe04f5115"
+  integrity sha512-gdDE9eYNuJqIxmpWFfFsTx24uJv3BV/S+MKi3vj/TgWFeGMnsqHP+xIf46Hby2OwRbr6yYzsVwfJMAzF7ItCQQ==
+
+"@stdlib/constants-float16-exponent-bias@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float16-exponent-bias/-/constants-float16-exponent-bias-0.3.1.tgz#92851106af18dfda8feb7d55801f860838075df9"
+  integrity sha512-fUqcun9eGniI8sqsZf06qa064cKcp6cARfX9dXuGnCQWSWEwn8Q/LKr8zEgUVEu6cJCVyCMHgm8VPpkTpnFPAQ==
+
+"@stdlib/constants-float16-exponent-mask@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float16-exponent-mask/-/constants-float16-exponent-mask-0.1.1.tgz#f9473e724a8c8000cd1a92bc213bea85db9b65c5"
+  integrity sha512-5J38bgxW+UlF9AHG+C9Z7ilx25aPSOr3ECyK0LThG9H8Kw2zL+9cNbt72vRnVr0BSCv3NKvgxPza+B/bB7IJpg==
+
+"@stdlib/constants-float16-max@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float16-max/-/constants-float16-max-0.2.3.tgz#c113781bde63e4fb1bfc52e87dca548a278dc6db"
+  integrity sha512-M1Hgv/fUdnuV6uw9yyXXOAf7Bzf7I/8naaYolXGX4h7B6XSuCT6Of/0BRxXlU9D+V6zPniGo2zdBaXUGfek28g==
+
+"@stdlib/constants-float16-num-significand-bits@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float16-num-significand-bits/-/constants-float16-num-significand-bits-0.0.2.tgz#601b5642ca407ef8706575dbc5c53b42bccb355d"
+  integrity sha512-qml2Wmm1/gHOGmEfrR1w5G2wYsBHKfCLBaJ8idZ4IMcBfmR8Ez4I9K3uQ3EZ6mW8QU2nUIgp0Fc99lnzLoH+7A==
+
+"@stdlib/constants-float16-sign-mask@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float16-sign-mask/-/constants-float16-sign-mask-0.1.1.tgz#068c43af225a606fed18cbe5a47a59b7b00fd85a"
+  integrity sha512-LpLyCmkhzwotXb1mAAkAZ4sTk5lh5lW3Q1pOp6jtepEFT/marQsoeTe+0r0mIwSncGbym/eEB455qUZQsdiTBg==
+
+"@stdlib/constants-float16-significand-mask@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float16-significand-mask/-/constants-float16-significand-mask-0.1.1.tgz#768f462cecdd202a8f11c9f51c30bcbdc53ee612"
+  integrity sha512-+IA0fHkBV7X00ZTqAo0ZZSSuh9fjLGB8+4ot8iR0irC0YxPLkvyPzFHujnWFu8UD1Eu3SZcyaCY20CLcgsGr9Q==
+
+"@stdlib/constants-float16-smallest-normal@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float16-smallest-normal/-/constants-float16-smallest-normal-0.2.3.tgz#170e5405bdaa377d8913366d69bfea8dba81218a"
+  integrity sha512-u/EzlthAeRba4TePLQzTyivIAp4GB9jLdOwE9FdxSYmqUwAbEIODkd7vft1ArzuCILRHM4NNNESJeaLlv9Qd7w==
+
+"@stdlib/constants-float32-abs-mask@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-abs-mask/-/constants-float32-abs-mask-0.2.3.tgz#0a5fc3a28aecf291d827a00f99ade93bb88ea334"
+  integrity sha512-owGGn8KvmHmne0u5ItTvOpHL6lUJP+tuUe2wzrKYiZuoUTg+7cOhNW4fPWCK8AFYxs11Ha3qPA7oAzjqlq+Log==
+
+"@stdlib/constants-float32-eps@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-eps/-/constants-float32-eps-0.2.3.tgz#ff250a160a152a312acc3a97fba6dddb92390e2e"
+  integrity sha512-yJY7ipPOriceMh2zQvNVDYRrBJlQoBN+7cejox5DxTTn5zytyJn9sfdBQs2buGBqT7BiV+RJE7iE1vQdhuslcQ==
+  dependencies:
+    "@stdlib/number-float64-base-to-float32" "^0.2.2"
+
+"@stdlib/constants-float32-exponent-bias@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-exponent-bias/-/constants-float32-exponent-bias-0.2.3.tgz#60da7cf175adf6d25cf3e6d1d31b9c1b916c5f51"
+  integrity sha512-AdJFdh75o8cBwT/zjRebtZGGz0lYY2P/ITKrxHo4snqinm+DoMFRChkYM2s0QYn8ZgFBHQ1iEPB0cYzxTLk3tg==
+
+"@stdlib/constants-float32-exponent-mask@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-exponent-mask/-/constants-float32-exponent-mask-0.2.3.tgz#c021ab7eaf8c9574fd4d644c9ef426b6d1a467ab"
+  integrity sha512-mkSAIakaixXJy45Ss8G7QbrS6eQemGjfIZhwmwlWDHxCJEVcfpuIijO/N0gtlF/MnGSOACwgn3Qkt1t3Eg30IQ==
+
+"@stdlib/constants-float32-max@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-max/-/constants-float32-max-0.2.3.tgz#423642eb02e29c02aafe6766f70b1cb272691ae0"
+  integrity sha512-b+G9qRNbN4/Ke1BKK3fP7+nWahbWJhcCpbieaiAsbdJyucx7oIaHyzcnNDSmPYhVP57iGEqL9RzhVRd0u4+u4w==
+
+"@stdlib/constants-float32-ninf@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-ninf/-/constants-float32-ninf-0.2.3.tgz#55c22e787ef9f5639b4bff81b1474f0cded41c78"
+  integrity sha512-X0t2gw6UKfzDRRjYH8k8dqRv2C6iI2sn3UrunRIzCL4WYYR+QWn1UwjZWG4fviIE+QuEGTyoKKb4wG6gTiS8yw==
+  dependencies:
+    "@stdlib/array-float32" "^0.2.3"
+    "@stdlib/array-uint32" "^0.2.3"
+
+"@stdlib/constants-float32-num-significand-bits@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-num-significand-bits/-/constants-float32-num-significand-bits-0.1.1.tgz#715da4aa556cbbd4fbdabf85567dab8ef8bc37ce"
+  integrity sha512-pb5IMIdVb22DP6yJc1PmsqTc3mmn02ze4P1oE5aZY/0v4bPUf9yegUmYIyCEWPfM1HX/xnW4GwXDZ3QptSgLqg==
+
+"@stdlib/constants-float32-pinf@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-pinf/-/constants-float32-pinf-0.2.3.tgz#048bfe6731947ebe1388cd98ef7326e08551d2cf"
+  integrity sha512-ofzg0/NDAjALtXw0GPGzsfwpTEziENlSNln2PqoPphno6u7yfCD7BWblIinvDALFwbpsUVWuxAvarL8XnXl4mA==
+  dependencies:
+    "@stdlib/array-float32" "^0.2.3"
+    "@stdlib/array-uint32" "^0.2.3"
+
+"@stdlib/constants-float32-sign-mask@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-sign-mask/-/constants-float32-sign-mask-0.2.3.tgz#5f9dbad85893e43fd1c46f44517128637d5d7ad5"
+  integrity sha512-CdGdK5nHesLEkS6TeQ/jdl3iThAZYrNCysRVshkpz15ORgvbFyHiXaYFIGkwt0a5RnA4i11e3nioHBNWxITGxQ==
+
+"@stdlib/constants-float32-significand-mask@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-significand-mask/-/constants-float32-significand-mask-0.2.4.tgz#c865e26dd8f957b1f1e36e10df7b44b2367eb6a5"
+  integrity sha512-6oBi94bfEEqEPHyzgS3YNBK0fjCRsh/8A6xyaPuHBP+ltGmGfNsZmsZ5vQ+vChszKVyJG1/Bd/j4wif7GGJ/3A==
+
+"@stdlib/constants-float32-smallest-normal@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float32-smallest-normal/-/constants-float32-smallest-normal-0.2.3.tgz#1249ec795abab6bd7f00f6a33762095623fabc18"
+  integrity sha512-NHUPJr9+Bwcr0lMZ2goX7T5jWpel9AQcv4fZfnlabQ3HSYDkAhLBmoCUJh2jxjItR4SbWXzpIEKL3RNDeiKEeQ==
+
+"@stdlib/constants-float64-e@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-e/-/constants-float64-e-0.2.3.tgz#af95c499dea8839692f5c42f4d1496824c4c526e"
+  integrity sha512-8nQCMqyeLPdNN2Kzc+tSeoksZbvyfRpqUgB2xCujfWIxdsPKvAXclWpMQ0EZuk19MBpNPSOEbiXbUiAIrk1Ksg==
+
+"@stdlib/constants-float64-eps@^0.2.2", "@stdlib/constants-float64-eps@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-eps/-/constants-float64-eps-0.2.3.tgz#c44375b44d445e90ad398e53a5e6547c7808606f"
+  integrity sha512-TB4+YU9vc9RwMmSrCt9+UuFeXp+a29Q1KrzcBTcxU8uB/2totg6yYAFwhs8+48Vr5T/bQOsTQpuxXA5KEaThrg==
+
+"@stdlib/constants-float64-eulergamma@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-eulergamma/-/constants-float64-eulergamma-0.2.3.tgz#1b9d1567b17d5cd33db93a80932f5e91f29003d3"
+  integrity sha512-8scw10W2H/rgE2gSmW3Ubp310dsxW0UGppUoDcm5aJNOu/KgCUMqStoPLU653f5AbPZ//hSBpRh2+Nv31WCieg==
+
+"@stdlib/constants-float64-exponent-bias@^0.2.2", "@stdlib/constants-float64-exponent-bias@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-exponent-bias/-/constants-float64-exponent-bias-0.2.3.tgz#84394264c08267961a2edd61c3e3edfadf7c86e9"
+  integrity sha512-GjhdDNlHP96WooqvgEvsCPcK64ZsfpU6DlAsjRMJAPuh/QJ+Ut4WC7vMxuLp/Qio/N3AEsRvCOWIqa5jTvEWUw==
+
+"@stdlib/constants-float64-fourth-pi@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-fourth-pi/-/constants-float64-fourth-pi-0.2.3.tgz#d29dde65193a69a0d0508deddb67e1558354f85b"
+  integrity sha512-Ib/W5K0Pf/sDLjnGclxigJkGQJ/1Jtb+id4kuyRrf1qrlQwiP7tZq60prd+czL14r+1r2y3MYE/7ow4Fc1chUA==
+
+"@stdlib/constants-float64-gamma-lanczos-g@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-gamma-lanczos-g/-/constants-float64-gamma-lanczos-g-0.2.3.tgz#a44d5bfa29a4e6e7b7c04b12d428f901c18b24cd"
+  integrity sha512-bAC0FhhxMDeU6UsCGsAzVZXjnJOc65StXINkvIzhKTw8SjrlQGifNNcanOVtrwKMnpq13MLsVcG+m0R7BmiUZA==
+
+"@stdlib/constants-float64-half-ln-two@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-half-ln-two/-/constants-float64-half-ln-two-0.2.3.tgz#f8ad29a381a2ab1c447708f5fad534ed84cdc9a0"
+  integrity sha512-5FcB6dmhWYNSvCRIukJ3fdd5kNH2eTbpgKo1pYqksp3dwMD6GKR3i/832maewutCvcT72Baj95Si1bqX037AXQ==
+
+"@stdlib/constants-float64-half-pi@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-half-pi/-/constants-float64-half-pi-0.2.3.tgz#52fffa43c0068d8e6ed53ec562394121ce54fd17"
+  integrity sha512-JBDU7c03I5H0kvmOM0ZyxwVxK6kZTLogYSXAS8ho3jkHU8P+DFHXxn6X9DhGKKlTaCTHCAEYQ7zSmV8H886TMA==
+
+"@stdlib/constants-float64-high-word-abs-mask@^0.2.2", "@stdlib/constants-float64-high-word-abs-mask@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-high-word-abs-mask/-/constants-float64-high-word-abs-mask-0.2.3.tgz#f9bdaeee8afc9fda9744d008b4109adf64f88ecc"
+  integrity sha512-AXa286EisR1y71U71M18QvzldmIWsh1TNimoBjrUdCQn5jELOJAQPriTKt0H8kngfOUYfy/+EJwCpuQEL/VWrg==
+
+"@stdlib/constants-float64-high-word-exponent-mask@^0.2.2", "@stdlib/constants-float64-high-word-exponent-mask@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-high-word-exponent-mask/-/constants-float64-high-word-exponent-mask-0.2.3.tgz#46b9831c99bbaec0760da44df9f213e1d165980c"
+  integrity sha512-/q5YMZwugOvQGCXp2kusJY04/KHDzAKMv/QEFBB98fDhN6Ux2VWbVyBESJzn55zVGQvb9XhULwkBy/KdB6YuqQ==
+
+"@stdlib/constants-float64-high-word-sign-mask@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-high-word-sign-mask/-/constants-float64-high-word-sign-mask-0.2.1.tgz#c5b4bc07c023e92aee6bc4dd5c737b9a6374cd55"
+  integrity sha512-Fep/Ccgvz5i9d5k96zJsDjgXGno8HJfmH7wihLmziFmA2z9t7NSacH4/BH4rPJ5yXFHLkacNLDxaF1gO1XpcLA==
+
+"@stdlib/constants-float64-high-word-significand-mask@^0.2.2", "@stdlib/constants-float64-high-word-significand-mask@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-high-word-significand-mask/-/constants-float64-high-word-significand-mask-0.2.3.tgz#bf9571a4e3cda975b0ff56700cc286a31eb7a72e"
+  integrity sha512-SGQfHBnS71PFGQt7Tv6ptAHStJy0sTXmUEjOOXoJlnlClizsgdHXwkeho4xIvycxyNe7L4nT34cFPDMRFguT7w==
+
+"@stdlib/constants-float64-ln-sqrt-two-pi@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-ln-sqrt-two-pi/-/constants-float64-ln-sqrt-two-pi-0.2.3.tgz#0aaeffee0ad8202990a79ed09915a32c1285fe9e"
+  integrity sha512-+VE4Z3OoPmyVzYJ7mbQUkKdkT7+uHeSG821U0hZLtUQAD2AmPWQNUzKk+G6IF8FUQv03Ly6U4lLL9aoXxXjz0A==
+
+"@stdlib/constants-float64-ln-two@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-ln-two/-/constants-float64-ln-two-0.2.3.tgz#67eaa256266b13b8cafcfbb1a50d38e4942a1990"
+  integrity sha512-pCNVc7Cmr56sg+jOrN2yLSWNHdN0UECAZIJ79sDaLBpF2FqeL6EI52EJesLmD64oGSNUC4yZNdGBe+DpKc1ZXw==
+
+"@stdlib/constants-float64-max-base2-exponent-subnormal@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-max-base2-exponent-subnormal/-/constants-float64-max-base2-exponent-subnormal-0.2.1.tgz#57a5550f0f148cab0f51872237016344e6b0b10c"
+  integrity sha512-D1wBNn54Hu2pK6P/yBz0FtPBI3/7HdgK8igYjWDKWUKzC92R/6PHZ9q5NzedcGxoBs8MUk1zNpP0tZyYj9Y4YQ==
+
+"@stdlib/constants-float64-max-base2-exponent@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-max-base2-exponent/-/constants-float64-max-base2-exponent-0.2.3.tgz#1190197444c06c484f38da3a7253483eb062f5a8"
+  integrity sha512-DXOhw/QF63NCeB7o7zAgq2g6IeT7jGDT5kBoRP67qbOeHm+NpZdrFdHXo7acH+pwLJXf5iECnVdyQ/axDLQ5mQ==
+
+"@stdlib/constants-float64-max-ln@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-max-ln/-/constants-float64-max-ln-0.2.3.tgz#0cd40642f4242135a83b63f050946abd261161ff"
+  integrity sha512-M/qzo1CWhgX84vCuF6Nba/Jf+doaQKxQHNXr3yXKL7BEatz7MWweEMaU2pxfKWa5wADMDvLttskYm5jLWnkiNg==
+
+"@stdlib/constants-float64-max-nth-factorial@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-max-nth-factorial/-/constants-float64-max-nth-factorial-0.1.1.tgz#297572ff596f90ad8296262dd2f9d065336cae9d"
+  integrity sha512-krwhCczEOQQDllianEG3LMR7m887BBMZV/udK1/0bYhXJPA2joOEp3RNz3F+IOMJZgPwMnK/x5P66Yp44jeydg==
+
+"@stdlib/constants-float64-max-safe-integer@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-max-safe-integer/-/constants-float64-max-safe-integer-0.2.3.tgz#c710430b4879af87439a115fb4ae02cf3bd306fc"
+  integrity sha512-T1CHYahzAHGLEIS5NMiHjOkGzvgZ0KFtBvFB62shkfMbnkc2gHxVuUzmbxaIm8jQO9X4qafQkRpHFg8AE/e4kg==
+
+"@stdlib/constants-float64-max@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-max/-/constants-float64-max-0.2.3.tgz#8568678c15060a9db118de7c1609691967b1aaf5"
+  integrity sha512-UiN+AZ8FuWCq0vXjTYRzQVpMA5Dnx5lBGaYP46/XiT9DY5v4I4ooJiSGcRpnMa/AcFvM+ZLVq/K/2c1VdL8h3g==
+
+"@stdlib/constants-float64-min-base2-exponent-subnormal@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-min-base2-exponent-subnormal/-/constants-float64-min-base2-exponent-subnormal-0.2.1.tgz#b09334e3ba1ef29a166a46bf21d10c5896f46968"
+  integrity sha512-fTXfvctXWj/48gK+gbRBrHuEHEKY4QOJoXSGp414Sz6vUxHusHJJ686p8ze3XqM7CY6fmL09ZgdGz/uhJl/7lw==
+
+"@stdlib/constants-float64-min-base2-exponent@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-min-base2-exponent/-/constants-float64-min-base2-exponent-0.2.3.tgz#bc2d30586dfe3de799c497ded0608f2c8f875890"
+  integrity sha512-N6Xh+ZCnSCMC+ImkgmYAPHFn4V+94pA5KM2ekhNUC3as1pZVJRkJVacogGnqJ9vnoAbZ0QgZpkJpap8Jy7Pldw==
+
+"@stdlib/constants-float64-min-ln@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-min-ln/-/constants-float64-min-ln-0.2.3.tgz#b9ad44b9121b632a53ae2536f758d5e5a3ab625d"
+  integrity sha512-xiA2KS0yVt69fPehhEgl2glBJJrMLH/0q6eornMRkrZuG+o03wLKaqAqTcrkm2nhIMmhNXEVm+gQU0nfiI8Cmw==
+
+"@stdlib/constants-float64-ninf@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-ninf/-/constants-float64-ninf-0.2.3.tgz#b527f3aa535ad36113b00d7bfed7416f5c634bb6"
+  integrity sha512-1yBmgdNkvxWR0IfebDnhS4KOHPNgTpe3j6CCRt3qUW98l45tUkjuqyKKu8jNvjJCq+qKaNHNNk8xAl+/eDuABg==
+  dependencies:
+    "@stdlib/number-ctor" "^0.2.3"
+
+"@stdlib/constants-float64-num-high-word-significand-bits@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-num-high-word-significand-bits/-/constants-float64-num-high-word-significand-bits-0.1.1.tgz#0ced0f68a27765700617c921d0de3f4502245923"
+  integrity sha512-qyZWHlGYIS6Hjxnt8TTBWlvkGQlFJT2UVQhaoBrQfp456YF8aghgiwHiaUTXzngMH1llcEq2tyPjCxBdTLs6Hg==
+
+"@stdlib/constants-float64-pi@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-pi/-/constants-float64-pi-0.2.3.tgz#a7f51e7d385af41023370a5d797c01cb813d8f61"
+  integrity sha512-1s/4TBYzAj+tOgi2yRX6Iecos8SUn968Vymsl8U7+5pDpJzicfBpB9ZIbWNVMQVkBRWFnMx/T3BUzW1+g/dEsA==
+
+"@stdlib/constants-float64-pinf@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-pinf/-/constants-float64-pinf-0.2.3.tgz#9338540a8af01ed6039049890dabd08ad9120ab5"
+  integrity sha512-8kRy0XOvW7QiJlxdy8MXx7rM3S4H/ZsUI+q9dNoarKVDBtWzkqnEG/u5QYouVjGHaSVL8C7b7qwL1FdpSD+24g==
+
+"@stdlib/constants-float64-smallest-normal@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-smallest-normal/-/constants-float64-smallest-normal-0.2.3.tgz#8ec33cb60da0a7b37720122ec6c90bf717bc38bb"
+  integrity sha512-z2IDWJD7s6QwrfzI5o4q3OnZ7mEzUIs1V1PdTuHDofyWkpFGEr7GgwGI/0cZbuhW3aY3xydvM3rZ5SxT+6KQoQ==
+
+"@stdlib/constants-float64-smallest-subnormal@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-smallest-subnormal/-/constants-float64-smallest-subnormal-0.2.3.tgz#f3f945bea3c35fdab6a46947c6a89d8fd3b375fe"
+  integrity sha512-NcXOJRA9vuhWcPPvwQf+c86Oab8UtJ3P8Y2DwKt9eRzjRdFFMw73pDmYXEOHSwczn/mGaTHG4HxmVBTugh/ezw==
+
+"@stdlib/constants-float64-sqrt-eps@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-sqrt-eps/-/constants-float64-sqrt-eps-0.2.3.tgz#033b970eb43564400fc5f8309ec4507d0bd97956"
+  integrity sha512-N6ga0XNLkDgrGCs1cgajXzTYFgl6gDrgWOJW3AQhZPaFEswTtD+yMmcw3p4ye1LZpU3JyDr8hcY2iwL8whX+nA==
+
+"@stdlib/constants-float64-sqrt-two-pi@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-sqrt-two-pi/-/constants-float64-sqrt-two-pi-0.2.3.tgz#6eb2a73ed539e1f2e9acb25276f6494e17419d46"
+  integrity sha512-XVCJ0voDf2U/MMqqnLOo9CB8IEC4odQoercGolrJBud6MXmWp1eVrRYM6y0ocJuyaAPgsYSoPKp0+Gc907InTQ==
+
+"@stdlib/constants-float64-sqrt-two@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-sqrt-two/-/constants-float64-sqrt-two-0.2.3.tgz#1989d98cfb904a64c2e3605f502455f264a211cb"
+  integrity sha512-vehmaN+P1IYJ6HhbH70ebhLAZOYnuTm1ezWpFBm/IEC9NGiKKmyrtO+z1xp6iWGl1VrAAhWJE+bBQEP4wVQsCw==
+
+"@stdlib/constants-float64-two-pi@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-two-pi/-/constants-float64-two-pi-0.2.3.tgz#e5496eccb403be4ce65dd6dce5f1dd73c4d2f46d"
+  integrity sha512-KoNeAgq+jSDT0lYYHAYosZJwRSH9VlykKjI7BK8TVox7z5QqlXG4Sa94NeGwP8qhp+g4N3Mb7BqXlol3t4vPfg==
+
+"@stdlib/constants-int32-max@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-int32-max/-/constants-int32-max-0.3.1.tgz#a4e88f15b53c7d781034b70414bc12a79e79854d"
+  integrity sha512-ZAhWfNaBhVzDatkha1q0vu7tO6XRbP6kxJk/Erh4emgE/4JpC9WPlXfkZvhOoCWQ1Rsll7tevxN3rfu6oGN7OA==
+
+"@stdlib/constants-uint16-max@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-uint16-max/-/constants-uint16-max-0.2.3.tgz#4a2a02831087eb7adb94d2babdc8210cfdd2a4b4"
+  integrity sha512-QLqt85JMBnL8ozliswgAeR9oWrsmWeaeWjr10P0zbGV1dKhM2HoRK3VXjO4SCtNWUwiV4w8Wa5ylSYdJhORDjA==
+
+"@stdlib/constants-uint32-max@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-uint32-max/-/constants-uint32-max-0.2.3.tgz#2bb5184fb71e3b0504624dd9e03c85b9408cdf65"
+  integrity sha512-NYQIGMA3Z8+1gp2qUfmr90whvZJLDq737ipNeujrFm98/RcbBlCRmXCLlj0WMwxniw2T35ysfclAcFSE7caUCA==
+
+"@stdlib/constants-uint8-max@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-uint8-max/-/constants-uint8-max-0.2.3.tgz#dd67b8a257cdafd85de334dc10341f978356bc15"
+  integrity sha512-B4VzHho0T43dJk3m1x9V3GZ1OOK9AKNojo3jOweixBLLlofaEIe0E9f4Gihc2ef7+M4azYptsJdPY1jPy7kK2g==
+
+"@stdlib/error-tools-fmtprodmsg@^0.2.2", "@stdlib/error-tools-fmtprodmsg@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/error-tools-fmtprodmsg/-/error-tools-fmtprodmsg-0.2.3.tgz#05dcb260c0a36b4ad20a1936e9a669dacc12f959"
+  integrity sha512-mt4YRp52oCkNWhxkUIJkeGaFnSvZkyfl4rOJX8Drz99xFiIdanXcSacckhrXXu6NQvMDKidCGr6DvrhHHx15LQ==
+
+"@stdlib/fs-exists@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/fs-exists/-/fs-exists-0.2.3.tgz#7ad449a494c0aae74392613039ef3399bb45e29a"
+  integrity sha512-kfHok9sKxvCftgWriVtNjqezNZA72Q/rJh78lcrGCLPvSHGIAL460olzl7D1OgAgQvM3Cwdoupay0o3dBCCwVQ==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+
+"@stdlib/fs-resolve-parent-path@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/fs-resolve-parent-path/-/fs-resolve-parent-path-0.2.3.tgz#b001218db97dee8a5676dd767beb395da98b19bc"
+  integrity sha512-bof7pQQewv8LLaSi2Ut77mkEv4v45Z/w/hYocG0UUzmXhu4lXIiCcXz9ZAMJC4tdN5hwBReJGfJ0mQryddhGGA==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.3"
+    "@stdlib/assert-is-function" "^0.2.3"
+    "@stdlib/assert-is-plain-object" "^0.2.3"
+    "@stdlib/assert-is-string" "^0.2.3"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.3"
+    "@stdlib/fs-exists" "^0.2.3"
+    "@stdlib/process-cwd" "^0.2.3"
+    "@stdlib/string-format" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+
+"@stdlib/function-ctor@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/function-ctor/-/function-ctor-0.2.3.tgz#78af9153aef38fa38cc3de9bf69dd2a80ebabf26"
+  integrity sha512-/Ny143oEz3YAwauaPZ+J9A3IGFdE+0dam5/ATJPGLcl2nDj8P2shAsMp30coyEyzKDoMZqYSKTFFTV5rxyChAA==
+
+"@stdlib/math-base-assert-is-even@^0.2.4":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-even/-/math-base-assert-is-even-0.2.5.tgz#d6047fc9bf387ea6e22dfddae174b3851fa61020"
+  integrity sha512-EtCGbIAnrhgYpCrCrYNQC6aqOPviTdU2Ui1t9grPG2e1eE8cMjzSpTg1TJmcZeMShzlWl9BcgeCS2GQPaYhkCQ==
+  dependencies:
+    "@stdlib/math-base-assert-is-integer" "^0.2.7"
+    "@stdlib/napi-argv" "^0.2.3"
+    "@stdlib/napi-argv-double" "^0.2.2"
+    "@stdlib/napi-create-int32" "^0.0.3"
+    "@stdlib/napi-export" "^0.3.1"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-assert-is-finite@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-finite/-/math-base-assert-is-finite-0.2.3.tgz#9b53bfc8e04b471191b73614a5effe7a3894e182"
+  integrity sha512-PqqxkiubjHe9jdIfAf/PTHZLbYIk1wcFwPGALM+PR3kjRngEkti7NbbkTQX3sByZCCfRwOf7VxLPWDlGo3EmLw==
+  dependencies:
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/napi-argv" "^0.2.3"
+    "@stdlib/napi-argv-double" "^0.2.2"
+    "@stdlib/napi-create-int32" "^0.0.3"
+    "@stdlib/napi-export" "^0.3.1"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-assert-is-finitef@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-finitef/-/math-base-assert-is-finitef-0.2.3.tgz#73b1381ab1ed471c138462bf5e4ad071ecdedbee"
+  integrity sha512-FiP4w+PjwD6zapXgrD0hLEtnUMi+uCcBQw+tU9cAGyB+7NrhnUoKSWgHsjtLGLMD08gWsFOIjZzZRavx4PocfA==
+  dependencies:
+    "@stdlib/constants-float32-ninf" "^0.2.2"
+    "@stdlib/constants-float32-pinf" "^0.2.2"
+    "@stdlib/napi-argv" "^0.2.3"
+    "@stdlib/napi-argv-float" "^0.2.3"
+    "@stdlib/napi-create-int32" "^0.0.3"
+    "@stdlib/napi-export" "^0.3.1"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-assert-is-infinite@^0.2.2", "@stdlib/math-base-assert-is-infinite@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-infinite/-/math-base-assert-is-infinite-0.2.3.tgz#bf017f3264215ccacbc63b8b6d67365fb0716c82"
+  integrity sha512-tWQoN9z7j56DIop5cBnbdkP/o1MGQ0K8bX4v6Nxsgqngk7YBXYlxGRVw+46FVyxNButJY20VwxpMhrv4fQg35g==
+  dependencies:
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-assert-is-integer@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-integer/-/math-base-assert-is-integer-0.2.7.tgz#d492a59934f0f9ea31a9e487b9153a3546deefd2"
+  integrity sha512-rsxiM7N9Y5kd9elTEJpx1kAcHBeHETH46vn2s5FoKyNt7oZLqv9iE5oKF3oNznA3H47o7SNyQSdcJpUDqS1W3w==
+  dependencies:
+    "@stdlib/math-base-special-floor" "^0.2.4"
+    "@stdlib/napi-argv" "^0.2.3"
+    "@stdlib/napi-argv-double" "^0.2.2"
+    "@stdlib/napi-create-int32" "^0.0.3"
+    "@stdlib/napi-export" "^0.3.1"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-assert-is-nan@^0.2.2", "@stdlib/math-base-assert-is-nan@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-nan/-/math-base-assert-is-nan-0.2.3.tgz#26595e26b862d89be0c00de062be6ac797002e31"
+  integrity sha512-mj1p+JUSfbsiBI3+hwRV7bS0qgI2nWdzrFtBJUSLk+17MJSdA4aboUsXM12wIV1kg5JNfEAn+5eh4NF/sMvaoQ==
+  dependencies:
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-assert-is-nanf@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-nanf/-/math-base-assert-is-nanf-0.2.3.tgz#b80dc2a752a8596e956732085bb0d2e5b2322212"
+  integrity sha512-sWMMFhTrkeYu/t5bv7KZ8Rm7H4pD+O1+wYYNu1CsJ4y1Q6HwSDeHBNIH7Z4zHOOSFiOidb04jnqMGSsL5UCFRg==
+  dependencies:
+    "@stdlib/napi-argv" "^0.2.3"
+    "@stdlib/napi-argv-float" "^0.2.3"
+    "@stdlib/napi-create-int32" "^0.0.3"
+    "@stdlib/napi-export" "^0.3.1"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-assert-is-negative-zero@^0.2.2", "@stdlib/math-base-assert-is-negative-zero@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-negative-zero/-/math-base-assert-is-negative-zero-0.2.3.tgz#8c3129b2765246e2f81ee8a1cdcb8c09e7fb1eec"
+  integrity sha512-5XzTwloDrG60ZRd5vgbw/lXKn794s2q8Hb0pT2LUy0WG2j98LhAQNEv0f0a7brhHlGOMTX5Hmg1DZXw+ve2u5Q==
+  dependencies:
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-assert-is-odd@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-odd/-/math-base-assert-is-odd-0.3.2.tgz#d155ccf32ffe913b2c096ab0299d30a00f843e97"
+  integrity sha512-AVtda9LMQ7WgracZDygZzh7rBDys8KKn4qzAIVv2hWG3ns8X8btQ46plekP44iRyGjYagXMzLJn2jo/Irkf71Q==
+  dependencies:
+    "@stdlib/math-base-assert-is-even" "^0.2.4"
+    "@stdlib/napi-argv" "^0.2.3"
+    "@stdlib/napi-argv-double" "^0.2.2"
+    "@stdlib/napi-create-int32" "^0.0.3"
+    "@stdlib/napi-export" "^0.3.1"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-assert-is-positive-zero@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-positive-zero/-/math-base-assert-is-positive-zero-0.2.3.tgz#52521604eca956e6c69b0cea553048fe25275650"
+  integrity sha512-V+f8enSK2dEk2V/nHMezyJaUfSC0QJNUD8+mQYON7JtFaxq/+xURnPMllF9h84cFqQ9SAuxWXP+Y7MoE+ENORw==
+  dependencies:
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-napi-binary@^0.3.2", "@stdlib/math-base-napi-binary@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-napi-binary/-/math-base-napi-binary-0.3.3.tgz#1ff134eaafd16b805099f8c27d8a124c89a0bf05"
+  integrity sha512-rLBojVTK0GRhy5v0MEKLmamggOrosEMaDcMS5ITuUe6Jgz4DM3lsiB/EHhd0TamPdqo+5HPjqSo10zpFVbLZbA==
+  dependencies:
+    "@stdlib/complex-float32-ctor" "^0.1.0"
+    "@stdlib/complex-float32-reim" "^0.1.3"
+    "@stdlib/complex-float64-ctor" "^0.1.1"
+    "@stdlib/complex-float64-reim" "^0.1.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-napi-unary@^0.2.6", "@stdlib/math-base-napi-unary@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-napi-unary/-/math-base-napi-unary-0.2.7.tgz#9a1aea49988b6dad2c3f052fd62bedfc9c73daec"
+  integrity sha512-eEu0nAq8WzCGe15ppGJWtLGhKOoG4OcMJQpsfbjwaa3sZ9h1sREmV1iiAFWyi/mHy8C0y6PiG2szx4D/F0ywmg==
+  dependencies:
+    "@stdlib/complex-float32-ctor" "^0.1.0"
+    "@stdlib/complex-float32-reim" "^0.1.3"
+    "@stdlib/complex-float64-ctor" "^0.1.1"
+    "@stdlib/complex-float64-reim" "^0.1.3"
+    "@stdlib/number-float16-base-to-float64" "^0.1.1"
+    "@stdlib/number-float16-ctor" "^0.1.1"
+    "@stdlib/number-float64-base-to-float16" "^0.1.1"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-abs@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-abs/-/math-base-special-abs-0.2.3.tgz#0b3df2b604279bf0f441b6fe037a879fb2163371"
+  integrity sha512-0n2Jb1NQv/siPL5EJFf6/cCuK63zqgqFjQwPujJI8B+dDizlHJKF4jR6yOtavrB5RvVf37/3Ibpdjf8UPf3uzA==
+  dependencies:
+    "@stdlib/constants-float64-high-word-abs-mask" "^0.2.2"
+    "@stdlib/math-base-napi-unary" "^0.2.6"
+    "@stdlib/number-float64-base-to-words" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-absf@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-absf/-/math-base-special-absf-0.2.3.tgz#1c4d34ad784d313088daba853e0df7fb0e8479c4"
+  integrity sha512-lUEEnIo6jpR397bn4mphlihPBMncdgKYQQYZ8nwnL/wGNE9InwqLqrO6otM+CO2nkG/kOyt0dSAhSSffqBZU6g==
+  dependencies:
+    "@stdlib/constants-float32-abs-mask" "^0.2.2"
+    "@stdlib/math-base-napi-unary" "^0.2.6"
+    "@stdlib/number-float32-base-to-word" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-acos@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-acos/-/math-base-special-acos-0.2.4.tgz#2ea41f6b305a221990054ea72b323fbc8ef29ec0"
+  integrity sha512-lidI9Q1No+jYM7glXFXMPzxQKwrzqV/QuAp4hVDmidDTL1d6NW0jPBAiaRL7RLcqXqd8oYVirTrQIga8RhMatQ==
+  dependencies:
+    "@stdlib/constants-float64-fourth-pi" "^0.2.2"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-asin" "^0.2.3"
+    "@stdlib/math-base-special-sqrt" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-asin@^0.2.3", "@stdlib/math-base-special-asin@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-asin/-/math-base-special-asin-0.2.4.tgz#3c395cd82c0c4962fd7593959c8cac584186af7e"
+  integrity sha512-HM/x7n25umG0plZrAil2wq21m6+9rA9TDTXErYXAv27HEM5NZGCZn9i+kpTog5/IDSdM58OkTsEB5FOfaBCjuw==
+  dependencies:
+    "@stdlib/constants-float64-fourth-pi" "^0.2.2"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-sqrt" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-beta@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-beta/-/math-base-special-beta-0.3.1.tgz#30dd6b02fbf62708c7ba3e2d52b5f290f14cf290"
+  integrity sha512-DabfQZifUcNF529IYtj/9A5oAmZD6g4JhQt1drx8sMMLUJ89r8TZLIyMZU/bgp4cpzSkRGRSPjfXWL/98y5Y7w==
+  dependencies:
+    "@stdlib/constants-float64-e" "^0.2.3"
+    "@stdlib/constants-float64-eps" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-exp" "^0.2.4"
+    "@stdlib/math-base-special-log1p" "^0.2.4"
+    "@stdlib/math-base-special-pow" "^0.3.0"
+    "@stdlib/math-base-special-sqrt" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-betainc@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-betainc/-/math-base-special-betainc-0.2.3.tgz#fc2b8c3bd46a8bd613274c7f6b1c3b6a2c20f5d1"
+  integrity sha512-yTGYcCptTWVFxL9hv4Uc221kb7tULU5JkRp5oklPhZmg2uj/eRIvaGYtYvzuTnEU2HpdgWcTVwdDaWsG68F6NQ==
+  dependencies:
+    "@stdlib/math-base-special-kernel-betainc" "^0.2.2"
+
+"@stdlib/math-base-special-betaincinv@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-betaincinv/-/math-base-special-betaincinv-0.2.3.tgz#5f3eb1d471915714184e137a6c7993aa43d6a664"
+  integrity sha512-PbOUNFuVaNvaLLXANFc8d+Y7MX0HrHugWR7AvCKEH9Kc+codwuZaZOXgErsJKNaCP34M61kCR918Kn/X/BwZWA==
+  dependencies:
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-special-kernel-betaincinv" "^0.2.2"
+
+"@stdlib/math-base-special-binomcoef@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-binomcoef/-/math-base-special-binomcoef-0.3.1.tgz#f1b18cb58769781b5c8bd9b270eb8428e6812a79"
+  integrity sha512-ywcno89Y7ntRdj3NdAVfVzYoIrJb5lILhq+K+NqhgrJBOcrE8ZF+/yPhyVwjUvksfGy990tBnyhx+06VLVFAQg==
+  dependencies:
+    "@stdlib/constants-float64-max-safe-integer" "^0.2.2"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-integer" "^0.2.7"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-assert-is-odd" "^0.3.2"
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/math-base-special-floor" "^0.2.4"
+    "@stdlib/math-base-special-gcd" "^0.3.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-ceil@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-ceil/-/math-base-special-ceil-0.2.3.tgz#3ade41a589db9036a6bfafc29dda5a5d058c338a"
+  integrity sha512-QJsGAxftN8RLjDkqKqyOcWh8tGFauyXMvqLxoq4C22tm+1ABJ+1rU5wEATOgvOHaDVc7HvHA7fakHTB0UsDUyw==
+  dependencies:
+    "@stdlib/math-base-napi-unary" "^0.2.6"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-copysign@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-copysign/-/math-base-special-copysign-0.2.3.tgz#45e1280b4480675d01304d25d4365cc62f65eeee"
+  integrity sha512-kOPVuWHQht53FcFXO4L1yqXSZy4emdI6qITJAWRENDuW9YZ6QRTONBqOaDC5uU/dRZg3LcMUpQ7iuqYqa/pbeQ==
+  dependencies:
+    "@stdlib/constants-float64-high-word-abs-mask" "^0.2.3"
+    "@stdlib/constants-float64-high-word-sign-mask" "^0.2.1"
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/number-float64-base-from-words" "^0.2.2"
+    "@stdlib/number-float64-base-get-high-word" "^0.2.3"
+    "@stdlib/number-float64-base-to-words" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-cos@^0.3.0", "@stdlib/math-base-special-cos@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-cos/-/math-base-special-cos-0.3.1.tgz#85b642e16f3eef6df518f0dbbfa94daba9cfb35d"
+  integrity sha512-efthz58G0wf8rXh4+jbYeRuRCagNlYb8AL3es1GxwV9P9/8ZpKAlkQiRPY3AI3ZJMB17aR/KHpVw7Pz+rw4Fhg==
+  dependencies:
+    "@stdlib/constants-float64-high-word-abs-mask" "^0.2.3"
+    "@stdlib/constants-float64-high-word-exponent-mask" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-kernel-cos" "^0.2.4"
+    "@stdlib/math-base-special-kernel-sin" "^0.2.4"
+    "@stdlib/math-base-special-rempio2" "^0.3.0"
+    "@stdlib/number-float64-base-get-high-word" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-erfc@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-erfc/-/math-base-special-erfc-0.2.5.tgz#baa84bdf384cc0b27570914d66f51868fe1fa22b"
+  integrity sha512-qA2iPLKr8SjYpI9TCT7LoQCbUrbx17kmiRidDewWk/aHL0pcpSm8KITCjBUtsmletSEUNUS+8MyAPqisXT3N1g==
+  dependencies:
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-exp" "^0.2.4"
+    "@stdlib/number-float64-base-set-low-word" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-erfcinv@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-erfcinv/-/math-base-special-erfcinv-0.2.4.tgz#2e19adbdaa723355f7c1cbbc9aafe3a237e29e20"
+  integrity sha512-oF/3UXs2zZFAOKe19rRcWg2SFZFHQbnFJ4ucbSzYykM79pDnvVtSP/dRPtDy3uevUix6BzeloFyK0dLbQsYt+w==
+  dependencies:
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-ln" "^0.2.5"
+    "@stdlib/math-base-special-sqrt" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-exp@^0.2.4", "@stdlib/math-base-special-exp@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-exp/-/math-base-special-exp-0.2.5.tgz#42ba3468307c96744d36590859c955f333347163"
+  integrity sha512-1xZWUc+uDQHRD/mHJMsAjenRq7w6ZZqAUc8Jtxwcd5Ccv23CckP0TvDNkC6RqVWWPJploxoxDArQ+BUXgHbpeA==
+  dependencies:
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-ldexp" "^0.2.4"
+    "@stdlib/math-base-special-trunc" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-expm1@^0.2.3", "@stdlib/math-base-special-expm1@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-expm1/-/math-base-special-expm1-0.2.4.tgz#7b476c60c0450ca3c7c22d96c933b1420b831fc9"
+  integrity sha512-/2HSORRdM0vAdiEEILreYV8cKtnUfW2OrxKLc5dbkCMHe895gURlrpTA507lF3x02uAnHh8PiasMsYTOXcGeCA==
+  dependencies:
+    "@stdlib/constants-float64-exponent-bias" "^0.2.3"
+    "@stdlib/constants-float64-half-ln-two" "^0.2.3"
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/number-float64-base-from-words" "^0.2.2"
+    "@stdlib/number-float64-base-get-high-word" "^0.2.3"
+    "@stdlib/number-float64-base-set-high-word" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-factorial@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-factorial/-/math-base-special-factorial-0.3.2.tgz#11472e40c7f506c05919a1edff1b5b3133be9356"
+  integrity sha512-YOqPZBtZPP+Pa6jQn/IY0JjGx1sShxQ27XYbpgupg9yZCvabLzhHg+J6/mnjqf4eti6UcVtCITFUZOZ671GyOQ==
+  dependencies:
+    "@stdlib/constants-float64-max-nth-factorial" "^0.1.1"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-integer" "^0.2.7"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-gamma" "^0.3.0"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-floor@^0.2.3", "@stdlib/math-base-special-floor@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-floor/-/math-base-special-floor-0.2.4.tgz#70f228ddb83d4894af93079eac7c3df53ee1a472"
+  integrity sha512-YSDt9gHSp8SeVBVzHfpZZ1HFEQDPihHUF92zTDCRGKeKBC4BTFlw9Q4/fNWqS1mtuBGli1zgpRbiTv3atQ5EjQ==
+  dependencies:
+    "@stdlib/math-base-napi-unary" "^0.2.6"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-fmod@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-fmod/-/math-base-special-fmod-0.1.1.tgz#8868b3132d5c6dd1684f74837de312bbc23ed8eb"
+  integrity sha512-pW0Jn1S9D8Eh34tEmEJUzZlkfN2nhOmi0dCO8xDWhgdit3+qG/U85t0bULT+/5kRezy8SspnTFkGOoopHztzQQ==
+  dependencies:
+    "@stdlib/constants-float64-exponent-bias" "^0.2.2"
+    "@stdlib/constants-float64-high-word-abs-mask" "^0.2.2"
+    "@stdlib/constants-float64-high-word-exponent-mask" "^0.2.2"
+    "@stdlib/constants-float64-high-word-sign-mask" "^0.2.1"
+    "@stdlib/constants-float64-high-word-significand-mask" "^0.2.2"
+    "@stdlib/constants-float64-min-base2-exponent" "^0.2.2"
+    "@stdlib/math-base-napi-binary" "^0.3.2"
+    "@stdlib/number-float64-base-from-words" "^0.2.2"
+    "@stdlib/number-float64-base-to-words" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-gamma-delta-ratio@^0.3.0", "@stdlib/math-base-special-gamma-delta-ratio@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-gamma-delta-ratio/-/math-base-special-gamma-delta-ratio-0.3.1.tgz#063222d703ca94c46965da8991e7bc4007b58f70"
+  integrity sha512-Tekp7Flw36nZPZ8fQilkPRiGyMbYyzWjRV/HZWuBaqqDWE3+J2W68qflGFCad0M6qkWDxLV65TJ9E8yJiTYxAQ==
+  dependencies:
+    "@stdlib/constants-float64-e" "^0.2.3"
+    "@stdlib/constants-float64-eps" "^0.2.3"
+    "@stdlib/constants-float64-gamma-lanczos-g" "^0.2.3"
+    "@stdlib/constants-float64-max-nth-factorial" "^0.1.1"
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-exp" "^0.2.5"
+    "@stdlib/math-base-special-factorial" "^0.3.2"
+    "@stdlib/math-base-special-floor" "^0.2.4"
+    "@stdlib/math-base-special-gamma" "^0.3.0"
+    "@stdlib/math-base-special-gamma-lanczos-sum" "^0.3.2"
+    "@stdlib/math-base-special-log1p" "^0.2.4"
+    "@stdlib/math-base-special-pow" "^0.3.1"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-gamma-lanczos-sum-expg-scaled@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-gamma-lanczos-sum-expg-scaled/-/math-base-special-gamma-lanczos-sum-expg-scaled-0.2.2.tgz#7658bb3b002081a3259b09ecf80a58365b5a39b9"
+  integrity sha512-P8exugMuGijA+9FzG1krmfPIHWqRolFm9xws+H1OGTw9lq6c+sPAny/1KNLo/QbL/UaKrjhbeUDVHOjN3wj2Hw==
+  dependencies:
+    "@stdlib/math-base-napi-unary" "^0.2.6"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-gamma-lanczos-sum@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-gamma-lanczos-sum/-/math-base-special-gamma-lanczos-sum-0.3.2.tgz#6e32b01add2f8794ed7ad3ebfae4f66f25658a9e"
+  integrity sha512-wIH23KUPBKhu0nCraZ3aY882ICDtLIDxeiiBY4F1hNeBBrMeODcCWJc3+jwXvzjigBXPRFHWJqjOyL57FyoGBQ==
+  dependencies:
+    "@stdlib/math-base-napi-unary" "^0.2.6"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-gamma1pm1@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-gamma1pm1/-/math-base-special-gamma1pm1-0.3.1.tgz#1ec0752df30ac47513031d2d24c2f2c5adc6d0cf"
+  integrity sha512-cZ6m+qn350Hi6nBXoqH/4WLRInDRJ4cZLVgfzuP/49waT9iOGX+kszKAVnMjvp4AYe96ZEBJ1DwUcMYDrX3S1A==
+  dependencies:
+    "@stdlib/constants-float64-eps" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-expm1" "^0.2.4"
+    "@stdlib/math-base-special-gamma" "^0.3.0"
+    "@stdlib/math-base-special-ln" "^0.2.5"
+    "@stdlib/math-base-special-log1p" "^0.2.4"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-gamma@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-gamma/-/math-base-special-gamma-0.3.1.tgz#5cf359fd3d7e6e99f29eccf9c4134cfe5a3565c7"
+  integrity sha512-WONtgh00BdeBbgvhjjmn4kviBXb2ybFa4IDOhknxvKS3m8mIVJU59tzLHVa9XiGcomq1H7Mm6CeGPmjmkD+Rpw==
+  dependencies:
+    "@stdlib/constants-float64-eulergamma" "^0.2.3"
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pi" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/constants-float64-sqrt-two-pi" "^0.2.3"
+    "@stdlib/math-base-assert-is-integer" "^0.2.7"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-assert-is-negative-zero" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-exp" "^0.2.5"
+    "@stdlib/math-base-special-floor" "^0.2.4"
+    "@stdlib/math-base-special-pow" "^0.3.1"
+    "@stdlib/math-base-special-sin" "^0.3.0"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-gammainc@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-gammainc/-/math-base-special-gammainc-0.3.1.tgz#05c19c1fed52bbe26753bfbbc280776e84783ebf"
+  integrity sha512-w9R2wnk+5gvZaWiPsnlpZVELYvQ+6ZccgBY2JmRmwBLbvj5t/u8M0jC7MM3CaMCIt5jBmocCD4kCtconzx4WuQ==
+  dependencies:
+    "@stdlib/constants-float32-smallest-normal" "^0.2.3"
+    "@stdlib/constants-float64-e" "^0.2.3"
+    "@stdlib/constants-float64-eps" "^0.2.3"
+    "@stdlib/constants-float64-gamma-lanczos-g" "^0.2.3"
+    "@stdlib/constants-float64-max" "^0.2.3"
+    "@stdlib/constants-float64-max-ln" "^0.2.3"
+    "@stdlib/constants-float64-max-nth-factorial" "^0.1.1"
+    "@stdlib/constants-float64-min-ln" "^0.2.3"
+    "@stdlib/constants-float64-pi" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/constants-float64-sqrt-eps" "^0.2.3"
+    "@stdlib/constants-float64-sqrt-two-pi" "^0.2.3"
+    "@stdlib/constants-float64-two-pi" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-erfc" "^0.2.5"
+    "@stdlib/math-base-special-exp" "^0.2.5"
+    "@stdlib/math-base-special-floor" "^0.2.4"
+    "@stdlib/math-base-special-gamma" "^0.3.0"
+    "@stdlib/math-base-special-gamma-lanczos-sum-expg-scaled" "^0.2.2"
+    "@stdlib/math-base-special-gamma1pm1" "^0.3.0"
+    "@stdlib/math-base-special-gammaln" "^0.3.0"
+    "@stdlib/math-base-special-ln" "^0.2.5"
+    "@stdlib/math-base-special-log1pmx" "^0.2.4"
+    "@stdlib/math-base-special-max" "^0.3.1"
+    "@stdlib/math-base-special-min" "^0.2.4"
+    "@stdlib/math-base-special-pow" "^0.3.1"
+    "@stdlib/math-base-special-powm1" "^0.3.2"
+    "@stdlib/math-base-special-sqrt" "^0.2.3"
+    "@stdlib/math-base-tools-continued-fraction" "^0.2.3"
+    "@stdlib/math-base-tools-evalpoly" "^0.2.3"
+    "@stdlib/math-base-tools-sum-series" "^0.2.3"
+    "@stdlib/napi-argv" "^0.2.3"
+    "@stdlib/napi-argv-bool" "^0.1.1"
+    "@stdlib/napi-argv-double" "^0.2.2"
+    "@stdlib/napi-create-double" "^0.0.3"
+    "@stdlib/napi-export" "^0.3.1"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-gammaincinv@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-gammaincinv/-/math-base-special-gammaincinv-0.2.3.tgz#aacf915abfcbe1975e5da1c88371a38d6544eb51"
+  integrity sha512-eH3TCXZdH4WvtgKc+jI3ATeaYq87eKcActfSpV0ZZE6Otc326vmNzhv7dXnjVxgSY81bKgKeBzfaTW/fGyXT7w==
+  dependencies:
+    "@stdlib/constants-float32-max" "^0.2.3"
+    "@stdlib/constants-float32-smallest-normal" "^0.2.3"
+    "@stdlib/constants-float64-ln-sqrt-two-pi" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/constants-float64-sqrt-two-pi" "^0.2.3"
+    "@stdlib/constants-float64-two-pi" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-erfcinv" "^0.2.4"
+    "@stdlib/math-base-special-exp" "^0.2.5"
+    "@stdlib/math-base-special-gamma" "^0.3.0"
+    "@stdlib/math-base-special-gammainc" "^0.3.0"
+    "@stdlib/math-base-special-gammaln" "^0.3.0"
+    "@stdlib/math-base-special-ln" "^0.2.5"
+    "@stdlib/math-base-special-min" "^0.2.4"
+    "@stdlib/math-base-special-pow" "^0.3.1"
+    "@stdlib/math-base-special-sqrt" "^0.2.3"
+    "@stdlib/math-base-tools-evalpoly" "^0.2.3"
+    debug "^2.6.9"
+
+"@stdlib/math-base-special-gammaln@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-gammaln/-/math-base-special-gammaln-0.3.1.tgz#c96f303f53e87d6a95a5e168e5bb2c2dd7650085"
+  integrity sha512-ptzVz18xkfxzgekgAbk6ytMoDc7MYAUY4xZuAW/SyFGO6sCPVbwU4GH1/1IQAGLrDKYizKeVoTsO5NGK5Zpvyw==
+  dependencies:
+    "@stdlib/constants-float64-pi" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-infinite" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-ln" "^0.2.5"
+    "@stdlib/math-base-special-sinpi" "^0.3.0"
+    "@stdlib/math-base-special-trunc" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-gcd@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-gcd/-/math-base-special-gcd-0.3.2.tgz#32b2948a50c4ab62e5d4731346fbeefe6296b189"
+  integrity sha512-eQKqRFOlHGw5Ce4mo91uilqywONEp/7L4d/bDEUqL1sRj3bTAIZeCa6ap7wl8vnMXCHLGI0ve7xp6wxVHo4Bdg==
+  dependencies:
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/constants-int32-max" "^0.3.1"
+    "@stdlib/math-base-assert-is-integer" "^0.2.7"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/math-base-special-fmod" "^0.1.1"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-kernel-betainc@^0.2.2", "@stdlib/math-base-special-kernel-betainc@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-kernel-betainc/-/math-base-special-kernel-betainc-0.2.3.tgz#d7dfaa8cbecae2cbcd46f008c812d2a159f894c8"
+  integrity sha512-ho7hVn2GAnHsoj+SKJxrgo5rvftmIinE2H2J9/NWXYU6ubjQJ1EmJAzZ6fMSED++lK+eARS1kUl8hUeKRuIbDQ==
+  dependencies:
+    "@stdlib/constants-float64-e" "^0.2.3"
+    "@stdlib/constants-float64-eps" "^0.2.3"
+    "@stdlib/constants-float64-gamma-lanczos-g" "^0.2.3"
+    "@stdlib/constants-float64-half-pi" "^0.2.3"
+    "@stdlib/constants-float64-max" "^0.2.3"
+    "@stdlib/constants-float64-max-ln" "^0.2.3"
+    "@stdlib/constants-float64-min-ln" "^0.2.3"
+    "@stdlib/constants-float64-pi" "^0.2.3"
+    "@stdlib/constants-float64-smallest-normal" "^0.2.3"
+    "@stdlib/constants-int32-max" "^0.3.1"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-asin" "^0.2.4"
+    "@stdlib/math-base-special-beta" "^0.3.1"
+    "@stdlib/math-base-special-binomcoef" "^0.3.1"
+    "@stdlib/math-base-special-exp" "^0.2.5"
+    "@stdlib/math-base-special-expm1" "^0.2.4"
+    "@stdlib/math-base-special-factorial" "^0.3.2"
+    "@stdlib/math-base-special-floor" "^0.2.4"
+    "@stdlib/math-base-special-gamma" "^0.3.0"
+    "@stdlib/math-base-special-gamma-delta-ratio" "^0.3.0"
+    "@stdlib/math-base-special-gamma-lanczos-sum-expg-scaled" "^0.2.2"
+    "@stdlib/math-base-special-gammainc" "^0.3.0"
+    "@stdlib/math-base-special-gammaln" "^0.3.0"
+    "@stdlib/math-base-special-ln" "^0.2.5"
+    "@stdlib/math-base-special-log1p" "^0.2.4"
+    "@stdlib/math-base-special-max" "^0.3.1"
+    "@stdlib/math-base-special-maxabs" "^0.3.1"
+    "@stdlib/math-base-special-min" "^0.2.4"
+    "@stdlib/math-base-special-minabs" "^0.2.4"
+    "@stdlib/math-base-special-pow" "^0.3.1"
+    "@stdlib/math-base-special-sqrt" "^0.2.3"
+    "@stdlib/math-base-tools-continued-fraction" "^0.2.3"
+    "@stdlib/math-base-tools-sum-series" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+
+"@stdlib/math-base-special-kernel-betaincinv@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-kernel-betaincinv/-/math-base-special-kernel-betaincinv-0.2.3.tgz#db281955f42f7b9a7b933e9a0a2e58be64ab2ccc"
+  integrity sha512-k93/sg4xC/eIsUUw1OD3Rwb8Y2Bl5moTMuOoKeSo5aogqpP6mFwSKOkoW9VS4iAHFUHkjPLgpaN7eRStm1/Deg==
+  dependencies:
+    "@stdlib/constants-float64-eps" "^0.2.3"
+    "@stdlib/constants-float64-half-pi" "^0.2.3"
+    "@stdlib/constants-float64-max" "^0.2.3"
+    "@stdlib/constants-float64-pi" "^0.2.3"
+    "@stdlib/constants-float64-smallest-normal" "^0.2.3"
+    "@stdlib/constants-float64-smallest-subnormal" "^0.2.3"
+    "@stdlib/constants-float64-sqrt-two" "^0.2.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-acos" "^0.2.4"
+    "@stdlib/math-base-special-asin" "^0.2.4"
+    "@stdlib/math-base-special-beta" "^0.3.1"
+    "@stdlib/math-base-special-betainc" "^0.2.3"
+    "@stdlib/math-base-special-cos" "^0.3.1"
+    "@stdlib/math-base-special-erfcinv" "^0.2.4"
+    "@stdlib/math-base-special-exp" "^0.2.5"
+    "@stdlib/math-base-special-expm1" "^0.2.4"
+    "@stdlib/math-base-special-floor" "^0.2.4"
+    "@stdlib/math-base-special-gamma-delta-ratio" "^0.3.1"
+    "@stdlib/math-base-special-gammaincinv" "^0.2.3"
+    "@stdlib/math-base-special-kernel-betainc" "^0.2.3"
+    "@stdlib/math-base-special-ldexp" "^0.2.5"
+    "@stdlib/math-base-special-ln" "^0.2.5"
+    "@stdlib/math-base-special-log1p" "^0.2.4"
+    "@stdlib/math-base-special-max" "^0.3.1"
+    "@stdlib/math-base-special-min" "^0.2.4"
+    "@stdlib/math-base-special-pow" "^0.3.1"
+    "@stdlib/math-base-special-round" "^0.3.1"
+    "@stdlib/math-base-special-signum" "^0.2.3"
+    "@stdlib/math-base-special-sin" "^0.3.1"
+    "@stdlib/math-base-special-sqrt" "^0.2.3"
+    "@stdlib/math-base-tools-evalpoly" "^0.2.3"
+
+"@stdlib/math-base-special-kernel-cos@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-kernel-cos/-/math-base-special-kernel-cos-0.2.4.tgz#e787e9f567ce0128e066dbf1c29d15a0cf84713a"
+  integrity sha512-DFaoDJCFhPXiOuiGPSU1tmlUQ2UzRWMMB7lKKARjUoxbFpNLwB1TAqAnlx/rguQcCMf7uSZYALpTfxYlJHDPyg==
+  dependencies:
+    "@stdlib/math-base-napi-binary" "^0.3.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-kernel-sin@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-kernel-sin/-/math-base-special-kernel-sin-0.2.4.tgz#a2d111f87ef27fed1f8c9993817db2d55beba84d"
+  integrity sha512-mMXh47MXZd4gB45747Y+6Z5G4oQW0Uaqo5sx+HmJ7JPol/Sp3B6JSqahT+OtAf7oZVBAJ7qWmNlmib6IiueosQ==
+  dependencies:
+    "@stdlib/math-base-napi-binary" "^0.3.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-ldexp@^0.2.4", "@stdlib/math-base-special-ldexp@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-ldexp/-/math-base-special-ldexp-0.2.5.tgz#195b2804560f08d945261e243d5231f312c47db7"
+  integrity sha512-ZbuCayeY8zsmptOxDsTnDmRGmEt10wjOXOdsKTCNGZwLP7h7e0ImTRbJ8wpKiLWv8JKef/xE+rp61wQrjZHS3A==
+  dependencies:
+    "@stdlib/constants-float64-exponent-bias" "^0.2.3"
+    "@stdlib/constants-float64-max-base2-exponent" "^0.2.3"
+    "@stdlib/constants-float64-max-base2-exponent-subnormal" "^0.2.1"
+    "@stdlib/constants-float64-min-base2-exponent-subnormal" "^0.2.1"
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-infinite" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-special-copysign" "^0.2.3"
+    "@stdlib/number-float64-base-exponent" "^0.2.3"
+    "@stdlib/number-float64-base-from-words" "^0.2.2"
+    "@stdlib/number-float64-base-normalize" "^0.2.4"
+    "@stdlib/number-float64-base-to-words" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-ln@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-ln/-/math-base-special-ln-0.2.5.tgz#aac6b9e194c67ca5db6caa2f10c58942a0cdf997"
+  integrity sha512-ki+/tyoi767DsNyaw95O5NDMt1MbmRp5PI5ZfZo11AE6yUDKeS1H5cm3N3SE2GdwtuKyT3ZBc5/d8MtWzTPObA==
+  dependencies:
+    "@stdlib/constants-float64-exponent-bias" "^0.2.3"
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/number-float64-base-get-high-word" "^0.2.2"
+    "@stdlib/number-float64-base-set-high-word" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-log1p@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-log1p/-/math-base-special-log1p-0.2.4.tgz#c3a0b7783c9cf06754b0d7ff2b133f0b8c0c1bfa"
+  integrity sha512-x7YYsmM3NqfcZlDwZ4x88e5MtkXHTtUAroPhuDgDk2Ez9J/ZWQY4/t3RHb+wwEYtZU1WG4PQ7VMDlHOJUvEhBQ==
+  dependencies:
+    "@stdlib/constants-float64-exponent-bias" "^0.2.3"
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/number-float64-base-get-high-word" "^0.2.2"
+    "@stdlib/number-float64-base-set-high-word" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-log1pmx@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-log1pmx/-/math-base-special-log1pmx-0.2.4.tgz#daf57fba5595468335a41092806f5b0da202b142"
+  integrity sha512-CrF4ucxzA1hkR4zSHaXWZGhfFuHS9A80nZP8cvIBvrtU8Dl21fHqCegOSSZBNvzL7WPssCXNzgkfdf5GUGvwlw==
+  dependencies:
+    "@stdlib/constants-float64-eps" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-ln" "^0.2.5"
+    "@stdlib/math-base-special-log1p" "^0.2.4"
+    "@stdlib/math-base-tools-sum-series" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-max@^0.3.0", "@stdlib/math-base-special-max@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-max/-/math-base-special-max-0.3.1.tgz#cab155ee47a6292864e38827469bba4482ba78d3"
+  integrity sha512-TV4GK3gt5BCy4se6Rn59zSbcL2EQBYynJ4g15KeniZWrQbvpm7WdjdJRJk/Ly78ESAoM6Qd2KEaP/bTGukGTqA==
+  dependencies:
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-assert-is-positive-zero" "^0.2.3"
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-maxabs@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-maxabs/-/math-base-special-maxabs-0.3.1.tgz#5c12ffc6da05833fa4dcb24362f55c48278fe1b7"
+  integrity sha512-nvlh0Pkwrmh3E6Nva+o0dbAksJ7BErsp9v3Q783TGNlwsRNovOc8FmrkqvmuDhWkSoUUuYtefYyxz1HZ+CzvDg==
+  dependencies:
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-max" "^0.3.0"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-min@^0.2.3", "@stdlib/math-base-special-min@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-min/-/math-base-special-min-0.2.4.tgz#96753ac5454bc44524390fc684aa86a051b2c6dc"
+  integrity sha512-RjwMYI+CqdD8Pg41RBsvv0g50nl3d2a5SJBXDcjzHIs0Lj4+qdOXSYQYbn2IQH0dVCNlZrBwaGX3L8O9tu5umQ==
+  dependencies:
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-assert-is-negative-zero" "^0.2.2"
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-minabs@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-minabs/-/math-base-special-minabs-0.2.4.tgz#629528095a3b66c8ea3dcc2e035edaffeface043"
+  integrity sha512-aRQBXaoSBj026u90ZTreKa88GAF8SWSqm2WD43v22TFJVJ0qhjtSmQXRLs+tD2ug7LDUHa8Bf1Ui2DYuVw41uQ==
+  dependencies:
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-min" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-pow@^0.3.0", "@stdlib/math-base-special-pow@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-pow/-/math-base-special-pow-0.3.1.tgz#8a8ecfaa1259463c0c5c0ad31bcfee4142639245"
+  integrity sha512-8i5zbz0KfhnNeACMsT+94/iv1/zCNj5JurXvrNHfLg3eLwvKIvwI28G+anpaqGZdPX3aJq66M5+dKDMSWvUvyw==
+  dependencies:
+    "@stdlib/constants-float64-exponent-bias" "^0.2.3"
+    "@stdlib/constants-float64-high-word-abs-mask" "^0.2.3"
+    "@stdlib/constants-float64-high-word-significand-mask" "^0.2.3"
+    "@stdlib/constants-float64-ln-two" "^0.2.3"
+    "@stdlib/constants-float64-ninf" "^0.2.3"
+    "@stdlib/constants-float64-num-high-word-significand-bits" "^0.1.1"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-infinite" "^0.2.3"
+    "@stdlib/math-base-assert-is-integer" "^0.2.7"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-assert-is-odd" "^0.3.2"
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-copysign" "^0.2.3"
+    "@stdlib/math-base-special-ldexp" "^0.2.4"
+    "@stdlib/math-base-special-sqrt" "^0.2.3"
+    "@stdlib/number-float64-base-get-high-word" "^0.2.3"
+    "@stdlib/number-float64-base-set-high-word" "^0.2.3"
+    "@stdlib/number-float64-base-set-low-word" "^0.2.3"
+    "@stdlib/number-float64-base-to-words" "^0.2.3"
+    "@stdlib/number-uint32-base-to-int32" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-powm1@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-powm1/-/math-base-special-powm1-0.3.2.tgz#045feb0bc2efaf94388a5222906c077daefd50fb"
+  integrity sha512-GwjXuzaKy4uO+DDFirt1HIKlvL5359ssx4AgMhYuPnwcHvq+B8NSo8gld/jgcshTXelzkSHvupOcgZrBO8gZVQ==
+  dependencies:
+    "@stdlib/math-base-assert-is-infinite" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-binary" "^0.3.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-expm1" "^0.2.3"
+    "@stdlib/math-base-special-fmod" "^0.1.1"
+    "@stdlib/math-base-special-ln" "^0.2.5"
+    "@stdlib/math-base-special-pow" "^0.3.0"
+    "@stdlib/math-base-special-trunc" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-rempio2@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-rempio2/-/math-base-special-rempio2-0.3.1.tgz#910ba4d1edbc57838418b0d7d02ccc1141dc3eb8"
+  integrity sha512-tHqU2T0ewJKOUhlAqV5hc1iQzPC2KoBn88ahOBndQqfJUKUG0vg/sDPfi6LF35RVo+yW03pDMzeZlAmCi4bSzg==
+  dependencies:
+    "@stdlib/array-base-zeros" "^0.2.2"
+    "@stdlib/constants-float64-high-word-abs-mask" "^0.2.3"
+    "@stdlib/constants-float64-high-word-exponent-mask" "^0.2.3"
+    "@stdlib/constants-float64-high-word-significand-mask" "^0.2.3"
+    "@stdlib/math-base-special-floor" "^0.2.4"
+    "@stdlib/math-base-special-ldexp" "^0.2.5"
+    "@stdlib/math-base-special-round" "^0.3.1"
+    "@stdlib/napi-argv" "^0.2.3"
+    "@stdlib/napi-argv-double" "^0.2.2"
+    "@stdlib/napi-argv-float64array" "^0.2.3"
+    "@stdlib/napi-create-double" "^0.0.3"
+    "@stdlib/napi-export" "^0.3.1"
+    "@stdlib/number-float64-base-from-words" "^0.2.3"
+    "@stdlib/number-float64-base-get-high-word" "^0.2.3"
+    "@stdlib/number-float64-base-get-low-word" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-round@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-round/-/math-base-special-round-0.3.1.tgz#19f159dfc529b27ac5887ea6c669c612fd69f82b"
+  integrity sha512-YoFhBJb0J21QLG1sEHoC8Pxnb+eMfu+pAeT40jF1vlC6p18MFEDVgcX/iBpJg52jPal7CHJF86X6XxlbJCh3Yg==
+  dependencies:
+    "@stdlib/math-base-assert-is-nan" "^0.2.2"
+    "@stdlib/math-base-assert-is-negative-zero" "^0.2.2"
+    "@stdlib/math-base-napi-unary" "^0.2.6"
+    "@stdlib/math-base-special-floor" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-signum@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-signum/-/math-base-special-signum-0.2.3.tgz#b63284f2975dadf37fe9b324628e1962a3eb6094"
+  integrity sha512-a4Ar0QsFqsie6dOAvJQyb7OWpIZKIbaa6EVn/ZF+B/CPfczQvqrv7UujeH5tfwZYOXqFbKXAOXv//nQm8/4yHQ==
+  dependencies:
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-sin@^0.3.0", "@stdlib/math-base-special-sin@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-sin/-/math-base-special-sin-0.3.1.tgz#b3765db3d8f003463618daa2b5cc36194e4e32b9"
+  integrity sha512-t1mU2N6muFdXaafeYtxB3NQ9udxzL7gwFtKyph+GaMWJKLg1EAZ9G31StMFh5dqxmY0IjHLdkDUhwwh3pXxgPQ==
+  dependencies:
+    "@stdlib/constants-float64-high-word-abs-mask" "^0.2.3"
+    "@stdlib/constants-float64-high-word-exponent-mask" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-kernel-cos" "^0.2.4"
+    "@stdlib/math-base-special-kernel-sin" "^0.2.4"
+    "@stdlib/math-base-special-rempio2" "^0.3.0"
+    "@stdlib/number-float64-base-get-high-word" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-sinpi@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-sinpi/-/math-base-special-sinpi-0.3.1.tgz#00684e5842cc4e848c9f100be2015d6d5096c330"
+  integrity sha512-IHBiUy9KmG0pR6nqCaVktw/7j0IestUk6gIqMIQtQSyC11sgByhNJFKEBbIwqLgPGnLJ10B8Y3iN5jgBC7lRpQ==
+  dependencies:
+    "@stdlib/constants-float64-pi" "^0.2.3"
+    "@stdlib/math-base-assert-is-infinite" "^0.2.3"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-napi-unary" "^0.2.7"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/math-base-special-copysign" "^0.2.3"
+    "@stdlib/math-base-special-cos" "^0.3.0"
+    "@stdlib/math-base-special-fmod" "^0.1.1"
+    "@stdlib/math-base-special-sin" "^0.3.0"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/math-base-special-sqrt@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-sqrt/-/math-base-special-sqrt-0.2.3.tgz#dc261a2c1da977a594a92cda91b2f826a0ba378c"
+  integrity sha512-Pdgq9Imx4lxsmM4jouu4b2ynB1osgrKLkJtdsaNUjrA3kTxc16FALkAJVEdKA9/7FxEFLji9CvJ0VBOWXzoyTQ==
+  dependencies:
+    "@stdlib/math-base-napi-unary" "^0.2.6"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-special-trunc@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-trunc/-/math-base-special-trunc-0.2.3.tgz#8a5cb1b1585d9a2a946cff583727ef0791ccfe35"
+  integrity sha512-ga3rqr82G7Q3eqpF/aFR4v2Bj3meKhbuWRiEWrJwWARTqQa0e8aWTI7p9qYeQ0mFsKVoXH21oESjAHuJ1WfsQg==
+  dependencies:
+    "@stdlib/math-base-napi-unary" "^0.2.6"
+    "@stdlib/math-base-special-ceil" "^0.2.2"
+    "@stdlib/math-base-special-floor" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/math-base-tools-continued-fraction@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-tools-continued-fraction/-/math-base-tools-continued-fraction-0.2.3.tgz#697f55892acab8d408a50893074774b183807e90"
+  integrity sha512-EyzelNGzuL7wFfzbpuDFbf7//a3Z9iSRtIEbVbulduXQ8uYbB3YGMbbuKES2nG+WBeawpKFAgMDTC6siPdo1Vw==
+  dependencies:
+    "@stdlib/assert-has-generator-support" "^0.2.2"
+    "@stdlib/constants-float32-smallest-normal" "^0.2.3"
+    "@stdlib/constants-float64-eps" "^0.2.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+
+"@stdlib/math-base-tools-evalpoly@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-tools-evalpoly/-/math-base-tools-evalpoly-0.2.3.tgz#7a1fe76ad0b2ccbec420d4576e48955098bc8342"
+  integrity sha512-SJFnTcVUeDqVp+wJIZe9yj6Ddxn7kaf+aCepbmnxqdJLtvOtCsEyvOYX5q26x6Ik/JJULTNiOMQqWm2VInNAzQ==
+  dependencies:
+    "@stdlib/function-ctor" "^0.2.2"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+
+"@stdlib/math-base-tools-sum-series@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-tools-sum-series/-/math-base-tools-sum-series-0.2.3.tgz#2eb46fd2707edf9dfd6c3b12678824675bc0f868"
+  integrity sha512-2Tc5fjKCXizXLb266n+AxNu0tTXau3DLd2lVPDhyBSqXoCqT0N/PZBmxWujaRuTpr7WxmEMzoMTxegwz487oaA==
+  dependencies:
+    "@stdlib/assert-has-generator-support" "^0.2.2"
+    "@stdlib/constants-float64-eps" "^0.2.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+
+"@stdlib/napi-argv-bool@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/napi-argv-bool/-/napi-argv-bool-0.1.1.tgz#b9031157a8f681d041de3c9fc5791036d748f504"
+  integrity sha512-xW+BJ8wYeJAs3GPhu8SdlZur9WgzfKwFESJR8gzsaKkUy9+1POMs3jZA++I+Ote7CNY0AmFgC3/5v+qLNcb+Xw==
+  dependencies:
+    "@stdlib/assert-napi-is-type" "^0.2.2"
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/napi-argv" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/napi-argv-double@^0.2.1", "@stdlib/napi-argv-double@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/napi-argv-double/-/napi-argv-double-0.2.2.tgz#001f190ee4052afcb6a5f037cf8979b8064838ad"
+  integrity sha512-QJrnt4CTS8x7WHny4s8eHvGT2u5x8BSH6RWVaPg6ZrnHwqz9Jz48JGTawFKLgcyvZyeE9kCwKDkPIN7MbXcHKQ==
+  dependencies:
+    "@stdlib/assert-napi-is-type" "^0.2.2"
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/napi-argv" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/napi-argv-float64array@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/napi-argv-float64array/-/napi-argv-float64array-0.2.3.tgz#3f44ece4240b6a051d65f9d983cdb63b30c6c987"
+  integrity sha512-0uZaYZC/sV6UN/rDNJxQVn5U4CsdjPGztT2c0D7i0bPPwLscv4THKyLge6x41acHx1kjPuEvq03l+Wg94/DL+A==
+  dependencies:
+    "@stdlib/assert-napi-equal-typedarray-types" "^0.2.2"
+    "@stdlib/assert-napi-is-typedarray" "^0.2.2"
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/napi-argv" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/napi-argv-float@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/napi-argv-float/-/napi-argv-float-0.2.3.tgz#a1d648f0644d52af67184d516bfb1bd349a0d077"
+  integrity sha512-2hNFgenY7M5iVfIbRw+xccutxtKfk89VQb1RMGbSAOrRcR53J5OENAaddohrCp1zT1FKe14LCG/k+LlZR5jEdA==
+  dependencies:
+    "@stdlib/assert-napi-is-type" "^0.2.2"
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/napi-argv" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/napi-argv-int32@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/napi-argv-int32/-/napi-argv-int32-0.2.3.tgz#04a0ca9d15a9e74eebe137291bcbcf5ba5432099"
+  integrity sha512-Set5AdSIUePU/Y0gT+WC4lerzahwaAQJd1USCgnKQD55xmDfXAPMyJliZnZPNUyjQ6SsWN6PaiOfJluq+oVcVQ==
+  dependencies:
+    "@stdlib/assert-napi-is-type" "^0.2.2"
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/napi-argv" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/napi-argv@^0.2.2", "@stdlib/napi-argv@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/napi-argv/-/napi-argv-0.2.3.tgz#a81f5287c295eef2eed9a859629682f2f60b08d1"
+  integrity sha512-JQe8cqcCmxVhAMZ6z7Ysx0hmY8DtIGEXcM7Ymmjxl5VNaVXq/grw3HEQm5Fcb+TdqJIb7xEbsRHCiowRzvk0Pg==
+  dependencies:
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+
+"@stdlib/napi-create-double@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/napi-create-double/-/napi-create-double-0.0.3.tgz#0872854d79c3a6d58c2c39d1cefb5ee479b0ed4f"
+  integrity sha512-6JcSG40t8HQGOgRaaxpxMWKrkqqZbSnUIKi9qx8R4g1gWWzbP5/aRMmMcLpanmXP61PjryfpnjhtUC27WMFNfQ==
+  dependencies:
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/napi-argv" "^0.2.2"
+    "@stdlib/napi-argv-double" "^0.2.1"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/napi-create-int32@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/napi-create-int32/-/napi-create-int32-0.0.3.tgz#bb33f4fb12bb2cc3713ed147119ceeb8d85658d0"
+  integrity sha512-tIT9BWA3jmOjzz4XTwVplkKETI3dyTK4BZoMtbQGnTxfsHz+pNdgepbp8hEx7wJADHKO2L8YTqddTHij4H3Ptw==
+  dependencies:
+    "@stdlib/assert-napi-status-ok" "^0.2.2"
+    "@stdlib/napi-argv" "^0.2.2"
+    "@stdlib/napi-argv-int32" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/napi-export@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/napi-export/-/napi-export-0.3.1.tgz#5d60ab80ca9362b15c2b6286613e2f0a63711253"
+  integrity sha512-JQaR2FYyIGprLgjg02JwgGGbjaYgRsWJpF72T748AiUQMd8SEN/mjUkqPq4zYLRjYATpKxnDUQNvP642z9JnIg==
+
+"@stdlib/number-ctor@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-ctor/-/number-ctor-0.2.3.tgz#693f93d147deaf705c2b3e4c051548e9e4dc8928"
+  integrity sha512-T4xeLGny/gBRe4ZJcS5ugluT8E7Y/LCEHycTQingYWqbBK+5XJED7zJrcawkneewXd7CgqypCtVuI0BOxBBzcQ==
+
+"@stdlib/number-float16-base-to-float32@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float16-base-to-float32/-/number-float16-base-to-float32-0.1.2.tgz#956c6f3ca2c9af0d5abb86462258b0a88f8f5671"
+  integrity sha512-OClMQYz6GJEiSxrzhNp2LK4K8j75Rq6HCk+ReRBNQjXYdvNfzzaYoqnv3ZSzrXdvqUoGz+19XaVTLLzkKT1GCg==
+  dependencies:
+    "@stdlib/constants-float16-exponent-bias" "^0.3.1"
+    "@stdlib/constants-float16-exponent-mask" "^0.1.1"
+    "@stdlib/constants-float16-num-significand-bits" "^0.0.2"
+    "@stdlib/constants-float16-sign-mask" "^0.1.1"
+    "@stdlib/constants-float16-significand-mask" "^0.1.1"
+    "@stdlib/constants-float32-exponent-bias" "^0.2.3"
+    "@stdlib/constants-float32-exponent-mask" "^0.2.3"
+    "@stdlib/constants-float32-num-significand-bits" "^0.1.1"
+    "@stdlib/number-float16-ctor" "^0.1.2"
+    "@stdlib/number-float32-base-to-float16" "^0.1.0"
+    "@stdlib/number-float64-base-to-float16" "^0.1.2"
+    "@stdlib/number-float64-base-to-float32" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/number-float16-base-to-float64@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float16-base-to-float64/-/number-float16-base-to-float64-0.1.2.tgz#7827d8be25b4f82b50cca81251b48cbd8d198513"
+  integrity sha512-1MNdMfThDFEIMeJHKmum343x9sbiRplRmsjEHojVGyMQNuxOamzbzw+Gw3xl04GrfOIUG673KZEljwUwDFgtUA==
+  dependencies:
+    "@stdlib/number-float16-base-to-float32" "^0.1.1"
+    "@stdlib/number-float16-ctor" "^0.1.1"
+    "@stdlib/number-float64-base-to-float16" "^0.1.1"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/number-float16-ctor@^0.1.1", "@stdlib/number-float16-ctor@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float16-ctor/-/number-float16-ctor-0.1.2.tgz#31ee0a773a34d9661ae79cb7492301718a4d52d3"
+  integrity sha512-bdBhgwgtRClxBU9Ef8puY/WQ+DMqUr0oXfkfCrYKUATmqVQghv3bDw/dMggz01AguJo2ZtdjGp3PjQwNZlmHcg==
+  dependencies:
+    "@stdlib/assert-has-to-primitive-symbol-support" "^0.1.0"
+    "@stdlib/assert-is-number" "^0.2.3"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.3"
+    "@stdlib/number-float64-base-to-float16" "^0.1.2"
+    "@stdlib/string-format" "^0.2.3"
+    "@stdlib/symbol-to-primitive" "^0.1.1"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+    "@stdlib/utils-define-read-only-property" "^0.2.3"
+
+"@stdlib/number-float32-base-exponent@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float32-base-exponent/-/number-float32-base-exponent-0.2.4.tgz#be6c44015c60fd22d3d8f3e97e57e1bfe28c1525"
+  integrity sha512-JUuSZCPD6yWA2jJhtS5MIYSZGerJJCXfwStz0Mqsh76x166mSkiZ4dH3VpDz2OMrZk6rvt35UB2HhAZecTqFAw==
+  dependencies:
+    "@stdlib/constants-float32-exponent-bias" "^0.2.3"
+    "@stdlib/constants-float32-exponent-mask" "^0.2.3"
+    "@stdlib/number-float32-base-to-word" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/number-float32-base-to-float16@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float32-base-to-float16/-/number-float32-base-to-float16-0.1.1.tgz#3b06058367b59f841790eff4ae6b12e7a68c594e"
+  integrity sha512-phYWBtfheX0c/pXtbiK/xr6lVwU5HKYVNgmol8y0HE8NvwXG3oCXLySa2p0jr+Xi7G9xtMdXW4Eq0rShs4lTmQ==
+  dependencies:
+    "@stdlib/constants-float16-eps" "^0.2.3"
+    "@stdlib/constants-float16-max" "^0.2.3"
+    "@stdlib/constants-float16-smallest-normal" "^0.2.3"
+    "@stdlib/constants-float32-eps" "^0.2.3"
+    "@stdlib/constants-float32-exponent-mask" "^0.2.3"
+    "@stdlib/constants-float32-num-significand-bits" "^0.1.1"
+    "@stdlib/constants-float32-pinf" "^0.2.2"
+    "@stdlib/constants-float32-sign-mask" "^0.2.3"
+    "@stdlib/constants-float32-significand-mask" "^0.2.4"
+    "@stdlib/math-base-assert-is-finitef" "^0.2.2"
+    "@stdlib/math-base-assert-is-nanf" "^0.2.3"
+    "@stdlib/math-base-special-absf" "^0.2.3"
+    "@stdlib/number-float16-ctor" "^0.1.2"
+    "@stdlib/number-float32-base-exponent" "^0.2.4"
+    "@stdlib/number-float64-base-to-float32" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/number-float32-base-to-word@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float32-base-to-word/-/number-float32-base-to-word-0.2.3.tgz#d4242cb71d4e65b5ac83074b91f35221045f5e4b"
+  integrity sha512-E42KOQ+jqVDElwvFtrDMEkXYl03btIPan3g/YAScCibfmYDkYRDT9iuaydyYS/O3+m/MPM1Jhn+U/B8+f+C1HQ==
+  dependencies:
+    "@stdlib/array-float32" "^0.2.3"
+    "@stdlib/array-uint32" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/number-float64-base-exponent@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-exponent/-/number-float64-base-exponent-0.2.3.tgz#331eef6e28c00077edf87bc63cf5352643e96fe1"
+  integrity sha512-KRicBsOMrVCIB2veebT+mPpTrxyXCP6eknJTs8A59E/ATU2/gKYbMKzkdEX/FzxSBcdw5thvuuqmmwJKGZYSkA==
+  dependencies:
+    "@stdlib/constants-float64-exponent-bias" "^0.2.3"
+    "@stdlib/constants-float64-high-word-exponent-mask" "^0.2.3"
+    "@stdlib/number-float64-base-get-high-word" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/number-float64-base-from-words@^0.2.2", "@stdlib/number-float64-base-from-words@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-from-words/-/number-float64-base-from-words-0.2.3.tgz#cb598e59d57a799188e94cdf1c8623f4a5e8fa0a"
+  integrity sha512-7v0bOW1AjsoWqkiVFqljLxCWmGA+iZ3OA/NwuIFBsYOEOpZqMIevu6TkJkWYaP6YYUJUrSG0w6t7b1P9JuzBgw==
+  dependencies:
+    "@stdlib/array-float64" "^0.2.3"
+    "@stdlib/array-uint32" "^0.2.3"
+    "@stdlib/assert-is-little-endian" "^0.2.3"
+    "@stdlib/number-float64-base-to-words" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.4"
+
+"@stdlib/number-float64-base-get-high-word@^0.2.2", "@stdlib/number-float64-base-get-high-word@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-get-high-word/-/number-float64-base-get-high-word-0.2.3.tgz#45178c3c7768070ef547af49a65b07000f3ad621"
+  integrity sha512-yyJJR8+8BK88ldB5rM3GaM6S7vfUXZ3ib2VPse7Jb/ecd9r9gE6ojJv9v7N/M4STmKVrWWcggFEHzAVe/KMhrQ==
+  dependencies:
+    "@stdlib/array-float64" "^0.2.2"
+    "@stdlib/array-uint32" "^0.2.3"
+    "@stdlib/assert-is-little-endian" "^0.2.2"
+    "@stdlib/number-float64-base-to-words" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/number-float64-base-get-low-word@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-get-low-word/-/number-float64-base-get-low-word-0.2.3.tgz#b4c6e770a5f084c8727811f2e797ee2fcad7b7cd"
+  integrity sha512-e2OcnZ8wAYU5w/sFXY5d8bOFyjWYHW4UxdxLUsf24nVKyBPvS2Rhib8NbOETPeT8WYqFN6yrL2L4VlXO3Mz6ig==
+  dependencies:
+    "@stdlib/array-float64" "^0.2.2"
+    "@stdlib/array-uint32" "^0.2.3"
+    "@stdlib/assert-is-little-endian" "^0.2.2"
+    "@stdlib/number-float64-base-to-words" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/number-float64-base-normalize@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-normalize/-/number-float64-base-normalize-0.2.4.tgz#bd71229d501564c43e03d35e84177f1566b8f85d"
+  integrity sha512-WVtJYkAt1zZXRlcjmbGEYVlZUd6dpSsOKACmVLEWyI9kMlegRAwibAKGMRtAcuYFSOyRVONwJbYar35McmabHg==
+  dependencies:
+    "@stdlib/constants-float64-smallest-normal" "^0.2.3"
+    "@stdlib/math-base-assert-is-infinite" "^0.2.2"
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/number-float64-base-set-high-word@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-set-high-word/-/number-float64-base-set-high-word-0.2.3.tgz#42cdfcdd86e6c26a78d2f9c35f8adcad4bf1fdec"
+  integrity sha512-tWyEAJlbINvxcGMK5wgOlfFcZP9ILpqdBWLrc9HCpbUul41pmWEZi7+zI7dwe5zWIlACzguykdY0cEe7raceIw==
+  dependencies:
+    "@stdlib/array-float64" "^0.2.2"
+    "@stdlib/array-uint32" "^0.2.3"
+    "@stdlib/assert-is-little-endian" "^0.2.2"
+    "@stdlib/number-float64-base-to-words" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/number-float64-base-set-low-word@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-set-low-word/-/number-float64-base-set-low-word-0.2.3.tgz#ba4eeeb9e08327cd6df0e00eae59093e2df64e55"
+  integrity sha512-lmZvzkVlPqM+viBpmI0lBzArRb2+ifBMhuZ/Rtla+O91bcXgBtx/+L4UuqofAfQ5PRRnCW82r3kzILEKsxSoaw==
+  dependencies:
+    "@stdlib/array-float64" "^0.2.2"
+    "@stdlib/array-uint32" "^0.2.3"
+    "@stdlib/assert-is-little-endian" "^0.2.2"
+    "@stdlib/number-float64-base-to-words" "^0.2.2"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/number-float64-base-to-float16@^0.1.1", "@stdlib/number-float64-base-to-float16@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-to-float16/-/number-float64-base-to-float16-0.1.2.tgz#ad07ff3408c504bd3ee25931a9646b87faa771ff"
+  integrity sha512-d+ZJYGoykrzI3H0GRCI3qqyjspgNcIvECQ4OjyC1qdy1haT3cgoj1rwWkJS9uFKD/QgWlFGMrcmRzf0MVj17zg==
+  dependencies:
+    "@stdlib/constants-float16-eps" "^0.2.3"
+    "@stdlib/constants-float16-max" "^0.2.3"
+    "@stdlib/constants-float16-smallest-normal" "^0.2.3"
+    "@stdlib/constants-float64-eps" "^0.2.2"
+    "@stdlib/constants-float64-pinf" "^0.2.3"
+    "@stdlib/math-base-assert-is-finite" "^0.2.3"
+    "@stdlib/math-base-special-abs" "^0.2.3"
+    "@stdlib/number-float16-ctor" "^0.1.1"
+    "@stdlib/number-float32-base-to-float16" "^0.1.0"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/number-float64-base-to-float32@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-to-float32/-/number-float64-base-to-float32-0.2.3.tgz#987763094e7ecee69fb736b4cc9277bccaf02457"
+  integrity sha512-+Lu8vk1oLCxO8RaRzw8pEY+BP2TWROweNFiML0w7TP4i9ZyG5E6EJdxZ2J3c29LVPfsf+oLOOxyySHH2kjwIsw==
+  dependencies:
+    "@stdlib/array-float32" "^0.2.3"
+
+"@stdlib/number-float64-base-to-words@^0.2.2", "@stdlib/number-float64-base-to-words@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-to-words/-/number-float64-base-to-words-0.2.3.tgz#d6589afa6131f407711880bbc1d3e1899f404311"
+  integrity sha512-G63YuysfTKRP3Tkn19zBxTseS+uYnnOYZSN9VRTWrx5iNE8IYDzanAJIolSBZ7PuFMoE+HmjEZ0E9SX3NsLKvg==
+  dependencies:
+    "@stdlib/array-float64" "^0.2.2"
+    "@stdlib/array-uint32" "^0.2.3"
+    "@stdlib/assert-is-little-endian" "^0.2.2"
+    "@stdlib/os-byte-order" "^0.2.2"
+    "@stdlib/os-float-word-order" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.3"
+
+"@stdlib/number-uint32-base-to-int32@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-uint32-base-to-int32/-/number-uint32-base-to-int32-0.2.3.tgz#3a68c42bc6e975801b69c5aaff8e16a2911d0f11"
+  integrity sha512-C6jGEzdnoiy9Er7mTwWO34r+6DVPRRVKRGVtxSQW3yAiQOnLS1ZvimqvgZtl0PYu1OnE02ReegpOMkpqSGO3vQ==
+
+"@stdlib/object-ctor@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/object-ctor/-/object-ctor-0.2.2.tgz#28ace4b617125eb9d0489234d1ed1d031375d669"
+  integrity sha512-3zkUkzZ9LdX+J5fEyU/D7I2c+0qG+ejNI3tCtSFek35bezdqWs9tOAAUiU6HeQJcGgqOmkakB4apIxvN+eehCA==
+
+"@stdlib/os-byte-order@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/os-byte-order/-/os-byte-order-0.2.3.tgz#e9f88f8105391712d4126a619d6c71e2eec7673d"
+  integrity sha512-QU4JY7WN4inoLVz+ML92TOevgyxZa+d2RcA1EmaDC0y0TNrXez1GmIn1t7+L7UTJEdf39IUm6VfdMmYdcDwFTw==
+  dependencies:
+    "@stdlib/assert-is-big-endian" "^0.2.2"
+    "@stdlib/assert-is-little-endian" "^0.2.2"
+
+"@stdlib/os-float-word-order@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/os-float-word-order/-/os-float-word-order-0.2.3.tgz#fddb98c58909d4ef3ad0057ce3fa1da067f1d80c"
+  integrity sha512-5dLZBCNn9Fge3kq7uHIh7S1qshfe5L7pjLYLSUGxxKa7gecAbsaQBPLxDkFiFwMytr6tnGGjWQfyVbhq/+RjlQ==
+  dependencies:
+    "@stdlib/os-byte-order" "^0.2.2"
+
+"@stdlib/process-cwd@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/process-cwd/-/process-cwd-0.2.3.tgz#f18334dcf0b18ed1d327bca5ff0ce2c84c6c6ce0"
+  integrity sha512-T/sYVJjs9iHAOK9B8yGymGY+59eAz20G7eL/G4cObT6sWssAF7s/2+KgzAvWB0maE9qX6qnP4zBg2msCsWwvVg==
+
+"@stdlib/regexp-extended-length-path@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/regexp-extended-length-path/-/regexp-extended-length-path-0.2.3.tgz#573c222c4b0d6f64ecea0a6a316b9959af8c2262"
+  integrity sha512-3HYXiSzBpKz4nSOCtrYtMw9/OXN4EmTvq0owXv6HMvvDweFskieBcdNlVcOl0ViezjvUuvUL0DHJHdGp6SQEIw==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+
+"@stdlib/regexp-function-name@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/regexp-function-name/-/regexp-function-name-0.2.3.tgz#4d9a246c55bf3c2c5393e66cf03bc761025516d3"
+  integrity sha512-ER1C2rUW5Kzu5w4W0gbrJdIj5STNO5RfNy4GeiqycezeiXT99G393QeN4irqcOItYkeZhwbpY2ZzwlLxQvod1A==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+
+"@stdlib/stats-base-dists-beta-quantile@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/stats-base-dists-beta-quantile/-/stats-base-dists-beta-quantile-0.2.3.tgz#8aeb336a53883612569654bd93087b933e69ac01"
+  integrity sha512-nrQuVzQDkThbNrY+zd01QjWp/OUfPWvRWh4ClPAxKJdvMleWSKIYVfcxx8Kgc5moW4xk7Q8QgJRJ4wpuugkszg==
+  dependencies:
+    "@stdlib/math-base-assert-is-nan" "^0.2.3"
+    "@stdlib/math-base-special-betaincinv" "^0.2.2"
+    "@stdlib/utils-constant-function" "^0.2.3"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.3"
+
+"@stdlib/string-base-format-interpolate@^0.2.3":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-format-interpolate/-/string-base-format-interpolate-0.2.4.tgz#90a1a014946662a7bdf0adc7336a3181acc0eb4a"
+  integrity sha512-POG725+DPEmzEJbMFTFPdKM4vA5i+t7juNYs+H2cQz5JXiPV1+5+P3epnO+/DqHWzLhiMlsKDCZq03C3WcBkSA==
+
+"@stdlib/string-base-format-tokenize@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-format-tokenize/-/string-base-format-tokenize-0.2.4.tgz#ef6a8f265377eb59eff918899c93ca48f65d79f0"
+  integrity sha512-qYHSmqFv7vloLFvjBAbZCn5qtxj7M+Qru3VqBooJTxWMcUeZOEBZg18/PFgfUrZhji5MVWDXbRTAx5Bu5M5nQA==
+
+"@stdlib/string-base-lowercase@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-lowercase/-/string-base-lowercase-0.4.1.tgz#1f77c24d26cafa8be6861974a651e62d0035d222"
+  integrity sha512-3NcDy2j6HtvKrC2GRCt5mKiYaWWHLLSQRSbuu28WEzA98/2izmiHYkR0i9IeEd4Tqrxqof/FXP4gWj1f14RXTQ==
+
+"@stdlib/string-base-replace@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-replace/-/string-base-replace-0.2.3.tgz#2e3588f47dba7537c884424854ebc5b49785d71c"
+  integrity sha512-FJdh2GzIkgMlr0v/ZZKD5cWRs+SMOhBTWxAexmWoYFL3WL1YMDgwI5hRtYh/ySyOy94MjJmYwRMpIVdxeclrAw==
+
+"@stdlib/string-format@^0.2.2", "@stdlib/string-format@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-format/-/string-format-0.2.3.tgz#7843b7bee2d672525cc945b1e78adc328bb97692"
+  integrity sha512-uE0LHUUnWKfxFeipyfb9yWbs+iczz6dHaolSGC1WBzMVyeHqx8xvq+yP3f2POYWgEcknmxNgU21WSqToSNrxdA==
+  dependencies:
+    "@stdlib/string-base-format-interpolate" "^0.2.3"
+    "@stdlib/string-base-format-tokenize" "^0.2.4"
+
+"@stdlib/string-replace@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-replace/-/string-replace-0.2.3.tgz#2cb463afffd68c031f4f13f81a5830a800f364fc"
+  integrity sha512-CXJhl/L2TfRrkVUNVp8OfNsKeuUzOZXzJLUDoopHtQalbWBww1fDSDj1fwGpzgZV4IODs8LCsiIxLBnLRP6emg==
+  dependencies:
+    "@stdlib/assert-is-function" "^0.2.3"
+    "@stdlib/assert-is-regexp" "^0.2.3"
+    "@stdlib/assert-is-string" "^0.2.3"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.3"
+    "@stdlib/string-base-replace" "^0.2.3"
+    "@stdlib/string-format" "^0.2.3"
+    "@stdlib/utils-escape-regexp-string" "^0.2.3"
+
+"@stdlib/symbol-ctor@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/symbol-ctor/-/symbol-ctor-0.2.3.tgz#383c854acf3f4e882d51ec00fc710f860ae1e113"
+  integrity sha512-wnuFrxnmhg2p6QQP0B/j97LD5ys2d1bHuwVvh9yuUSCLoX/GankaVyGSufk2ROlsxrcm2HPhSDB/ILBHeUmamA==
+
+"@stdlib/symbol-to-primitive@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/symbol-to-primitive/-/symbol-to-primitive-0.1.2.tgz#09ec59610728239317e00ccb78f9bd088751fc93"
+  integrity sha512-//r52ighL35HprZrK5Pdiz1L27l47X9o+0LOJ84mTk5eB89i9shVRjOpHauKyx/uy9VkDoxUkMY0PwPrAIp4aw==
+  dependencies:
+    "@stdlib/assert-has-to-primitive-symbol-support" "^0.1.0"
+    "@stdlib/symbol-ctor" "^0.2.3"
+
+"@stdlib/types@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/types/-/types-0.4.3.tgz#a013b9cddd46d3e5928fd5b0c94e74f959396a7d"
+  integrity sha512-9GCqS2eni2VSwa5/CCniAJ4I1eWLtvior1z6hoPJp6VTNMgW9Lh4BiI84IO0xun/0qAclJ+mTGTiCTZxZLK13A==
+
+"@stdlib/utils-constant-function@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-constant-function/-/utils-constant-function-0.2.3.tgz#ba8a6f3dedf6e1a0b79c476d6e77fdd5bc9f26ab"
+  integrity sha512-mQ6606O8JKq4tgL508it1ro7hx+RK6j36URSjbRI7Dje72YYpdQJGnN6UJ183Im5TT0fN2s4oOCM6+SAGcQi2w==
+
+"@stdlib/utils-constructor-name@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-constructor-name/-/utils-constructor-name-0.2.3.tgz#429db956893bfbc92437054b391a38fdbf21e90d"
+  integrity sha512-/ApogDUIFxndcmnEeI6ctsqWt66c40g1T7R0nS9aOoYgnDOdmpUFSflzf++MDWksBycGsqgm1UD7IU54m4u7jg==
+  dependencies:
+    "@stdlib/assert-is-buffer" "^0.2.2"
+    "@stdlib/regexp-function-name" "^0.2.3"
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/utils-convert-path@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-convert-path/-/utils-convert-path-0.2.3.tgz#bc4287772cefa1178fd4eb8aa16b140255b1ba21"
+  integrity sha512-fmqJ6Qvce0HV7D+uYrram/+iAHB3u2gMys9zeh0uc/h411sB8Hw9X7i1w2cJevCpouMzqTnpzp75C+swkoQlKA==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.2.3"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.3"
+    "@stdlib/regexp-extended-length-path" "^0.2.3"
+    "@stdlib/string-base-lowercase" "^0.4.1"
+    "@stdlib/string-format" "^0.2.3"
+    "@stdlib/string-replace" "^0.2.2"
+
+"@stdlib/utils-define-nonenumerable-read-only-property@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-define-nonenumerable-read-only-property/-/utils-define-nonenumerable-read-only-property-0.2.3.tgz#1377835cec65cd397842303c8983be8c235f5ebf"
+  integrity sha512-W0rqnRsXgW3GjcwEcOMi0mI/CXn3TVqmFvcxItLUZPJNYmwrU6+t+9kGldhMw845DyOtv8uYASrnNoVE/VfiDw==
+  dependencies:
+    "@stdlib/types" "^0.4.3"
+    "@stdlib/utils-define-property" "^0.2.5"
+
+"@stdlib/utils-define-property@^0.2.4", "@stdlib/utils-define-property@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-define-property/-/utils-define-property-0.2.5.tgz#e7f237c88b8bf8b2068a79c50c7fddfa00d87ca7"
+  integrity sha512-WpbXc2uq8vtSqmWFzVrFifNj6HGoGHIZHolxX5GfRFbj4RNme1u/wtklmiOvcHE0s6SwPX764tuFXIgHBR5Vag==
+  dependencies:
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+
+"@stdlib/utils-define-read-only-property@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-define-read-only-property/-/utils-define-read-only-property-0.2.3.tgz#5e3fdbab38852ee7ef425e4e011c2301215dfbb7"
+  integrity sha512-3sGMpmmSlErHup+Y6YwIgN075GW3t1FD8ARS+zHaU1U1IKEaiOVKMH49WfBGiSsVfV7sfieoZC5B//MrSWQjaA==
+  dependencies:
+    "@stdlib/utils-define-property" "^0.2.4"
+
+"@stdlib/utils-escape-regexp-string@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-escape-regexp-string/-/utils-escape-regexp-string-0.2.3.tgz#39b451bf8d104420893635db53c363f115c622c4"
+  integrity sha512-ZQAq5HHF+C1fmK+RvqeMO0iIQf5kGl2Ofx9LYloURUPZD2zVMX+2hxDLFBTPAusqYxffQAjj3ap4LE/J0+YiRQ==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.3"
+    "@stdlib/string-format" "^0.2.3"
+
+"@stdlib/utils-eval@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-eval/-/utils-eval-0.2.3.tgz#8b4373aad107f0f77311f9f33dd2a03c94b9305e"
+  integrity sha512-T9rL6lEX58My6GcZ0bXD7reJoBEzoO/r5i3U/lj6dC94immyQtbqoz0djHfpCVrCnoK4Mzbq3t813cBQS7yfRg==
+
+"@stdlib/utils-get-prototype-of@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-get-prototype-of/-/utils-get-prototype-of-0.2.3.tgz#f133f98f8a397bbc9fcfbd98b00a9ecad698332e"
+  integrity sha512-unEoKhhAnV4AbQ87oPo1v+4xLjd00nQxJLSvl43PkdoBn/GKNv/B6SMnQWmM5b62esWTbxBu/uWCYoglbprxkA==
+  dependencies:
+    "@stdlib/assert-is-function" "^0.2.2"
+    "@stdlib/object-ctor" "^0.2.2"
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/utils-global@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-global/-/utils-global-0.2.3.tgz#f7d52cc6dbaa0d0154142c0590e2cbbe4ab42a73"
+  integrity sha512-e8gyuENhSeF8udH7vlZMDbNVQ/ZxZ4vWOcpB2iw06z1HSFZWc31Coh19ScfgagLfofo2GQYPJI3tJtZQYsUS6A==
+  dependencies:
+    "@stdlib/assert-is-boolean" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.3"
+    "@stdlib/string-format" "^0.2.3"
+
+"@stdlib/utils-library-manifest@^0.2.3", "@stdlib/utils-library-manifest@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-library-manifest/-/utils-library-manifest-0.2.4.tgz#d51f8e89b70e06608a1123dffc132b2e39845423"
+  integrity sha512-sNzEclCbpRRa35DBv8ZOcOjCesBLczkOFX8o7mMrG9VWhyZuJUCBtgSPmzGIIBLAsVEYJuguEk4iYoMqFnCwnw==
+  dependencies:
+    "@stdlib/fs-resolve-parent-path" "^0.2.3"
+    "@stdlib/utils-convert-path" "^0.2.2"
+    debug "^2.6.9"
+    resolve "^1.1.7"
+
+"@stdlib/utils-native-class@^0.2.2", "@stdlib/utils-native-class@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-native-class/-/utils-native-class-0.2.3.tgz#f74772c72819515251097a6771dc32b4b1c8dd79"
+  integrity sha512-UGXCPhgmOjwMpEQ5fFiifcqrhUnP8ICyWzEkHphUrh2/0pHyK0zilZvcODfROgzoy6L9ivUUuR6NjrAI+j14hA==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.2"
+    "@stdlib/assert-has-tostringtag-support" "^0.2.3"
+    "@stdlib/symbol-ctor" "^0.2.3"
+
+"@stdlib/utils-type-of@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-type-of/-/utils-type-of-0.2.3.tgz#788c90c42a2013def59e94ec34c8833fac056548"
+  integrity sha512-2KmDUfqIv0g4lrWtnyR5xw82NvdsEwUHON43JAe55XRlLWnk1V1troiyJiM9fccENtl524kVRBnD7RMohmUyyQ==
+  dependencies:
+    "@stdlib/utils-constructor-name" "^0.2.2"
+    "@stdlib/utils-global" "^0.2.3"
+
 "@tybys/wasm-util@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
@@ -841,6 +2887,13 @@ cross-spawn@^7.0.6:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@^4.3.1, debug@^4.3.2, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
@@ -1297,6 +3350,13 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hasown@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
+
 http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
@@ -1344,6 +3404,13 @@ ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+is-core-module@^2.16.1:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
+  dependencies:
+    hasown "^2.0.3"
 
 is-electron@2.2.2:
   version "2.2.2"
@@ -1664,6 +3731,11 @@ minimatch@^10.2.1, minimatch@^10.2.2:
   dependencies:
     brace-expansion "^5.0.2"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -1788,6 +3860,11 @@ path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-to-regexp@^8.0.0, path-to-regexp@^8.1.0:
   version "8.3.0"
@@ -1955,6 +4032,16 @@ resolve-pkg-maps@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
+resolve@^1.1.7:
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 restore-cursor@^5.0.0:
   version "5.1.0"
@@ -2187,6 +4274,11 @@ strip-ansi@^7.1.0, strip-ansi@^7.1.2:
   integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
   dependencies:
     ansi-regex "^6.2.2"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tinybench@^2.9.0:
   version "2.9.0"


### PR DESCRIPTION
## 관련 이슈
Closes #460

마스터 [#434](https://github.com/hyewon3938/slack-ai-agents/issues/434) Phase 7 — ADR-0024 실행. Beta-Binomial posterior를 가설 단위로 누적하고, 주간 리뷰 카드에 빈도주의 통계와 한 줄로 병기 + 시드 영향력 top 5 섹션 추가.

## 변경 내용

### 데이터 모델
- `pattern_stats`에 `posterior_alpha / posterior_beta / posterior_p` 3컬럼 추가 (마이그레이션 074, idempotent)
- prior Beta(1,1)에서 시작, 주차별 hit/miss 누적으로 α=1+H, β=1+M 진화

### 베이지안 헬퍼 (`src/shared/bayesian-posterior.ts`)
- `updatePosterior(prior, hits, misses)` — 단조 누적
- `posteriorMean(α, β) = α/(α+β)`
- `credibleInterval(α, β, conf=0.95)` — Beta inverse CDF (`@stdlib/stats-base-dists-beta-quantile`)
- `cumulativePosteriorFromHitMiss(h, m)` — prior Beta(1,1) 기준 초기화
- 16개 테스트 케이스 (`__tests__/bayesian-posterior.test.ts`)

### 가설 단위 누적 (`computeAndPersistWeeklyStats`)
- 가설별로 이전 주차 누적 hit/miss를 SELECT한 후 이번 주 hit/miss를 더해 α/β 업데이트
- `HypothesisStat`에 `posteriorAlpha/Beta/P + ciLower/Upper` 5필드 추가
- UPSERT 12컬럼으로 확장

### 카드 UI
- `buildCandidateCard` 3줄 구조: header / freqLine(p, q) / bayesLine(사후 ± CI)
- `buildSeedInfluenceSection(rows)` — top 5 시드 영향력 (총 누적 N + 사후 + CI)
  - 정렬: `ciLower DESC` (작은 N에 자연 페널티, 임의 컷오프 회피 — 헌장 ⑤)
  - 범례: `_사후 = 본인 패턴일 확률 추정 (50%=우연, 80%↑=강함) · [] = 95% 신뢰 구간 (좁을수록 정확)_`
- 버튼 라벨 통일: `가설 등록 → 가설 승인` / `이번엔 패스 → 가설 반려` / `거절 → 반려` (매트릭 카드도 동일)
- `buildWeeklyReviewBlocks` 시그니처에 `seedInfluence: SeedInfluenceRow[]` 4번째 인자 추가 (필수)

### 주간 cron 통합 (`weekly-hypothesis-review.ts`)
- `loadPrevStat`이 posterior 컬럼까지 SELECT + CI 도출
- `loadSeedInfluence(userId, topN=5)`: `pattern_summary` view(메타 + total_hits/misses) ⨯ `pattern_metrics` 단순집계(SUM α/β) 머지 → 평균/CI 계산 → ciLower 내림차순 정렬

### 문서
- `docs/domains/insight.md` §21 본문 (데이터 모델 / 헬퍼 API / 누적 흐름 / UI 흐름 / 정렬 근거 / view contract 보존 노트 / 버튼 라벨 표)
- `docs/features.md` 마스터 #434 라인에 Phase 7 추가, 다음 작업 포인터를 "인사이트 카드 UI"로 갱신
- `docs/design-notebook/personal-pattern-discovery.md` Phase 7 회고 7항목 + 후속 4건

## 코드 리뷰 결과
- [x] 보안 감사 통과 — SQL parameterized, credentials 노출 없음, PII 로깅 없음
- [x] 타입 안전성 확인 — `any` 없음, strict types
- [x] 컨벤션 점검 완료 — named export, kebab-case, ESM `.js` 확장자
- [x] 코드 품질 확인 — 단일 책임 분리(헬퍼 / cron / 카드), float→int 반올림 가드

## 테스트
- [x] `yarn build` (tsc) 통과
- [x] `yarn test` 통과 — 599 테스트 / 39 파일
- [x] 마이그레이션 074 운영 DB 적용 검증 (`\d+ pattern_stats` posterior 3컬럼 확인)
- [x] 신규 헬퍼 16 케이스 (Beta 분포 평균·CI·가드)
- [x] 카드 prefix·cap·필수 4번째 인자 회귀 테스트

## 운영 검증 (머지 후)
- 첫 발사: 다음 월요일 09:30 KST `weekly-hypothesis-review` cron
- 검증 포인트: 카드 베이지안 라인 정상 렌더 / 시드 영향력 top 5 섹션 노출 / 버튼 라벨 통일 / CI 범위 합리성