### PR TITLE
feat(insight): #479 매트릭 중심 패턴 검증 P1 — 스키마 재설계 + 신호 전역화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 *.log
 *.tsbuildinfo
 .DS_Store
+.obsidian/
 docs/_personal/
 .env.production
 .mcp.json

--- a/db/migrations/077_signal_defs_and_links.sql
+++ b/db/migrations/077_signal_defs_and_links.sql
@@ -1,0 +1,262 @@
+-- 077: 패턴 검증 스키마 재설계 + 신호 전역화 (#477 P1, ADR-0032·0033)
+-- A. signal_defs   — 전역 신호 정의 (kind=sql|tag). 시드와 무관한 측정 가능 정의.
+-- B. pattern_links — (시드 × 신호) = 가설 + 누적 검증상태. seed_id × signal_id 단위.
+-- C. 이관 — pattern_metrics → signal_defs(49 sql + 22 tag) + pattern_links(84, counters 1:1).
+-- D. 이관 정합 검증 — pattern_metrics DROP 전 대조 (불일치 시 RAISE → 파일 전체 암묵 트랜잭션 롤백).
+-- E. view 재정의 — pattern_summary(링크 기반) + saju_influence_summary(verified tier 제거).
+-- F. 폐기 — pattern_hypotheses·pattern_stats·pattern_metrics DROP.
+--          pattern_matches는 P2까지 유지(daily-insight #insight recent tier가 의존, ADR-0031).
+--          archive·transient 전환은 주간 검증 엔진(P2)과 함께 처리.
+
+-- ─── A. signal_defs ──────────────────────────────────────
+CREATE TABLE signal_defs (
+  id            SERIAL PRIMARY KEY,
+  user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name          TEXT NOT NULL,
+  kind          TEXT NOT NULL CHECK (kind IN ('sql', 'tag')),
+  -- sql kind 필드 --
+  sql_body      TEXT,
+  value_type    TEXT CHECK (value_type IN ('binary', 'continuous')),
+  direction     TEXT CHECK (direction IN ('above_avg', 'below_avg', 'above_abs', 'below_abs', 'flag_present')),
+  threshold     NUMERIC,
+  domain        TEXT CHECK (domain IN ('schedule', 'routine', 'sleep', 'expense', 'diary_meta', 'audit', 'expense_category_present')),
+  window_days   INTEGER,
+  -- tag kind 필드 --
+  tag_name      TEXT,
+  -- 공통 --
+  description   TEXT NOT NULL DEFAULT '',
+  source        TEXT NOT NULL DEFAULT 'seed' CHECK (source IN ('seed', 'llm')),
+  status        TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'pending', 'rejected')),
+  proposed_at   TIMESTAMPTZ,
+  approved_at   TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT signal_defs_sql_fields CHECK (
+    kind <> 'sql' OR (sql_body IS NOT NULL AND value_type IS NOT NULL AND direction IS NOT NULL)
+  ),
+  CONSTRAINT signal_defs_tag_fields CHECK (kind <> 'tag' OR tag_name IS NOT NULL),
+  -- 이관용 임시 추적 컬럼 (F에서 DROP) --
+  _legacy_metric_id INTEGER
+);
+-- tag 신호는 (user, tag) 단위 전역 1개 — 여러 시드가 공유
+CREATE UNIQUE INDEX uq_signal_defs_tag ON signal_defs (user_id, tag_name) WHERE kind = 'tag';
+CREATE INDEX idx_signal_defs_status_active ON signal_defs (status) WHERE status = 'active';
+
+COMMENT ON TABLE signal_defs IS
+  '전역 신호 정의 (#477 ADR-0033). kind=sql(객관 SQL 측정, 1차) | tag(일기 메타 태그, 보조). 시드와 무관하게 매일 측정 가능. value_type=binary|continuous, direction은 off-day 대조 판정 기준. source=llm은 자율 발견 신호. tag 신호는 (user, tag) 전역 1개를 여러 시드가 pattern_links로 공유.';
+COMMENT ON COLUMN signal_defs._legacy_metric_id IS
+  '이관 추적용 임시 컬럼 — 077 마이그레이션 종료 시 DROP. 운영 중 존재하면 안 됨.';
+
+-- ─── B. pattern_links ────────────────────────────────────
+CREATE TABLE pattern_links (
+  id              SERIAL PRIMARY KEY,
+  user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  seed_id         INTEGER NOT NULL REFERENCES pattern_catalog(id) ON DELETE CASCADE,
+  signal_id       INTEGER NOT NULL REFERENCES signal_defs(id) ON DELETE CASCADE,
+  source          TEXT NOT NULL DEFAULT 'manual' CHECK (source IN ('manual', 'discovery', 'llm')),
+  status          TEXT NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active', 'pending', 'weak', 'confirmed', 'rejected', 'archived')),
+  -- 누적 검증상태 (이관) --
+  hit_count          INTEGER NOT NULL DEFAULT 0,
+  miss_count         INTEGER NOT NULL DEFAULT 0,
+  inconclusive_count INTEGER NOT NULL DEFAULT 0,
+  last_matched_at    TIMESTAMPTZ,
+  posterior_alpha    NUMERIC(8, 2) NOT NULL DEFAULT 1.0,
+  posterior_beta     NUMERIC(8, 2) NOT NULL DEFAULT 1.0,
+  posterior_p        NUMERIC(6, 4),
+  -- 검증결과 (P2 주간 엔진 / P3 통계 증강이 채움 — P1에선 NULL 선언만) --
+  test_type       TEXT CHECK (test_type IN ('fisher_2x2', 'mann_whitney')),
+  effect          NUMERIC,
+  p_value         NUMERIC(10, 8),
+  q_value         NUMERIC(10, 8),
+  e_value         NUMERIC,
+  test_detail     JSONB,
+  confound        JSONB,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (seed_id, signal_id)
+);
+CREATE INDEX idx_pattern_links_seed ON pattern_links (seed_id) WHERE status = 'active';
+CREATE INDEX idx_pattern_links_signal ON pattern_links (signal_id);
+
+COMMENT ON TABLE pattern_links IS
+  '(시드 × 신호) 등록 = 검증 대상 가설 (#477 ADR-0033, 별도 가설 엔티티 폐기). 누적 검증상태(hit/miss/posterior) + 검증결과(test_type·effect·p·q·e_value·test_detail·confound) 보유. status=pending은 LLM 자율 제안 미승인 가설(매칭 제외). e_value·test_detail·confound·test_type 컬럼은 P1에서 선언만, 로직은 P2/P3.';
+
+-- ─── C. 이관 ─────────────────────────────────────────────
+-- C-1. sql 신호 (49, 1:1). status·source는 매트릭 보존(pending llm sql은 pending 유지).
+INSERT INTO signal_defs (user_id, name, kind, sql_body, value_type, direction, threshold,
+                         domain, window_days, description, source, status,
+                         proposed_at, approved_at, _legacy_metric_id)
+SELECT c.user_id, m.metric_name, 'sql', m.expected_metric_sql,
+       CASE WHEN m.expected_direction = 'flag_present' THEN 'binary' ELSE 'continuous' END,
+       m.expected_direction, m.expected_threshold, m.domain, m.window_days, m.description,
+       CASE m.source WHEN 'llm_autonomous' THEN 'llm' ELSE 'seed' END,
+       m.status, m.proposed_at, m.approved_at, m.id
+FROM pattern_metrics m
+  JOIN pattern_catalog c ON c.id = m.pattern_id
+WHERE m.domain <> 'diary_meta';
+
+-- C-2. tag 신호 (22). 객관 전역 detection이라 항상 active·seed. 여러 시드가 공유.
+INSERT INTO signal_defs (user_id, name, kind, value_type, domain, tag_name, description, source, status)
+SELECT DISTINCT user_id, tag, 'tag', 'binary', 'diary_meta', tag, '', 'seed', 'active'
+FROM diary_meta_tags;
+
+-- C-3. sql 링크 (49). _legacy_metric_id로 1:1. pending 매트릭 → pending 링크(매칭 제외).
+INSERT INTO pattern_links (user_id, seed_id, signal_id, source, status,
+                           hit_count, miss_count, inconclusive_count, last_matched_at,
+                           posterior_alpha, posterior_beta, posterior_p)
+SELECT c.user_id, m.pattern_id, s.id,
+       CASE m.source WHEN 'llm_autonomous' THEN 'llm' ELSE 'manual' END,
+       CASE WHEN m.status = 'active' THEN 'active' ELSE 'pending' END,
+       m.hit_count, m.miss_count, m.inconclusive_count, m.last_matched_at,
+       m.posterior_alpha, m.posterior_beta, m.posterior_p
+FROM pattern_metrics m
+  JOIN pattern_catalog c ON c.id = m.pattern_id
+  JOIN signal_defs s ON s._legacy_metric_id = m.id
+WHERE m.domain <> 'diary_meta';
+
+-- C-4. tag 링크 (35). diary 매트릭 SQL의 tag='X' 추출 → tag 신호 매칭. counters 1:1 복사.
+INSERT INTO pattern_links (user_id, seed_id, signal_id, source, status,
+                           hit_count, miss_count, inconclusive_count, last_matched_at,
+                           posterior_alpha, posterior_beta, posterior_p)
+SELECT c.user_id, m.pattern_id, s.id,
+       CASE m.source WHEN 'llm_autonomous' THEN 'llm' ELSE 'manual' END,
+       CASE WHEN m.status = 'active' THEN 'active' ELSE 'pending' END,
+       m.hit_count, m.miss_count, m.inconclusive_count, m.last_matched_at,
+       m.posterior_alpha, m.posterior_beta, m.posterior_p
+FROM pattern_metrics m
+  JOIN pattern_catalog c ON c.id = m.pattern_id
+  JOIN signal_defs s
+    ON s.kind = 'tag'
+   AND s.user_id = c.user_id
+   AND s.tag_name = substring(m.expected_metric_sql FROM 'tag\s*=\s*''?([a-z_]+)')
+WHERE m.domain = 'diary_meta';
+
+-- ─── D. 이관 정합 검증 (pattern_metrics DROP 전 대조, 데이터 독립) ──────
+DO $$
+DECLARE
+  exp_sql INT; got_sql INT;
+  exp_tag INT; got_tag_sig INT; got_tag_link INT;
+  exp_links INT; got_links INT;
+  pm_hit BIGINT; pl_hit BIGINT; pm_miss BIGINT; pl_miss BIGINT; pm_inc BIGINT; pl_inc BIGINT;
+BEGIN
+  -- sql 신호 = non-diary 매트릭 수
+  SELECT count(*) INTO exp_sql FROM pattern_metrics WHERE domain <> 'diary_meta';
+  SELECT count(*) INTO got_sql FROM signal_defs WHERE kind = 'sql';
+  IF got_sql <> exp_sql THEN
+    RAISE EXCEPTION 'sql 신호 수 불일치: 매트릭 %, signal_defs %', exp_sql, got_sql;
+  END IF;
+
+  -- tag 신호 = diary_meta_tags distinct tag
+  SELECT count(DISTINCT tag) INTO exp_tag FROM diary_meta_tags;
+  SELECT count(*) INTO got_tag_sig FROM signal_defs WHERE kind = 'tag';
+  IF got_tag_sig <> exp_tag THEN
+    RAISE EXCEPTION 'tag 신호 수 불일치: distinct tag %, signal_defs %', exp_tag, got_tag_sig;
+  END IF;
+
+  -- tag 링크 = diary 매트릭 수 (전부 형성됐는지)
+  SELECT count(*) INTO got_tag_link
+  FROM pattern_links pl JOIN signal_defs s ON s.id = pl.signal_id WHERE s.kind = 'tag';
+  IF got_tag_link <> (SELECT count(*) FROM pattern_metrics WHERE domain = 'diary_meta') THEN
+    RAISE EXCEPTION 'tag 링크 수 불일치: diary 매트릭 %, tag 링크 %',
+      (SELECT count(*) FROM pattern_metrics WHERE domain = 'diary_meta'), got_tag_link;
+  END IF;
+
+  -- 총 링크 = 총 매트릭 (1:1)
+  SELECT count(*) INTO exp_links FROM pattern_metrics;
+  SELECT count(*) INTO got_links FROM pattern_links;
+  IF got_links <> exp_links THEN
+    RAISE EXCEPTION '링크 총수 불일치: 매트릭 %, 링크 %', exp_links, got_links;
+  END IF;
+
+  -- 카운터 합 보존 (hit/miss/inconclusive)
+  SELECT COALESCE(sum(hit_count), 0), COALESCE(sum(miss_count), 0), COALESCE(sum(inconclusive_count), 0)
+    INTO pm_hit, pm_miss, pm_inc FROM pattern_metrics;
+  SELECT COALESCE(sum(hit_count), 0), COALESCE(sum(miss_count), 0), COALESCE(sum(inconclusive_count), 0)
+    INTO pl_hit, pl_miss, pl_inc FROM pattern_links;
+  IF pl_hit <> pm_hit OR pl_miss <> pm_miss OR pl_inc <> pm_inc THEN
+    RAISE EXCEPTION '카운터 합 불일치: 매트릭 %/%/%　링크 %/%/%',
+      pm_hit, pm_miss, pm_inc, pl_hit, pl_miss, pl_inc;
+  END IF;
+
+  RAISE NOTICE '[077] 이관 정합 OK — sql 신호 %, tag 신호 %, 링크 % (hit/miss/inc %/%/%)',
+    got_sql, got_tag_sig, got_links, pl_hit, pl_miss, pl_inc;
+END $$;
+
+-- ─── E. view 재정의 ──────────────────────────────────────
+-- saju_influence_summary가 pattern_summary에 의존 → 의존 view 먼저 DROP
+DROP VIEW saju_influence_summary;
+DROP VIEW pattern_summary;
+
+-- pattern_summary — pattern_links 기반 (컬럼명·순서·타입 보존, ADR-0023 시드 합계 derive)
+CREATE VIEW pattern_summary AS
+SELECT c.id AS pattern_id, c.user_id, c.name AS pattern_name, c.sipsin,
+       c.trigger_target_type, c.trigger_target_id, c.pattern_kind,
+       c.description AS pattern_description, c.active,
+       count(l.id) AS metric_count,
+       COALESCE(sum(l.hit_count), 0) AS total_hits,
+       COALESCE(sum(l.miss_count), 0) AS total_misses,
+       COALESCE(sum(l.inconclusive_count), 0) AS total_inconclusive,
+       max(l.last_matched_at) AS last_matched_at,
+       CASE WHEN sum(l.posterior_alpha + l.posterior_beta) > 0
+            THEN sum(l.posterior_alpha) / sum(l.posterior_alpha + l.posterior_beta)
+            ELSE NULL END AS aggregate_posterior_p
+FROM pattern_catalog c
+LEFT JOIN pattern_links l ON l.seed_id = c.id AND l.status = 'active'
+GROUP BY c.id;
+
+COMMENT ON VIEW pattern_summary IS
+  '시드 단위 검증 합계 — pattern_links(status=active) 집계 (#477 P1, ADR-0023). hit/miss/inconclusive 합·aggregate posterior를 derive. 컬럼 계약은 v2 시절과 동일 유지(weekly-report·fast-path·saju_influence_summary 호환).';
+
+-- saju_influence_summary — verified tier(가설/통계, 0행이었음) 제거.
+-- accumulating(new pattern_summary) + recent(pattern_matches 유지, ADR-0031 daily-insight) 2층.
+CREATE VIEW saju_influence_summary AS
+WITH accumulating AS (
+  SELECT ps.user_id,
+         ps.pattern_id AS signal_id,
+         ps.pattern_name AS signal_name,
+         ps.sipsin,
+         ps.pattern_description AS description,
+         ps.trigger_target_type,
+         NULL::text AS enum_target,
+         'accumulating'::text AS confidence_tier,
+         ps.total_hits::numeric / NULLIF(ps.total_hits + ps.total_misses, 0)::numeric AS metric_value,
+         NULL::numeric AS fdr_q,
+         NULL::date AS evaluated_at
+  FROM pattern_summary ps
+  WHERE ps.active
+    AND (ps.total_hits + ps.total_misses) >= 5
+    AND (ps.total_hits::numeric / NULLIF(ps.total_hits + ps.total_misses, 0)::numeric) > 0.55
+),
+recent_raw AS (
+  SELECT m.user_id, m.pattern_id AS signal_id, count(*) AS match_count, max(m.date) AS last_match_date
+  FROM pattern_matches m
+  WHERE m.date >= (CURRENT_DATE - '7 days'::interval) AND m.trigger_activated = true
+  GROUP BY m.user_id, m.pattern_id
+),
+recent AS (
+  SELECT r.user_id, r.signal_id, c.name AS signal_name, c.sipsin, c.description, c.trigger_target_type,
+         NULL::text AS enum_target, 'recent'::text AS confidence_tier,
+         r.match_count::numeric AS metric_value, NULL::numeric AS fdr_q, r.last_match_date AS evaluated_at
+  FROM recent_raw r
+    JOIN pattern_catalog c ON c.id = r.signal_id
+  WHERE NOT EXISTS (
+    SELECT 1 FROM accumulating a WHERE a.signal_id = r.signal_id AND a.user_id = r.user_id
+  )
+)
+SELECT user_id, signal_id, signal_name, sipsin, description, trigger_target_type,
+       enum_target, confidence_tier, metric_value, fdr_q, evaluated_at
+FROM accumulating
+UNION ALL
+SELECT user_id, signal_id, signal_name, sipsin, description, trigger_target_type,
+       enum_target, confidence_tier, metric_value, fdr_q, evaluated_at
+FROM recent;
+
+COMMENT ON VIEW saju_influence_summary IS
+  '사주 영향 3층 → P1에서 2층(accumulating·recent). verified tier(가설×통계)는 #477 P1에서 폐기(0행) — P2 주간 엔진이 pattern_links confirmed로 복원 예정. recent는 pattern_matches 최근 7일 trigger(ADR-0031 daily-insight 의존). 컬럼 계약 보존.';
+
+-- ─── F. 폐기 (pattern_matches는 P2까지 유지) ──────────────
+-- pattern_stats가 pattern_hypotheses로 FK 보유 → stats 먼저 DROP.
+DROP TABLE pattern_stats;
+DROP TABLE pattern_hypotheses;
+DROP TABLE pattern_metrics;
+ALTER TABLE signal_defs DROP COLUMN _legacy_metric_id;

--- a/docs/design-notebook/metric-first-verification.md
+++ b/docs/design-notebook/metric-first-verification.md
@@ -123,6 +123,45 @@ v2 헌장 4개 + 마스터 #434 헌장 5개를 계승한다 (본문 복제하지
 
 디테일한 사주 규칙 인코딩이 확증편향 아니냐는 우려: 규칙은 feature를 *계산*할 뿐 효과를 *단언*하지 않음 + 독립 객관 outcome에 off-day 대조 검정 → 틀린 규칙 feature는 상관 안 나와 걸러짐. 위험 셋(주관 태그 오염→객관 우선 / feature 과다→FDR·절제 / 결과 보고 튜닝→사전 고정)만 지키면 디테일이 목적에 봉사. 단 데이터 검증 전 무한 정밀화는 비효율 → 대표 규칙부터, 데이터가 어떤 feature 사는지 보고 확장.
 
+## Phase 1: 스키마 + 신호 전역화 (2026-06-05)
+
+- 이슈: [#479](https://github.com/hyewon3938/slack-ai-agents/issues/479)
+- 관련 계획서: `.claude/plans/479-p1-schema.md`
+- 상태: 구현 완료 (PR 대기)
+
+### 결정 요약
+
+시드 종속 `pattern_metrics`를 전역 `signal_defs`(신호 정의) + `pattern_links`(시드×신호 = 가설 + 누적 검증상태)로 분리한다. diary 22태그를 `kind=tag` 신호로 흡수(객관 sql 신호와 동격, 보조). `pattern_hypotheses`·`pattern_stats`(0행)·`pattern_metrics`(이관 완료) DROP, 두 뷰(`pattern_summary`·`saju_influence_summary`) 재정의.
+
+**빌드 중 설계 수정 (Option A)**: `pattern_matches` 일별행을 P1에서 폐기하려던 원안은 **daily-insight(#insight) 라이브 알림을 끊는다**는 사실이 빌드 탐색에서 드러나 철회. `saju_influence_summary` recent tier(최근 7일 trigger, 96/97행)가 `pattern_matches`에 의존하고 daily-insight routine이 이를 소비한다(ADR-0031). → `pattern_matches`는 **P2까지 유지**(archive·transient·verify는 주간 엔진과 함께 P2로 이동). 일별 cron은 raw trigger-log 기록을 유지하되 verify(카운터 확정)·confirmed 가설 라인만 제거. 주간 cron 중 가설×통계 의존인 `weekly-hypothesis-review`만 중단, `pillar-level-distribution-review`는 `pattern_matches` 유지로 무탈 → 살려둠.
+
+### 의사결정 분기점
+
+- **`pattern_matches` 처리 (빌드 중 재결정)**: 원안은 archive(rename) 후 P2 DROP. 그러나 빌드 탐색에서 `saju_influence_summary` 3층 뷰(ADR-0020)의 recent tier가 `pattern_matches` 최근 7일 trigger에 의존(현재 97행 중 96행)하고, 이를 **daily-insight #insight 라이브 알림**이 소비함을 발견. 사용자 체크포인트 → **유지(P2까지)** 채택. 위상 경계도 더 정합적 — "지속 검증 → transient" 전환은 그것을 대체할 P2 주간 엔진이 생긴 뒤가 맞다. (놓친 이유: 설계 cross-check가 검증 서브시스템 4테이블에 집중, 별도 마스터 #421 산출물인 daily-insight의 뷰 의존을 못 봄.)
+- **매트릭 이관 (전역화 정도)**: dedup(즉시 전역 실현) / 1:1(구조만 전역) — **1:1** 채택. P1은 이관 리스크 최소화가 우선. signal_defs 스키마는 전역 지원하되 기존 84 매트릭은 링크 단위 1:1, 미래 신호부터 공유. diary는 예외 — 태그가 본질상 전역이라 22 tag signal로 자연 dedup(35 link가 참조).
+- **pending 미승인 표현 (uniform)**: signal.status / link.status 어디에 둘지 — **link.status='pending'** 채택(`pattern_links` enum에 추가). tag 신호는 객관 detection이라 항상 active여야 해서, sql/tag 통일하려면 미승인성을 링크가 들어야 함. 매칭 게이트 = `link.status='active' AND signal.status='active'`. P5 승인 = 링크 활성화 단일 경로.
+- **value_type 매핑**: 데이터가 갈라줌 — `flag_present` → binary, 나머지 → continuous. 빌드 검증: 비-diary 49 중 binary 5(expense_category_present) / continuous 44, tag 22 binary.
+- **주간 cron 처리**: A 채택으로 `pattern_matches` 유지되니 `pillar-level-distribution-review`는 안 깨짐 → **유지**(무탈). 가설×통계 테이블 DROP에 의존하는 `weekly-hypothesis-review`만 플래그 중단.
+
+### 포기한 안 / 미룬 항목
+
+- **dedup 이관**: 미룸. 기존 중복 sql 신호는 P5 발굴 단계에서 자연 통합. P1 강제 dedup은 name/의미 정규화 리스크라 제외.
+- **주간 검증 엔진**(window 재계산·Fisher·BH-FDR·status 전이) + **`pattern_matches` archive/transient/일별 verify**: P2 (한 묶음 — transient는 주간 엔진이 지속 검증을 대체한 뒤).
+- **e-value·block permutation·Mann-Whitney·EB 수축**: P3. 단 컬럼(`e_value`·`test_detail`·`confound`)은 P1에서 미리 선언(헌장 ④ "후속 미루지 않기"), 로직만 P2/P3.
+- **매트릭 승인 게이트·가설 발굴 인터랙션**: P2(발굴)/P5(승인 게이트) 재설계까지 플래그 중단. 데이터(pending 링크 5건)는 보존.
+
+### 미해결·가설 → 빌드에서 해소
+
+- **diary 매트릭 35 → tag 매핑** (해소): 모든 diary_meta 매트릭이 `SELECT … WHERE tag='X'` 형식 → 정규식 `tag\s*=\s*''?([a-z_]+)`로 추출. 35개 전부 추출 성공, (시드,tag) 충돌 0 → 35 링크 전부 고유 형성. 마이그레이션이 DROP 전 DO 블록으로 카운트·합 대조(불일치 시 롤백).
+- **잠재 버그 발견**: `pattern_metrics`에 `user_id` 컬럼이 없어 `showPendingMetrics`/`metric_approve`의 `WHERE user_id=$2`가 이미 깨진 상태였음 — P1 포팅(signal_defs/pattern_links, user_id 보유)이 부수적으로 교정.
+- **transient 매칭 정확도**: A 채택으로 일별 기록을 유지하므로 쟁점 소멸(P2에서 transient 전환 시 재검토).
+
+### 회고
+
+> TODO(`/build`): 첫 운영 신호(P2 진입 전 pattern_links 누적) 확인 후 보강. daily-insight 의존성을 설계가 놓친 점 — cross-check 범위에 "이 마스터 밖이지만 같은 테이블을 읽는 소비자"를 넣는 교훈.
+
+---
+
 ## 회고 (TODO: `/build` 구현 후 보강)
 
 > 빌드 후 추가. e-value 시뮬레이션 검증 결과, 첫 운영 신호 품질도 같이.

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -1430,13 +1430,60 @@ ALTER TABLE pattern_matches
 
 **구 insightMorningTask 폐기**: 아침 일운 포맷 알림(Node.js cron, LLM 없음)은 이 routine으로 이관. `SLOT_TASKS`·DB 슬롯(`insightMorning` active=false)에서 제거 (ADR-0027 — LLM 비동기는 routine으로).
 
+### 24. 매트릭 중심 패턴 검증 — Phase 1 (스키마 + 신호 전역화, #479)
+
+시드 종속 `pattern_metrics`를 **전역 신호 정의(`signal_defs`)** + **(시드 × 신호) 검증 단위(`pattern_links`)** 로 분리. (시드 × 신호) 쌍 자체가 검증 대상 가설이며 별도 가설 엔티티는 폐기 (상세 [ADR-0033](../adr/0033-metric-as-hypothesis-and-saju-feature-substrate.md), 통계 스택 [ADR-0032](../adr/0032-metric-first-verification-statistics.md)).
+
+**데이터 모델** (마이그레이션 077):
+
+| 테이블 | 역할 | 핵심 컬럼 |
+|--------|------|----------|
+| `signal_defs` | 전역 신호 정의 (시드 무관) | `kind`(sql\|tag), `sql_body`·`direction`·`value_type`·`threshold`·`domain`·`window_days`(sql), `tag_name`(tag), `source`(seed\|llm), `status`(active\|pending\|rejected) |
+| `pattern_links` | (시드 × 신호) = 가설 + 누적 검증상태 | `seed_id`×`signal_id` UNIQUE, `source`(manual\|discovery\|llm), `status`(active\|pending\|weak\|confirmed\|rejected\|archived), `hit/miss/inconclusive_count`, `posterior_*`, 검증결과(`test_type`·`effect`·`p_value`·`q_value`·`e_value`·`test_detail`·`confound`) |
+
+- **신호 종류**: `kind=sql`(객관 SQL 측정, 1차) — 기존 매트릭 SQL + off-day 대조 판정(`direction`). `kind=tag`(일기 메타 22태그, 보조) — 그날 태그 존재 여부를 binary로 평가. 객관 SQL이 1차, 주관 태그가 보조 (ADR-0033 §5, 확증편향 방어).
+- **검증결과 컬럼**(`e_value`·`test_detail`·`confound` 등)은 P1에서 **선언만** — 로직은 P2(주간 엔진)/P3(통계 증강). 헌장 ④ "후속 미루지 않기"에 따라 컬럼은 미리 둠.
+
+**이관 매핑** (077, 데이터 독립 검증 DO 블록이 DROP 전 대조 — 불일치 시 전체 롤백):
+
+| 원천 (`pattern_metrics` 84) | → signal_defs (71) | → pattern_links (84, counters 1:1) |
+|------|------|------|
+| 비-diary 매트릭 49 | sql 신호 49 (1:1, `_legacy_metric_id` 추적) | sql 링크 49 |
+| diary 매트릭 35 | tag 신호 22 (`tag='X'` SQL 추출 → distinct dedup) | tag 링크 35 (추출 tag JOIN) |
+
+- `value_type`: `flag_present` → `binary`, 나머지 → `continuous`.
+- `source`: `llm_autonomous` → `llm`(signal)·`llm`(link), 그 외 → `seed`(signal)·`manual`(link).
+- pending 매트릭(LLM 미승인, 5건 = sql 3 + diary 2) → 링크 `status='pending'`(매칭 제외). 매칭 게이트 = `link.status='active' AND signal.status='active'`.
+- 카운터 합(hit/miss/inconclusive) 이관 전후 보존.
+
+**평가 흐름** (`pattern-match.ts`): `loadActiveSeeds`가 `pattern_links × signal_defs`(둘 다 active) 조회 → `evaluateMetric`이 `kind`로 분기(sql=SQL+baseline/임계, tag=`diary_meta_tags` 존재 여부). 일별 cron(`daily-pattern-matching.ts`, 07:00)은 매칭 + `pattern_matches` 기록(raw trigger-log) + #life 한 줄 잔소리.
+
+**P1 경계 — 무탈 우선**:
+
+| 대상 | 처리 | 이유 |
+|------|------|------|
+| `pattern_matches` | **유지** (archive·transient는 P2) | daily-insight #insight가 `saju_influence_summary` recent tier(최근 7일 trigger, 96/97행)로 의존 (ADR-0031). 지속 검증을 대체할 P2 주간 엔진이 생긴 뒤 transient 전환이 정합적 |
+| 일별 verify(카운터 확정) | **제거** | 카운터는 링크에 누적(이관 완료) → P2 주간 엔진이 raw에서 윈도우 결정론 재계산 |
+| confirmed 가설 일일 라인 | **제거** (`pickConfirmedHypothesisLines`) | `pattern_hypotheses`/`pattern_stats` DROP. P2가 `pattern_links` confirmed로 복원 |
+| `weekly-hypothesis-review` | **중단** (플래그) | 가설×통계 테이블 DROP — P2 주간 검증 엔진으로 재구축 |
+| `pillar-level-distribution-review` | **유지** | `pattern_matches`(유지)·`pattern_catalog`만 읽어 무탈 |
+| 매트릭 승인/가설 등록 인터랙션 | **중단** (플래그) | 승인 게이트가 `pattern_links` 기반으로 P5 재설계 |
+
+**뷰 재정의** (077): `pattern_summary`(컬럼 계약 보존, `pattern_links` 집계로 derive — weekly-report·fast-path 호환), `saju_influence_summary`(verified tier=가설×통계 제거, 0행이었음 → accumulating·recent 2층, recent는 `pattern_matches` 유지로 daily-insight 무탈).
+
+**폐기**: `pattern_hypotheses`·`pattern_stats`(0행)·`pattern_metrics`(이관 완료) DROP.
+
+**헌장 준수**: ① 정량 매트릭 1차·태그 보조 (kind 분기) / ② off-day 대조 (신호 전역 측정) / ④ 후속 미루지 않기 (검증결과 컬럼 미리 선언). **다음 phase**: P2 주간 검증 엔진(window 재계산 + Fisher/BH-FDR + status 전이 + `pattern_matches` archive/transient 전환).
+
+> 계획서 `.claude/plans/479-p1-schema.md`, 서사 [design-notebook](../design-notebook/metric-first-verification.md) Phase 1 섹션.
+
 ## 파일 구조
 
 ```
 src/agents/insight/
 ├── index.ts                       # 에이전트 생성, fast path 매칭, LLM 에이전트 루프
 ├── prompt.ts                      # 시스템 프롬프트 빌더 (DB 데이터 실시간 로드)
-├── actions.ts                     # 인터랙티브 버튼 핸들러 (+ Phase 4 가설 등록/폐기)
+├── actions.ts                     # 인터랙티브 버튼 핸들러 (가설 등록·매트릭 승인/거절은 #477 P1 비활성, P2/P5 재설계)
 ├── blocks.ts                      # Slack Block Kit 메시지 빌더
 ├── diary-fast-path.ts             # 일기 저장 + 자연스러운 응답
 ├── saju-seed-fast-path.ts         # 사주 시드 보기/끄기/켜기 (Phase 3)
@@ -1445,17 +1492,17 @@ src/agents/insight/
 └── metric-approval-cards.ts       # Phase 6 LLM 매트릭 후보 카드 + 승인/거절 payload
 
 src/shared/
-├── saju-match.ts                  # Phase 3 매칭 엔진 (evaluateTrigger 6종 + evaluateMetric)
+├── pattern-match.ts               # 매칭 엔진 (evaluateTrigger + evaluateMetric kind=sql|tag). #477 P1: pattern_links × signal_defs 기반
 ├── saju-mappings.ts               # 십성 알고리즘 계산 (LLM 프롬프트용)
-├── insight-thresholds.ts          # Phase 1/3 인사이트·시드 임계치 단일 관리 (Phase 4 임계치는 saju-hypothesis.ts 상수)
-├── insights.ts                    # Phase 1 SQL 결정론 11종 + Phase 4 confirmed 가설 라인
-└── saju-hypothesis.ts             # Phase 4 통계 (Fisher + BH-FDR + lifecycle)
+├── insight-thresholds.ts          # Phase 1/3 인사이트·시드 임계치 단일 관리 (Phase 4 임계치는 pattern-hypothesis.ts 상수)
+├── insights.ts                    # Phase 1 SQL 결정론 11종 (confirmed 가설 라인은 #477 P1에서 제거, P2 복원)
+└── pattern-hypothesis.ts          # Fisher + BH-FDR + lifecycle (#477 P1: 주간 엔진 P2 재구축까지 미사용)
 
 src/cron/
-├── daily-pattern-matching.ts              # 07:00 사주 일일 매칭 + 갭 자동 백필 + confirmed 가설 슬롯 (Phase 3/4, #475)
+├── daily-pattern-matching.ts              # 07:00 사주 일일 매칭 + 갭 자동 백필 (#477 P1: verify·가설 라인 제거, raw 기록 유지)
 ├── diary-meta-extract.ts                  # 일기 → enum 태그 추출 cron (Phase 3, Opus)
-├── weekly-hypothesis-review.ts            # 월 08:00 주간 가설 리포트 (Phase 4)
-└── pillar-level-distribution-review.ts    # 월 09:15 운 레벨 분포 분석 (Phase 2.5)
+├── weekly-hypothesis-review.ts            # 월 08:00 주간 가설 리포트 (#477 P1: P2 주간 엔진까지 비활성)
+└── pillar-level-distribution-review.ts    # 월 09:15 운 레벨 분포 분석 (Phase 2.5, #477 P1 유지)
 
 scripts/
 ├── saju-hypothesis-backtest.ts    # Phase 4 임계치 튜닝 CLI

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -369,6 +369,8 @@ Baseline 윈도우는 `BASELINE_WINDOW_DAYS = 28`. SQL 템플릿은 `$user_id`, 
 
 ### 11. 프로액티브 인사이트 v2 — Phase 4 (가설-검증 정량 파이프라인)
 
+> ⚠️ **#477 P1(### 24)에서 supersede**: `pattern_hypotheses`·`pattern_stats` DROP, `weeklyHypothesisReview`·confirmed 가설 라인 중단. 아래는 P1 이전 서사 — 현재 검증 단위는 (시드×신호) `pattern_links`(### 24), 주간 검증 엔진은 P2 재구축.
+
 Phase 3까지는 11종 결정론 패턴 + 60갑자 일일 매칭으로 "기록"만 했다. Phase 4는 그 위에 통계적으로 검증된 가설만 잔소리로 노출하는 자동 파이프라인을 얹는다. 사람 직관(혹은 LLM 추측)이 아니라 누적 데이터의 효과량 + p-value로 active/confirmed/rejected를 판정.
 
 #### 데이터 모델 (migration 058)
@@ -506,6 +508,8 @@ Phase 4는 신규 fast path 명령어 없음. 카드 액션 버튼(`hypothesis_r
 
 #### Phase A2 — `saju_influence_summary` view + idempotency 테이블
 
+> ⚠️ **#477 P1(### 24)에서 view 재정의**: verified tier(가설×통계) 제거 → accumulating·recent 2층. recent는 `pattern_matches` 유지로 daily-insight 무탈. 아래 verified tier 서술은 P1 이전.
+
 마이그레이션:
 - `db/migrations/061_saju_influence_summary_view.sql` — view 정의
 - `db/migrations/062_saju_weekly_reviews.sql` — idempotency 테이블
@@ -608,6 +612,8 @@ TODO: #408 Phase 5-B(영향력 데이터 expose) 완료 후 view 확장 + 풀이
 설계 결정 배경: [ADR-0020](../adr/0020-fortune-system-responsibility-split-via-view.md) — 사주 풀이 시스템과 v2 매칭 시스템 책임 분리 + view 인터페이스 도입.
 
 ### 14. 본인 1명 패턴 발견 시스템 — Phase 1 (스키마 일반화 + `pattern_*` rename)
+
+> ⚠️ **#477 P1(### 24)에서 supersede**: `pattern_metrics`는 `signal_defs`+`pattern_links`로 분리·DROP, `pattern_summary` view는 링크 기반 재정의. 아래 스키마는 P1 이전 — 현재는 ### 24.
 
 > [#434](https://github.com/hyewon3938/slack-ai-agents/issues/434) Phase 1
 > 설계 서사: [design-notebook/personal-pattern-discovery.md](../design-notebook/personal-pattern-discovery.md)

--- a/src/agents/insight/actions.ts
+++ b/src/agents/insight/actions.ts
@@ -20,6 +20,14 @@ import {
   decodeMetricActionPayload,
 } from './metric-approval-cards.js';
 
+/**
+ * #477 P1 — 가설 등록·매트릭 승인/거절 인터랙션 비활성 플래그.
+ * pattern_hypotheses/pattern_metrics DROP + 승인 게이트가 pattern_links 기반으로 재설계됨(P5).
+ * 발굴(P2)·승인 게이트(P5) 재구축 시 false 전환 + pattern_links 대상으로 포팅.
+ * dismiss(순수 UI, DB 미변경)는 유지.
+ */
+const PATTERN_INTERACTION_SUSPENDED_P1 = true;
+
 const resolveBodyUserId = async (body: { user?: string | { id: string } }): Promise<number> => {
   const slackUserId = body.user ? (typeof body.user === 'string' ? body.user : body.user.id) : '';
   if (!slackUserId) return DEFAULT_USER_ID;
@@ -39,6 +47,12 @@ const extractRawValue = (body: unknown): string | null => {
 export const registerInsightActions = (app: App): void => {
   app.action(HYPOTHESIS_REGISTER_ACTION_ID, async ({ ack, body, client }) => {
     await ack();
+    if (PATTERN_INTERACTION_SUSPENDED_P1) {
+      console.warn(
+        '[Insight Action] hypothesis_register — #477 P1, 발굴/등록 P2 재설계 대기 (skip)',
+      );
+      return;
+    }
     const raw = extractRawValue(body);
     if (!raw) return;
     const payload = decodeActionPayload(raw);
@@ -90,6 +104,10 @@ export const registerInsightActions = (app: App): void => {
 
   app.action(METRIC_APPROVE_ACTION_ID, async ({ ack, body, client }) => {
     await ack();
+    if (PATTERN_INTERACTION_SUSPENDED_P1) {
+      console.warn('[Insight Action] metric_approve — #477 P1, 승인 게이트 P5 재설계 대기 (skip)');
+      return;
+    }
     const raw = extractRawValue(body);
     if (!raw) return;
     const payload = decodeMetricActionPayload(raw);
@@ -132,6 +150,10 @@ export const registerInsightActions = (app: App): void => {
 
   app.action(METRIC_REJECT_ACTION_ID, async ({ ack, body, client }) => {
     await ack();
+    if (PATTERN_INTERACTION_SUSPENDED_P1) {
+      console.warn('[Insight Action] metric_reject — #477 P1, 승인 게이트 P5 재설계 대기 (skip)');
+      return;
+    }
     const raw = extractRawValue(body);
     if (!raw) return;
     const payload = decodeMetricActionPayload(raw);

--- a/src/agents/insight/index.ts
+++ b/src/agents/insight/index.ts
@@ -96,7 +96,7 @@ const tryFortuneFastPath = async (
   return true;
 };
 
-/** pending 매트릭 목록 조회 fast path (ADR-0030) */
+/** pending 후보 목록 조회 fast path (ADR-0030 → #477 P1: pending pattern_links 기반) */
 const showPendingMetrics = async (
   say: Parameters<AgentHandler>[1],
   userId: number,
@@ -108,11 +108,15 @@ const showPendingMetrics = async (
       proposed_at: string;
       seed_name: string | null;
     }>(
-      `SELECT pm.id, pm.description, pm.proposed_at,
-              (SELECT name FROM pattern_catalog WHERE id = pm.pattern_id) AS seed_name
-         FROM pattern_metrics pm
-        WHERE pm.user_id = $1 AND pm.status = 'pending'
-        ORDER BY pm.proposed_at DESC
+      `SELECT l.id,
+              COALESCE(NULLIF(s.description, ''), s.name) AS description,
+              l.created_at::text AS proposed_at,
+              seed.name AS seed_name
+         FROM pattern_links l
+         JOIN signal_defs s ON s.id = l.signal_id
+         JOIN pattern_catalog seed ON seed.id = l.seed_id
+        WHERE l.user_id = $1 AND l.status = 'pending'
+        ORDER BY l.created_at DESC
         LIMIT 20`,
       [userId],
     );

--- a/src/cron/daily-pattern-matching.ts
+++ b/src/cron/daily-pattern-matching.ts
@@ -1,19 +1,20 @@
 /**
- * Phase 3+4 — 매일 07시 패턴 일일 매칭 cron (08:00 일일 종합 인사이트 선행, #475).
- * ADR-0017 + ADR-0026(pattern_* rename) + ADR-0031(매칭 선행) 참조.
+ * 매일 07시 패턴 일일 매칭 cron (08:03 일일 종합 인사이트 선행, #475 ADR-0031).
+ * ADR-0017 + ADR-0026(pattern_* rename) + ADR-0033(매트릭=가설 재정의, #477 P1) 참조.
  *
  * 흐름:
  *   0) 마지막 매칭일~오늘 갭 자동 백필 (봇 다운 복귀 시 누락일 복구, 기록만)
- *   1) 어제 pending 매칭 verify_status 확정 (hit/miss/inconclusive)
- *   2) 오늘 활성 시드 평가 → pattern_matches UPSERT
- *   3) matched=true 시드를 #life 잔소리 끝 한 줄로 압축 전송
+ *   1) 오늘 활성 시드 평가 → pattern_matches UPSERT (raw trigger-log; daily-insight recent tier 원천)
+ *   2) matched=true 시드를 #life 잔소리 끝 한 줄로 압축 전송
+ *
+ * #477 P1: 일별 verify(카운터 확정)·confirmed 가설 라인은 P2 주간 검증 엔진까지 제거.
+ * pattern_matches 기록은 유지 — P2가 raw에서 윈도우 재계산하고, recent tier(daily-insight)가 의존.
  */
 
 import type { App } from '@slack/bolt';
 import {
   matchAllSeedsForDay,
   recordDailyMatches,
-  verifyDailyMatches,
   compactMatchedLine,
   getDailyContext,
 } from '../shared/pattern-match.js';
@@ -21,7 +22,6 @@ import { postToChannel } from '../shared/slack.js';
 import { getEffectiveTodayISO, addDays } from '../shared/kst.js';
 import { query } from '../shared/db.js';
 import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
-import { pickConfirmedHypothesisLines } from '../shared/insights.js';
 import type { LifeCronConfig } from './life-cron.js';
 
 /** 봇 장기 다운/최초 실행 시 백필 폭주를 막는 상한 (일). 초과분은 가장 최근 구간만 백필 + 로그. */
@@ -32,7 +32,6 @@ export interface DailyPatternMatchingResult {
   triggeredCount: number;
   matchedCount: number;
   line: string | null;
-  hypothesisLines: string[];
 }
 
 /**
@@ -44,7 +43,7 @@ export const runDailyPatternMatchingDryRun = async (
 ): Promise<DailyPatternMatchingResult> => {
   const ctx = await getDailyContext(userId, date);
   if (!ctx) {
-    return { date, triggeredCount: 0, matchedCount: 0, line: null, hypothesisLines: [] };
+    return { date, triggeredCount: 0, matchedCount: 0, line: null };
   }
 
   const results = await matchAllSeedsForDay(userId, date);
@@ -53,9 +52,8 @@ export const runDailyPatternMatchingDryRun = async (
   const triggeredCount = results.filter((r) => r.triggerActivated).length;
   const matchedCount = results.filter((r) => r.matched).length;
   const line = await compactMatchedLine(ctx, results);
-  const hypothesisLines = await pickConfirmedHypothesisLines(userId, date);
 
-  return { date, triggeredCount, matchedCount, line, hypothesisLines };
+  return { date, triggeredCount, matchedCount, line };
 };
 
 /**
@@ -67,13 +65,6 @@ export const dailyPatternMatchingForUser = async (
   channelId: string,
   date: string,
 ): Promise<void> => {
-  try {
-    await verifyDailyMatches(userId);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[Pattern Match] verify 실패 user=${userId}: ${msg}`);
-  }
-
   let result: DailyPatternMatchingResult;
   try {
     result = await runDailyPatternMatchingDryRun(userId, date);
@@ -93,15 +84,6 @@ export const dailyPatternMatchingForUser = async (
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[Pattern Match] Slack 전송 실패 user=${userId}: ${msg}`);
-    }
-  }
-
-  if (result.hypothesisLines.length > 0) {
-    try {
-      await postToChannel(app.client, channelId, result.hypothesisLines.join('\n'));
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[Pattern Match] 가설 라인 전송 실패 user=${userId}: ${msg}`);
     }
   }
 };
@@ -140,8 +122,8 @@ const findBackfillDays = async (userId: number, today: string): Promise<string[]
 };
 
 /**
- * 누락된 과거 날짜 백필(매칭 기록만, Slack 전송 X) 후 오늘분 정규 처리(verify + match + 전송).
- * 백필분은 다음 verifyDailyMatches(date <= 어제 전체 처리)가 자동으로 hit/miss 확정한다.
+ * 누락된 과거 날짜 백필(매칭 기록만, Slack 전송 X) 후 오늘분 정규 처리(match + 전송).
+ * #477 P1: 백필분의 hit/miss 확정은 P2 주간 엔진이 raw에서 재계산(일별 verify 제거).
  */
 const backfillAndMatchForUser = async (
   app: App,

--- a/src/cron/weekly-hypothesis-review.ts
+++ b/src/cron/weekly-hypothesis-review.ts
@@ -33,6 +33,13 @@ import type { LifeCronConfig } from './life-cron.js';
 
 const SEED_INFLUENCE_TOP_N = 5;
 
+/**
+ * #477 P1 — 주간 가설 리뷰 비활성 플래그.
+ * pattern_hypotheses/pattern_stats DROP으로 가설×통계 기반 리뷰는 동작 불가.
+ * P2 주간 검증 엔진(pattern_links window 재계산)으로 재구축 시 false로 전환/제거.
+ */
+const WEEKLY_REVIEW_SUSPENDED_P1 = true;
+
 /** 오늘이 월요일이라는 전제 — 전주 월요일(=7일 전) 반환 */
 export const previousMondayISO = (todayIso: string): string => {
   const d = new Date(`${todayIso}T12:00:00+09:00`);
@@ -257,6 +264,11 @@ export const weeklyHypothesisReviewTask = async (
   app: App,
   config: LifeCronConfig,
 ): Promise<void> => {
+  // #477 P1: 가설×통계 테이블 DROP — P2 주간 검증 엔진 재구축까지 비활성. 등록은 유지(P2 교체).
+  if (WEEKLY_REVIEW_SUSPENDED_P1) {
+    console.warn('[Hypothesis Review] #477 P1 — P2 주간 검증 엔진 대기, 비활성 (skip)');
+    return;
+  }
   if (getKSTDayOfWeek() !== 1) return;
   const weekStart = previousMondayISO(getTodayISO());
   const mappings = await queryAllUserMappings();

--- a/src/shared/__tests__/pattern-match.test.ts
+++ b/src/shared/__tests__/pattern-match.test.ts
@@ -31,7 +31,6 @@ import {
   evaluateTrigger,
   evaluateMetric,
   compactMatchedLine,
-  verifyDailyMatches,
   recordDailyMatches,
   __resetCacheForTest,
   type SajuSeedWithMetrics,
@@ -427,12 +426,16 @@ describe('evaluateTrigger - sibiunsung', () => {
 
 describe('evaluateMetric', () => {
   const baseMetric = (overrides: Partial<SajuMetric> = {}): SajuMetric => ({
-    id: 1,
+    link_id: 1,
+    signal_id: 1,
     pattern_id: 1,
     metric_name: 'test_metric',
+    kind: 'sql',
     expected_metric_sql: 'SELECT 1',
     expected_direction: 'above_avg',
     expected_threshold: null,
+    value_type: 'continuous',
+    tag_name: null,
     domain: 'schedule',
     ...overrides,
   });
@@ -496,6 +499,35 @@ describe('evaluateMetric', () => {
     const result = await evaluateMetric(metric, 1, '2026-05-17');
     expect(result.todayValue).toBe(0);
     expect(result.passed).toBe(false);
+  });
+
+  it('kind=tag — 그날 태그 존재하면 passed (binary, #477 P1)', async () => {
+    mockQuery.mockImplementation(() => Promise.resolve({ rows: [{ '?column?': 1 }] }));
+    const metric = baseMetric({
+      kind: 'tag',
+      tag_name: 'anxiety',
+      domain: 'diary_meta',
+      expected_metric_sql: null,
+      expected_direction: null,
+    });
+    const result = await evaluateMetric(metric, 1, '2026-05-17');
+    expect(result.passed).toBe(true);
+    expect(result.todayValue).toBe(1);
+    expect(result.direction).toBe('flag_present');
+  });
+
+  it('kind=tag — 그날 태그 없으면 not passed', async () => {
+    mockQuery.mockImplementation(() => Promise.resolve({ rows: [] }));
+    const metric = baseMetric({
+      kind: 'tag',
+      tag_name: 'anxiety',
+      domain: 'diary_meta',
+      expected_metric_sql: null,
+      expected_direction: null,
+    });
+    const result = await evaluateMetric(metric, 1, '2026-05-17');
+    expect(result.passed).toBe(false);
+    expect(result.todayValue).toBe(0);
   });
 });
 
@@ -823,149 +855,6 @@ describe('evaluateTrigger - life_signal', () => {
     });
     const ctx = baseCtx();
     expect(await evaluateTrigger(seed, ctx, stemMap, branchMap)).toBe(false);
-  });
-});
-
-// ─── Phase 4: verifyDailyMatches (matched 카운터 + Bayesian posterior) ─────
-
-describe('verifyDailyMatches (Phase 4)', () => {
-  /**
-   * verifyDailyMatches 호출은 SELECT 2건 + UPDATE 다수 패턴.
-   * mockQuery에 순차적 응답을 등록하고 호출 인자를 검증.
-   */
-
-  it('hit 매칭은 pattern_metrics hit_count + posterior_alpha UPDATE', async () => {
-    mockQuery.mockImplementation((sql: string) => {
-      if (sql.includes("verify_status = 'pending'") && sql.includes('trigger_activated = true')) {
-        return Promise.resolve({ rows: [{ id: 100, pattern_id: 7, matched: true }] });
-      }
-      if (sql.includes("verify_status = 'pending'") && sql.includes('OR matched IS NULL')) {
-        return Promise.resolve({ rows: [] });
-      }
-      return Promise.resolve({ rows: [] });
-    });
-
-    await verifyDailyMatches(1);
-
-    const calls = mockQuery.mock.calls;
-    // UPDATE pattern_matches verify_status='hit'
-    const matchUpdate = calls.find(
-      ([sql, params]) =>
-        typeof sql === 'string' &&
-        sql.includes('UPDATE pattern_matches') &&
-        sql.includes('verify_status') &&
-        Array.isArray(params) &&
-        params[0] === 'hit',
-    );
-    expect(matchUpdate).toBeDefined();
-
-    // UPDATE pattern_metrics hit_count + posterior_alpha
-    const metricUpdate = calls.find(
-      ([sql, params]) =>
-        typeof sql === 'string' &&
-        sql.includes('UPDATE pattern_metrics') &&
-        sql.includes('hit_count       = hit_count + 1') &&
-        sql.includes('posterior_alpha = posterior_alpha + 1.0') &&
-        Array.isArray(params) &&
-        params[0] === 7,
-    );
-    expect(metricUpdate).toBeDefined();
-  });
-
-  it('miss 매칭은 pattern_metrics miss_count + posterior_beta UPDATE', async () => {
-    mockQuery.mockImplementation((sql: string) => {
-      if (sql.includes("verify_status = 'pending'") && sql.includes('trigger_activated = true')) {
-        return Promise.resolve({ rows: [{ id: 101, pattern_id: 8, matched: false }] });
-      }
-      if (sql.includes("verify_status = 'pending'") && sql.includes('OR matched IS NULL')) {
-        return Promise.resolve({ rows: [] });
-      }
-      return Promise.resolve({ rows: [] });
-    });
-
-    await verifyDailyMatches(1);
-
-    const calls = mockQuery.mock.calls;
-    const metricUpdate = calls.find(
-      ([sql, params]) =>
-        typeof sql === 'string' &&
-        sql.includes('UPDATE pattern_metrics') &&
-        sql.includes('miss_count      = miss_count + 1') &&
-        sql.includes('posterior_beta  = posterior_beta + 1.0') &&
-        Array.isArray(params) &&
-        params[0] === 8,
-    );
-    expect(metricUpdate).toBeDefined();
-  });
-
-  it('evidence-only (matched IS NULL)는 SELECT 1에서 제외되어 카운터 UPDATE 안 함', async () => {
-    mockQuery.mockImplementation((sql: string) => {
-      if (sql.includes("verify_status = 'pending'") && sql.includes('trigger_activated = true')) {
-        // matched IS NOT NULL 필터로 인해 빈 결과
-        return Promise.resolve({ rows: [] });
-      }
-      if (sql.includes("verify_status = 'pending'") && sql.includes('OR matched IS NULL')) {
-        // evidence-only 1건
-        return Promise.resolve({ rows: [{ id: 200, pattern_id: 9, matched: null }] });
-      }
-      return Promise.resolve({ rows: [] });
-    });
-
-    await verifyDailyMatches(1);
-
-    const calls = mockQuery.mock.calls;
-    const metricUpdate = calls.find(
-      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE pattern_metrics'),
-    );
-    expect(metricUpdate).toBeUndefined();
-
-    // verify_status='inconclusive' UPDATE는 실행되어야 함
-    const inconclusiveUpdate = calls.find(
-      ([sql, params]) =>
-        typeof sql === 'string' &&
-        sql.includes('UPDATE pattern_matches') &&
-        sql.includes("verify_status = 'inconclusive'") &&
-        Array.isArray(params) &&
-        params[0] === 200,
-    );
-    expect(inconclusiveUpdate).toBeDefined();
-  });
-
-  it('trigger_off (matched IS NOT NULL but trigger_activated=false)는 inconclusive_count UPDATE', async () => {
-    mockQuery.mockImplementation((sql: string) => {
-      if (sql.includes("verify_status = 'pending'") && sql.includes('trigger_activated = true')) {
-        return Promise.resolve({ rows: [] });
-      }
-      if (sql.includes("verify_status = 'pending'") && sql.includes('OR matched IS NULL')) {
-        return Promise.resolve({ rows: [{ id: 300, pattern_id: 10, matched: false }] });
-      }
-      return Promise.resolve({ rows: [] });
-    });
-
-    await verifyDailyMatches(1);
-
-    const calls = mockQuery.mock.calls;
-    const inconclusiveCounter = calls.find(
-      ([sql, params]) =>
-        typeof sql === 'string' &&
-        sql.includes('UPDATE pattern_metrics') &&
-        sql.includes('inconclusive_count = inconclusive_count + 1') &&
-        Array.isArray(params) &&
-        params[0] === 10,
-    );
-    expect(inconclusiveCounter).toBeDefined();
-  });
-
-  it('pending 없으면 UPDATE 호출 0회', async () => {
-    mockQuery.mockImplementation(() => Promise.resolve({ rows: [] }));
-    await verifyDailyMatches(1);
-
-    const updates = mockQuery.mock.calls.filter(
-      ([sql]) =>
-        typeof sql === 'string' &&
-        (sql.includes('UPDATE pattern_matches') || sql.includes('UPDATE pattern_metrics')),
-    );
-    expect(updates.length).toBe(0);
   });
 });
 

--- a/src/shared/insights.ts
+++ b/src/shared/insights.ts
@@ -738,54 +738,5 @@ export const pickNightNudges = (today: string, userId: number): Promise<Insight[
 export const pickWeeklyInsights = (today: string, userId: number): Promise<Insight[]> =>
   pickByTiming(today, userId, 'weekly');
 
-// ─── ADR-0019 Phase 4: confirmed 가설 → 일일 잔소리 합류 ───
-
-interface ConfirmedHypothesisRow {
-  enum_target: string;
-  signal_name: string;
-  rate_ratio: string | null;
-}
-
-/**
- * 오늘 trigger가 발현한 confirmed 가설들의 잔소리 라인 반환.
- * - confirmed 가설(pattern_hypotheses.status='confirmed') × 오늘 pattern_matches.trigger_activated=true 조인
- * - 가설별 최신 rate_ratio를 같이 보여줘 효과 크기 인지
- * - 빈 결과면 빈 배열 반환 → daily-pattern-matching 측에서 분기
- */
-export const pickConfirmedHypothesisLines = async (
-  userId: number,
-  today: string,
-): Promise<string[]> => {
-  try {
-    const res = await query<ConfirmedHypothesisRow>(
-      `SELECT
-         h.enum_target,
-         c.name AS signal_name,
-         (
-           SELECT s.rate_ratio::TEXT
-             FROM pattern_stats s
-            WHERE s.hypothesis_id = h.id
-            ORDER BY s.week_start DESC LIMIT 1
-         ) AS rate_ratio
-       FROM pattern_hypotheses h
-       JOIN pattern_catalog c ON c.id = (h.trigger_spec->>'signalId')::INTEGER
-       JOIN pattern_matches m
-         ON m.user_id = h.user_id
-        AND m.pattern_id = c.id
-        AND m.date = $2
-        AND m.trigger_activated = true
-       WHERE h.user_id = $1 AND h.status = 'confirmed'
-       ORDER BY c.name`,
-      [userId, today],
-    );
-    return res.rows.map((row) => {
-      const ratio = Number(row.rate_ratio);
-      const ratioPart = Number.isFinite(ratio) ? ` (평균 ${ratio.toFixed(1)}x)` : '';
-      return `*${row.signal_name}* 패턴 켜졌어 → \`${row.enum_target}\` 주의${ratioPart}.`;
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[Insights] confirmed 가설 라인 조회 실패: ${msg}`);
-    return [];
-  }
-};
+// #477 P1: confirmed 가설 일일 라인(pickConfirmedHypothesisLines)은 pattern_hypotheses/pattern_stats
+// DROP과 함께 제거. P2 주간 검증 엔진이 pattern_links(status='confirmed') 기반으로 복원 예정.

--- a/src/shared/pattern-match.ts
+++ b/src/shared/pattern-match.ts
@@ -1,13 +1,16 @@
 /**
  * 사주 시드 카탈로그 기반 일일 매칭 엔진.
- * ADR-0017 + ADR-0026(pattern_* rename) 참조.
+ * ADR-0017 + ADR-0026(pattern_* rename) + ADR-0033(매트릭=가설 5어휘 재정의, #477 P1) 참조.
  *
  * 흐름:
- *   1) loadActiveSeeds — pattern_catalog + pattern_metrics 조회
+ *   1) loadActiveSeeds — pattern_catalog + pattern_links × signal_defs(전역 신호) 조회
  *   2) getDailyContext — 일운(getDayPillar) + 본명(saju_profiles) 로드
  *   3) evaluateTrigger — trigger_target_type별 분기 평가
- *   4) evaluateMetrics — 메트릭 SQL 실행 + 28일 baseline 비교 → matched 판정
- *   5) recordDailyMatch — pattern_matches UPSERT
+ *   4) evaluateMetric — 신호 평가: kind=sql(SQL + baseline/임계 비교) | kind=tag(그날 태그 존재 여부)
+ *   5) recordDailyMatch — pattern_matches UPSERT (P2 주간 검증 엔진 전까지 raw trigger-log 지속)
+ *
+ * P1(#477): 검증 단위는 (시드 × 신호) = pattern_links. hit/miss 카운터는 링크에 누적(이관 완료),
+ * 주간 재계산은 P2. 일별 verify(카운터 확정)는 P2 엔진으로 이관 — 본 모듈은 매칭·기록만.
  */
 
 import { query, queryWithClient } from './db.js';
@@ -55,13 +58,22 @@ export interface SajuSeed {
   source: 'seed' | 'llm_promoted';
 }
 
+/**
+ * (시드 × 신호) 평가 단위. #477 P1: pattern_links × signal_defs JOIN 결과.
+ * kind=sql이면 expected_metric_sql/expected_direction 보유(CHECK 보장),
+ * kind=tag이면 tag_name 보유 + 그날 태그 존재 여부를 binary로 평가.
+ */
 export interface SajuMetric {
-  id: number;
+  link_id: number;
+  signal_id: number;
   pattern_id: number;
   metric_name: string;
-  expected_metric_sql: string;
-  expected_direction: 'above_avg' | 'below_avg' | 'above_abs' | 'below_abs' | 'flag_present';
+  kind: 'sql' | 'tag';
+  expected_metric_sql: string | null;
+  expected_direction: 'above_avg' | 'below_avg' | 'above_abs' | 'below_abs' | 'flag_present' | null;
   expected_threshold: number | null;
+  value_type: 'binary' | 'continuous' | null;
+  tag_name: string | null;
   domain:
     | 'schedule'
     | 'routine'
@@ -354,13 +366,16 @@ export const loadActiveSeeds = async (userId: number): Promise<SajuSeedWithMetri
   if (seeds.rows.length === 0) return [];
 
   const ids = seeds.rows.map((s) => s.id);
-  // Phase 1: 결정론 시드 매트릭만 활성. LLM 자율 매트릭(status='pending')은 Phase 4에서.
+  // #477 P1: 검증 단위 = (시드 × 신호) 활성 링크 × 활성 신호. pending 링크/신호(LLM 미승인)는 제외.
   const metrics = await query<MetricRow>(
-    `SELECT id, pattern_id, metric_name, expected_metric_sql,
-            expected_direction, expected_threshold, domain
-       FROM pattern_metrics
-      WHERE pattern_id = ANY($1) AND status = 'active'
-      ORDER BY id`,
+    `SELECT l.id AS link_id, l.seed_id AS pattern_id, s.id AS signal_id,
+            s.name AS metric_name, s.kind,
+            s.sql_body AS expected_metric_sql, s.direction AS expected_direction,
+            s.threshold AS expected_threshold, s.value_type, s.tag_name, s.domain
+       FROM pattern_links l
+       JOIN signal_defs s ON s.id = l.signal_id
+      WHERE l.seed_id = ANY($1) AND l.status = 'active' AND s.status = 'active'
+      ORDER BY l.id`,
     [ids],
   );
 
@@ -670,23 +685,61 @@ const baselineAvg = async (sql: string, userId: number, date: string): Promise<n
   return n > 0 ? sum / n : 0;
 };
 
+/** tag 신호 — 그날 해당 일기 메타 태그 존재 여부 (binary). */
+const tagPresent = async (userId: number, date: string, tagName: string): Promise<boolean> => {
+  const result = await query(
+    `SELECT 1 FROM diary_meta_tags WHERE user_id = $1 AND date = $2 AND tag = $3 LIMIT 1`,
+    [userId, date, tagName],
+  );
+  return result.rows.length > 0;
+};
+
 export const evaluateMetric = async (
   metric: SajuMetric,
   userId: number,
   date: string,
 ): Promise<MetricEvaluation> => {
-  const todayValue = await runMetricSql(metric.expected_metric_sql, userId, date);
+  // kind=tag — off-day 대조용 객관 보조 신호. 그날 태그가 찍혔으면 hit(binary).
+  if (metric.kind === 'tag') {
+    const present = metric.tag_name ? await tagPresent(userId, date, metric.tag_name) : false;
+    return {
+      metric_name: metric.metric_name,
+      domain: metric.domain,
+      todayValue: present ? 1 : 0,
+      baselineAvg: null,
+      threshold: 1,
+      direction: 'flag_present',
+      passed: present,
+    };
+  }
+
+  // kind=sql — signal_defs CHECK가 sql_body/direction NOT NULL 보장. 방어적으로 좁힘.
+  const sql = metric.expected_metric_sql;
+  const direction = metric.expected_direction;
+  if (!sql || !direction) {
+    return {
+      metric_name: metric.metric_name,
+      domain: metric.domain,
+      todayValue: 0,
+      baselineAvg: null,
+      threshold: metric.expected_threshold,
+      direction: direction ?? 'flag_present',
+      passed: false,
+    };
+  }
+
+  const todayValue = await runMetricSql(sql, userId, date);
 
   let baseline: number | null = null;
   let passed = false;
 
-  switch (metric.expected_direction) {
+  switch (direction) {
     case 'above_avg':
-      baseline = await baselineAvg(metric.expected_metric_sql, userId, date);
+      baseline = await baselineAvg(sql, userId, date);
       passed = todayValue > baseline;
       break;
     case 'below_avg':
-      baseline = await baselineAvg(metric.expected_metric_sql, userId, date);
+      baseline = await baselineAvg(sql, userId, date);
       passed = todayValue < baseline;
       break;
     case 'above_abs':
@@ -706,7 +759,7 @@ export const evaluateMetric = async (
     todayValue,
     baselineAvg: baseline,
     threshold: metric.expected_threshold,
-    direction: metric.expected_direction,
+    direction,
     passed,
   };
 };
@@ -841,79 +894,10 @@ export const recordDailyMatches = async (
   }
 };
 
-// ─── 검증 사이클 (다음날 verify_status 확정 + outcome 카운트 누적) ─────
-
-export const verifyDailyMatches = async (userId: number): Promise<void> => {
-  // 어제 trigger_activated=true + matched IS NOT NULL인 pending → hit/miss 확정 + pattern_metrics 카운터 UPDATE.
-  // ADR-0023: counter source of truth는 pattern_metrics. ADR-0024: posterior_alpha/beta Beta-Binomial.
-  const pending = await query<{ id: number; pattern_id: number; matched: boolean | null }>(
-    `SELECT id, pattern_id, matched
-       FROM pattern_matches
-      WHERE user_id = $1 AND verify_status = 'pending'
-        AND date <= (CURRENT_DATE - INTERVAL '1 day')
-        AND trigger_activated = true
-        AND matched IS NOT NULL`,
-    [userId],
-  );
-
-  for (const row of pending.rows) {
-    const outcome = row.matched ? 'hit' : 'miss';
-    await query(`UPDATE pattern_matches SET verify_status = $1 WHERE id = $2`, [outcome, row.id]);
-    if (outcome === 'hit') {
-      await query(
-        `UPDATE pattern_metrics
-            SET hit_count       = hit_count + 1,
-                last_matched_at = NOW(),
-                posterior_alpha = posterior_alpha + 1.0,
-                posterior_p     = (posterior_alpha + 1.0) /
-                                  (posterior_alpha + posterior_beta + 1.0)
-          WHERE pattern_id = $1 AND status = 'active'`,
-        [row.pattern_id],
-      );
-    } else {
-      await query(
-        `UPDATE pattern_metrics
-            SET miss_count      = miss_count + 1,
-                last_matched_at = NOW(),
-                posterior_beta  = posterior_beta + 1.0,
-                posterior_p     = posterior_alpha /
-                                  (posterior_alpha + posterior_beta + 1.0)
-          WHERE pattern_id = $1 AND status = 'active'`,
-        [row.pattern_id],
-      );
-    }
-  }
-
-  // trigger_activated=false 또는 matched IS NULL(evidence-only)은 inconclusive 처리.
-  // matched IS NOT NULL이지만 trigger_activated=false인 케이스만 매트릭 inconclusive_count++.
-  const inconclusiveRows = await query<{
-    id: number;
-    pattern_id: number;
-    matched: boolean | null;
-  }>(
-    `SELECT id, pattern_id, matched
-       FROM pattern_matches
-      WHERE user_id = $1 AND verify_status = 'pending'
-        AND date <= (CURRENT_DATE - INTERVAL '1 day')
-        AND (trigger_activated = false OR matched IS NULL)`,
-    [userId],
-  );
-
-  for (const row of inconclusiveRows.rows) {
-    await query(`UPDATE pattern_matches SET verify_status = 'inconclusive' WHERE id = $1`, [
-      row.id,
-    ]);
-    if (row.matched !== null) {
-      await query(
-        `UPDATE pattern_metrics
-            SET inconclusive_count = inconclusive_count + 1,
-                last_matched_at    = NOW()
-          WHERE pattern_id = $1 AND status = 'active'`,
-        [row.pattern_id],
-      );
-    }
-  }
-};
+// ─── 검증 사이클 ─────────────────────────────────────────
+// #477 P1: 일별 verify(verify_status 확정 + 카운터 누적)는 P2 주간 검증 엔진으로 이관.
+// 카운터(hit/miss/posterior)는 pattern_links에 누적(이관 완료) → 주간 재계산이 raw pattern_matches
+// 윈도우를 결정론 재산출(ADR-0033 §2). 본 모듈은 매칭·기록(raw trigger-log)까지만 담당.
 
 // ─── Slack 한 줄 압축 ────────────────────────────────────
 


### PR DESCRIPTION
## 관련 이슈
Closes #479 (마스터 #477 Phase 1)

## 변경 내용
- 시드 종속 `pattern_metrics` → 전역 `signal_defs`(신호 정의) + `pattern_links`(시드×신호=가설) 분리
- diary 22태그를 `kind=tag` 신호로 흡수 (객관 sql 1차, 태그 보조)
- 매트릭 84건 링크 1:1 이관 (sql 49 + tag 35), hit/miss/inconclusive 합 보존, DROP 전 DO 블록 정합 검증
- 두 뷰(`pattern_summary`·`saju_influence_summary`) 재정의 — 컬럼 계약 보존
- `pattern_hypotheses`·`pattern_stats`·`pattern_metrics` DROP
- 일별 매칭 새 스키마 포팅 + raw trigger-log 유지. 일별 verify·confirmed 가설 라인은 P2 주간 엔진으로 이관
- 주간 가설 리뷰·승인 인터랙션은 P2(발굴)/P5(승인 게이트) 재구축까지 중단. 운 레벨 분포 리뷰는 유지

## 설계 변경 (빌드 중)
- 일일 종합 인사이트(#insight)가 `saju_influence_summary` recent tier를 통해 `pattern_matches`에 의존함을 발견 → P1 archive/transient를 P2로 미루고 `pattern_matches` 유지 (기존 알림 무탈)

## 정본
[ADR-0032](docs/adr/0032-metric-first-verification-statistics.md)·[ADR-0033](docs/adr/0033-metric-as-hypothesis-and-saju-feature-substrate.md), [design-notebook Phase 1](docs/design-notebook/metric-first-verification.md), [domain ### 24](docs/domains/insight.md)

## 코드 리뷰 결과
- [x] 보안 감사 통과 (하드코딩 시크릿·개인정보 없음, 파라미터화 쿼리)
- [x] 타입 안전성 (`kind` 분기 discriminated, nullable 좁힘)
- [x] 컨벤션 점검 (kebab·named export·any 없음)
- [x] 마이그레이션 prod 롤백 트랜잭션 실행 검증 (뷰·DO 정합)

## 테스트
- [x] tsc·vitest(599 통과)·eslint(0 error)
- [x] 마이그레이션 롤백 검증: signal 71 / link 84 / 카운터 합 보존 / 뷰 recent 91행 무탈 / pending 링크 5