### PR TITLE
docs(insight): 은퇴한 카드 빌더 참조에 교체 안내 추가

### DIFF
--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -434,6 +434,8 @@ LLM 추출은 Sonnet → Opus 이관 ([#409](https://github.com/hyewon3938/slack
 
 #### Block Kit 카드 (`src/agents/insight/hypothesis-cards.ts`)
 
+> **이후 교체됨 (#477)**: `buildCandidateCard`·`buildWeeklyReviewBlocks`는 #477에서 은퇴. 현재 카드 빌더는 `buildVerificationBlocks`·`buildSeedInfluenceSection`(주간 검증) + `buildDiscoveryCandidateCard`(발굴 승인, action_id `discovery_approve`/`discovery_dismiss`). 상세는 ### 26. 아래는 Phase 4 시점 기록.
+
 - **`buildCandidateCard`**: discoverCandidates 결과를 등록/폐기 버튼 카드로 변환. action_id: `hypothesis_register` / `hypothesis_dismiss`. payload는 type-safe JSON 인코딩.
 - **`buildWeeklyReviewBlocks`**: active 가설 표 (전주 대비 rate_ratio 변화 ▲▼─ 10% 임계) + 신규 후보 묶음.
 
@@ -694,7 +696,7 @@ GROUP BY c.id;
 
 #### `saju_influence_summary` view body 재정의 (운영 자산 보존)
 
-> ⚠️ *아래는 마스터 A(068) 시점 기록. 이후 #477 P1(2층)·**P3(3층 verified/emerging/recent, ### 26)**으로 재정의 — 현재 tier 정의는 ### 26 기준.*
+> ⚠️ *아래는 마스터 A(068) 시점 기록. 이후 #477 P1(2층)·**P3**(3층 verified/emerging/recent, ### 26)으로 재정의 — 현재 tier 정의는 ### 26 기준.*
 
 | 항목 | 결정 |
 |------|------|
@@ -1323,6 +1325,8 @@ Phase 7 (Bayesian update)에서 active 매트릭의 `posterior_alpha/beta/p`가 
 > hit를 별도 컬럼으로 추가하지 않고 `rate_trigger × n_trigger_days`로 derive하는 이유: 기존 row만으로 충분, 스키마 변경 최소.
 
 **UI 흐름**
+
+> **이후 교체됨 (#477)**: 아래 `buildCandidateCard` 카드는 #477에서 `buildVerificationBlocks`(주간 검증 카드, 자연어 카피)로 교체. 현재 카드 형식은 ### 26 참조.
 
 가설 카드(`buildCandidateCard`)는 frequentist(p/q)와 Bayesian(사후/CI)를 한 줄에 병기:
 


### PR DESCRIPTION
## 변경 내용
#477에서 은퇴한 카드 빌더(`buildCandidateCard`·`buildWeeklyReviewBlocks`)가 `docs/domains/insight.md` Phase 4·7 섹션에 현재형으로 남아 있어, 읽는 사람이 아직 존재하는 빌더로 오해할 소지가 있었음. **역사 서술·옛 카드 예시는 그대로 보존**하고(덮어쓰기 없음), "이후 교체됨 (#477)" 시점 註만 덧붙여 현재 빌더로 안내.

- `### 11 Phase 4 > Block Kit 카드`: 교체 안내 註 (현재 = `buildVerificationBlocks`·`buildSeedInfluenceSection` + `buildDiscoveryCandidateCard`, action_id `discovery_approve`/`discovery_dismiss`)
- `### 21 Phase 7 > UI 흐름`: 교체 안내 註
- (drive-by) `saju_influence_summary` 시점 註의 깨진 GFM 강조 1건 수정 (`)`+`**`+한글 패턴)

## 보존한 것 (의도)
- ### 21의 옛 카드 예시(`buildCandidateCard` 렌더)는 #434 Phase 7 역사 기록이라 **그대로 둠**
- `### 19 Phase 5 변경 파일` 목록·design-notebook 서술의 부수적 언급은 명백한 시점 기록이라 미수정

## 배경
#501/#502(카드 카피 자연어화) 작업 중 발견한 문서 drift. 코드·현행 카드 예시 동기화는 #502에서 처리했고, 본 PR은 은퇴 빌더의 잔존 문서 참조 안내만 정리.

## 코드 리뷰 결과
- [x] 문서 전용 변경 (코드·로직·테스트 무관)
- [x] 역사 서술 보존 (phase narrative 본문 미수정)
- [x] GFM 강조 전수 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)