### PR TITLE
feat(insight): #477 P6 — 교란 플래그 (공동발현 시드 marginal 탐지)

### DIFF
--- a/docs/adr/0041-confound-cofiring-flag.md
+++ b/docs/adr/0041-confound-cofiring-flag.md
@@ -1,0 +1,101 @@
+# 0041. 교란 플래그 — marginal 공동발현 overlap 탐지 + annotate-only (P6/P7 분리)
+
+- Status: Accepted
+- Date: 2026-06-06
+- Related: [#477](https://github.com/hyewon3938/slack-ai-agents/issues/477), [#493](https://github.com/hyewon3938/slack-ai-agents/issues/493), [ADR-0032](0032-metric-first-verification-statistics.md) (§6 교란 데이터 게이트), [ADR-0033](0033-metric-as-hypothesis-and-saju-feature-substrate.md) (feature 환원), [ADR-0037](0037-verification-fdr-family-split.md) (FDR 가족)
+- Tags: insight, statistics, architecture
+
+## Context
+
+off-day 대조 검증(P2)은 "시드 발현일 vs 비발현일"에서 신호 발현율을 2×2로 비교해 **단일 시드의 marginal 연관**만 본다. 그런데 같은 날 공존하는 제3변수가 시드와 신호 둘 다를 끌면 가짜 연관(교란, confounding)이 생긴다. 두 부류:
+
+- **달력 주기**: 요일·주말·월 위치·계절·공휴일. 사주 시드가 우연히 주말에 자주 켜지고 신호도 주말에 높으면, 그 연관은 시드가 아니라 주말의 효과일 수 있다("어부지리").
+- **공존 사주 시드**: 같은 날 다른 사주 시드가 같이 켜져서, 진짜 원인은 그쪽인데 이 시드에 공이 돌아가는 경우.
+
+[ADR-0032](0032-metric-first-verification-statistics.md) §6은 교란을 데이터 게이트 자동 활성으로 위임했다 — 두 시드 공동발현 횟수가 임계(\~30일) 넘으면 다변량(elastic-net) 분리 자동 on, **그 전엔 "교란 의심" 플래그만**. 본 ADR은 그 **플래그 절반(Phase 6)** 을 확정한다. 다변량 분리(Phase 7, 데이터 게이트)는 본 ADR 범위 밖.
+
+**헌장 cross-check 결과 — "feature 환원"이 이미 끝나 있다**: 교란변수(요일·계절·월 위치 등)가 이미 18개 `life_signal` 결정론 시드([072](../../db/migrations/072_life_signal_seed_pool.sql): 요일 7 + 주말/평일 2 + 월위치 3 + 계절 4 + 공휴일 2)로 존재한다. 즉 [ADR-0033](0033-metric-as-hypothesis-and-saju-feature-substrate.md)의 "운 레벨 modulation을 결정론 feature로 환원"이 달력 변수엔 #434 P3에서 이미 적용됐다. 교란 후보가 활성 시리즈를 갖는 시드라, 플래그는 **기존 off-day 프리미티브 재사용**으로 환원된다(P5a 발굴이 쓰는 그 시드/신호 시리즈).
+
+## Decision
+
+교란을 **새 통계 검정이 아니라 기존 off-day 프리미티브 재사용으로 푼다**(feature 환원/층화 노선, P4 결정론 feature 선례). Phase 6는 marginal 플래그까지, 추정치 *조정*(층화/다변량)은 Phase 7(데이터 게이트)로 분리한다.
+
+### 1. 교란 후보 = 모든 공동발현 시드
+
+`life_signal` 달력 18개 + 다른 active 사주 시드 전부를 후보로 둔다. 전부 결정론 활성 시리즈를 가지므로 후보 Z의 시리즈는 이미 계산돼 있다(발굴이 쓰는 active 시드 시리즈 공유). [ADR-0032](0032-metric-first-verification-statistics.md) §6 정의("다중 트리거 공존")와 Context 예시("편재·월말·주말 동시")에 충실 — 달력만이 아니라 사주끼리의 어부지리도 잡는다.
+
+### 2. marginal 플래그 기준 (2조건)
+
+링크 (시드 S × 신호 X)에 대해 후보 Z(≠S)가 둘 다 만족하면 "교란 의심"으로 기록한다:
+
+- **(a) 공동발현 overlap**: `P(Z active | S active) ≥ confoundMinOverlap`, 그리고 공동발현일 수 `≥ confoundMinCofireDays`(노이즈 바닥). S가 켜질 때 Z도 대체로 켜진다.
+- **(b) Z↔X 연관**: (Z active vs Z off) × (X pass/fail) 2×2의 rate ratio `≥ minRateRatio`. Z 자체가 신호와 연관돼야 교란원이 될 수 있다.
+
+(a)만으론 부족하다 — 겹치기만 하고 신호와 무관한 시드는 교란이 아니다. 둘 다 기존 `buildContingency`/`verifyContingency` 재사용 → **새 통계 코어 0**.
+
+### 3. annotate-only (정직 플래그)
+
+플래그는 `pattern_links.confound` JSONB([077](../../db/migrations/077_signal_defs_and_links.sql)에서 선언만)에 기록하고 주간 검증 카드에 "교란 의심: {Z} 공존"으로 노출한다:
+
+```json
+{ "scannedAt": "2026-06-08",
+  "suspected": [{ "seedId": 0, "seedName": "주말", "overlap": 0.0, "effectZX": 0.0, "nCofire": 0 }] }
+```
+
+**verdict·status·e-value·tier는 건드리지 않는다.** 추정치 보정·확정 취소는 Phase 7의 일이다. 플래그는 "이 연관은 Z와 겹쳐 어부지리일 수 있다"를 사용자에게 정직하게 알릴 뿐, 확정을 죽이지 않는다. `scannedAt`을 항상 기록해 "점검했으나 깨끗"과 "미점검"을 구분한다.
+
+### 4. always-on (데이터 게이트 아님)
+
+플래그 계산은 싸고(캐시된 시리즈 위 overlap + 2×2) marginal이라 데이터 적어도 valid → 매주 무조건 실행한다. `nCofire`를 기록해 Phase 7이 `≥ 임계(\~30일)`에서 다변량 분리를 자동 활성하게 한다([ADR-0032](0032-metric-first-verification-statistics.md) §6, 헌장 ④).
+
+### 5. 노브 외부화 (헌장 ⑤)
+
+`insight-thresholds.confound = { minOverlap, minCofireDays, minEffectZX, topN }`. `minEffectZX`는 `patternVerification.minRateRatio`(1.3) 승계. 값은 calibration 노브(첫 몇 주 튜닝).
+
+## Alternatives considered
+
+### A. 새 confound 전용 통계 검정 (partial correlation / 조건부 로지스틱)
+
+- 장점: 한 번에 조정된 추정치까지.
+- 기각: n=1 소표본 회귀 부담 + "새 통계 코어 0"(P4a/P4b/P5a 4연속) 이탈. 교란변수가 이미 결정론 시드라 회귀 없이 시드 overlap으로 충분. Mantel-Haenszel 층화·elastic-net 같은 *조정*은 Phase 7(데이터 게이트)로 미룬다.
+
+### B. overlap만으로 플래그 (Z↔X 연관 검사 생략)
+
+- 장점: 더 단순.
+- 기각: 공동발현만 보면 신호와 무관한 시드까지 다 플래그돼 노이즈가 폭발한다. 교란의 정의상 Z는 신호와도 연관돼야 한다 → (b) 필수.
+
+### C. annotate가 아니라 soft-demote (교란 의심 확정 링크를 검증됨→검증중 강등)
+
+- 장점: 더 강한 보수성.
+- 기각(Phase 6에선): 강등은 추정치 *판단*이라 Phase 7 다변량 분리의 결과로 해야 정직하다. marginal 겹침만으로 임의 강등하면 진짜 패턴을 죽일 위험. Phase 6 = 노출(정직), Phase 7 = 조정(데이터).
+
+### D. 교란변수를 달력 18개로 한정
+
+- 장점: 단순.
+- 기각: [ADR-0032](0032-metric-first-verification-statistics.md) §6 정의가 "다중 트리거 공존"(시드 일반)이고 Context 예시도 사주+달력 혼합. 사주 시드끼리의 어부지리를 놓친다.
+
+## Consequences
+
+### 장점
+
+- **새 통계 코어 0 · 마이그레이션 0**(077 `confound` 컬럼 재사용) — P5a/P5b 패턴 4연속 유지.
+- 교란을 "데이터로만 가린다" 정신 위에서 정직하게 노출 — 확정을 숨기지도, 임의로 죽이지도 않는다.
+- `nCofire` 기록으로 Phase 7 다변량 분리가 데이터 게이트로 자동 얹힌다(헌장 ④).
+
+### 단점 / 제약
+
+- marginal 플래그는 "겹친다"까지만 — Z를 통제하면 S 효과가 *실제로* 사라지는지는 Phase 7까지 미확정. 플래그 = 의심이지 판정 아님(카피에 명시).
+- 달력 near-duplicate(주말 ≡ 토+일)는 중복 플래그 → 표시 단계 dedup·`topN` cap으로 완화.
+- 교란 후보 스캔이 (claimable 링크 × active 시드)라 비용 증가 — 월 1회 n=1 수용, 배칭은 후속.
+
+### 후속 작업
+
+- [ ] **Phase 7**: `nCofire ≥ 임계` 시 층화/elastic-net 다변량 분리(데이터 게이트 자동 on) + daily-insight verified tier 교란 caveat(`saju_influence_summary` 재정의).
+- [ ] 교란 후보 정책·임계 변경 시 ADR 갱신.
+
+---
+
+**참고 자료**
+
+- [ADR-0032](0032-metric-first-verification-statistics.md) §6 (교란 분리 데이터 게이트), References의 Mantel-Haenszel·elastic-net
+- [ADR-0033](0033-metric-as-hypothesis-and-saju-feature-substrate.md) (운 레벨 → 결정론 feature 환원)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -147,6 +147,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0038](0038-saju-relation-hwa-feature-depth.md) | 사주 관계·합화 변환 feature 깊이 — 검증 결정론(v1a)·해석 LLM 분리 + FDR 가족 확장 | Accepted | 2026-06-05 | insight, statistics, architecture, saju |
 | [0039](0039-pattern-discovery-surface-and-approval-gate.md) | 패턴 발굴 — surface-only 제안 + 사람 승인 게이트(노출·큐레이션 vs 믿음 분리) | Accepted | 2026-06-05 | insight, statistics, architecture |
 | [0040](0040-llm-signal-sql-validation-and-execution-isolation.md) | LLM-생성 신호 SQL 검증·실행 격리 — untrusted 측정 SQL 2단 방어 (+ 옛 LLM 제안 재정의) | Accepted | 2026-06-06 | insight, security, llm, architecture |
+| [0041](0041-confound-cofiring-flag.md) | 교란 플래그 — marginal 공동발현 overlap 탐지 + annotate-only (P6/P7 분리) | Accepted | 2026-06-06 | insight, statistics, architecture |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/metric-first-verification.md
+++ b/docs/design-notebook/metric-first-verification.md
@@ -515,6 +515,56 @@ LLM-생성 SQL을 untrusted input으로 다루는 2단 방어(등록 정적 검�
 
 **운영 검증 남음**: routine(`monthly-signal-suggest`) 배포 후 첫 발사 시 후보 SQL 품질 + 게이트 #1 통과율 확인. read-only TX 격리는 단위(`queryReadOnly` SET TRANSACTION READ ONLY 단언) + 통합(승인된 llm 신호의 첫 주간 검증 실행) 양면 확인.
 
+## Phase 6: 교란 플래그 — 공동발현 시드 marginal 탐지 (2026-06-06)
+
+- 이슈: [#493](https://github.com/hyewon3938/slack-ai-agents/issues/493)
+- 관련 계획서: `.claude/plans/493-p6-confound-flag.md`
+- 상태: 설계 완료 (구현 대기)
+- 정본 결정: [ADR-0041](../adr/0041-confound-cofiring-flag.md)
+
+### 결정 요약
+
+off-day 검증은 단일 시드의 **marginal 연관**만 본다 — 같은 날 공존하는 제3변수(요일·계절·월 위치 = 달력 주기, 또는 다른 사주 시드)가 시드와 신호 둘 다를 끌면 가짜 연관(교란, "어부지리")이 생긴다. P6는 그걸 **플래그**한다. 추정치 *조정*(층화/다변량)은 P7(데이터 게이트).
+
+- **feature 환원 노선** (vs 새 통계 검정): 교란변수가 **이미 18 `life_signal` 결정론 시드**(072: 요일 7+주말/평일 2+월위치 3+계절 4+공휴일 2)라 활성 시리즈를 가진다 → 플래그는 **기존 시드 활성 시리즈 overlap + 기존 2×2 재사용**. **새 통계 코어 0, 마이그레이션 0**(077 `confound` 컬럼 재사용). P4a/P4b/P5a 패턴 5연속.
+- **marginal 2조건**: 링크(S×X)에 대해 후보 Z가 (a) 공동발현 `P(Z|S)≥minOverlap` & `nCofire≥minCofireDays` **AND** (b) Z↔X 연관 `effect≥minRateRatio`면 "교란 의심" 기록. (a)만으론 노이즈 폭발 — 교란원은 신호와도 연관돼야(b 필수).
+- **annotate-only(정직 플래그)**: `pattern_links.confound` JSONB(`{scannedAt, suspected:[{seedId,seedName,overlap,effectZX,nCofire}]}`) + 주간 카드 "교란 의심: {Z} 공존". **verdict·status·e-value·tier 불변** — 확정을 죽이지 않고 정직하게 알릴 뿐. 강등·조정은 P7.
+- **always-on**: 플래그 싸고 marginal이라 데이터 적어도 valid → 매주 무조건. `nCofire` 기록이 P7 데이터 게이트(\~30일) 입력.
+
+### 의사결정 분기점
+
+1. **P6 스코프 = 교란 플래그 단독** (vs 노트북 표 원안 "알림+큐레이션+교란 플래그"). **cross-check 발견 1**: 표의 알림(#insight 카드·daily-insight 3-tier)·큐레이션(승인 게이트)·status는 **P2/P3/P5에서 이미 분산 구현** → P6 실질 잔여 = 교란 플래그뿐. 메모리의 "P7=dormant graded"는 압축 노이즈, 정본 P7 = 교란 다변량 분리(데이터 게이트) — P3 L261·P4a L301·P5a L418 모두 "P6 플래그 / P7 데이터 게이트"로 일관 위임.
+2. **새 통계 검정 vs feature 환원/층화** (사용자가 든 핵심 결정) → **feature 환원**. **cross-check 발견 2**: 교란변수(요일·계절·월위치)가 이미 결정론 `life_signal` 시드라 [ADR-0033](../adr/0033-metric-as-hypothesis-and-saju-feature-substrate.md) "운 레벨 → feature 환원"이 달력 변수엔 #434 P3에서 이미 적용됨 → "새 통계 검정 vs feature 환원" 갈림길의 답이 P6에선 거의 강제(feature 환원 = 이미 깔린 길). 새 통계 검정(partial correlation 등)은 기각([ADR-0041](../adr/0041-confound-cofiring-flag.md) A).
+3. **교란 대상 = 달력 + 모든 공동발현 시드** (vs 달력 18개 한정). [ADR-0032](../adr/0032-metric-first-verification-statistics.md) §6 "다중 트리거 공존" 정의 + Context 예시("편재·월말·주말 동시") 충실 — 사주끼리의 어부지리도 포착. ([ADR-0041](../adr/0041-confound-cofiring-flag.md) D).
+4. **annotate-only vs soft-demote** → annotate. 강등은 추정치 판단이라 P7 다변량 분리 결과로 해야 정직 — marginal 겹침만으로 임의 강등하면 진짜 패턴 살해 위험([ADR-0041](../adr/0041-confound-cofiring-flag.md) C). P6=노출, P7=조정.
+
+### 포기한 안 / 미룬 항목
+
+- **새 confound 전용 통계 검정**(partial correlation/조건부 로지스틱): 기각 — n=1 부담 + "새 통계 코어 0" 이탈. Mantel-Haenszel 층화·elastic-net 같은 *조정*은 P7.
+- **soft-demote**(교란 의심 확정 링크 강등): 기각(P6) — P7 다변량 분리 결과로.
+- **다변량 교란 분리**(층화/elastic-net로 독립 기여 추정): P7, 데이터 게이트(`nCofire≥\~30`) 자동 on. dormant 빌드(헌장 ④).
+- **daily-insight verified tier 교란 caveat**: P7로 — `saju_influence_summary` 뷰가 P7에서 조정 추정치로 재정의되므로 caveat 렌더링을 거기 묶음(이틀 안에 P7이라 P6 주간 카드 노출로 정직성 즉시 충족, 뷰 이중 재정의 회피). P6 = 마이그레이션 0 유지.
+
+### 미해결·가설 → 빌드에서 해소
+
+- **시리즈 공유**: 교란 패스는 (claimable 링크의 시드/신호 + 모든 active 후보 시드) 시리즈가 필요 — 발굴(`discoverCandidates`)이 이미 계산하는 active 시드/신호 시리즈와 겹침. 발굴 시리즈 계산을 `computeActiveSeriesBundle`로 추출해 발굴+교란 공유 vs 교란 자체 재계산(월 1회 n=1 수용, P5a 재계산 선례). `verifyUserLinks` 코어는 무변경(blast radius 최소). 빌드 결정.
+- **claimable 링크 로드 범위**: 노출 대상 = `status IN ('active','confirmed')`(confirmed는 sticky라 `verifyUserLinks` results에 없음 → 교란 패스 독립 로드). verdict 의존 없이 디커플.
+- **노브 초기값**: `minOverlap`·`minCofireDays`·`minEffectZX`(=minRateRatio 1.3 승계)·`topN` — calibration 노브(첫 몇 주 튜닝, 헌장 ⑤).
+- **near-duplicate dedup**: 달력 nesting(주말≡토+일)은 중복 플래그 → 표시 단계 dedup + `topN` cap. 코어 정확성엔 무해.
+- **카드 노출 위치**: `buildVerificationBlocks`(hypothesis-cards.ts) 링크 라인에 confound.suspected 비었지 않으면 caveat 한 줄.
+
+### 도메인 문서 본문 채우기
+
+- [ ] `docs/domains/insight.md` ### 31 (Phase 6) 본문 — 교란 알고리즘(2조건)·confound JSONB·annotate-only·always-on·P6/P7 경계·노브 + 파일 구조 코멘트 갱신.
+
+### 기술적 의의
+
+교란변수가 이미 결정론 feature 시드(달력 18개 + 사주)임을 cross-check로 확인해, 교란 통제를 **새 통계 없이 기존 off-day 프리미티브 재사용**으로 환원했다(feature 환원 노선). 노출(P6 marginal 플래그, 정직)과 조정(P7 다변량 분리, 데이터 게이트)을 분리해 — marginal 겹침만으로 진짜 패턴을 죽이지 않으면서 "어부지리 의심"을 사용자에게 정직하게 도달시킨다. (어필 표현은 portfolio-candidates.)
+
+### 회고
+
+> TODO(`/build`): 첫 교란 패스 결과(플래그된 링크 수, 달력 vs 사주 교란 분포, near-dup 노이즈) 확인 후 보강.
+
 ---
 
 ## 회고 (TODO: `/build` 구현 후 보강)

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -1768,6 +1768,54 @@ LLM이 새 측정 신호(`signal_defs`, `kind='sql'`, `source='llm'`)를 월간 
 
 **월간 routine** (`monthly-signal-suggest`, 로컬 SKILL·repo 외): 매월 09:30 KST Opus([ADR-0027](../adr/0027-llm-async-work-as-claude-app-routines.md)). 입력 풀 = 라이프 메트릭 표(카운트·평균만, **금액 제외**) + 시드 description + 기존 active/rejected 신호(중복·재제안 관리). 텍스트 원문 0(헌장 v2 ①). 생성 계약 = 단일 SELECT·`user_id=$1`·화이트리스트 테이블·`value_type`/`direction` 지정. idempotency(이번 달 `source='llm'` 존재 시 종료) + cap 월 5. 등록 INSERT는 DB proxy `validateProxySQL` 통과, 임베드 `sql_body`는 게이트 #1/#2가 심판.
 
+### 31. 매트릭 중심 패턴 검증 — Phase 6 (교란 플래그: 공동발현 시드 marginal 탐지, #493)
+
+off-day 검증(P2)은 단일 시드의 **marginal 연관**만 본다 — 같은 날 공존하는 제3변수(요일·주말·월위치·계절 = 달력 주기, 또는 다른 사주 시드)가 시드와 신호 둘 다를 끌면 가짜 연관(교란·"어부지리")이 생긴다. P6는 claimable (시드 S × 신호 X) 링크마다 공동발현 교란 시드 Z를 탐지해 `pattern_links.confound`에 기록하고 주간 카드에 노출한다. 정본 [ADR-0041](../adr/0041-confound-cofiring-flag.md). **새 통계 코어 0, 마이그레이션 0**(077 `confound` 컬럼 재사용) — P4a/P4b/P5a 패턴 5연속.
+
+**feature 환원 노선** (vs 새 통계 검정): 교란변수가 **이미 18개 `life_signal` 결정론 시드**([072](../../db/migrations/072_life_signal_seed_pool.sql): 요일 7 + 주말/평일 2 + 월위치 3 + 계절 4 + 공휴일 2)라 활성 시리즈를 가진다 → 플래그가 **기존 시드 활성 시리즈 + 기존 2×2(`buildContingency`/`verifyContingency`) 재사용**으로 환원된다([ADR-0033](../adr/0033-metric-as-hypothesis-and-saju-feature-substrate.md) "운 레벨 → feature 환원"이 달력 변수엔 #434 P3에서 이미 적용됨). partial correlation 같은 새 회귀 검정은 기각.
+
+**교란 알고리즘 (marginal 2조건)** ([confound.ts](../../src/shared/confound.ts) `flagConfoundersForLink`): 링크(S × X)에 대해 후보 Z(≠ S)가 **둘 다** 만족하면 "교란 의심"으로 수집(overlap 내림차순 → `topN` cap):
+
+| 조건 | 식 | 의미 |
+|------|------|------|
+| (a) 공동발현 | `P(Z active \| S active) ≥ minOverlap` **AND** `nCofire ≥ minCofireDays` | S 켜질 때 Z도 대체로 켜짐(노이즈 바닥) |
+| (b) Z↔X 연관 | `(Z active vs off) × (X pass/fail)` 2×2의 `rate ratio ≥ minEffectZX` | Z 자체가 신호와 연관돼야 교란원 |
+
+(a)만으론 신호와 무관한 겹침 시드까지 다 잡혀 노이즈 폭발 → **(b) 필수**. 후보 Z = **달력 18 + 모든 active 사주 시드**(달력만이 아니라 사주끼리의 어부지리도 포착, [ADR-0032](../adr/0032-metric-first-verification-statistics.md) §6 "다중 트리거 공존").
+
+**`confound` JSONB** ([077](../../db/migrations/077_signal_defs_and_links.sql) 선언, P6 채움):
+
+```json
+{ "scannedAt": "2026-06-08",
+  "suspected": [{ "seedId": 0, "seedName": "주말", "overlap": 0.0, "effectZX": 0.0, "nCofire": 0 }] }
+```
+
+`scannedAt`을 항상 기록해 "점검했으나 깨끗(suspected=[])"과 "미점검"을 구분한다.
+
+**annotate-only(정직 플래그)**: 플래그는 `confound`에 SET + 주간 카드 verified/emerging 라인에 `⚠️ 교란 의심: {Z} 공존` 한 줄(reject는 연관 자체가 약해 생략). **verdict·status·e-value·tier는 건드리지 않는다** — 확정을 죽이지 않고 "어부지리일 수 있다"를 정직하게 알릴 뿐. 강등·추정치 조정은 P7.
+
+**always-on(데이터 게이트 아님)**: 플래그는 싸고(캐시된 시리즈 위 overlap + 2×2) marginal이라 데이터 적어도 valid → 매주 무조건 실행. `nCofire`를 기록해 **P7 다변량 분리가 `nCofire ≥ 임계(\~30일)`에서 자동 활성**(헌장 ④)되게 한다.
+
+**흐름** (주간 엔진 [weekly-verification.ts](../../src/cron/weekly-verification.ts) `processUser`, `verifyUserLinks` 후·카드 전):
+
+```
+flagConfounds(userId, today)                          # confound.ts 로더
+  → claimable 링크 로드 (status IN active|confirmed, JOIN active 신호·시드)
+  → 후보 = 모든 active 시드 (loadActiveSeeds)
+  → 시드 활성 시리즈 시드당 1회 (computeSeedActivationSeries, strength_band 2-pass 캐시)
+  → 링크 등장 신호 시리즈 신호당 1회 (computeSignalSeries)
+  → 링크별 flagConfoundersForLink → ConfoundResult[]
+persistConfound (per-link 격리, UPDATE confound) → confoundByLink 맵
+buildVerificationBlocks(…, confoundByLink)            # 카드 caveat
+```
+
+- **claimable = `status IN ('active','confirmed')`**: confirmed는 sticky라 `verifyUserLinks`(active만) results에 없음 → 교란 패스가 독립 로드. 카드 노출은 active만, DB 기록은 둘 다(P7 다변량 분리가 confirmed 링크도 읽음).
+- **시리즈 self-contained**: P5a 발굴과 동형으로 자체 계산·격리 — `verifyUserLinks` 코어 무변경(blast radius 최소). 발굴과의 시리즈 공유(`computeActiveSeriesBundle` 추출)는 follow-up 최적화. 검증/발굴/교란 3단계는 독립 try-catch로 격리(한 단계 실패가 나머지를 막지 않음).
+
+**P6 vs P7 경계**: P6 = marginal 플래그(노출, always-on). P7 = 다변량 분리(층화/elastic-net로 Z 통제 후 S 독립 기여 추정 = *조정*, 데이터 게이트 `nCofire ≥ \~30`, dormant 빌드). marginal 겹침만으로 임의 강등하면 진짜 패턴 살해 위험 → 조정은 데이터가 충분할 때만. daily-insight verified tier 교란 caveat는 P7로(`saju_influence_summary` 뷰가 P7에서 조정 추정치로 재정의되므로 거기 묶음).
+
+**노브** ([insight-thresholds.ts](../../src/shared/insight-thresholds.ts) `confound`, 헌장 ⑤): `minOverlap`(0.6)·`minCofireDays`(10)·`minEffectZX`(1.3, `patternVerification.minRateRatio` 승계)·`topN`(3). calibration 노브 — 첫 몇 주 튜닝.
+
 ## 파일 구조
 
 ```
@@ -1786,6 +1834,7 @@ src/shared/
 ├── signal-sql-guard.ts            # #477 P5b LLM SQL 게이트 #1 정적 검증 (validateSignalSql + 테이블 화이트리스트, ADR-0040)
 ├── pattern-match.ts               # 매칭 엔진 (evaluateTrigger + evaluateMetric kind=sql|tag). #477 P1: pattern_links × signal_defs 기반 + P4b hwa_sipsung trigger + P5b runLlmSignalSql(게이트 #2)
 ├── pattern-verification.ts        # #477 P2/P3 off-day 검증 엔진 (2×2 + block-perm + e-value + 연속 MW → EB posterior → verdict/status) + P4a 강도-밴드 2-pass + P4b FDR 3가족(saju_relation)
+├── confound.ts                    # #477 P6 교란 플래그 (공동발현 시드 marginal 탐지: overlap + Z×신호 2×2 재사용 → confound JSONB, annotate-only, ADR-0041)
 ├── saju-strength.ts               # #477 P4a 실효강도 엔진 (생조−극설 + 월령 + 통근, 절대 신강/신약, 오행 비율) + P4b 합화 변환 반영
 ├── saju-strength-params.ts        # #477 P4a 명리학 파라미터 (위치가중·월령·통근·분위수) + P4b 합화 노브(통근·충개합·일간합·깊은 노브 off)
 ├── saju-hwa.ts                    # #477 P4b 합화 변환 탐지(천간합/육합/삼합 + 통근 게이트 + 충개합 v1a) + 효과적 십성 그룹
@@ -1799,7 +1848,7 @@ src/shared/
 src/cron/
 ├── daily-pattern-matching.ts              # 07:00 사주 일일 매칭 → seed_daily_activations transient 기록 (#477 P2: 검증·백필·발송 제거)
 ├── diary-meta-extract.ts                  # 일기 → enum 태그 추출 cron (Phase 3, Opus)
-├── weekly-verification.ts                 # 월 06:00 주간 off-day 검증 엔진 (#477 P2/P3: e-value persist + 주간 스냅샷 + 3-tier 카드)
+├── weekly-verification.ts                 # 월 06:00 주간 off-day 검증 엔진 (#477 P2/P3: e-value persist + 주간 스냅샷 + 3-tier 카드, P5a 발굴, P6 교란 플래그)
 └── pillar-level-distribution-review.ts    # 월 09:15 운 레벨 분포 분석 (Phase 2.5, #477 P2 seed_daily_activations 재배선)
 
 scripts/

--- a/src/agents/insight/hypothesis-cards.ts
+++ b/src/agents/insight/hypothesis-cards.ts
@@ -8,6 +8,7 @@
 
 import type { KnownBlock } from '@slack/types';
 import type { LinkVerification } from '../../shared/pattern-verification.js';
+import type { ConfoundData } from '../../shared/confound.js';
 import type { DiscoveryCandidate } from './hypothesis-discovery.js';
 import { INSIGHT_THRESHOLDS } from '../../shared/insight-thresholds.js';
 
@@ -192,8 +193,18 @@ const emergingLine = (l: LinkVerification, prevE: number | undefined): string =>
 const rejectLine = (l: LinkVerification): string =>
   `• ✗ ${KIND_LABEL[l.patternKind]} ${l.signalName} × \`${l.seedName}\` — 연관 약함(effect ${formatRatio(l.effect)})`;
 
+/**
+ * 교란 의심 caveat 한 줄(있으면) — annotate-only(P6, ADR-0041). suspected는 엔진에서 overlap 정렬 + topN cap.
+ * verified/emerging 라인에만 덧붙임(reject는 연관 자체가 약해 교란 무의미).
+ */
+const confoundCaveat = (l: LinkVerification, confoundByLink: Map<number, ConfoundData>): string => {
+  const suspected = confoundByLink.get(l.linkId)?.suspected ?? [];
+  if (suspected.length === 0) return '';
+  return `\n  ⚠️ 교란 의심: ${suspected.map((s) => s.seedName).join(', ')} 공존`;
+};
+
 const TIER_LEGEND =
-  '_✅ 검증됨 = e-value≥20 통계 확정(우연 아님, 단 연관이지 인과는 아님) · 🌱 검증중 = off-day 경향은 보이나 아직 확정 전 · ✗ 기각 = 연관 약함._';
+  '_✅ 검증됨 = e-value≥20 통계 확정(우연 아님, 단 연관이지 인과는 아님) · 🌱 검증중 = off-day 경향은 보이나 아직 확정 전 · ✗ 기각 = 연관 약함 · ⚠️ 교란 의심 = 같이 켜지는 시드와 겹쳐 어부지리일 수 있음._';
 
 /**
  * 주간 검증 리포트 — 시드 영향력 + 3-tier 검증 현황(검증됨/검증중/기각).
@@ -204,6 +215,7 @@ export const buildVerificationBlocks = (
   links: LinkVerification[],
   seedInfluence: SeedInfluenceRow[],
   prevEValues: Map<number, number> = new Map(),
+  confoundByLink: Map<number, ConfoundData> = new Map(),
 ): KnownBlock[] => {
   const blocks: KnownBlock[] = [
     {
@@ -247,7 +259,10 @@ export const buildVerificationBlocks = (
   if (verified.length > 0) {
     blocks.push({
       type: 'section',
-      text: { type: 'mrkdwn', text: verified.map(verifiedLine).join('\n') },
+      text: {
+        type: 'mrkdwn',
+        text: verified.map((l) => verifiedLine(l) + confoundCaveat(l, confoundByLink)).join('\n'),
+      },
     });
   }
 
@@ -256,7 +271,11 @@ export const buildVerificationBlocks = (
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: emerging.map((l) => emergingLine(l, prevEValues.get(l.linkId))).join('\n'),
+        text: emerging
+          .map(
+            (l) => emergingLine(l, prevEValues.get(l.linkId)) + confoundCaveat(l, confoundByLink),
+          )
+          .join('\n'),
       },
     });
   }

--- a/src/cron/weekly-verification.ts
+++ b/src/cron/weekly-verification.ts
@@ -23,6 +23,7 @@ import {
   type LinkVerification,
   type StrengthCutpoint,
 } from '../shared/pattern-verification.js';
+import { flagConfounds, type ConfoundData, type ConfoundResult } from '../shared/confound.js';
 import { posteriorMean, credibleInterval } from '../shared/bayesian-posterior.js';
 import {
   buildVerificationBlocks,
@@ -164,6 +165,18 @@ const persistStrengthCutpoints = async (
       [userId, c.target, c.low, c.high, c.nSamples],
     );
   }
+};
+
+/**
+ * 교란 플래그를 pattern_links.confound에 SET (annotate-only, P6 ADR-0041).
+ * verdict·status·e-value·tier는 건드리지 않음 — 사이드카 주석. user_id 가드로 교차 유저 차단.
+ */
+const persistConfound = async (userId: number, r: ConfoundResult): Promise<void> => {
+  await query(`UPDATE pattern_links SET confound = $1::jsonb WHERE id = $2 AND user_id = $3`, [
+    JSON.stringify(r.confound),
+    r.linkId,
+    userId,
+  ]);
 };
 
 /** 직전 주(들) 링크별 e_value — emerging 진행바 "지난주 → 이번주" delta용 (link당 최신 1행). */
@@ -329,7 +342,34 @@ const processUser = async (
     `[Verification] user=${userId} 링크 ${results.length} (persist ${persisted}) verified ${verified} reject ${rejects}`,
   );
 
-  const blocks = buildVerificationBlocks(weekStart, results, seedInfluence, prevEValues);
+  // 교란 플래그(P6, ADR-0041) — 검증/발굴과 독립 격리. 실패해도 검증 카드는 무탈(빈 맵).
+  const confoundByLink = new Map<number, ConfoundData>();
+  try {
+    const cr = await flagConfounds(userId, today);
+    let flagged = 0;
+    for (const r of cr) {
+      try {
+        await persistConfound(userId, r);
+        confoundByLink.set(r.linkId, r.confound);
+        if (r.confound.suspected.length > 0) flagged += 1;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[Confound] persist 실패 link=${r.linkId}: ${msg}`);
+      }
+    }
+    console.warn(`[Confound] user=${userId} 교란 플래그 ${flagged}/${cr.length} 링크`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[Confound] user=${userId} 교란 플래그 실패: ${msg}`);
+  }
+
+  const blocks = buildVerificationBlocks(
+    weekStart,
+    results,
+    seedInfluence,
+    prevEValues,
+    confoundByLink,
+  );
   const fallback = `패턴 검증 주간 리포트 (${weekStart} ~) — 링크 ${results.length}건`;
   try {
     await postBlockMessage(app.client, channelId, fallback, blocks);

--- a/src/shared/__tests__/confound.test.ts
+++ b/src/shared/__tests__/confound.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeOverlap,
+  flagConfoundersForLink,
+  type ConfoundCandidate,
+  type ConfoundThresholds,
+} from '../confound.js';
+import type { DaySeries } from '../pattern-verification.js';
+
+// 합성 시리즈 헬퍼 — 10일 윈도우(d0..d9). buildContingency/verifyContingency는 이미 검증됨(pattern-verification.test) →
+// 여기선 교란 조립 로직(2조건 AND·정렬·topN·자기 제외)에 집중.
+const DAYS = Array.from({ length: 10 }, (_, i) => `d${i}`);
+
+const act = (activeDates: string[]): Map<string, boolean> => {
+  const s = new Set(activeDates);
+  return new Map(DAYS.map((d) => [d, s.has(d)]));
+};
+
+const sig = (passDates: string[]): DaySeries => {
+  const p = new Set(passDates);
+  return new Map(DAYS.map((d) => [d, p.has(d)]));
+};
+
+const T: ConfoundThresholds = { minOverlap: 0.6, minCofireDays: 3, minEffectZX: 1.3, topN: 3 };
+
+// 링크 시드 S 활성 = d0..d4, 신호 X = S 발현일에 pass(둘이 정렬).
+const S_ACTIVE = ['d0', 'd1', 'd2', 'd3', 'd4'];
+const actS = act(S_ACTIVE);
+const SIG = sig(['d0', 'd1', 'd2', 'd3', 'd4']);
+
+// ─── computeOverlap ──────────────────────────────────────
+
+describe('computeOverlap', () => {
+  it('S 발현일 대비 Z 공동발현 비율 + cofire 수', () => {
+    const r = computeOverlap(act(['d0', 'd1', 'd2', 'd3']), act(['d0', 'd1', 'd8']));
+    expect(r.nCofire).toBe(2); // {d0, d1}
+    expect(r.overlap).toBeCloseTo(0.5); // 2/4
+  });
+
+  it('S 발현 0이면 {0, 0}', () => {
+    expect(computeOverlap(act([]), act(['d0', 'd1']))).toEqual({ overlap: 0, nCofire: 0 });
+  });
+});
+
+// ─── flagConfoundersForLink ──────────────────────────────
+
+describe('flagConfoundersForLink', () => {
+  // overlap 0.8(4/5) + 신호와 강하게 연관 → flagged.
+  const conf: ConfoundCandidate = {
+    seedId: 2,
+    seedName: '주말',
+    act: act(['d0', 'd1', 'd2', 'd3']),
+  };
+  // S와 거의 안 겹침(cofire 1) → overlap·cofire 게이트 컷.
+  const lowOverlap: ConfoundCandidate = {
+    seedId: 3,
+    seedName: '저겹침',
+    act: act(['d0', 'd5', 'd6', 'd7']),
+  };
+  // overlap 0.6 통과하나 신호와 무관(pass/fail 균등) → effectZX 게이트 컷(조건 b 필수).
+  const noAssoc: ConfoundCandidate = {
+    seedId: 4,
+    seedName: '무관',
+    act: act(['d0', 'd1', 'd2', 'd5', 'd6', 'd7']),
+  };
+
+  it('overlap + effectZX 둘 다 통과 → flagged', () => {
+    const r = flagConfoundersForLink(1, actS, SIG, [conf], 'today', T);
+    expect(r.suspected).toHaveLength(1);
+    expect(r.suspected[0]?.seedId).toBe(2);
+    expect(r.suspected[0]?.overlap).toBeCloseTo(0.8);
+    expect(r.suspected[0]?.nCofire).toBe(4);
+    expect(r.suspected[0]?.effectZX).toBeGreaterThanOrEqual(1.3);
+  });
+
+  it('overlap 통과 + effectZX 미달(신호와 무관) → 미flag (조건 b 필수)', () => {
+    const r = flagConfoundersForLink(1, actS, SIG, [noAssoc], 'today', T);
+    expect(r.suspected).toHaveLength(0);
+  });
+
+  it('overlap 미달 → 미flag', () => {
+    const r = flagConfoundersForLink(1, actS, SIG, [lowOverlap], 'today', T);
+    expect(r.suspected).toHaveLength(0);
+  });
+
+  it('nCofire < minCofireDays → 미flag (노이즈 바닥)', () => {
+    // conf는 nCofire=4. 바닥을 5로 올리면 overlap·effect 통과해도 cofire 게이트가 컷.
+    const r = flagConfoundersForLink(1, actS, SIG, [conf], 'today', { ...T, minCofireDays: 5 });
+    expect(r.suspected).toHaveLength(0);
+  });
+
+  it('Z == S 자기 제외', () => {
+    const selfCand: ConfoundCandidate = {
+      seedId: 1, // = 링크 시드 S
+      seedName: 'self',
+      act: act(['d0', 'd1', 'd2', 'd3']), // 통계상 flag감이나 자기 제외로 빠짐
+    };
+    const r = flagConfoundersForLink(1, actS, SIG, [selfCand, conf], 'today', T);
+    expect(r.suspected.map((s) => s.seedId)).not.toContain(1);
+    expect(r.suspected.map((s) => s.seedId)).toContain(2);
+  });
+
+  it('overlap 내림차순 정렬 + topN cap', () => {
+    // 신호 X는 pass 폭을 넓혀(d0..d6) 세 후보 모두 effectZX 통과·유한.
+    const sigWide = sig(['d0', 'd1', 'd2', 'd3', 'd4', 'd5', 'd6']);
+    const c1: ConfoundCandidate = {
+      seedId: 11,
+      seedName: 'a',
+      act: act(['d0', 'd1', 'd2', 'd3', 'd4']),
+    }; // 1.0
+    const c2: ConfoundCandidate = { seedId: 12, seedName: 'b', act: act(['d0', 'd1', 'd2', 'd3']) }; // 0.8
+    const c3: ConfoundCandidate = { seedId: 13, seedName: 'c', act: act(['d0', 'd1', 'd2']) }; // 0.6
+    const r = flagConfoundersForLink(1, actS, sigWide, [c3, c1, c2], 'today', { ...T, topN: 2 });
+    expect(r.suspected).toHaveLength(2);
+    expect(r.suspected.map((s) => s.seedId)).toEqual([11, 12]); // overlap 내림차순, topN=2
+  });
+
+  it('의심 없어도 scannedAt 기록(점검함 vs 미점검 구분)', () => {
+    const r = flagConfoundersForLink(1, actS, SIG, [lowOverlap], 'today', T);
+    expect(r.suspected).toHaveLength(0);
+    expect(r.scannedAt).toBe('today');
+  });
+});

--- a/src/shared/confound.ts
+++ b/src/shared/confound.ts
@@ -1,0 +1,235 @@
+/**
+ * 교란 플래그 엔진 — 공동발현 시드 marginal 탐지 (#477 P6, ADR-0041).
+ *
+ * off-day 검증(P2)은 단일 시드의 **marginal 연관**만 본다. 같은 날 공존하는 제3변수(달력 주기 =
+ * 요일·주말·월위치·계절, 또는 다른 사주 시드)가 시드와 신호 둘 다를 끌면 가짜 연관(교란·"어부지리").
+ * P6는 claimable(활성·확정) (시드 S × 신호 X) 링크마다 공동발현 교란 시드 Z를 탐지해 기록한다.
+ *
+ * 핵심(헌장 ④): 교란변수가 이미 결정론 시드(life_signal 18 + 사주)라 feature 환원이 끝나 있음 →
+ * 기존 시드 활성 시리즈 + 기존 2×2(buildContingency/verifyContingency) 재사용. 새 통계 코어 0.
+ *
+ * annotate-only(ADR-0041 §3): verdict·status·e-value·tier 불변. 강등·다변량 분리는 P7(데이터 게이트).
+ * 본 모듈은 순수 계산 + 읽기만. UPDATE pattern_links.confound·카드 발송은 weekly-verification.ts.
+ */
+
+import { query } from './db.js';
+import {
+  buildWindowDates,
+  buildContingency,
+  verifyContingency,
+  computeSignalSeries,
+  computeSeedActivationSeries,
+  type SignalDef,
+  type SignalDirection,
+  type DaySeries,
+} from './pattern-verification.js';
+import { loadActiveSeeds, buildNameIdMap, type DailyContext } from './pattern-match.js';
+import type { BandCuts } from './quantile.js';
+import { INSIGHT_THRESHOLDS } from './insight-thresholds.js';
+
+const T = INSIGHT_THRESHOLDS.confound;
+const V = INSIGHT_THRESHOLDS.patternVerification;
+
+// ─── 타입 ────────────────────────────────────────────────
+
+/** 교란 의심 후보 — 링크 시드 S와 공동발현 + 신호 X와도 연관된 제3시드 Z. */
+export interface SuspectedConfounder {
+  seedId: number;
+  seedName: string;
+  overlap: number; // P(Z active | S active)
+  effectZX: number; // Z↔X rate ratio (발현일 pass율 / 비발현일 pass율)
+  nCofire: number; // |actS ∩ actZ| 공동발현일 수 (P7 데이터 게이트 입력)
+}
+
+/** confound JSONB 형태 — "점검했다"는 사실(scannedAt) + 의심 목록(없으면 빈 배열). */
+export interface ConfoundData {
+  scannedAt: string;
+  suspected: SuspectedConfounder[];
+}
+
+export interface ConfoundResult {
+  linkId: number;
+  confound: ConfoundData;
+}
+
+/** 교란 임계 (insight-thresholds.confound). 파라미터로 받아 테스트가 커스텀 주입 가능. */
+export interface ConfoundThresholds {
+  minOverlap: number;
+  minCofireDays: number;
+  minEffectZX: number;
+  topN: number;
+}
+
+/** 교란 후보 = active 시드 + 미리 계산된 활성 시리즈. */
+export interface ConfoundCandidate {
+  seedId: number;
+  seedName: string;
+  act: Map<string, boolean>;
+}
+
+// ─── 순수 계산 ───────────────────────────────────────────
+
+/**
+ * S 발현일 대비 Z 공동발현 비율 + 공동발현일 수.
+ * overlap = |{d: actS[d] ∧ actZ[d]}| / |{d: actS[d]}|. S 발현 0이면 {0, 0}.
+ */
+export const computeOverlap = (
+  actS: Map<string, boolean>,
+  actZ: Map<string, boolean>,
+): { overlap: number; nCofire: number } => {
+  let sActive = 0;
+  let inter = 0;
+  for (const [date, active] of actS) {
+    if (!active) continue;
+    sActive++;
+    if (actZ.get(date)) inter++;
+  }
+  return { overlap: sActive > 0 ? inter / sActive : 0, nCofire: inter };
+};
+
+/**
+ * 한 링크(시드 S × 신호 X)의 교란 의심 시드 수집.
+ * 후보 Z(≠ S)가 둘 다 만족하면 의심: (a) overlap≥minOverlap ∧ nCofire≥minCofireDays(노이즈 바닥),
+ * (b) Z↔X 연관 effectZX≥minEffectZX (기존 2×2 재사용). overlap 내림차순 정렬 후 topN cap.
+ * (a)만으론 신호와 무관한 겹침 시드까지 다 잡혀 노이즈 폭발 → (b) 필수(ADR-0041 §2).
+ */
+export const flagConfoundersForLink = (
+  seedId: number,
+  actS: Map<string, boolean>,
+  sigX: DaySeries,
+  candidates: ConfoundCandidate[],
+  today: string,
+  t: ConfoundThresholds,
+): ConfoundData => {
+  const suspected: SuspectedConfounder[] = [];
+  for (const z of candidates) {
+    if (z.seedId === seedId) continue; // 자기 제외
+    const { overlap, nCofire } = computeOverlap(actS, z.act);
+    if (overlap < t.minOverlap || nCofire < t.minCofireDays) continue;
+    const v = verifyContingency(buildContingency(z.act, sigX));
+    if (!Number.isFinite(v.effect) || v.effect < t.minEffectZX) continue;
+    suspected.push({
+      seedId: z.seedId,
+      seedName: z.seedName,
+      overlap,
+      effectZX: v.effect,
+      nCofire,
+    });
+  }
+  suspected.sort((a, b) => b.overlap - a.overlap);
+  return { scannedAt: today, suspected: suspected.slice(0, t.topN) };
+};
+
+// ─── 읽기 (로더) ─────────────────────────────────────────
+
+interface ClaimableLinkRow {
+  link_id: number;
+  seed_id: number;
+  signal_id: number;
+}
+
+interface SignalDefRow {
+  id: number;
+  name: string;
+  kind: 'sql' | 'tag';
+  source: 'seed' | 'llm';
+  sql_body: string | null;
+  value_type: 'binary' | 'continuous' | null;
+  direction: SignalDirection | null;
+  threshold: string | null;
+  tag_name: string | null;
+  window_days: number | null;
+}
+
+const toSignalDef = (r: SignalDefRow): SignalDef => ({
+  id: r.id,
+  name: r.name,
+  kind: r.kind,
+  source: r.source,
+  sqlBody: r.sql_body,
+  valueType: r.value_type,
+  direction: r.direction,
+  threshold: r.threshold === null ? null : Number(r.threshold),
+  tagName: r.tag_name,
+  windowDays: r.window_days,
+});
+
+/**
+ * 한 유저의 claimable 링크(status IN active|confirmed)마다 교란 플래그 산출.
+ * confirmed는 sticky라 verifyUserLinks(active만 재검증) results에 없음 → 여기서 독립 로드
+ * (카드 노출은 active만, DB 기록은 둘 다 — P7 다변량 분리가 confirmed 링크도 읽음).
+ * 시리즈는 self-contained(P5a 발굴과 동형 — 자체 계산·격리, verifyUserLinks 코어 무변경 = blast radius 최소).
+ * 시드 활성 시리즈는 시드당 1회(strength_band 2-pass 캐시 공유), 신호 시리즈는 (등장한) 신호당 1회.
+ */
+export const flagConfounds = async (userId: number, today: string): Promise<ConfoundResult[]> => {
+  const linkRes = await query<ClaimableLinkRow>(
+    `SELECT l.id AS link_id, l.seed_id, l.signal_id
+       FROM pattern_links l
+       JOIN signal_defs s ON s.id = l.signal_id
+       JOIN pattern_catalog c ON c.id = l.seed_id
+      WHERE l.user_id = $1 AND l.status IN ('active', 'confirmed')
+        AND s.status = 'active' AND c.active = true
+      ORDER BY l.id`,
+    [userId],
+  );
+  if (linkRes.rows.length === 0) return [];
+
+  const windowDates = buildWindowDates(today, V.windowCapDays);
+  const [stemMap, branchMap] = await Promise.all([
+    buildNameIdMap('stems_master'),
+    buildNameIdMap('branches_master'),
+  ]);
+
+  // 후보 = 모든 active 시드. 활성 시리즈는 시드당 1회(strength_band 2-pass 캐시 공유).
+  const seeds = await loadActiveSeeds(userId);
+  const ctxCache = new Map<string, DailyContext | null>();
+  const strengthCache = new Map<string, Map<string, number>>();
+  const cutCache = new Map<string, BandCuts>();
+  const seedActById = new Map<number, Map<string, boolean>>();
+  for (const seed of seeds) {
+    seedActById.set(
+      seed.id,
+      await computeSeedActivationSeries(
+        seed,
+        userId,
+        windowDates,
+        ctxCache,
+        stemMap,
+        branchMap,
+        strengthCache,
+        cutCache,
+      ),
+    );
+  }
+  const candidates: ConfoundCandidate[] = [];
+  for (const seed of seeds) {
+    const act = seedActById.get(seed.id);
+    if (act) candidates.push({ seedId: seed.id, seedName: seed.name, act });
+  }
+
+  // 링크에 등장한 신호 시리즈(신호당 1회).
+  const signalIds = [...new Set(linkRes.rows.map((r) => r.signal_id))];
+  const signalRes = await query<SignalDefRow>(
+    `SELECT id, name, kind, source, sql_body, value_type, direction, threshold, tag_name, window_days
+       FROM signal_defs
+      WHERE user_id = $1 AND id = ANY($2::int[]) AND status = 'active'`,
+    [userId, signalIds],
+  );
+  const signalSeriesById = new Map<number, DaySeries>();
+  for (const row of signalRes.rows) {
+    const r = await computeSignalSeries(userId, toSignalDef(row), windowDates);
+    signalSeriesById.set(row.id, r.series);
+  }
+
+  const out: ConfoundResult[] = [];
+  for (const row of linkRes.rows) {
+    const actS = seedActById.get(row.seed_id);
+    const sigX = signalSeriesById.get(row.signal_id);
+    if (!actS || !sigX) continue;
+    out.push({
+      linkId: row.link_id,
+      confound: flagConfoundersForLink(row.seed_id, actS, sigX, candidates, today, T),
+    });
+  }
+  return out;
+};

--- a/src/shared/insight-thresholds.ts
+++ b/src/shared/insight-thresholds.ts
@@ -81,4 +81,12 @@ export const INSIGHT_THRESHOLDS = {
     discoveryMaxFisherP: 0.1, // block-perm 전 Fisher 사전선별 상한 (Monte Carlo 비용 절감)
     discoveryTopN: 5, // 주당 surface 상한 (승인 카드 폭주 방지 — 드롭 시 로그)
   },
+  // #477 P6 교란 플래그 (ADR-0041) — 공동발현 시드 marginal 탐지. annotate-only(verdict 불변).
+  // calibration 노브: 첫 몇 주 튜닝(헌장 ⑤). 강등·다변량 분리는 P7(데이터 게이트).
+  confound: {
+    minOverlap: 0.6, // P(Z active | S active) 최소 — S 켜질 때 Z도 대체로 켜짐
+    minCofireDays: 10, // 공동발현일 최소(노이즈 바닥; P7 게이트 ~30보다 낮게)
+    minEffectZX: 1.3, // Z↔신호 rate ratio 최소(= patternVerification.minRateRatio 승계)
+    topN: 3, // 링크당 표시 교란 후보 상한(near-dup 1차 완화)
+  },
 } as const;


### PR DESCRIPTION
## 관련 이슈
Closes #493

마스터 #477 (매트릭 중심 패턴 검증) Phase 6. 선행 P1~P5b 머지·배포 완료.

## 변경 내용

off-day 검증(P2)은 단일 시드의 **marginal 연관**만 본다 — 같은 날 공존하는 제3변수(요일·주말·월위치·계절 = 달력 주기, 또는 다른 사주 시드)가 시드와 신호 둘 다를 끌면 가짜 연관(교란)이 생긴다. P6는 claimable (시드 S × 신호 X) 링크마다 공동발현 교란 시드 Z를 탐지해 `confound`에 기록하고 주간 카드에 노출한다.

- **`confound.ts`** (신규): 교란 marginal 2조건 — (a) 공동발현 `P(Z\|S) ≥ minOverlap` & `nCofire ≥ minCofireDays`, (b) Z↔신호 2×2 `effect ≥ minEffectZX`. 둘 다 만족 시 "교란 의심" 수집(overlap 정렬 + topN cap).
- **feature 환원 노선**: 교란변수가 이미 결정론 시드(달력 18 `life_signal` + 사주)라 기존 off-day 프리미티브(`buildContingency`/`verifyContingency`) 재사용 → **새 통계 코어 0, 마이그레이션 0**(077 `confound` 컬럼 재사용).
- **annotate-only**: verdict·status·e-value·tier 불변. 주간 카드 verified/emerging 라인에 `⚠️ 교란 의심: {Z} 공존` caveat 노출만. 강등·다변량 분리는 P7(데이터 게이트).
- **always-on** + `nCofire` 기록(P7 다변량 분리 데이터 게이트 입력, 헌장 ④).
- 노브 외부화(`insight-thresholds.confound`), 시리즈 self-contained(검증 코어 무변경 = blast radius 최소).
- ADR-0041 + design-notebook Phase 6 + 도메인 ### 31.

## 코드 리뷰 결과
- [x] 보안 감사 통과 (전 쿼리 파라미터화 `$1/$2/$3`, `user_id` 가드, 외부 입력 없음, 로그에 PII·민감정보 없음)
- [x] 타입 안전성 확인 (any 없음, 타입 export)
- [x] 컨벤션 점검 완료 (네이밍·파일/함수 크기·import 순서·에러 경계)
- [x] 코드 품질 확인 (검증/발굴/교란 3단계 독립 try-catch 격리)

## 테스트
- [x] `confound.test.ts` 신규 9개 — `computeOverlap`(비율·cofire·S발현0 엣지), `flagConfoundersForLink`(2조건 AND·effectZX 게이트 필수·cofire 바닥·자기 제외·overlap 정렬+topN·빈 결과 scannedAt)
- [x] 전체 765개 통과, tsc·eslint 클린
- [x] 마이그레이션 0 — 첫 교란 패스 = 다음 월 06:00 주간 엔진