### PR TITLE
fix(insight): 행동신호→도메인 맵 단일화 (#510)

### DIFF
--- a/src/shared/__tests__/pattern-verification.test.ts
+++ b/src/shared/__tests__/pattern-verification.test.ts
@@ -430,6 +430,18 @@ describe('데이터-존재 시작일 헬퍼 (#504)', () => {
         starts,
       ),
     ).toBe('2026-03-07'); // streak→routine
+    // #510 회귀: slotGap·weekComparison은 routine_records 집계라 routine(옛 맵은 schedule=03-05로 오기).
+    for (const signal_name of ['slotGap', 'weekComparison']) {
+      expect(
+        seedDataStart(
+          {
+            trigger_target_type: 'life_signal',
+            trigger_aux: { kind: 'behavior_baseline', signal_name },
+          },
+          starts,
+        ),
+      ).toBe('2026-03-07'); // routine_records (≠ schedules 03-05)
+    }
     expect(
       seedDataStart(
         { trigger_target_type: 'life_signal', trigger_aux: { kind: 'weekday', dow: 6 } },

--- a/src/shared/pattern-verification.ts
+++ b/src/shared/pattern-verification.ts
@@ -49,6 +49,7 @@ import { tertileCuts, classifyBand, isBand, type BandCuts } from './quantile.js'
 import type { PillarSet } from './saju-calendar.js';
 import { INSIGHT_THRESHOLDS } from './insight-thresholds.js';
 import { seedLabel, signalLabel } from './insight-labels.js';
+import { BEHAVIOR_SIGNAL_DOMAIN } from './insights.js';
 
 const V = INSIGHT_THRESHOLDS.patternVerification;
 
@@ -171,20 +172,9 @@ const DATA_TABLES = [
   'diary_meta_tags',
 ] as const;
 
-/** life_signal behavior_baseline signal_name → 의존 도메인. */
-const BEHAVIOR_DOMAIN: Record<string, string> = {
-  streak: 'routine',
-  recovery: 'routine',
-  lapseAlert: 'routine',
-  weeklyRegression: 'routine',
-  spottyPattern: 'routine',
-  sleepTrend: 'sleep',
-  drift: 'sleep',
-  slotGap: 'schedule',
-  weekComparison: 'schedule',
-  overdueAlert: 'schedule',
-  categorySkew: 'schedule',
-};
+// life_signal behavior_baseline signal_name → 의존 도메인: insights.ts의 BEHAVIOR_SIGNAL_DOMAIN이
+// 단일 진실(각 detect 함수의 domain 선언). #510 — 옛 로컬 맵이 slotGap·weekComparison을 schedule로
+// 적던 드리프트 제거(실제는 routine_records 집계 = routine).
 
 export interface UserDataStarts {
   /** 테이블별 첫 기록일(YYYY-MM-DD). 데이터 없는 테이블은 키 없음. */
@@ -230,7 +220,11 @@ const lifeSignalDomain = (aux: Record<string, unknown> | null): string | null =>
   }
   if (kind === 'behavior_baseline') {
     const name = aux['signal_name'];
-    return (typeof name === 'string' ? BEHAVIOR_DOMAIN[name] : undefined) ?? null;
+    return (
+      (typeof name === 'string'
+        ? (BEHAVIOR_SIGNAL_DOMAIN as Record<string, string>)[name]
+        : undefined) ?? null
+    );
   }
   return null; // weekday/weekday_group/month_position/season/calendar_event = 캘린더(데이터 비의존)
 };


### PR DESCRIPTION
## 관련 이슈
Closes #510

## 변경 내용
#504 데이터-존재 윈도우(ADR-0044)가 쓰던 `pattern-verification.ts`의 로컬 맵 `BEHAVIOR_DOMAIN`이 `slotGap`·`weekComparison`을 `schedule`로 매핑하던 드리프트를 제거. 실제 감지 로직(`insights.ts`)은 두 신호 모두 `routine_records`를 집계하고 `domain: 'routine'`을 선언한다.

- `BEHAVIOR_DOMAIN` 로컬 맵 삭제 → #508이 추가한 단일 진실 `BEHAVIOR_SIGNAL_DOMAIN`(`Record<InsightType, InsightDomain>`)에서 파생.
- 두 시드의 데이터-존재 윈도우가 올바른 도메인 테이블(routine_records) 기준으로 잡힘. 향후 드리프트 구조적 차단.

## 코드 리뷰 결과
- [x] 보안 감사 통과 (로직 변경만, 크리덴셜·SQL·외부입력 무관)
- [x] 타입 안전성 (tsc strict, 순환 import 없음)
- [x] 코드 품질 (맵 중복 제거 = 단일 진실)

## 테스트
- [x] 전체 797 통과
- [x] seedDataStart 회귀: slotGap·weekComparison → routine_records 시작일(≠ schedules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)