### PR TITLE
feat(insight): 일일 종합 인사이트 — 사주 일운 + 검증된 개인 패턴 통합 발송

### DIFF
--- a/db/migrations/076_daily_insight.sql
+++ b/db/migrations/076_daily_insight.sql
@@ -1,0 +1,22 @@
+-- 076: 일일 종합 인사이트 (#475)
+-- A. daily_insight_log — 종합 인사이트 발송 멱등 로그 (routine 중복 실행 시 재발송 차단)
+-- B. 파이프라인 순서 정렬: 매칭(dailySajuMatching)을 08:00 종합보다 선행하도록 07:00으로 당김
+-- C. 구 insightMorning cron 비활성화 — 일운 포맷 알림을 daily-insight routine으로 이관 (ADR-0031)
+
+-- A. 발송 멱등 로그
+CREATE TABLE IF NOT EXISTS daily_insight_log (
+  id         SERIAL PRIMARY KEY,
+  user_id    INTEGER NOT NULL,
+  date       DATE NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, date)
+);
+
+COMMENT ON TABLE daily_insight_log IS
+  '일일 종합 인사이트(daily-insight routine) 발송 멱등 로그. (user_id, date) UNIQUE — 같은 날 재실행 시 INSERT ... ON CONFLICT DO NOTHING으로 중복 발송 차단.';
+
+-- B. 매칭 선행 (08:00 종합이 그날 발현 시드를 읽도록 07:00으로)
+UPDATE notification_settings SET time_value = '07:00' WHERE slot_name = 'dailySajuMatching';
+
+-- C. 구 insightMorning cron 비활성화 (routine 이관). SLOT_TASKS 매핑도 코드에서 제거됨.
+UPDATE notification_settings SET active = false WHERE slot_name = 'insightMorning';

--- a/docs/adr/0031-daily-insight-synthesis.md
+++ b/docs/adr/0031-daily-insight-synthesis.md
@@ -1,0 +1,96 @@
+# 0031. 일일 종합 인사이트 — 개인화 주입 지점을 생성에서 발송으로 이동
+
+- Status: Accepted
+- Date: 2026-06-03
+- Related: #475, 마스터 #421 (A3), 데이터 소스 #393/#434
+- Tags: data, insight, llm, architecture
+
+## Context
+
+ADR-0020이 사주 풀이 시스템과 v2 매칭 학습 시스템의 책임을 분리하고, 학습 결과를 노출하는 `saju_influence_summary` view(verified/accumulating/recent 3-tier)를 깔았다. 첫 소비자는 주간 회고(`weekly-saju-review-v2`)였다.
+
+그러나 **매일 발송되는 일운에는 학습 결과가 전혀 주입되지 않았다**:
+
+- `weekly-fortune` routine(일요일 밤)은 만세력으로 미래 7일 일운을 생성해 `fortune_analyses`에 저장하는데, freeze된 구 `saju_patterns`만 참조하고 view는 읽지 않는다.
+- 매일 아침 발송(`insightMorningTask`, Node.js cron 08:00)은 `fortune_analyses` 오늘치를 `formatFortuneText`로 **포맷만** 한다. LLM도, 학습 주입도 없다.
+- 결과적으로 #393/#434가 매일 누적하는 매칭·검증 데이터(view)가 사용자에게 닿는 일일 경로가 없었다.
+
+원래 A3 계획은 "weekly-fortune이 생성 시점에 view를 주입"이었으나 두 구조적 한계가 있었다:
+
+1. **7일 스냅샷 지연** — 주1회 생성이라 그 주 안에 매트릭이 승인되거나 시드가 격상돼도 다음 일요일까지 반영 안 됨.
+2. **life_signal의 시간성** — 라이프 신호(수면·루틴·지출 등 행동 기반 시드)는 "오늘 기준" 누적 데이터로 평가된다. 미래 7일치를 미리 생성할 수 없다.
+
+추가로 현황 데이터 확인 결과(2026-06-02): view의 `verified` tier는 **0개**, `accumulating` 1개, `recent` 65개. 오늘 발현 시드와 verified/accumulating의 교집합은 **0**. 즉 "검증된 인과"만으로는 당분간 메시지가 빈손이 된다.
+
+## Decision
+
+**개인화 주입 지점을 생성(weekly-fortune)에서 발송(매일 아침)으로 이동한다.**
+
+매일 08:00 KST에 도는 **일일 종합 인사이트 routine**(`daily-insight`, Claude 앱 routine, Opus)을 신설한다. 이 routine은 오늘 사주 일운과 오늘 발현 시드를 신뢰도 tier별로 종합해 인사이트 채널에 단일 메시지로 발송한다.
+
+**3층 종합 구조:**
+
+1. **베이스 — 오늘 사주 일운**: `weekly-fortune`이 미리 생성한 `fortune_analyses` 오늘치(만세력 기반 교과서 해석)
+2. **검증 레이어 — 인과 단언**: 오늘 발현 시드 중 `verified`/`accumulating`. "너는 X일 때 실제로 Y하더라" (지금 거의 0, 검증 누적되며 성장)
+3. **현황 레이어 — 배경 맥락**: 오늘 발현 시드 중 미검증(`recent`). "오늘 이런 기운·신호가 활성" — **인과 주장 금지, 발현 사실만**
+
+**역할 분담:**
+
+- `weekly-fortune`은 미래 7일 사주 예보 생성으로 **불변** (/일운 조회 + daily-insight의 베이스 재료).
+- `insightMorningTask`(cron, 포맷만)는 routine으로 이관, Node.js 코드·SLOT_TASKS·DB 슬롯에서 제거 (ADR-0027 — LLM 비동기 작업은 routine으로 통일).
+- 매칭 cron(`dailySajuMatching`)을 09:00 → **07:00**으로 당겨 08:00 종합이 그날 발현 시드를 읽도록 선행. `daily_insight_log` 테이블로 발송 멱등 보장.
+
+**헌장 준수 (마스터 #393/#434):**
+
+- 헌장 ① (텍스트 의존 최소화): LLM 입력에 diary 원문 금지. view `description`·시드명·카운트·메트릭만.
+- 헌장 ④ (신뢰 비용 분리): tier별 해석 강도 차등 (verified=단언 / accumulating=경향 / recent=현황).
+- 기각안 "풀이 LLM이 새 가설 생성" 준수: view/매칭에 **있는 시드만** 사용, 새 패턴 생성 금지 (할루시네이션 차단).
+- 사주 시드(`stem`/`branch`/`ganji`/`relation`/`sibiunsung`/`element_density`/`cumulative_pillar_count`)와 `life_signal`을 레이어로 분리 표시.
+
+## Alternatives considered
+
+### A. weekly-fortune이 생성 시점에 view 주입 (원래 A3 계획)
+
+- 장점: 새 routine 불필요, 기존 생성 경로 재사용
+- 단점: 7일 스냅샷 지연, 사주 시드만 가능(life_signal 미래 생성 불가)
+- 기각 이유: 매일 발송으로 흡수하면 지연·시간성 문제가 동시에 사라짐
+
+### B. 구 `saju_patterns` 26개를 신 시스템(pattern_catalog)으로 이관 후 활용
+
+- 장점: 기존 풀이 자산 재활용
+- 단점: 큰 마이그레이션 작업 + 통계 검증이 약한 데이터
+- 기각 이유: 범위 과대. A3 후속(별도 트랙)으로 분리
+
+### C. recent 제외, 검증된 시드만 종합
+
+- 장점: 인과 신뢰도 최고, 할루시네이션 위험 최소
+- 단점: 현재 verified∩발현 = 0이라 메시지가 사실상 빈손
+- 기각 이유: 운영 초기 빈약함. 현황 레이어를 인과 주장 없이 포함하면 신선함 확보 + 검증 누적 시 자동으로 격상
+
+### D. 매일 발송 시점 종합 + 3층(베이스/검증/현황) + recent 현황 포함 (선택)
+
+- 장점: 매일 신선, 사주+라이프 통합, weekly-fortune 불변, 검증 누적 시 시드가 recent→accumulating→verified 자동 격상
+- 단점: 매일 Opus 1회, insightMorning 이관에 따른 봇 코드·DB 변경, 매칭 선행 의존
+
+## Consequences
+
+### 장점
+
+- 학습이 **매일** 발송에 반영 — 매트릭 승인·시드 격상이 다음날 바로 닿음 (7일 스냅샷 지연 제거)
+- 사주 + 라이프 신호 통합 — life_signal의 "오늘 기준" 시간성을 발송 시점 평가로 자연 해소
+- `weekly-fortune`은 미래 예보로 불변 — 책임 경계 유지
+- view의 tier 승급(recent→accumulating→verified)이 메시지 강도에 자동 반영 — 별도 작업 없이 품질 성장
+- ADR-0027 routine 통일 원칙과 일관
+
+### 단점 / 제약
+
+- 매일 Opus routine 1회 (구독 비용)
+- `insightMorningTask` 이관으로 봇 코드·DB 설정 동시 변경 (마이그레이션 076)
+- 매칭 선행 의존 — 매칭 cron이 죽으면 그날 발현 데이터 누락. 갭 자동 백필로 완화하나 당일 07:00 실패 시 08:00 종합은 전날까지 데이터만 반영
+- routine SKILL.md는 repo 외부 — 변경 이력은 ADR·도메인 문서로만 추적
+
+### 후속 작업
+
+- [ ] 구 `saju_patterns` 정리 (weekly-fortune 관점 5) — A3 후속
+- [ ] 월·세·대운 종합 확장 (#408 이후) — 일운 종합을 템플릿으로
+- [ ] 검증 시드 누적 후 인과 레이어 품질 점검 (운영 1\~3개월)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -137,6 +137,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0028](0028-pillar-level-and-threshold-pool.md) | 사주 시드 운 레벨 차원 도입 + 풀셋 임계치 철학 + 임의값 배제 | Accepted | 2026-05-28 | data, insight, architecture, process |
 | [0029](0029-life-signal-trigger-aux-standard.md) | `life_signal` 단일 type 통합 + `trigger_aux.kind` 평가 명세 표준 | Accepted | 2026-05-28 | data, insight, architecture, schema |
 | [0030](0030-llm-metric-suggest-input-and-cadence.md) | LLM 매트릭 제안 슬롯 — 입력 풀 구성 + 거절 재제안 + 월간 cron | Accepted | 2026-05-28 | llm, insight, ops |
+| [0031](0031-daily-insight-synthesis.md) | 일일 종합 인사이트 — 개인화 주입 지점을 생성에서 발송으로 이동 + 신뢰도 tier 종합 | Accepted | 2026-06-03 | data, insight, llm, architecture |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/fortune-rework.md
+++ b/docs/design-notebook/fortune-rework.md
@@ -2,7 +2,7 @@
 
 > 마스터 이슈: [#421](https://github.com/hyewon3938/slack-ai-agents/issues/421)
 > 시작: 2026-05-26
-> 상태: Phase A1·A2 완료 (2026-05-26 머지), Phase A3는 #408 머지 대기
+> 상태: Phase A1·A2 완료 (2026-05-26 머지), Phase A3 일운 종합 인사이트 (2026-06-03, #475)
 > 출처: [insight-engine-v2.md](./insight-engine-v2.md) Phase 5 진입 시도 중 분리됨
 
 ## 개요
@@ -18,7 +18,7 @@
 
 - [x] **Phase A1**: 책임 분리 + 형태 재설계 + Opus 이관 + 중복 발송 fix (PR #423 머지)
 - [x] **Phase A2**: v2 데이터 expose 경로 — `saju_influence_summary` view + idempotency 테이블 (PR #422 머지)
-- [ ] **Phase A3**: 4층 레이어 데이터 주입 (의존: [#408](https://github.com/hyewon3938/slack-ai-agents/issues/408) Phase 5 머지)
+- [x] **Phase A3**: 일운 발송 재설계 — 일일 종합 인사이트 routine (개인화 주입 지점 생성→발송 이동, #475). 월/세/대운 종합 확장은 후속 ([#408](https://github.com/hyewon3938/slack-ai-agents/issues/408) 이후)
 
 ---
 
@@ -108,3 +108,66 @@
 - 다음 월요일(2026-06-01) 08:00 KST 첫 발송 — Block Kit 카드 가독성·idempotency 동작·Opus prose 톤 운영 검증
 - Phase A3 (4층 레이어 expose) — #408 Phase 5-B 머지 후 view에 월운 layer 추가 (컬럼 contract 유지)
 - A1 첫 주 운영 후 임계치 조정 여부 판단: accumulating tier hit rate > 55% / 5건 임계가 카드에 너무 많이/적게 잡으면 외부화 검토 (ADR-0020 후속 작업 항목)
+
+---
+
+## Phase A3: 일운 종합 인사이트 (2026-06-03, #475)
+
+- 이슈: [#475](https://github.com/hyewon3938/slack-ai-agents/issues/475)
+- 관련 plan: `.claude/plans/475-daily-insight-synthesis.md` (gitignored, 휘발)
+- ADR: [ADR-0031](../adr/0031-daily-insight-synthesis.md) — 개인화 주입 지점을 생성에서 발송으로 이동
+- 상태: design + build 완료
+
+### 개요
+
+원래 A3는 "weekly-fortune이 생성 시점에 view를 주입(4층 레이어, #408 월운 의존)"이었으나, 인터뷰 중 두 구조적 제약이 드러나며 **"일운 발송 재설계"로 확장**됐다. A2에서 view(`saju_influence_summary`)를 깔고 weekly-saju-review-v2가 첫 소비자가 됐지만, **매일 발송되는 일운에는 학습이 전혀 주입되지 않는** 공백이 남아 있었다. 이 공백을 메우는 게 A3.
+
+매일 08:00 KST 일일 종합 인사이트 routine(`daily-insight`, Opus)을 신설 — 오늘 사주 일운(베이스) + 오늘 발현 시드를 신뢰도 tier별로 종합. 개인화 지점을 "주1회 생성(weekly-fortune)"에서 "매일 발송"으로 이동.
+
+### 의사결정 분기점
+
+> 사용자 인터뷰 다수 턴 + 헌장 cross-check.
+
+- **접근 방향 (단일 선택)**: (1) 연결 인프라 먼저 / (2) 검증 재료부터 / (3) 구패턴 이관. → **(1) 연결 먼저**. 이유: 작은 작업 + 후퇴 없음 + 미래 데이터 성장을 전제로 깔면 검증 누적이 자동으로 품질을 올림
+- **개인화 주입 지점 (핵심 전환)**: weekly-fortune 생성 시점 주입 → **매일 발송 시점 종합으로 전환**. 이유: ① 생성은 주1회라 7일 스냅샷 지연 ② life_signal은 "오늘 기준" 누적이라 미래 7일치를 미리 생성 불가. 발송 시점 종합이 두 제약을 동시 해소 + weekly-fortune은 미래 예보로 불변 유지
+- **일운을 "오늘의 총 종합"으로 격상 (단일 선택)**: 일운 따로 + 종합 따로 / **일운 자체를 종합 인사이트로**. 이유: 인사이트 채널에서 사주+라이프 패턴을 한 메시지로 커버. 라이프 채널 잔소리(매칭 한 줄)는 별도 유지 — 채널 역할 분리
+- **미래 종합 여부 (단일 선택)**: 미래 7일 종합 / **오늘만**. 이유: life_signal의 시간성상 미래 미리 생성 불가 + 사용자도 "미래는 사주 예보(weekly-fortune)로 충분, 종합 미래는 불필요"
+- **recent 처리 (핵심)**: 검증된 것만 / **현황 포함(인과는 검증분만)**. 이유: 현재 verified∩발현 = 0이라 검증만으로는 메시지가 빈손. recent를 "오늘 이런 기운·신호가 활성"이라는 **현황 맥락**으로 포함하되 인과 주장은 금지. 검증 누적되면 시드가 recent→accumulating→verified로 자동 격상되며 인과 레이어가 성장
+- **매칭 순서 (단일 선택)**: **A. 매칭 07:00로 당기기** / B. 종합을 매칭 후로 미루기. 이유: 08:00 종합이 그날 발현 시드를 읽으려면 매칭이 선행해야 함. 09:00→07:00이 가장 단순. + 갭 자동 백필로 누락 재발 방지
+
+### 포기한 안 / 미룬 항목
+
+- **weekly-fortune view 주입 (원래 1단계)**: 7일 지연 + 사주 시드만 가능 → 매일 발송 종합으로 흡수
+- **구 `saju_patterns` 26개 신 시스템 이관**: 큰 작업 + 통계 검증 약함 → A3 후속(별도 트랙). weekly-fortune 관점 5 정리와 묶어서
+- **recent 검증된 것만**: verified∩발현 0 → 빈손 → 현황 포함으로
+- **종합 미래 확장**: life_signal 시간성 → 오늘만. 월·세·대운 종합은 #408 이후 (일운 종합을 템플릿으로)
+
+### 미해결·가설
+
+- **현황 데이터(2026-06-02 확인)**: 주 928건 매칭, 활성 시드 229개. view tier verified **0** / accumulating **1** / recent 65. 하루 발현 사주 16 + 라이프 14 (풍부)지만 verified/accumulating과 교집합 0 → 당분간 현황 레이어 + 사주 베이스가 주력. 인과 레이어는 매트릭 승인 누적되며 성장 (운영 1\~3개월 후 품질 점검)
+- **6/1 매칭 누락 의심 → 실제 정상**: 진단 결과 5/26\~6/3 매일 데이터 존재(누락 0). 6/1도 229건. 단 cron이 "오늘만" 매칭이라 봇 다운 시 구조적 누락 가능 → 갭 백필 추가 (현재 백필 불필요, 재발 방지)
+- **prose vs Block Kit**: 1차안 prose (기존 일운 톤 연속성). 검증/현황 섹션 구분 가독성은 운영 후 판단
+- **매일 Opus 비용 vs 가치**: 운영하며 체감 점검
+
+### 회고 (인터뷰 + 구현)
+
+- **액면 요청 → 진짜 가치 분기 (누적 패턴)**: "일운에 사주 데이터 주입" 요청이 인터뷰 중 기술 제약(7일 스냅샷 지연 · life_signal 시간성) 제시로 "매일 종합 인사이트"로 진화. A1에서 "Phase 5 진입 → 주간 리뷰 개편" 분기에 이어 fortune-rework 마스터의 두 번째 동일 패턴. 첫 진입 인터뷰에서 액면 키워드와 진짜 동기가 어긋나는 건 단골
+- **DB 사실 확인이 설계를 전환**: verified 0 / 검증∩발현 0을 raw count로 확인 → "검증된 것만" 안을 기각하고 "recent 현황 포함 + 미래 성장" 구조 채택. 설계 판단을 추측이 아니라 운영 데이터로 내린 사례
+- **매칭 백필 부재 발견**: 6/1 누락 의심 조사 과정에서 cron이 `getEffectiveTodayISO()`로 "오늘만" 매칭함을 발견 → 실제 누락은 아니었으나 구조적 누락 가능성을 선제 차단(갭 백필). 사고 조사가 잠재 결함 발견으로 이어진 사례
+
+### 기술적 의의
+
+- **개인화 주입 지점 이동(생성→발송)**: 신선도(스냅샷 지연 제거)와 시간성(life_signal "오늘 기준")을 한 번에 해소. view tier 승급이 메시지 강도에 자동 반영돼 코드 변경 없이 품질이 성장하는 구조
+- **신뢰도 tier 기반 표현 강도 차등 + 할루시네이션 차단**: verified=단언 / accumulating=경향 / recent=현황. view·매칭에 **있는 시드만** 사용하고 LLM이 새 패턴 생성 금지 (헌장 ④ + 기각안 일관). A2의 신뢰도 라벨링 view 패턴을 일일 발송에 적용
+- **갭 자동 백필이 UPSERT 멱등성에 기댐**: `recordDailyMatches`의 ON CONFLICT DO UPDATE 덕분에 "마지막 매칭일+1~오늘" 재실행이 안전. 봇 다운 복귀 시 자동 복구. 14일 상한 + truncation 로그로 백필 폭주 방지
+
+## Phase A3: 결과 (2026-06-03)
+
+- PR #475 (예정): 마이그레이션 076 (`daily_insight_log` + 매칭 07:00 + insightMorning 비활성) + 매칭 갭 백필 + insightMorning cron 제거 + ADR-0031 + 도메인 §23
+- routine SKILL.md (`~/.claude/scheduled-tasks/daily-insight/`)는 repo 외부 — 변경 이력은 ADR-0031 + 도메인 §23로 추적
+
+### 구현 단계에서 확인된 것
+
+- **CronScheduler가 미매핑/비활성 슬롯 안전 스킵**: `loadAndSchedule`이 `!setting.active` + `!SLOT_TASKS[slot_name]` 둘 다 `continue`. insightMorning을 코드(SLOT_TASKS)와 DB(active=false) 양쪽에서 제거 — belt-and-suspenders
+- **formatFortuneText 이중 사용처**: life-cron(insightMorning, 제거)과 agents/insight(유저 트리거 /일운 조회, 유지). insightMorning 제거 후 life-cron import만 정리, fortune-format.ts·유저 트리거 경로는 불변
+- **verifyDailyMatches는 이미 갭 안전**: `date <= CURRENT_DATE - 1` 전체 pending을 처리 → 백필분이 pending으로 기록되면 같은 cron 실행 내 verify가 자동으로 hit/miss 확정. 백필 설계가 기존 검증 사이클에 무손실로 얹힘

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -104,7 +104,7 @@ saju_patterns:
 - `세운` / `올해 세운` -> period='yearly', date=해당 년 1월 1일
 - `대운` -> period='major', ORDER BY date DESC LIMIT 1
 
-표시 포맷: 공유 헬퍼 `src/shared/fortune-format.ts`의 `formatFortuneText` — `summary` *볼드* + `analysis` 본문 + `advice` _기울임_ 결합. insightMorningTask(아침 일운 푸시)도 동일 헬퍼 사용.
+표시 포맷: 공유 헬퍼 `src/shared/fortune-format.ts`의 `formatFortuneText` — `summary` *볼드* + `analysis` 본문 + `advice` _기울임_ 결합. (유저 트리거 /일운 조회 전용. 아침 일운 자동 발송은 2026-06-03부터 일일 종합 인사이트 routine으로 이관 — §23)
 
 ### 1-1. 운세 분석 생성 정책 (weekly-fortune)
 weekly-fortune routine이 일운/월운/세운/대운을 생성. fortune_analyses 필드 활용:
@@ -122,6 +122,8 @@ weekly-fortune routine이 일운/월운/세운/대운을 생성. fortune_analyse
 **period별 길이**: daily 350\~500자 / monthly 600\~800자 / yearly·major 800\~1200자. advice는 모든 period에서 1\~2문장.
 
 **톤**: 명리학자가 애정을 담아 풀어주는 / 사실 숨기지 않는 / 권유형. 상세는 [ADR 0012](../adr/0012-fortune-personalization.md) 참조.
+
+**발송 분리 (2026-06-03, #475)**: weekly-fortune은 미래 7일 일운 생성 + /일운 조회 베이스로 **불변**. 매일 아침 발송은 일일 종합 인사이트 routine(§23)이 이 생성물(오늘치)을 베이스로 학습 데이터(`saju_influence_summary` view)와 종합해 발송. 상세 [ADR-0031](../adr/0031-daily-insight-synthesis.md).
 
 ### 2. 일기 자동 저장
 - 사용자 메시지가 일기/감정/이벤트 성격이면 `diary_entries`에 자동 저장
@@ -143,6 +145,7 @@ weekly-fortune routine이 일운/월운/세운/대운을 생성. fortune_analyse
 - 같은 trigger_element가 여러 도메인에 발현하면 분리하지 않고 같은 row의 evidence에 누적
 - 감지 횟수 추적 (detection_count), 신뢰도 평가 (confidence)
 - 비활성화 시 `active = false`, `deactivated_at = NOW()`
+- **일일 종합 인사이트(§23)는 `saju_patterns`를 쓰지 않는다** — `saju_influence_summary` view(verified/accumulating/recent, #393/#434 학습 결과)를 사용. `saju_patterns`는 시스템 프롬프트 조회 + weekly-fortune 관점 5 용으로만 잔존 (정리는 마스터 A A3 후속)
 
 ### 5. 시스템 프롬프트 구성
 `buildInsightSystemPrompt()`가 실시간으로 아래 데이터를 로드하여 프롬프트에 주입:
@@ -1398,6 +1401,35 @@ ALTER TABLE pattern_matches
 
 설계 결정 배경: [design-notebook personal-pattern-discovery](../design-notebook/personal-pattern-discovery.md) Phase 8 섹션 + 마무리 회고
 
+### 23. 일일 종합 인사이트 (마스터 A — Phase A3, #475)
+
+매일 아침 사주 일운 + 학습된 개인 패턴을 신뢰도 강도별로 종합해 인사이트 채널에 단일 메시지로 발송. 개인화 주입 지점을 weekly-fortune **생성**에서 매일 **발송** 시점으로 이동 (상세 [ADR-0031](../adr/0031-daily-insight-synthesis.md)).
+
+**routine**: `~/.claude/scheduled-tasks/daily-insight/SKILL.md` (Claude 앱 routine, repo 외부). 매일 08:00 KST, Opus, 인사이트 채널. DB Proxy API로 접근 (ADR-0027).
+
+**3층 종합 구조**:
+
+| 레이어 | 소스 | 표현 강도 |
+|--------|------|----------|
+| 베이스 — 오늘 사주 일운 | `fortune_analyses` (weekly-fortune 생성물 오늘치) | 만세력 교과서 해석 |
+| 검증 — 인과 단언 | 오늘 발현 시드 ∩ `saju_influence_summary` verified/accumulating | "너는 X일 때 실제로 Y하더라" |
+| 현황 — 배경 맥락 | 오늘 발현 시드 중 미검증(recent) | "오늘 이런 기운·신호 활성" — **인과 주장 금지** |
+
+**데이터 수집** (메트릭/카운트만, diary 원문 입력 금지):
+- 오늘 일운: `fortune_analyses WHERE period='daily' AND date=CURRENT_DATE`
+- 오늘 발현 시드: `pattern_matches (date=CURRENT_DATE, trigger_activated=true)` JOIN `pattern_catalog` + `saju_influence_summary`(tier 판정). 사주 시드(stem/branch/ganji/relation/sibiunsung/element_density/cumulative_pillar_count)와 `life_signal`을 레이어로 분리 표시
+- `life_themes` active
+
+**멱등**: `daily_insight_log (user_id, date) UNIQUE` (마이그레이션 076). `INSERT ... ON CONFLICT DO NOTHING RETURNING` — 비면 "이미 발송, 종료".
+
+**파이프라인 순서**: 매칭(`dailySajuMatching`) **07:00** → 종합 **08:00**. 매칭 선행으로 그날 발현 시드를 종합이 읽음 (구 09:00에서 당김, 마이그레이션 076). 매칭 cron은 누락일 자동 백필 포함 — `daily-pattern-matching.ts`의 "마지막 매칭일+1~오늘" 루프 (14일 상한).
+
+**종료 조건**: ① 오늘 일운 미생성(weekly-fortune 누락) → "사주 일운 미생성, 종료" ② 이미 발송(멱등) → 종료.
+
+**헌장 준수**: ① diary 원문 미입력 (view description·시드명·카운트만) / ④ tier별 강도 차등. view·매칭에 **있는 시드만** 사용 — 새 패턴 생성 금지 (할루시네이션 차단).
+
+**구 insightMorningTask 폐기**: 아침 일운 포맷 알림(Node.js cron, LLM 없음)은 이 routine으로 이관. `SLOT_TASKS`·DB 슬롯(`insightMorning` active=false)에서 제거 (ADR-0027 — LLM 비동기는 routine으로).
+
 ## 파일 구조
 
 ```
@@ -1420,7 +1452,7 @@ src/shared/
 └── saju-hypothesis.ts             # Phase 4 통계 (Fisher + BH-FDR + lifecycle)
 
 src/cron/
-├── daily-saju-matching.ts                 # 09:00 사주 일일 매칭 + confirmed 가설 슬롯 (Phase 3/4)
+├── daily-pattern-matching.ts              # 07:00 사주 일일 매칭 + 갭 자동 백필 + confirmed 가설 슬롯 (Phase 3/4, #475)
 ├── diary-meta-extract.ts                  # 일기 → enum 태그 추출 cron (Phase 3, Opus)
 ├── weekly-hypothesis-review.ts            # 월 08:00 주간 가설 리포트 (Phase 4)
 └── pillar-level-distribution-review.ts    # 월 09:15 운 레벨 분포 분석 (Phase 2.5)
@@ -1455,6 +1487,10 @@ db/migrations/  (마스터 #434 Phase 7 — 2026-05-29)
 db/migrations/  (마스터 #434 Phase 8a — 2026-05-29)
 └── 075_pattern_cleanup.sql                      # catalog deprecated 카운터 DROP + pattern_matches.error_message + verify_status='error' enum
 
+db/migrations/  (마스터 A Phase A3 — 2026-06-03)
+└── 076_daily_insight.sql                        # daily_insight_log + 매칭 07:00 + insightMorning 비활성
+
 ~/.claude/scheduled-tasks/  (Claude 앱 routines, repo 외부)
-└── monthly-metric-suggest/SKILL.md              # Phase 6 매월 1일 09:30 LLM 매트릭 후보 제안
+├── monthly-metric-suggest/SKILL.md              # Phase 6 매월 1일 09:30 LLM 매트릭 후보 제안
+└── daily-insight/SKILL.md                       # 일일 종합 인사이트 매일 08:00 (마스터 A A3, #475)
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -31,6 +31,7 @@
 - 사주 일일 매칭 시드 카탈로그 (`pattern_catalog`, Phase 3 — 결정론 매칭, 마스터 #434 Phase 1 rename per ADR-0026, 마스터 #434 Phase 2에서 6종 풀세트 161개 신규 시드 추가, Phase 2.5에서 `pillar_level` 차원 + `cumulative_pillar_count` trigger + 14 신규 시드 추가)
 - 일기 LLM enum 16종 추출 (`diary_meta_tags`, Phase 3)
 - 주간 사주 회고 카드 (`weekly-saju-review-v2`, 매주 월요일 08:00 KST `#insight` — 마스터 #421)
+- 일일 종합 인사이트 (`daily-insight` routine, 매일 08:00 KST `#insight` — 오늘 사주 일운 + 검증된 개인 패턴 신뢰도별 종합, 마스터 A A3 #475)
 - 상세: [docs/domains/insight.md](./domains/insight.md)
 
 ### 지출 / 예산 (`#money` 채널 / 웹 대시보드)
@@ -64,7 +65,7 @@
 
 - 60갑자 마스터 정규화(\~466 rows) 위에 시드 catalog를 얹어 사용자 임상 가설을 정량 검증
 - polymorphic trigger 6종(stem / branch / ganji / element_density / sibiunsung / relation) + 메트릭 5방향(above_avg / below_avg / above_abs / below_abs / flag_present)
-- 매일 09:00 일일 매칭 cron — 어제 pending 매칭 검증(hit/miss/inconclusive) + 오늘 활성 시드 평가 + `#life` 한 줄 발송
+- 매일 07:00 일일 매칭 cron — 어제 pending 매칭 검증(hit/miss/inconclusive) + 오늘 활성 시드 평가 + 누락일 갭 자동 백필 + `#life` 한 줄 발송 (07:00 = 08:00 종합 인사이트 선행, #475)
 - 일기 LLM enum 16종 자동 추출(허용 enum 외 출력 폐기) → `diary_meta_tags` 적재
 - 약한 시드(누적 \~10건 + hit rate < 30%) 주간 알림 → 사용자 명령어로 active 토글
 - 슬랙 조회/토글: `사주 시드 보기` / `사주 시드 모두 보기` / `사주 시드 끄기 #N` / `사주 시드 켜기 #N`
@@ -99,7 +100,8 @@
 
 | 시간 | 내용 |
 |------|------|
-| 09:00 | 사주 일일 매칭 — 어제 검증(hit/miss/inconclusive) + 오늘 평가 + `#life` 한 줄 (Phase 3) |
+| 07:00 | 사주 일일 매칭 — 어제 검증(hit/miss/inconclusive) + 오늘 평가 + 누락일 갭 백필 + `#life` 한 줄 (Phase 3) |
+| 08:00 | 일일 종합 인사이트 — 오늘 사주 일운 + 검증/현황 개인 패턴 종합 (`#insight`, routine·Opus, #475) |
 | 09:05 | 오늘 일정 + 낮 루틴 체크리스트 + 어제 리뷰 + morning 인사이트 |
 | 09:10 | LLM 자율 발견 outcome 검증 (대기열 50건) |
 | 월요일 09:00 | 주간 인사이트 리포트 (Block Kit) |

--- a/src/cron/daily-pattern-matching.ts
+++ b/src/cron/daily-pattern-matching.ts
@@ -1,8 +1,9 @@
 /**
- * Phase 3+4 — 매일 09시 패턴 일일 매칭 cron.
- * ADR-0017 + ADR-0026(pattern_* rename) 참조.
+ * Phase 3+4 — 매일 07시 패턴 일일 매칭 cron (08:00 일일 종합 인사이트 선행, #475).
+ * ADR-0017 + ADR-0026(pattern_* rename) + ADR-0031(매칭 선행) 참조.
  *
  * 흐름:
+ *   0) 마지막 매칭일~오늘 갭 자동 백필 (봇 다운 복귀 시 누락일 복구, 기록만)
  *   1) 어제 pending 매칭 verify_status 확정 (hit/miss/inconclusive)
  *   2) 오늘 활성 시드 평가 → pattern_matches UPSERT
  *   3) matched=true 시드를 #life 잔소리 끝 한 줄로 압축 전송

--- a/src/cron/daily-pattern-matching.ts
+++ b/src/cron/daily-pattern-matching.ts
@@ -17,10 +17,14 @@ import {
   getDailyContext,
 } from '../shared/pattern-match.js';
 import { postToChannel } from '../shared/slack.js';
-import { getEffectiveTodayISO } from '../shared/kst.js';
+import { getEffectiveTodayISO, addDays } from '../shared/kst.js';
+import { query } from '../shared/db.js';
 import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
 import { pickConfirmedHypothesisLines } from '../shared/insights.js';
 import type { LifeCronConfig } from './life-cron.js';
+
+/** 봇 장기 다운/최초 실행 시 백필 폭주를 막는 상한 (일). 초과분은 가장 최근 구간만 백필 + 로그. */
+const MAX_BACKFILL_DAYS = 14;
 
 export interface DailyPatternMatchingResult {
   date: string;
@@ -102,8 +106,67 @@ export const dailyPatternMatchingForUser = async (
 };
 
 /**
+ * 마지막 매칭일+1 ~ 어제까지 누락된 날짜 목록 (오늘 제외).
+ * 봇 다운 등으로 매칭이 빠진 날을 자동 복구하기 위함 — cron이 "오늘만" 매칭하면
+ * 봇이 멈춘 날은 영구 누락된다. recordDailyMatches가 UPSERT 멱등이라 재실행 안전.
+ * 갭이 MAX_BACKFILL_DAYS를 초과하면 가장 최근 구간만 백필하고 truncation을 로그로 남긴다.
+ */
+const findBackfillDays = async (userId: number, today: string): Promise<string[]> => {
+  const result = await query<{ last_date: string | null }>(
+    `SELECT MAX(date)::text AS last_date FROM pattern_matches WHERE user_id = $1`,
+    [userId],
+  );
+  const lastDate = result.rows[0]?.last_date;
+  if (!lastDate) return []; // 매칭 이력 없음(최초 실행) → 백필 없이 오늘분만 정규 처리
+
+  const rawStart = addDays(lastDate, 1);
+  const earliest = addDays(today, -MAX_BACKFILL_DAYS);
+  // ISO 날짜 문자열(YYYY-MM-DD)은 사전식 비교가 곧 시간순 비교
+  const truncated = rawStart < earliest;
+  let cursor = truncated ? earliest : rawStart;
+
+  const days: string[] = [];
+  while (cursor < today) {
+    days.push(cursor);
+    cursor = addDays(cursor, 1);
+  }
+  if (truncated) {
+    console.warn(
+      `[Pattern Match] 갭이 ${MAX_BACKFILL_DAYS}일 초과 user=${userId}: ${rawStart}~${addDays(earliest, -1)} 스킵, 최근 ${days.length}일만 백필`,
+    );
+  }
+  return days;
+};
+
+/**
+ * 누락된 과거 날짜 백필(매칭 기록만, Slack 전송 X) 후 오늘분 정규 처리(verify + match + 전송).
+ * 백필분은 다음 verifyDailyMatches(date <= 어제 전체 처리)가 자동으로 hit/miss 확정한다.
+ */
+const backfillAndMatchForUser = async (
+  app: App,
+  userId: number,
+  channelId: string,
+  today: string,
+): Promise<void> => {
+  const backfillDays = await findBackfillDays(userId, today);
+  for (const day of backfillDays) {
+    try {
+      const r = await runDailyPatternMatchingDryRun(userId, day);
+      console.warn(
+        `[Pattern Match] 갭 백필 user=${userId} date=${day} triggered=${r.triggeredCount} matched=${r.matchedCount}`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[Pattern Match] 갭 백필 실패 user=${userId} date=${day}: ${msg}`);
+    }
+  }
+  await dailyPatternMatchingForUser(app, userId, channelId, today);
+};
+
+/**
  * 패턴 일일 매칭 cron 본체. SLOT_TASKS에서 호출.
  * #life 채널로 전송 (life channel mapping 사용).
+ * 누락일 자동 백필 포함 (봇 다운 복귀 시 갭 메움).
  */
 export const dailyPatternMatchingTask = async (app: App, config: LifeCronConfig): Promise<void> => {
   const today = getEffectiveTodayISO();
@@ -111,13 +174,13 @@ export const dailyPatternMatchingTask = async (app: App, config: LifeCronConfig)
 
   if (mappings.length === 0) {
     if (!config.channelId) return;
-    await dailyPatternMatchingForUser(app, DEFAULT_USER_ID, config.channelId, today);
+    await backfillAndMatchForUser(app, DEFAULT_USER_ID, config.channelId, today);
     return;
   }
 
   for (const mapping of mappings) {
     const channelId = mapping.lifeChannelId ?? mapping.slackUserId;
     if (!channelId) continue;
-    await dailyPatternMatchingForUser(app, mapping.userId, channelId, today);
+    await backfillAndMatchForUser(app, mapping.userId, channelId, today);
   }
 };

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -24,7 +24,6 @@ import {
   decrementReminderCount,
 } from '../shared/life-queries.js';
 import { postBlockMessage, postToChannel } from '../shared/slack.js';
-import { formatFortuneText } from '../shared/fortune-format.js';
 import {
   getTodayISO,
   getYesterdayISO,
@@ -527,38 +526,7 @@ const nightTask = async (app: App, config: LifeCronConfig): Promise<void> => {
 };
 
 // ─── Insight 크론 태스크 ─────────────────────────────────
-
-/** 아침 일운 분석 알림 → insight 채널 (유저별) */
-const insightMorningTask = async (app: App, config: LifeCronConfig): Promise<void> => {
-  const today = getTodayISO();
-
-  await forEachUser(config, 'insight', '일운 분석 알림', async (userId, channelId) => {
-    const result = await query(
-      `SELECT analysis, summary, advice FROM fortune_analyses
-       WHERE user_id = $1 AND date = $2 AND period = 'daily'
-       ORDER BY created_at DESC LIMIT 1`,
-      [userId, today],
-    );
-
-    if (result.rows.length > 0) {
-      const fortune = result.rows[0] as {
-        analysis: string;
-        summary: string | null;
-        advice: string | null;
-      };
-      const text = formatFortuneText(fortune);
-      await postToChannel(app.client, channelId, text);
-      console.warn(`[Life Cron] 일운 분석 알림 전송 완료 (유저=${userId})`);
-    } else {
-      await postToChannel(
-        app.client,
-        channelId,
-        '오늘의 일운 분석이 아직 준비되지 않았어. 곧 업데이트될 거야.',
-      );
-      console.warn(`[Life Cron] 일운 분석 없음 — 대기 메시지 전송 (유저=${userId})`);
-    }
-  });
-};
+// (아침 일운 알림 insightMorningTask는 daily-insight routine으로 이관 — ADR-0031)
 
 /** 밤 일기 리뷰 → insight 채널.
  * 오늘 일기가 있으면 LLM 1회로 하루 코멘트, 없으면 간단 리마인더 전송. */
@@ -651,7 +619,6 @@ const SLOT_TASKS: Record<string, CronTaskFn> = {
   morning: morningTask,
   night: nightTask,
   weeklyReport: weeklyReportTask,
-  insightMorning: insightMorningTask,
   insightNight: insightNightTask,
   weeklyLlmInsight: weeklyLlmInsightTask,
   monthlyLlmInsight: monthlyLlmInsightTask,


### PR DESCRIPTION
## 관련 이슈
Closes #475

## 변경 내용
- **일일 종합 인사이트 routine 신설** (매일 08:00 KST, Opus, `#insight`) — 오늘 사주 일운(베이스) + 오늘 발현 개인 패턴을 신뢰도 tier별로 종합. 개인화 주입 지점을 weekly-fortune **생성**에서 매일 **발송**으로 이동 (3층: 베이스/검증=인과 단언/현황=배경 맥락)
- **매칭 cron 09:00 → 07:00** (08:00 종합 선행) + **누락일 자동 갭 백필** — 봇 다운 복귀 시 "마지막 매칭일+1\~오늘" 복구 (UPSERT 멱등, 14일 상한 + truncation 로그)
- **`daily_insight_log` 멱등 테이블** (마이그레이션 076) — 중복 발송 차단
- **구 insightMorning cron 제거** → routine 이관 (ADR-0027). `formatFortuneText`는 유저 트리거 /일운 조회용으로 유지
- ADR-0031 + design-notebook A3 + 도메인 insight.md §23 + features 카탈로그
- 파일 구조 stale name 정정 (`daily-saju-matching` → `daily-pattern-matching`, ADR-0026 rename 누락분)

## 설계 배경
ADR-0020이 `saju_influence_summary` view를 깔았지만 매일 발송되는 일운에는 학습이 주입되지 않는 공백이 있었음. 원래 A3("weekly-fortune 생성 시점 주입")은 7일 스냅샷 지연 + life_signal 시간성 제약이 있어, 발송 시점 종합으로 전환. 상세 [ADR-0031](docs/adr/0031-daily-insight-synthesis.md).

## 코드 리뷰 결과
- [x] 보안 감사 통과 — 파라미터 바인딩(`$1`), DB Proxy 경유, diary 원문 미노출(헌장 ①)
- [x] 타입 안전성 — any 없음, null 가드
- [x] 컨벤션 점검 — 네이밍·import·에러 처리
- [x] 코드 품질 — 백필 일별 try/catch 격리, 멱등성

## 테스트
- [x] 타입체크(tsc) / lint / 전체 602 테스트 통과
- [x] 매칭 cron 가동·6/3 데이터 정상 확인 (07:00 이동 전 점검 — 누락 0)
- [x] SKILL 핵심 쿼리 실제 DB 검증 (오늘 일운 존재 / 발현 시드 tier 조회 정상)
- [ ] 배포 후: daily-insight 첫 발송 운영 검증 (3층 prose, 멱등, 원문 미노출)

## 배포 메모
- 마이그레이션 076 부팅 시 자동 적용 (`runMigrations` → `CronScheduler.init` 순서 보장) — 매칭 07:00·insightMorning 비활성·테이블 생성 모두 배포로 반영, 수동 DB 작업 불필요
- `daily-insight` SKILL.md는 repo 외부(`~/.claude/scheduled-tasks/`) — **머지·배포 후** Claude 앱에서 08:00 routine 등록 + Opus 모델 지정 필요 (배포로 매칭이 07:00 선행된 뒤 enable해야 첫 발송부터 그날 발현 시드 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)