### PR TITLE
feat(insight): 패턴 증거 집계 레이어 (saju_response_profile) (#523 Phase 1)

### DIFF
--- a/db/migrations/088_saju_response_profile.sql
+++ b/db/migrations/088_saju_response_profile.sql
@@ -1,0 +1,50 @@
+-- 088: 개인화 가중치 집계 레이어 — saju_response_profile (#523 Phase 1, #408 5-B 구체화, ADR-0049)
+-- 검증된(confirmed)·검증중(active) pattern_links를 사주 축으로 집계한 파생 셀 프로필.
+-- Phase 2(기간 해석)·Phase 3(예측 장부)가 이 프로필을 기간 pillar에 조인한다.
+--
+-- 이중계산 구조적 차단(D4): 원천 기여 = 링크당 정확히 1 source 셀(stem→천간글자, branch→지지글자,
+-- hwa_sipsung→그룹, strength_band 강→오행밴드). 글자 source는 결정론 롤업 → 십성 → 십성그룹(α/β·nActive 합산).
+-- 어떤 조회도 두 레벨을 합산하지 않음(단일 레벨 resolution). 천간/지지 글자는 별도 축(char_stem/char_branch) —
+-- 한글 동음이의(천간 辛 vs 지지 申='신')가 다른 십성으로 가므로 병합 금지. 오행은 그룹 셀의 별칭(일간 고정 시
+-- 동형) → 별도 레벨 저장 안 함. element_band(강 밴드만)는 별도 축.
+--
+-- 파생 테이블 — 진실 아님(원천 = pattern_links). 주간 검증 엔진이 user당 full-replace(원자적 CTE).
+
+CREATE TABLE saju_response_profile (
+  id              SERIAL PRIMARY KEY,
+  user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  axis_level      TEXT NOT NULL,    -- 'char_stem'(천간글자) | 'char_branch'(지지글자) | 'sipsung'(십성) | 'group'(십성그룹) | 'element_band'(오행 강밴드)
+  axis_key        TEXT NOT NULL,    -- 갑(천간)/자(지지) | 비견(십성) | 비겁(그룹) | 목(오행)
+  element         TEXT,             -- char/group/element_band → 오행 별칭; sipsung → NULL
+  domain          TEXT NOT NULL,    -- 신호 도메인(schedule/routine/sleep/expense/diary_meta) — 셀 분할 축
+  tier            TEXT NOT NULL,    -- 'verified'(confirmed 링크 포함) | 'emerging'(효과·발현일 게이트 충족)
+  alpha           NUMERIC NOT NULL, -- Σ posterior_alpha (롤업 합산)
+  beta            NUMERIC NOT NULL, -- Σ posterior_beta
+  shrunk_effect   NUMERIC,          -- shrunk(posterior_p/rate_off, attenuated는 min)의 nActive 가중평균 — winner's curse 차단(D3). NULL=유한 효과 없음
+  n_links         INTEGER NOT NULL, -- 이 셀에 기여한 링크 수
+  n_active_days   INTEGER NOT NULL, -- Σ nActive (발현일 합)
+  stability       BOOLEAN,          -- 전·후반 효과 부호 일치(표시용, 게이트 아님). NULL=판정 불가
+  source_link_ids JSONB NOT NULL,   -- provenance — 기여 링크 id 배열
+  computed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (axis_level IN ('char_stem', 'char_branch', 'sipsung', 'group', 'element_band')),
+  CHECK (tier IN ('verified', 'emerging')),
+  UNIQUE (user_id, axis_level, axis_key, domain)
+);
+
+COMMENT ON TABLE saju_response_profile IS
+  '파생 — pattern_links에서 재생성 가능(진실 아님). 주간 검증 엔진이 confirmed+active 링크를 글자(천간/지지 분리)→십성→그룹(+오행 별칭) 단일레벨 계층 + element_band(강 밴드)로 집계해 user당 full-replace. 이중계산 구조적 차단(D4): 링크당 1 source 셀 + 결정론 롤업, 조회는 단일 레벨(비합산). 효과는 shrunk(D3). #523 Phase 1, ADR-0049.';
+
+-- UNIQUE(user_id, axis_level, axis_key, domain) btree가 resolveCell 조회(user+level+key+domain) 커버 →
+-- 별도 인덱스 불요(셀 수십 행 규모).
+
+DO $$
+DECLARE
+  has_table INT;
+BEGIN
+  SELECT count(*) INTO has_table FROM information_schema.tables
+   WHERE table_name = 'saju_response_profile';
+  IF has_table <> 1 THEN
+    RAISE EXCEPTION '[088] saju_response_profile 테이블 생성 실패';
+  END IF;
+  RAISE NOTICE '[088] saju_response_profile 파생 테이블 생성 OK (집계는 주간 엔진이 full-replace)';
+END $$;

--- a/docs/adr/0049-response-profile-aggregation.md
+++ b/docs/adr/0049-response-profile-aggregation.md
@@ -1,0 +1,78 @@
+# 0049. 개인화 가중치 집계 레이어 — saju_response_profile
+
+- Status: Accepted
+- Date: 2026-06-13
+- Related: #523 (마스터), #527, #408 (5-B)
+- Tags: insight, statistics, architecture, saju
+
+## Context
+
+검증 엔진(off-day 2×2 + e-value + 가족 BH-FDR)은 (시드 × 신호) = pattern_links 단위로 "이 사주 feature가 발현한 날 이 행동 신호가 달라지는가"를 검정한다. 이 링크 단위 증거를 사주 해석(월운·세운·대운)으로 확장하려면, 흩어진 링크를 **사주 축**으로 모아 "이 사람은 어떤 십성·오행에 어떻게 반응하는가"의 개인화 프로필이 필요하다(#408 5-B 구체화). 단 단순 합산은 세 함정에 빠진다:
+
+- **이중계산**: 글자(천간/지지) 시드와 그 글자가 속한 십성·십성그룹을 따로 세면 같은 증거가 여러 번 가중된다.
+- **글자 단위 희소성**: 특정 천간은 \~1/10, 60갑자는 1/60 발현 → 글자 셀만으로는 검정력 확보에 수년. 상위 계층 집계가 통계적으로 필수.
+- **승자의 저주(winner's curse)**: 선택된 링크의 raw 효과크기는 체계적 과대 → 가중치 입력이 되는 순간 외삽으로 증폭.
+
+또한 글자 한글 표기에 동음이의가 있다: 천간 辛과 지지 申은 둘 다 한글 "신"이지만 일간 대비 십성이 다르다(정관 vs 편관). 한 셀로 병합하면 안 된다.
+
+## Decision
+
+파생 테이블 `saju_response_profile`(마이그 088)을 두고, 주간 검증 엔진이 confirmed+active 링크를 집계해 **user당 full-replace**한다(트랜잭션). "진실 아님 — pattern_links에서 재생성 가능" COMMENT.
+
+### 축 구조 (이중계산 구조적 차단)
+
+- **계층 축**: 글자 → 십성 → 십성그룹. 글자 레벨은 **천간/지지 분리**(`char_stem`/`char_branch`) — 동음이의 차단, axis_key는 깨끗한 글자 유지.
+- **원천 기여 = 링크당 정확히 1 source 셀**: stem→천간글자, branch→지지글자(단일만), hwa_sipsung→십성그룹 직접, strength_band 강×오행→element_band.
+- **상위 레벨은 쓰기 시점 결정론 롤업**: 글자 셀이 자기 십성(`getSipsung`/`getJijiSipsung`)·그룹으로 α/β·nActive를 합산해 올라간다. hwa_sipsung은 그룹에 직접 기여 → 그룹 셀 = (십성 롤업) + (hwa 직접).
+- **오행은 그룹 셀의 별칭 컬럼**: 일간 고정 시 십성그룹 5 = 오행 5 동형이므로 별도 레벨 저장 안 함(`element` 컬럼).
+- **element_band 축(별도)**: 강도밴드 시드 중 **오행 × 강(high) 밴드**만 편입 — 기간 pillar의 오행에 직접 조인. 일간·약·적정 밴드는 비편입(생극 간접추론 배제). relation·sibiunsung·element_density·life_signal은 비편입(v1).
+
+### 읽기 = 단일 레벨 resolution
+
+글자 셀이 게이트 통과(verified 또는 nActive ≥ cellMinActive=15)면 거기서 정지, 미달이면 한 단계 위(십성 → 그룹)로 fallback. **어떤 조회도 두 레벨을 합산하지 않는다.** `resolveHierarchyCell`/`resolveElementBandCell`(Phase 2·3 공용)이 캡슐화. `source_link_ids` provenance 동봉.
+
+### 효과 = shrunk (승자의 저주 차단)
+
+링크 효과는 raw rate ratio가 아니라 `shrunk = posterior_p / rate_off`(둘 다 영속값, 재계산 불요). explained_away 교란 링크는 입력에서 제외, attenuated는 `min(shrunk, 조정 RR)`. 셀 효과는 링크 shrunk의 **nActive 가중평균**. 셀 posterior(α/β)는 합산 — multi-link 셀에서 prior가 누적돼 약간 더 수축되나, n=1·보수적 집계 철학상 안전한 방향.
+
+### tier·stability
+
+confirmed 링크 포함 → verified / nActive·효과 게이트 충족 → emerging / 미달 → 행 생략(무증거 = 행 부재). `stability`(전·후반 효과 부호 일치, 표시용 비게이트)는 셀의 기여 링크가 전부 일치할 때만 true(보수적).
+
+## Alternatives considered
+
+### A. 오행을 별도 레벨로 저장
+
+- 단점: 일간 고정 시 십성그룹과 동형 → 같은 데이터 2벌 + 이중계산 표면. 기각.
+
+### B. 천간/지지 글자를 한 char 레벨로 병합
+
+- 단점: 동음이의(辛/申='신')가 다른 십성으로 가는데 병합하면 롤업이 두 십성으로 동시에 흘러 불변식 깨짐. char_stem/char_branch 분리로 해결.
+
+### C. view·캐시로 집계
+
+- 단점: 십성 매핑·수축·교란 판정이 TS 단일 진실 → SQL view로 옮기면 로직 이원화. 파생 테이블 + 주간 full-replace가 단순·정직(원천은 pattern_links).
+
+### D. 다변량 회귀(elastic net 등)로 가중치 통합 추정
+
+- 단점: 95\~163일 × n=1에 과적합 기계. 링크 단위 증거의 보수적 계층 집계가 옳음. 기각(§7).
+
+## Consequences
+
+### 장점
+
+- 이중계산이 데이터 모델 수준에서 차단(링크당 1 source + 결정론 롤업 + 단일레벨 조회). 불변식 단위 테스트로 고정.
+- 글자 희소성을 계층 fallback으로 흡수 → 상위 레벨이 검정력 확보.
+- Phase 2(해석)·3(예측 장부)이 `resolveCell` 하나로 기간 pillar를 조인.
+
+### 단점 / 제약
+
+- 파생 테이블이라 측정 로직 변경 시 재생성 필요(주간 run이 자동 충전, full-replace 멱등).
+- α/β 합산은 multi-link 셀에서 prior 누적 → 약한 추가 수축(의도된 보수성, 표시 posterior에만 영향 — tier 게이트는 nActive·shrunk 기반이라 무영향).
+- element_band가 강 방향만 → 약 방향 작용은 해석 레이어 참고 언급으로만(통계 주장 아님).
+
+### 후속 작업
+
+- [ ] Phase 2: `resolveCell`로 기간 해석 payload 조립(측정 셀 vs 교과서 분리 발화).
+- [ ] Phase 3: 예측 장부가 셀 tier·shrunk로 후보 줄세움.
+- [ ] relation 링크 confirmed 발생 시 D4 확장 검토(현 비편입).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -155,6 +155,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0046](0046-signal-seed-precision.md) | 신호·시드 측정 정밀화 — 방향 분리 + 누적→강도밴드 위임 + 포화 양방향 가드 + 동어반복 필터 | Accepted | 2026-06-08 | insight, statistics, architecture |
 | [0047](0047-discovery-recommendation-cadence.md) | 발굴 후보 재추천 — 데일리 반응형 cadence (전용 슬롯 + pattern_links 파생 상태, 묶음 전부 패스 시 다음 best) | Accepted | 2026-06-08 | insight, architecture, process |
 | [0048](0048-enrollment-clip-and-rebaseline.md) | enrollment 클립 + 측정 로직 변경 시 재기준선 (발굴 선택 편향 차단 + sticky confirmed 재검증 경로) | Accepted | 2026-06-13 | insight, statistics, process |
+| [0049](0049-response-profile-aggregation.md) | 개인화 가중치 집계 레이어 — saju_response_profile (글자→십성→그룹 단일레벨 + element_band, 이중계산 구조적 차단 + shrunk 효과) | Accepted | 2026-06-13 | insight, statistics, architecture, saju |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -2036,6 +2036,44 @@ Phase 1이 측정을 고친 뒤 다음 병목은 가독성이었다. 프로액�
 
 거친 측정 채널(고정 임계 누적)을 이미 존재하는 정밀 채널(상대 분위수 강도 밴드)로 은퇴·위임한 게 핵심 — 신규 통계 코어 0. 측정 불가능성(off-day 0)을 큐레이션 판단(ADR-0039 사람 게이트)과 분리해 자동·양방향 위생으로 환원: 사람은 "믿을지"만, 기계는 "검정 가능한지"를 판정. 설계 중 사용자가 archive-only의 빈틈(1년 뒤 탈포화 시드 영구 사장)을 지적 → 부활 대칭 추가. 빌드 중 `BEHAVIOR_DOMAIN`(데이터-존재 윈도우, #504)이 `slotGap`/`weekComparison`을 schedule로 매핑하는 오기를 발견(④는 `insights.ts` 진실 사용, #504 맵 교정은 후속).
 
+### 37. 세운·대운 확장 + 검증 엔진 교정 — Phase 1 (개인화 가중치 집계, #523, ADR-0049)
+
+링크 단위 증거(검증된·검증중 pattern_links)를 사주 축으로 모아 "이 사람은 어떤 십성·오행에 어떻게 반응하는가"의 개인화 프로필을 만든다(#408 5-B 구체화). Phase 2(기간 해석)·Phase 3(예측 장부)가 기간 pillar(월운/세운/대운)에 조인할 원료. 측정 교정(Phase 0)된 confirmed+active 링크만 입력.
+
+#### 데이터 모델 (migration 088)
+
+`saju_response_profile` — **파생 테이블**(진실 아님, pattern_links에서 재생성 가능). 주간 검증 엔진(`weekly-verification.ts` `processUser` 말미, 격리)이 user당 full-replace(트랜잭션).
+
+| 컬럼 | 의미 |
+|------|------|
+| `axis_level` | `char_stem`(천간글자)·`char_branch`(지지글자)·`sipsung`(십성)·`group`(십성그룹)·`element_band`(오행 강밴드) |
+| `axis_key` | 갑/자(글자)·비견(십성)·비겁(그룹)·목(오행) |
+| `element` | 오행 별칭(char/group/element_band) — sipsung은 NULL |
+| `domain` | 신호 도메인(셀 분할 축) |
+| `tier` | `verified`(confirmed 포함) / `emerging`(nActive·효과 게이트) |
+| `alpha`/`beta` | Σ posterior(롤업 합산) |
+| `shrunk_effect` | shrunk(posterior_p/rate_off)의 nActive 가중평균 — winner's curse 차단(D3) |
+| `n_links`/`n_active_days` | 기여 링크 수 / Σ 발현일 |
+| `stability` | 전·후반 효과 부호 일치(표시용, 비게이트) |
+| `source_link_ids` | provenance |
+
+UNIQUE(user_id, axis_level, axis_key, domain).
+
+#### 이중계산 구조적 차단 (D4) — `response-profile.ts`
+
+- **원천 기여 = 링크당 정확히 1 source 셀**: stem→천간글자, branch→지지글자(단일만), hwa_sipsung→십성그룹 직접, strength_band 강×오행→element_band. relation·sibiunsung·element_density·life_signal·일간/약/적정 밴드는 비편입(v1).
+- **결정론 롤업**: 글자 셀이 자기 십성(`getSipsung`/`getJijiSipsung`)·그룹으로 α/β·nActive 합산해 올라감. 그룹 셀 = (십성 롤업) + (hwa 직접).
+- **천간/지지 글자 분리**: 한글 동음이의(천간 辛 vs 지지 申='신')가 다른 십성으로 가므로 `char_stem`/`char_branch` 별도 축(병합 금지). 오행은 그룹 셀 별칭(일간 고정 시 동형 → 별도 레벨 없음).
+- **읽기 = 단일 레벨 resolution**(`resolveHierarchyCell`/`resolveElementBandCell`, Phase 2·3 공용): 글자 셀이 게이트 통과(verified 또는 nActive≥15)면 정지, 미달이면 십성→그룹 fallback. **두 레벨을 절대 합산하지 않음.**
+
+#### 효과·교란 (D3)
+
+효과는 raw rate ratio가 아니라 `shrunk = posterior_p / rate_off`(영속값). explained_away 교란 링크는 제외, attenuated는 `min(shrunk, 조정 RR)`. 셀 효과는 링크 shrunk의 nActive 가중평균.
+
+#### DoD
+
+주간 run 후 `SELECT axis_level, count(*), sum(n_links) FROM saju_response_profile GROUP BY 1;` — char 레벨 sum(n_links) = stem+branch 편입 링크 수 일치, provenance spot check. Phase 0 직후 confirmed 0 → 당분간 셀은 거의 emerging.
+
 ## 파일 구조
 
 ```
@@ -2055,6 +2093,7 @@ src/shared/
 ├── pattern-match.ts               # 매칭 엔진 (evaluateTrigger + evaluateMetric kind=sql|tag). #477 P1: pattern_links × signal_defs 기반 + P4b hwa_sipsung trigger + P5b runLlmSignalSql(게이트 #2)
 ├── pattern-verification.ts        # #477 P2/P3 off-day 검증 엔진 (2×2 + block-perm + e-value + 연속 MW → EB posterior → verdict/status) + P4a 강도-밴드 2-pass + P4b FDR 3가족(saju_relation)
 ├── confound.ts                    # #477 P6 교란 플래그(marginal 탐지, ADR-0041) + P7 다변량 분리(MH 층화 조정 → confound.adjusted/explainedAway → 노출 soft-demote, ADR-0042)
+├── response-profile.ts            # #523 P1 개인화 가중치 집계(글자→십성→그룹 단일레벨 롤업 + element_band, 이중계산 차단 + shrunk 효과, resolveCell Phase 2·3 공용, ADR-0049)
 ├── saju-strength.ts               # #477 P4a 실효강도 엔진 (생조−극설 + 월령 + 통근, 절대 신강/신약, 오행 비율) + P4b 합화 변환 반영
 ├── saju-strength-params.ts        # #477 P4a 명리학 파라미터 (위치가중·월령·통근·분위수) + P4b 합화 노브(통근·충개합·일간합·깊은 노브 off)
 ├── saju-hwa.ts                    # #477 P4b 합화 변환 탐지(천간합/육합/삼합 + 통근 게이트 + 충개합 v1a) + 효과적 십성 그룹

--- a/src/agents/insight/__tests__/hypothesis-cards.test.ts
+++ b/src/agents/insight/__tests__/hypothesis-cards.test.ts
@@ -46,6 +46,7 @@ const makeLink = (overrides: Partial<LinkVerification> = {}): LinkVerification =
   lastMatchedAt: '2026-06-01',
   windowStart: '2026-03-10',
   family: 'baseline',
+  stability: true,
   verdict: 'confirm',
   nextStatus: 'active',
   ...overrides,

--- a/src/cron/weekly-verification.ts
+++ b/src/cron/weekly-verification.ts
@@ -13,7 +13,7 @@
  */
 
 import type { App } from '@slack/bolt';
-import { query } from '../shared/db.js';
+import { query, withTransaction } from '../shared/db.js';
 import { getKSTDayOfWeek, getTodayISO } from '../shared/kst.js';
 import { postBlockMessage } from '../shared/slack.js';
 import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
@@ -25,7 +25,12 @@ import {
 } from '../shared/pattern-verification.js';
 import { flagConfounds, type ConfoundData, type ConfoundResult } from '../shared/confound.js';
 import { posteriorMean, credibleInterval } from '../shared/bayesian-posterior.js';
-import { loadActiveSeeds } from '../shared/pattern-match.js';
+import { loadActiveSeeds, loadNatalContext, buildNameIdMap } from '../shared/pattern-match.js';
+import {
+  buildResponseProfile,
+  type ProfileLink,
+  type ResponseCell,
+} from '../shared/response-profile.js';
 import { seedLabel } from '../shared/insight-labels.js';
 import { runSaturationSweep, type SaturationSweepResult } from '../shared/seed-saturation.js';
 import {
@@ -68,6 +73,8 @@ export const persistLinkVerification = async (l: LinkVerification): Promise<void
     signal_kind: l.signalKind,
     value_type: l.valueType,
     verdict: l.verdict,
+    // 전·후반 효과 부호 일치(표시용, 게이트 아님) — response_profile 셀 stability 입력. #523 P1.
+    stability: l.stability,
     // 클립 합성 윈도우 시작(데이터-존재 + enrollment) — 관측성. discovery/llm은 등록 익일 이상이어야 정상.
     window_start: l.windowStart,
     // P3: p_value 컬럼 = block-perm p(자기상관 보정). Fisher·MW·e-value는 참고용 보존.
@@ -269,6 +276,142 @@ const loadSeedInfluence = async (userId: number, topN: number): Promise<SeedInfl
   return rows.slice(0, topN);
 };
 
+/** saju_response_profile INSERT 컬럼(user_id 제외 — 행마다 $1 공유). */
+const RESPONSE_PROFILE_COLS = [
+  'axis_level',
+  'axis_key',
+  'element',
+  'domain',
+  'tier',
+  'alpha',
+  'beta',
+  'shrunk_effect',
+  'n_links',
+  'n_active_days',
+  'stability',
+  'source_link_ids',
+] as const;
+
+/** 파생 셀 user당 full-replace — DELETE → 다중 INSERT를 한 트랜잭션으로(원자적, ADR-0049). */
+const replaceResponseProfile = async (userId: number, cells: ResponseCell[]): Promise<void> => {
+  await withTransaction(async (client) => {
+    await client.query('DELETE FROM saju_response_profile WHERE user_id = $1', [userId]);
+    if (cells.length === 0) return;
+    const params: unknown[] = [userId];
+    const valueRows: string[] = [];
+    for (const c of cells) {
+      const b = params.length; // 다음 placeholder = $(b+1)
+      params.push(
+        c.axisLevel,
+        c.axisKey,
+        c.element,
+        c.domain,
+        c.tier,
+        c.alpha,
+        c.beta,
+        c.shrunkEffect,
+        c.nLinks,
+        c.nActiveDays,
+        c.stability,
+        JSON.stringify(c.sourceLinkIds),
+      );
+      valueRows.push(
+        `($1, $${b + 1}, $${b + 2}, $${b + 3}, $${b + 4}, $${b + 5}, $${b + 6}, ` +
+          `$${b + 7}, $${b + 8}, $${b + 9}, $${b + 10}, $${b + 11}, $${b + 12}::jsonb)`,
+      );
+    }
+    await client.query(
+      `INSERT INTO saju_response_profile (user_id, ${RESPONSE_PROFILE_COLS.join(', ')})
+       VALUES ${valueRows.join(', ')}`,
+      params,
+    );
+  });
+};
+
+interface ProfileLinkRow {
+  link_id: number;
+  seed_id: number;
+  status: string;
+  domain: string | null;
+  posterior_alpha: string | null;
+  posterior_beta: string | null;
+  posterior_p: string | null;
+  hit_count: number;
+  miss_count: number;
+  test_detail: Record<string, unknown> | null;
+  confound: ConfoundData | null;
+}
+
+/**
+ * confirmed+active 링크 → saju_response_profile 집계 후 user당 full-replace (#523 P1, ADR-0049).
+ * processUser 말미 격리 호출 — 실패해도 검증 카드·발굴 무탈(파생 레이어). confirmed는 sticky라
+ * verifyUserLinks 결과에 없으므로 여기서 DB로 직접 로드(active+confirmed 둘 다, 교정된 Phase 0 수치).
+ */
+const persistResponseProfile = async (userId: number): Promise<void> => {
+  const natal = await loadNatalContext(userId);
+  if (!natal) {
+    console.warn(`[ResponseProfile] user=${userId} 원국 없음 — 집계 생략`);
+    return;
+  }
+  const [stemNameToId, branchNameToId] = await Promise.all([
+    buildNameIdMap('stems_master'),
+    buildNameIdMap('branches_master'),
+  ]);
+  const stemNameById = new Map([...stemNameToId].map(([name, id]) => [id, name] as const));
+  const branchNameById = new Map([...branchNameToId].map(([name, id]) => [id, name] as const));
+  const seeds = await loadActiveSeeds(userId);
+  const seedById = new Map(seeds.map((s) => [s.id, s]));
+
+  const linkRes = await query<ProfileLinkRow>(
+    `SELECT l.id AS link_id, l.seed_id, l.status, s.domain,
+            l.posterior_alpha, l.posterior_beta, l.posterior_p,
+            l.hit_count, l.miss_count, l.test_detail, l.confound
+       FROM pattern_links l
+       JOIN signal_defs s ON s.id = l.signal_id
+       JOIN pattern_catalog c ON c.id = l.seed_id
+      WHERE l.user_id = $1 AND l.status IN ('active', 'confirmed')
+        AND s.status = 'active' AND c.active = true
+      ORDER BY l.id`,
+    [userId],
+  );
+
+  const links: ProfileLink[] = [];
+  for (const r of linkRes.rows) {
+    if (!r.domain) continue; // 도메인 없는 신호는 셀 분할 불가 — 제외
+    const td: Record<string, unknown> = r.test_detail ?? {};
+    const rateOff = typeof td['rate_off'] === 'number' ? (td['rate_off'] as number) : NaN;
+    const stabilityRaw = td['stability'];
+    const confound = r.confound;
+    const att = confound?.adjusted?.find((a) => a.verdict === 'attenuated');
+    links.push({
+      linkId: r.link_id,
+      seedId: r.seed_id,
+      status: r.status === 'confirmed' ? 'confirmed' : 'active',
+      domain: r.domain,
+      posteriorAlpha: Number(r.posterior_alpha),
+      posteriorBeta: Number(r.posterior_beta),
+      posteriorP: r.posterior_p === null ? NaN : Number(r.posterior_p),
+      rateOff,
+      nActive: r.hit_count + r.miss_count,
+      stability: typeof stabilityRaw === 'boolean' ? stabilityRaw : null,
+      explainedAway: confound?.explainedAway === true,
+      attenuatedEffect: att && Number.isFinite(att.adjEffect) ? att.adjEffect : null,
+    });
+  }
+
+  const cells = buildResponseProfile(
+    links,
+    seedById,
+    natal.dayMaster,
+    stemNameById,
+    branchNameById,
+  );
+  await replaceResponseProfile(userId, cells);
+  console.warn(
+    `[ResponseProfile] user=${userId} 셀 ${cells.length} (입력 링크 ${links.length}) full-replace`,
+  );
+};
+
 const processUser = async (
   app: App,
   userId: number,
@@ -409,6 +552,14 @@ const processUser = async (
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[Discovery] user=${userId} 발굴 실패: ${msg}`);
+  }
+
+  // 개인화 가중치 집계(#523 P1) — 파생 레이어 격리. 실패해도 검증·발굴 무탈(Phase 2·3가 소비).
+  try {
+    await persistResponseProfile(userId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[ResponseProfile] user=${userId} 집계 실패: ${msg}`);
   }
 };
 

--- a/src/shared/__tests__/pattern-verification.test.ts
+++ b/src/shared/__tests__/pattern-verification.test.ts
@@ -14,6 +14,7 @@ import {
   seedDataStart,
   maxDate,
   enrollmentStart,
+  splitHalvesConsistent,
   type DaySeries,
   type UserDataStarts,
 } from '../pattern-verification.js';
@@ -534,5 +535,60 @@ describe('enrollment 클립이 검정 시퀀스에서 등록 전 일자를 제�
       { active: true, pass: false }, // 01-06
       { active: false, pass: true }, // 01-07
     ]);
+  });
+});
+
+// ─── splitHalvesConsistent (#523 P1, stability 플래그) ─────
+
+describe('splitHalvesConsistent', () => {
+  const o = (active: boolean, pass: boolean): { active: boolean; pass: boolean } => ({
+    active,
+    pass,
+  });
+
+  it('전·후반 효과 부호 같음 → true', () => {
+    const seq = [
+      o(true, true),
+      o(false, false),
+      o(true, true),
+      o(false, false), // 전반: active 우세(+)
+      o(true, true),
+      o(false, false),
+      o(true, true),
+      o(false, false), // 후반: active 우세(+)
+    ];
+    expect(splitHalvesConsistent(seq)).toBe(true);
+  });
+
+  it('전·후반 부호 뒤집힘 → false', () => {
+    const seq = [
+      o(true, true),
+      o(false, false),
+      o(true, true),
+      o(false, false), // 전반: active 우세(+)
+      o(true, false),
+      o(false, true),
+      o(true, false),
+      o(false, true), // 후반: active 열세(−)
+    ];
+    expect(splitHalvesConsistent(seq)).toBe(false);
+  });
+
+  it('한 반에 발현·비발현 한쪽만 → null(판정 보류)', () => {
+    const seq = [
+      o(true, true),
+      o(true, false),
+      o(true, true),
+      o(true, false), // 전반: 전부 발현 → off 없음
+      o(true, true),
+      o(false, false),
+      o(true, true),
+      o(false, false),
+    ];
+    expect(splitHalvesConsistent(seq)).toBeNull();
+  });
+
+  it('너무 짧으면(<minPerHalf*2) null', () => {
+    expect(splitHalvesConsistent([o(true, true), o(false, false)])).toBeNull();
   });
 });

--- a/src/shared/__tests__/response-profile.test.ts
+++ b/src/shared/__tests__/response-profile.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mapSeedToCell,
+  buildResponseProfile,
+  groupElement,
+  indexCells,
+  resolveHierarchyCell,
+  resolveElementBandCell,
+  cellKey,
+  type ProfileLink,
+  type ResponseCell,
+  type SeedForCell,
+} from '../response-profile.js';
+import type { Cheongan } from '../saju-calendar.js';
+
+// ─── 고정 일간 갑(양목) — 십성 매핑 결정론 검증 기준 ──────
+const DM: Cheongan = '갑';
+const CHEONGAN = ['갑', '을', '병', '정', '무', '기', '경', '신', '임', '계'];
+const JIJI = ['자', '축', '인', '묘', '진', '사', '오', '미', '신', '유', '술', '해'];
+// stems_master/branches_master id → 글자 역맵 (id i = i번째 글자, 1-based).
+const stemNameById = new Map<number, string>(CHEONGAN.map((c, i) => [i + 1, c]));
+const branchNameById = new Map<number, string>(JIJI.map((j, i) => [i + 1, j]));
+
+const stemSeed = (id: number, stemId: number): [number, SeedForCell] => [
+  id,
+  { trigger_target_type: 'stem', trigger_target_id: stemId, trigger_aux: null },
+];
+const branchSeed = (
+  id: number,
+  branchId: number,
+  aux: Record<string, unknown> | null = null,
+): [number, SeedForCell] => [
+  id,
+  { trigger_target_type: 'branch', trigger_target_id: aux ? null : branchId, trigger_aux: aux },
+];
+const hwaSeed = (id: number, sipsin: string): [number, SeedForCell] => [
+  id,
+  {
+    trigger_target_type: 'hwa_sipsung',
+    trigger_target_id: null,
+    trigger_aux: { sipsin, via: 'hwa' },
+  },
+];
+const bandSeed = (id: number, target: string, band: string): [number, SeedForCell] => [
+  id,
+  { trigger_target_type: 'strength_band', trigger_target_id: null, trigger_aux: { target, band } },
+];
+
+/** 기본 confirmed 링크(=verified tier 항상 출현 → 카운팅 불변식 깔끔). over로 tier/효과 조정. */
+const mkLink = (linkId: number, seedId: number, over: Partial<ProfileLink> = {}): ProfileLink => ({
+  linkId,
+  seedId,
+  status: 'confirmed',
+  domain: 'sleep',
+  posteriorAlpha: 13,
+  posteriorBeta: 8,
+  posteriorP: 0.6,
+  rateOff: 0.3,
+  nActive: 20,
+  stability: true,
+  explainedAway: false,
+  attenuatedEffect: null,
+  ...over,
+});
+
+const isChar = (c: { axisLevel: string }): boolean =>
+  c.axisLevel === 'char_stem' || c.axisLevel === 'char_branch';
+
+// ─── mapSeedToCell ────────────────────────────────────────
+
+describe('mapSeedToCell', () => {
+  it('stem → char_stem 천간 글자 + 오행', () => {
+    expect(mapSeedToCell(stemSeed(1, 1)[1], DM, stemNameById, branchNameById)).toEqual({
+      axisLevel: 'char_stem',
+      axisKey: '갑',
+      element: '목',
+    });
+    // 병(화)
+    expect(mapSeedToCell(stemSeed(2, 3)[1], DM, stemNameById, branchNameById)).toEqual({
+      axisLevel: 'char_stem',
+      axisKey: '병',
+      element: '화',
+    });
+  });
+
+  it('branch → char_branch 지지 글자 + 본기 오행 (단일만)', () => {
+    // 인(본기 갑, 목)
+    expect(mapSeedToCell(branchSeed(3, 3)[1], DM, stemNameById, branchNameById)).toEqual({
+      axisLevel: 'char_branch',
+      axisKey: '인',
+      element: '목',
+    });
+    // or_branches 정확히 1개 → 그 글자
+    expect(
+      mapSeedToCell(branchSeed(4, 0, { or_branches: ['자'] })[1], DM, stemNameById, branchNameById),
+    ).toMatchObject({ axisLevel: 'char_branch', axisKey: '자' });
+    // or_branches 다중 → 비편입(null)
+    expect(
+      mapSeedToCell(
+        branchSeed(5, 0, { or_branches: ['자', '축'] })[1],
+        DM,
+        stemNameById,
+        branchNameById,
+      ),
+    ).toBeNull();
+  });
+
+  it('hwa_sipsung → group 직접 + 오행 별칭', () => {
+    expect(mapSeedToCell(hwaSeed(6, '재성')[1], DM, stemNameById, branchNameById)).toEqual({
+      axisLevel: 'group',
+      axisKey: '재성',
+      element: '토', // 갑(목)의 재성 = 목극토
+    });
+  });
+
+  it('strength_band — 강 밴드 × 오행만 element_band, 그 외 비편입', () => {
+    expect(mapSeedToCell(bandSeed(7, '화', 'high')[1], DM, stemNameById, branchNameById)).toEqual({
+      axisLevel: 'element_band',
+      axisKey: '화',
+      element: '화',
+    });
+    expect(
+      mapSeedToCell(bandSeed(8, 'day_master', 'high')[1], DM, stemNameById, branchNameById),
+    ).toBeNull();
+    expect(mapSeedToCell(bandSeed(9, '목', 'low')[1], DM, stemNameById, branchNameById)).toBeNull();
+    expect(
+      mapSeedToCell(bandSeed(10, '목', 'mid')[1], DM, stemNameById, branchNameById),
+    ).toBeNull();
+  });
+
+  it('relation·sibiunsung·element_density·life_signal·ganji → 비편입(null)', () => {
+    for (const t of ['relation', 'sibiunsung', 'element_density', 'life_signal', 'ganji']) {
+      const seed: SeedForCell = { trigger_target_type: t, trigger_target_id: 1, trigger_aux: {} };
+      expect(mapSeedToCell(seed, DM, stemNameById, branchNameById)).toBeNull();
+    }
+  });
+});
+
+// ─── groupElement — 일간 고정 시 그룹↔오행 동형 ───────────
+
+describe('groupElement (갑 일간)', () => {
+  it('비겁=목·식상=화·재성=토·관성=금·인성=수', () => {
+    expect(groupElement(DM, '비겁')).toBe('목');
+    expect(groupElement(DM, '식상')).toBe('화');
+    expect(groupElement(DM, '재성')).toBe('토');
+    expect(groupElement(DM, '관성')).toBe('금');
+    expect(groupElement(DM, '인성')).toBe('수');
+  });
+});
+
+// ─── 십성 매핑 결정론 스냅샷 + 이중계산 부재 불변식 ───────
+
+describe('buildResponseProfile — 천간10·지지12 결정론 롤업', () => {
+  // 천간 10 + 지지 12 = 22 글자 링크(각 confirmed, domain sleep). 일간 갑 기준.
+  const seedEntries: [number, SeedForCell][] = [];
+  const links: ProfileLink[] = [];
+  for (let i = 1; i <= 10; i++) {
+    const id = 100 + i;
+    seedEntries.push(stemSeed(id, i));
+    links.push(mkLink(id, id));
+  }
+  for (let i = 1; i <= 12; i++) {
+    const id = 200 + i;
+    seedEntries.push(branchSeed(id, i));
+    links.push(mkLink(id, id));
+  }
+  const cells = buildResponseProfile(links, new Map(seedEntries), DM, stemNameById, branchNameById);
+
+  it('글자 셀 = 22개, 각 1링크 (Σ char nLinks == 편입 글자 링크)', () => {
+    const chars = cells.filter((c) => isChar(c));
+    expect(chars.length).toBe(22);
+    expect(chars.every((c) => c.nLinks === 1)).toBe(true);
+    expect(chars.reduce((s, c) => s + c.nLinks, 0)).toBe(22);
+  });
+
+  it('십성 롤업 결정론 — 갑 일간 십성별 글자 수', () => {
+    const sip = new Map(
+      cells.filter((c) => c.axisLevel === 'sipsung').map((c) => [c.axisKey, c.nLinks]),
+    );
+    // 천간: 갑비견 을겁재 병식신 정상관 무편재 기정재 경편관 신정관 임편인 계정인
+    // 지지: 자정인 축정재 인비견 묘겁재 진편재 사식신 오상관 미정재 신편관 유정관 술편재 해편인
+    expect(sip.get('비견')).toBe(2); // 갑, 인
+    expect(sip.get('겁재')).toBe(2); // 을, 묘
+    expect(sip.get('식신')).toBe(2); // 병, 사
+    expect(sip.get('상관')).toBe(2); // 정, 오
+    expect(sip.get('편재')).toBe(3); // 무, 진, 술
+    expect(sip.get('정재')).toBe(3); // 기, 축, 미
+    expect(sip.get('편관')).toBe(2); // 경, 신(지지)
+    expect(sip.get('정관')).toBe(2); // 신(천간), 유
+    expect(sip.get('편인')).toBe(2); // 임, 해
+    expect(sip.get('정인')).toBe(2); // 계, 자
+    expect([...sip.values()].reduce((a, b) => a + b, 0)).toBe(22); // Σ sipsung == Σ char
+  });
+
+  it('그룹 롤업 = 십성 합산 (Σ group nLinks == Σ char nLinks)', () => {
+    const grp = new Map(
+      cells.filter((c) => c.axisLevel === 'group').map((c) => [c.axisKey, c.nLinks]),
+    );
+    expect(grp.get('비겁')).toBe(4); // 비견2+겁재2
+    expect(grp.get('식상')).toBe(4); // 식신2+상관2
+    expect(grp.get('재성')).toBe(6); // 편재3+정재3
+    expect(grp.get('관성')).toBe(4); // 편관2+정관2
+    expect(grp.get('인성')).toBe(4); // 편인2+정인2
+    expect([...grp.values()].reduce((a, b) => a + b, 0)).toBe(22);
+  });
+
+  it('오행 별칭 — char 갑=목, group 재성=토', () => {
+    const cha = cells.find((c) => isChar(c) && c.axisKey === '갑');
+    expect(cha?.element).toBe('목');
+    const grp = cells.find((c) => c.axisLevel === 'group' && c.axisKey === '재성');
+    expect(grp?.element).toBe('토');
+    const sip = cells.find((c) => c.axisLevel === 'sipsung');
+    expect(sip?.element).toBeNull(); // 십성 레벨은 오행 별칭 없음
+  });
+
+  it('동음이의 천간 辛/지지 申(=한글 "신") 별도 셀 — 정관 vs 편관', () => {
+    // 천간 신(stemId8)=정관, 지지 신(branchId9)=편관. char 레벨 분리 안 하면 한 셀로 병합됨(버그).
+    const stemSin = cells.find((c) => c.axisLevel === 'char_stem' && c.axisKey === '신');
+    const branchSin = cells.find((c) => c.axisLevel === 'char_branch' && c.axisKey === '신');
+    expect(stemSin?.nLinks).toBe(1);
+    expect(branchSin?.nLinks).toBe(1);
+    expect(stemSin).not.toBe(branchSin); // 다른 셀
+  });
+});
+
+// ─── 그룹 = 십성 롤업 + hwa 직접 ──────────────────────────
+
+describe('buildResponseProfile — hwa 직접 기여', () => {
+  it('group 재성 = 무/기(롤업) + hwa 재성(직접) 합산', () => {
+    const seeds = new Map<number, SeedForCell>([
+      stemSeed(1, 5),
+      stemSeed(2, 6),
+      hwaSeed(3, '재성'),
+    ]);
+    // 무(stemId5)→편재→재성, 기(stemId6)→정재→재성, hwa 재성 직접.
+    const links = [mkLink(1, 1), mkLink(2, 2), mkLink(3, 3)];
+    const cells = buildResponseProfile(links, seeds, DM, stemNameById, branchNameById);
+    const grp = cells.find((c) => c.axisLevel === 'group' && c.axisKey === '재성');
+    expect(grp?.nLinks).toBe(3); // 무1 + 기1 + hwa1
+    expect(grp?.sourceLinkIds).toEqual([1, 2, 3]);
+    // hwa는 char·sipsung 미기여 → 글자/십성 셀은 무·기에서만(각 1)
+    expect(cells.filter((c) => isChar(c)).reduce((s, c) => s + c.nLinks, 0)).toBe(2);
+    expect(cells.filter((c) => c.axisLevel === 'sipsung').reduce((s, c) => s + c.nLinks, 0)).toBe(
+      2,
+    );
+  });
+
+  it('element_band은 별도 축 — char/sipsung/group과 분리', () => {
+    const seeds = new Map<number, SeedForCell>([stemSeed(1, 1), bandSeed(2, '화', 'high')]);
+    const links = [mkLink(1, 1), mkLink(2, 2)];
+    const cells = buildResponseProfile(links, seeds, DM, stemNameById, branchNameById);
+    const eb = cells.filter((c) => c.axisLevel === 'element_band');
+    expect(eb.length).toBe(1);
+    expect(eb[0]?.axisKey).toBe('화');
+    expect(eb[0]?.element).toBe('화');
+    // 글자 축은 갑 1개만(밴드는 글자축에 안 들어감)
+    expect(cells.filter((c) => isChar(c)).length).toBe(1);
+  });
+});
+
+// ─── tier 게이트 ──────────────────────────────────────────
+
+describe('buildResponseProfile — tier 게이트', () => {
+  it('confirmed 포함 → verified (효과·발현일 무관 출현)', () => {
+    const seeds = new Map([stemSeed(1, 1)]);
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'confirmed', nActive: 5, posteriorP: 0.3, rateOff: 0.3 })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    expect(cells.find((c) => isChar(c))?.tier).toBe('verified');
+  });
+
+  it('active + nActive≥15 + shrunk≥1.3 → emerging', () => {
+    const seeds = new Map([stemSeed(1, 1)]);
+    // shrunk = posteriorP/rateOff = 0.6/0.3 = 2.0 ≥ 1.3, nActive 20 ≥ 15
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'active' })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    const cha = cells.find((c) => isChar(c));
+    expect(cha?.tier).toBe('emerging');
+    expect(cha?.shrunkEffect).toBeCloseTo(2.0, 6);
+  });
+
+  it('active + nActive<15 → 행 부재', () => {
+    const seeds = new Map([stemSeed(1, 1)]);
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'active', nActive: 10 })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    expect(cells.length).toBe(0);
+  });
+
+  it('active + shrunk<1.3 → 행 부재', () => {
+    const seeds = new Map([stemSeed(1, 1)]);
+    // shrunk = 0.3/0.3 = 1.0 < 1.3
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'active', posteriorP: 0.3, rateOff: 0.3 })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    expect(cells.length).toBe(0);
+  });
+});
+
+// ─── explained_away 제외 + attenuated min (D3) ────────────
+
+describe('buildResponseProfile — 교란 반영(D3)', () => {
+  it('explained_away 링크 제외 → 셀 미생성', () => {
+    const seeds = new Map([stemSeed(1, 1)]);
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { explainedAway: true })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    expect(cells.length).toBe(0);
+  });
+
+  it('attenuated → shrunk = min(posterior_p/rate_off, adjEffect)', () => {
+    const seeds = new Map([stemSeed(1, 1)]);
+    // base shrunk = 0.6/0.2 = 3.0, attenuatedEffect 1.4 → min = 1.4
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'active', posteriorP: 0.6, rateOff: 0.2, attenuatedEffect: 1.4 })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    expect(cells.find((c) => isChar(c))?.shrunkEffect).toBeCloseTo(1.4, 6);
+  });
+
+  it('shrunk = nActive 가중평균 (두 링크)', () => {
+    // 같은 글자 셀에 두 active 링크: shrunk 2.0(nActive10) + 1.4(nActive30) → 가중평균 = (2.0*10+1.4*30)/40 = 1.55
+    const seeds = new Map([stemSeed(1, 1)]);
+    const links = [
+      mkLink(1, 1, { status: 'active', posteriorP: 0.4, rateOff: 0.2, nActive: 10 }), // 2.0
+      mkLink(2, 1, { status: 'active', posteriorP: 0.7, rateOff: 0.5, nActive: 30 }), // 1.4
+    ];
+    const cells = buildResponseProfile(links, seeds, DM, stemNameById, branchNameById);
+    expect(cells.find((c) => isChar(c))?.shrunkEffect).toBeCloseTo(1.55, 6);
+  });
+});
+
+// ─── stability 전파 ───────────────────────────────────────
+
+describe('buildResponseProfile — stability 전파', () => {
+  const seeds = new Map([stemSeed(1, 1)]);
+  const cellOf = (links: ProfileLink[]): ResponseCell | undefined =>
+    buildResponseProfile(links, seeds, DM, stemNameById, branchNameById).find((c) => isChar(c));
+
+  it('전부 true → true', () => {
+    expect(
+      cellOf([mkLink(1, 1, { stability: true }), mkLink(2, 1, { stability: true })])?.stability,
+    ).toBe(true);
+  });
+  it('하나라도 false → false', () => {
+    expect(
+      cellOf([mkLink(1, 1, { stability: true }), mkLink(2, 1, { stability: false })])?.stability,
+    ).toBe(false);
+  });
+  it('null은 무시(있는 것만 AND)', () => {
+    expect(
+      cellOf([mkLink(1, 1, { stability: true }), mkLink(2, 1, { stability: null })])?.stability,
+    ).toBe(true);
+  });
+  it('전부 null → null', () => {
+    expect(
+      cellOf([mkLink(1, 1, { stability: null }), mkLink(2, 1, { stability: null })])?.stability,
+    ).toBeNull();
+  });
+});
+
+// ─── 단일 레벨 resolution (정지·fallback·비합산) ──────────
+
+describe('resolveHierarchyCell — 단일 레벨', () => {
+  it('글자 셀 존재 → char에서 정지(비합산)', () => {
+    const seeds = new Map([stemSeed(1, 1)]); // 갑
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'active' })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    const idx = indexCells(cells);
+    const r = resolveHierarchyCell(idx, DM, 'stem', '갑', 'sleep');
+    expect(r?.resolvedLevel).toBe('char_stem');
+    expect(r?.cell.axisKey).toBe('갑');
+    // 반환 셀은 char 셀 객체 그 자체 — 십성/그룹과 합산되지 않음
+    expect(r?.cell).toBe(idx.get(cellKey('char_stem', '갑', 'sleep')));
+  });
+
+  it('글자 셀 부재 → 십성으로 fallback', () => {
+    // 인(branch, 본기 갑 → 비견) 링크만 → char 인 + sipsung 비견. stem 갑 조회는 char 갑 부재 → 비견 fallback.
+    const seeds = new Map([branchSeed(1, 3)]); // 인
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'active' })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    const idx = indexCells(cells);
+    const r = resolveHierarchyCell(idx, DM, 'stem', '갑', 'sleep');
+    expect(r?.resolvedLevel).toBe('sipsung');
+    expect(r?.cell.axisKey).toBe('비견');
+  });
+
+  it('글자·십성 부재 → 그룹으로 fallback (hwa 직접 그룹)', () => {
+    const seeds = new Map([hwaSeed(1, '재성')]); // 그룹 재성만
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'active' })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    const idx = indexCells(cells);
+    // 무(stem, 편재→재성) 조회: char 무·sipsung 편재 부재 → group 재성
+    const r = resolveHierarchyCell(idx, DM, 'stem', '무', 'sleep');
+    expect(r?.resolvedLevel).toBe('group');
+    expect(r?.cell.axisKey).toBe('재성');
+  });
+
+  it('어느 레벨도 없음 → null', () => {
+    const idx = indexCells([]);
+    expect(resolveHierarchyCell(idx, DM, 'stem', '갑', 'sleep')).toBeNull();
+  });
+
+  it('도메인 다르면 매칭 안 됨', () => {
+    const seeds = new Map([stemSeed(1, 1)]);
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'active', domain: 'sleep' })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    const idx = indexCells(cells);
+    expect(resolveHierarchyCell(idx, DM, 'stem', '갑', 'routine')).toBeNull();
+  });
+});
+
+describe('resolveElementBandCell — 별도 축(fallback 없음)', () => {
+  it('element_band 셀 직접 조회', () => {
+    const seeds = new Map([bandSeed(1, '화', 'high')]);
+    const cells = buildResponseProfile(
+      [mkLink(1, 1, { status: 'active' })],
+      seeds,
+      DM,
+      stemNameById,
+      branchNameById,
+    );
+    const idx = indexCells(cells);
+    expect(resolveElementBandCell(idx, '화', 'sleep')?.resolvedLevel).toBe('element_band');
+    expect(resolveElementBandCell(idx, '목', 'sleep')).toBeNull(); // 다른 오행 — fallback 없음
+  });
+});

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -48,6 +48,27 @@ export const query = async <T extends pg.QueryResultRow = pg.QueryResultRow>(
   return getPool().query<T>(text, params);
 };
 
+/**
+ * 트랜잭션 헬퍼 — 콜백 내 client.query들을 BEGIN/COMMIT으로 감싸고 예외 시 ROLLBACK.
+ * 파생 테이블 user당 full-replace(DELETE → 다중 INSERT) 등 원자적 다중 쓰기용 (#523 P1).
+ */
+export const withTransaction = async <T>(fn: (client: pg.PoolClient) => Promise<T>): Promise<T> => {
+  const client = await getPool().connect();
+  try {
+    await client.query('BEGIN');
+    const result = await fn(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {
+      /* 무시 */
+    });
+    throw err;
+  } finally {
+    client.release();
+  }
+};
+
 /** SQL 쿼리 실행 후 첫 번째 행 반환 (없으면 null) */
 export const queryOne = async <T extends pg.QueryResultRow = pg.QueryResultRow>(
   text: string,

--- a/src/shared/insight-thresholds.ts
+++ b/src/shared/insight-thresholds.ts
@@ -111,4 +111,9 @@ export const INSIGHT_THRESHOLDS = {
     minStratumCell: 5, // joint 층 viability — 각 층 n_k 최소(미달 시 가장 강한 단일 Z fallback)
     elasticNetEnabled: false, // 교란이 층화 한계 초과 시 elastic-net 조정(후속 노브, 기본 off)
   },
+  // #523 Phase 1 개인화 가중치 집계(saju_response_profile, ADR-0049) — 셀 emerging 게이트.
+  // 효과 하한은 patternVerification.emergingMinEffect(1.3) 승계, 발현일 하한만 여기서.
+  responseProfile: {
+    cellMinActive: 15, // 셀 emerging tier·단일레벨 resolution 정지 최소 합산 발현일(= emergingMinActive 승계)
+  },
 } as const;

--- a/src/shared/pattern-verification.ts
+++ b/src/shared/pattern-verification.ts
@@ -146,6 +146,8 @@ export interface LinkVerification {
   windowStart: string | null;
   /** BH-FDR 가족 (관측성 → 주간 로그 가족별 m 추적). #523 P0. */
   family: FdrFamily;
+  /** 전·후반 효과 부호 일치(표시용, 게이트 아님) → test_detail + 프로필 셀. #523 P1, §2-6. */
+  stability: boolean | null;
   verdict: Verdict;
   nextStatus: LinkLifecycleStatus;
 }
@@ -390,6 +392,38 @@ export const buildDaySequence = (
     seq.push({ active: activation.get(date) ?? false, pass });
   }
   return seq;
+};
+
+/**
+ * daySeq 전·후반 효과 부호(발현일 pass율 − 비발현일 pass율) 일치 여부 — 비정상성/단일국면 의존 표시 플래그
+ * (#523 P1, §2-6). 게이트 아님(노출용 stability). 각 반에 발현·비발현 양쪽 관측이 있어야 부호 산출 가능 —
+ * 한쪽이라도 결측이면 null(판정 보류). 길이 < minPerHalf*2 면 null. 입력 순서 고정 = SET 리플레이 불변(ADR-0034).
+ */
+export const splitHalvesConsistent = (
+  daySeq: ReadonlyArray<DayObservation>,
+  minPerHalf = 4,
+): boolean | null => {
+  if (daySeq.length < minPerHalf * 2) return null;
+  const mid = Math.floor(daySeq.length / 2);
+  const effectSign = (seq: ReadonlyArray<DayObservation>): number | null => {
+    let a = 0;
+    let b = 0;
+    let c = 0;
+    let d = 0;
+    for (const o of seq) {
+      if (o.active) {
+        if (o.pass) a++;
+        else b++;
+      } else if (o.pass) c++;
+      else d++;
+    }
+    if (a + b === 0 || c + d === 0) return null; // 한쪽 결측 → 부호 산출 불가
+    return Math.sign(a / (a + b) - c / (c + d));
+  };
+  const s1 = effectSign(daySeq.slice(0, mid));
+  const s2 = effectSign(daySeq.slice(mid));
+  if (s1 === null || s2 === null) return null;
+  return s1 === s2;
 };
 
 /** 2×2 → Fisher p + rate ratio + Beta-Binomial posterior. */
@@ -859,6 +893,7 @@ export const verifyUserLinks = async (
         blockP: blockPermutationP(daySeq, V.blockLen, V.blockPermIters),
         mannWhitney,
         eValue: evalueTestMartingale(daySeq),
+        stability: splitHalvesConsistent(daySeq),
         lastMatchedAt: lastActivationDate(activation),
       };
     })
@@ -909,6 +944,7 @@ export const verifyUserLinks = async (
       lastMatchedAt: x.lastMatchedAt,
       windowStart: x.windowStart,
       family: x.family,
+      stability: x.stability,
       verdict,
       nextStatus: statusForVerdict(verdict, x.row.status, x.eValue),
     };

--- a/src/shared/response-profile.ts
+++ b/src/shared/response-profile.ts
@@ -1,0 +1,400 @@
+/**
+ * 개인화 가중치 집계 레이어: saju_response_profile (#523 Phase 1, #408 5-B 구체화, ADR-0049).
+ *
+ * 검증된(confirmed)·검증중(active) pattern_links를 사주 축으로 집계해 "이 사람은 [십성/오행]에
+ * 어떻게 반응하는가"의 셀 프로필을 만든다. Phase 2(기간 해석)·Phase 3(예측 장부)가 이 프로필을
+ * 기간 pillar(월운/세운/대운)에 조인한다.
+ *
+ * 이중계산 구조적 차단(D4):
+ *   - 원천 기여 = 링크당 정확히 1 source 셀 (stem→천간글자, branch→지지글자, hwa_sipsung→그룹, strength_band 강→오행밴드).
+ *   - 글자 source는 결정론 롤업 → 십성 → 십성그룹(α/β·nActive 합산). 어떤 조회도 두 레벨을 합산하지 않음(resolveCell).
+ *   - 천간 글자와 지지 글자는 별도 축(char_stem/char_branch) — 한글 동음이의(천간 辛 vs 지지 申='신')가 다른 십성으로
+ *     가므로 한 셀로 병합하면 안 됨. axis_key는 깨끗한 글자 유지.
+ *   - 오행은 그룹 셀의 별칭(일간 고정 시 십성그룹 5 = 오행 5 동형) — 별도 레벨 저장 안 함.
+ *   - element_band(강 밴드만)는 별도 축 — 기간 pillar 오행에 직접 조인(생극 간접추론 배제).
+ *
+ * winner's curse 차단(D3): 효과 = shrunk(posterior_p/rate_off), explained_away 제외, attenuated는 min.
+ * 순수 함수(DB·시각 의존 0) → 결정론·단위 테스트 용이. DB I/O·full-replace는 weekly-verification.ts.
+ */
+
+import {
+  getElementByCheongan,
+  getElementByJiji,
+  getSipsung,
+  getJijiSipsung,
+  type Cheongan,
+  type Jiji,
+  type Element,
+  type Sipsung,
+} from './saju-calendar.js';
+import { elementToSipsinGroup, isSipsinGroup, type SipsinGroup } from './saju-hwa.js';
+import { INSIGHT_THRESHOLDS } from './insight-thresholds.js';
+
+const V = INSIGHT_THRESHOLDS.patternVerification;
+const RP = INSIGHT_THRESHOLDS.responseProfile;
+
+/** 글자 레벨은 천간/지지 분리(동음이의 차단). 십성·그룹은 통합, element_band는 별도 축. */
+export type AxisLevel = 'char_stem' | 'char_branch' | 'sipsung' | 'group' | 'element_band';
+export type CellTier = 'verified' | 'emerging';
+
+const CHEONGAN: readonly Cheongan[] = ['갑', '을', '병', '정', '무', '기', '경', '신', '임', '계'];
+const JIJI: readonly Jiji[] = [
+  '자',
+  '축',
+  '인',
+  '묘',
+  '진',
+  '사',
+  '오',
+  '미',
+  '신',
+  '유',
+  '술',
+  '해',
+];
+const ELEMENTS: readonly Element[] = ['목', '화', '토', '금', '수'];
+
+const isCheongan = (s: string): s is Cheongan => (CHEONGAN as readonly string[]).includes(s);
+const isJiji = (s: string): s is Jiji => (JIJI as readonly string[]).includes(s);
+const isElement = (s: string): s is Element => (ELEMENTS as readonly string[]).includes(s);
+
+/** 십성 → 십성그룹 (편/정 한 쌍이 한 그룹). 결정론 룩업. */
+const SIPSUNG_GROUP: Record<Sipsung, SipsinGroup> = {
+  비견: '비겁',
+  겁재: '비겁',
+  식신: '식상',
+  상관: '식상',
+  편재: '재성',
+  정재: '재성',
+  편관: '관성',
+  정관: '관성',
+  편인: '인성',
+  정인: '인성',
+};
+
+/** 십성그룹의 오행 별칭 — 일간 오행 대비 elementToSipsinGroup이 그 그룹을 내는 유일 오행(일간 고정 시 동형). */
+export const groupElement = (dayMaster: Cheongan, group: SipsinGroup): Element => {
+  const dm = getElementByCheongan(dayMaster);
+  for (const el of ELEMENTS) if (elementToSipsinGroup(dm, el) === group) return el;
+  return dm; // 비겁=일간 오행 — 도달 불가 방어
+};
+
+// ─── 시드 → source 셀 매핑 (링크당 정확히 1셀) ─────────────
+
+/** mapSeedToCell이 읽는 시드 최소 형태 (pattern_catalog 컬럼 일부). */
+export interface SeedForCell {
+  trigger_target_type: string;
+  trigger_target_id: number | null;
+  trigger_aux: Record<string, unknown> | null;
+}
+
+/** 한 시드가 기여하는 source 셀 (편입 안 되면 null). */
+export interface PrimaryCell {
+  axisLevel: AxisLevel; // char_stem | char_branch | group | element_band (sipsung은 source 아님 — char 롤업으로만)
+  axisKey: string;
+  element: Element | null;
+}
+
+/** branch 시드의 단일 지지 해소 — trigger_target_id 우선, or_branches는 정확히 1개일 때만(다중=비편입). */
+const resolveBranchChar = (
+  seed: SeedForCell,
+  branchNameById: ReadonlyMap<number, string>,
+): string | null => {
+  if (seed.trigger_target_id !== null) {
+    const c = branchNameById.get(seed.trigger_target_id);
+    if (c) return c;
+  }
+  const or = (seed.trigger_aux ?? {})['or_branches'];
+  if (Array.isArray(or) && or.length === 1 && typeof or[0] === 'string') return or[0];
+  return null;
+};
+
+/**
+ * 시드 → 1 source 셀. id→글자 역맵은 호출부(DB)에서 주입.
+ *   - stem → char_stem(천간 글자) / branch → char_branch(지지 글자, 단일만)
+ *   - hwa_sipsung → group(십성그룹 직접)
+ *   - strength_band 강 × 오행 → element_band (일간/약/적정 밴드는 비편입)
+ *   - relation·sibiunsung·element_density·life_signal·ganji·다중 branch → null (v1 비편입)
+ */
+export const mapSeedToCell = (
+  seed: SeedForCell,
+  dayMaster: Cheongan,
+  stemNameById: ReadonlyMap<number, string>,
+  branchNameById: ReadonlyMap<number, string>,
+): PrimaryCell | null => {
+  const aux = seed.trigger_aux ?? {};
+  switch (seed.trigger_target_type) {
+    case 'stem': {
+      const char =
+        seed.trigger_target_id !== null ? stemNameById.get(seed.trigger_target_id) : undefined;
+      if (!char || !isCheongan(char)) return null;
+      return { axisLevel: 'char_stem', axisKey: char, element: getElementByCheongan(char) };
+    }
+    case 'branch': {
+      const char = resolveBranchChar(seed, branchNameById);
+      if (!char || !isJiji(char)) return null;
+      return { axisLevel: 'char_branch', axisKey: char, element: getElementByJiji(char) };
+    }
+    case 'hwa_sipsung': {
+      const sipsin = aux['sipsin'];
+      if (!isSipsinGroup(sipsin)) return null;
+      return { axisLevel: 'group', axisKey: sipsin, element: groupElement(dayMaster, sipsin) };
+    }
+    case 'strength_band': {
+      const target = aux['target'];
+      const band = aux['band'];
+      // 강 밴드 × 오행(목화토금수)만 — day_master·약·적정은 비편입(생극 간접추론 배제, §4-1).
+      if (band !== 'high' || typeof target !== 'string' || !isElement(target)) return null;
+      return { axisLevel: 'element_band', axisKey: target, element: target };
+    }
+    default:
+      return null;
+  }
+};
+
+// ─── 집계 (1셀 기여 → 결정론 롤업 → tier·shrunk·stability) ──
+
+/** 집계 입력 링크 — pattern_links(confirmed+active) 1행 + 그 신호 도메인 + 교란 판정. */
+export interface ProfileLink {
+  linkId: number;
+  seedId: number;
+  status: 'active' | 'confirmed';
+  domain: string; // 신호 도메인 (셀 분할 축)
+  posteriorAlpha: number;
+  posteriorBeta: number;
+  posteriorP: number;
+  rateOff: number; // test_detail.rate_off
+  nActive: number; // hit_count + miss_count
+  stability: boolean | null; // test_detail.stability
+  explainedAway: boolean; // confound.explainedAway → 제외(D3)
+  attenuatedEffect: number | null; // confound.adjusted verdict='attenuated'의 adjEffect → min 대상(D3)
+}
+
+/** 집계 결과 셀 (saju_response_profile 1행). */
+export interface ResponseCell {
+  axisLevel: AxisLevel;
+  axisKey: string;
+  element: Element | null;
+  domain: string;
+  tier: CellTier;
+  alpha: number;
+  beta: number;
+  shrunkEffect: number | null;
+  nLinks: number;
+  nActiveDays: number;
+  stability: boolean | null;
+  sourceLinkIds: number[];
+}
+
+interface CellAccumulator {
+  axisLevel: AxisLevel;
+  axisKey: string;
+  element: Element | null;
+  domain: string;
+  alpha: number;
+  beta: number;
+  nActiveDays: number;
+  nLinks: number;
+  hasConfirmed: boolean;
+  weightedEffectNum: number; // Σ nActive·linkShrunk (유한 효과 링크만)
+  weightedEffectDen: number; // Σ nActive (유한 효과 링크만)
+  stabilities: Array<boolean | null>;
+  linkIds: number[];
+}
+
+/** 셀 lookup·resolution 키 — (레벨, 키, 도메인). */
+export const cellKey = (axisLevel: AxisLevel, axisKey: string, domain: string): string =>
+  `${axisLevel}|${axisKey}|${domain}`;
+
+/** 링크 1건의 shrunk 효과(D3): posterior_p/rate_off, attenuated면 min(·, adjEffect). 산출 불가면 null. */
+const linkShrunk = (link: ProfileLink): number | null => {
+  if (!(link.rateOff > 0) || !Number.isFinite(link.posteriorP)) return null;
+  const base = link.posteriorP / link.rateOff;
+  if (!Number.isFinite(base)) return null;
+  return link.attenuatedEffect !== null ? Math.min(base, link.attenuatedEffect) : base;
+};
+
+const addContribution = (
+  acc: Map<string, CellAccumulator>,
+  axisLevel: AxisLevel,
+  axisKey: string,
+  element: Element | null,
+  link: ProfileLink,
+): void => {
+  const k = cellKey(axisLevel, axisKey, link.domain);
+  let a = acc.get(k);
+  if (!a) {
+    a = {
+      axisLevel,
+      axisKey,
+      element,
+      domain: link.domain,
+      alpha: 0,
+      beta: 0,
+      nActiveDays: 0,
+      nLinks: 0,
+      hasConfirmed: false,
+      weightedEffectNum: 0,
+      weightedEffectDen: 0,
+      stabilities: [],
+      linkIds: [],
+    };
+    acc.set(k, a);
+  }
+  a.alpha += link.posteriorAlpha;
+  a.beta += link.posteriorBeta;
+  a.nActiveDays += link.nActive;
+  a.nLinks += 1;
+  if (link.status === 'confirmed') a.hasConfirmed = true;
+  const e = linkShrunk(link);
+  if (e !== null && link.nActive > 0) {
+    a.weightedEffectNum += link.nActive * e;
+    a.weightedEffectDen += link.nActive;
+  }
+  a.stabilities.push(link.stability);
+  a.linkIds.push(link.linkId);
+};
+
+const AXIS_ORDER: Record<AxisLevel, number> = {
+  char_stem: 0,
+  char_branch: 1,
+  sipsung: 2,
+  group: 3,
+  element_band: 4,
+};
+
+/** 집계 → tier 게이트(무증거=행 부재) 적용한 셀(또는 null). */
+const finalizeCell = (a: CellAccumulator): ResponseCell | null => {
+  const shrunkEffect = a.weightedEffectDen > 0 ? a.weightedEffectNum / a.weightedEffectDen : null;
+  let tier: CellTier | null = null;
+  if (a.hasConfirmed) {
+    tier = 'verified';
+  } else if (
+    a.nActiveDays >= RP.cellMinActive &&
+    shrunkEffect !== null &&
+    shrunkEffect >= V.emergingMinEffect
+  ) {
+    tier = 'emerging';
+  }
+  if (tier === null) return null; // 무증거 = 행 부재(§4-1)
+  const nonNull = a.stabilities.filter((s): s is boolean => s !== null);
+  const stability = nonNull.length === 0 ? null : nonNull.every((s) => s);
+  return {
+    axisLevel: a.axisLevel,
+    axisKey: a.axisKey,
+    element: a.element,
+    domain: a.domain,
+    tier,
+    alpha: a.alpha,
+    beta: a.beta,
+    shrunkEffect,
+    nLinks: a.nLinks,
+    nActiveDays: a.nActiveDays,
+    stability,
+    sourceLinkIds: [...a.linkIds].sort((x, y) => x - y),
+  };
+};
+
+/**
+ * confirmed+active 링크 → 셀 프로필. 링크당 1 source 기여 + 글자→십성→그룹 결정론 롤업.
+ * explained_away 제외(D3). 무증거 셀(tier 미충족)은 행 생략. 결정론(입력 동일 → 출력 동일).
+ */
+export const buildResponseProfile = (
+  links: ReadonlyArray<ProfileLink>,
+  seedById: ReadonlyMap<number, SeedForCell>,
+  dayMaster: Cheongan,
+  stemNameById: ReadonlyMap<number, string>,
+  branchNameById: ReadonlyMap<number, string>,
+): ResponseCell[] => {
+  const acc = new Map<string, CellAccumulator>();
+  for (const link of links) {
+    if (link.explainedAway) continue; // D3 — 어부지리 링크 제외
+    const seed = seedById.get(link.seedId);
+    if (!seed) continue;
+    const primary = mapSeedToCell(seed, dayMaster, stemNameById, branchNameById);
+    if (!primary) continue;
+
+    if (primary.axisLevel === 'char_stem' || primary.axisLevel === 'char_branch') {
+      // source: 글자 셀 1개. 결정론 롤업 → 십성 → 십성그룹(같은 링크가 각 레벨 1셀에만 기여 = 비합산 불변).
+      addContribution(acc, primary.axisLevel, primary.axisKey, primary.element, link);
+      const sipsung =
+        primary.axisLevel === 'char_stem'
+          ? getSipsung(dayMaster, primary.axisKey as Cheongan)
+          : getJijiSipsung(dayMaster, primary.axisKey as Jiji);
+      addContribution(acc, 'sipsung', sipsung, null, link);
+      const group = SIPSUNG_GROUP[sipsung];
+      addContribution(acc, 'group', group, groupElement(dayMaster, group), link);
+    } else if (primary.axisLevel === 'group') {
+      // hwa_sipsung: 그룹 직접(글자·십성 source 없음). 그룹 셀 = 십성 롤업 + hwa 직접의 합.
+      addContribution(acc, 'group', primary.axisKey, primary.element, link);
+    } else {
+      // element_band: 별도 축.
+      addContribution(acc, 'element_band', primary.axisKey, primary.element, link);
+    }
+  }
+
+  const cells: ResponseCell[] = [];
+  for (const a of acc.values()) {
+    const cell = finalizeCell(a);
+    if (cell) cells.push(cell);
+  }
+  cells.sort(
+    (x, y) =>
+      AXIS_ORDER[x.axisLevel] - AXIS_ORDER[y.axisLevel] ||
+      x.domain.localeCompare(y.domain) ||
+      x.axisKey.localeCompare(y.axisKey),
+  );
+  return cells;
+};
+
+// ─── 읽기: 단일 레벨 resolution (Phase 2·3 공용) ──────────
+
+export interface ResolvedCell {
+  cell: ResponseCell;
+  resolvedLevel: AxisLevel;
+}
+
+/** 셀 배열 → resolution 인덱스. */
+export const indexCells = (cells: ReadonlyArray<ResponseCell>): Map<string, ResponseCell> =>
+  new Map(cells.map((c) => [cellKey(c.axisLevel, c.axisKey, c.domain), c]));
+
+/** 글자 셀이 write 게이트 통과(verified 또는 nActive≥cellMinActive)면 거기서 정지할 자격. */
+const stopAtChar = (cell: ResponseCell | undefined): cell is ResponseCell =>
+  cell !== undefined && (cell.tier === 'verified' || cell.nActiveDays >= RP.cellMinActive);
+
+/**
+ * 글자 기준 단일 레벨 resolution: 글자(천간/지지) → 십성 → 그룹. 두 레벨을 절대 합산하지 않는다(§4-1).
+ * 글자 셀이 존재(=게이트 통과)하면 거기서 정지, 미달이면 한 단계 위. 어느 레벨도 없으면 null(무증거).
+ */
+export const resolveHierarchyCell = (
+  index: ReadonlyMap<string, ResponseCell>,
+  dayMaster: Cheongan,
+  charType: 'stem' | 'branch',
+  char: Cheongan | Jiji,
+  domain: string,
+): ResolvedCell | null => {
+  const charLevel: AxisLevel = charType === 'stem' ? 'char_stem' : 'char_branch';
+  const charCell = index.get(cellKey(charLevel, char, domain));
+  if (stopAtChar(charCell)) return { cell: charCell, resolvedLevel: charLevel };
+
+  const sipsung =
+    charType === 'stem'
+      ? getSipsung(dayMaster, char as Cheongan)
+      : getJijiSipsung(dayMaster, char as Jiji);
+  const sipsungCell = index.get(cellKey('sipsung', sipsung, domain));
+  if (stopAtChar(sipsungCell)) return { cell: sipsungCell, resolvedLevel: 'sipsung' };
+
+  const groupCell = index.get(cellKey('group', SIPSUNG_GROUP[sipsung], domain));
+  if (groupCell) return { cell: groupCell, resolvedLevel: 'group' };
+  return null;
+};
+
+/** element_band 축 resolution — 별도 축, fallback 없음(생극 간접추론 배제). */
+export const resolveElementBandCell = (
+  index: ReadonlyMap<string, ResponseCell>,
+  element: Element,
+  domain: string,
+): ResolvedCell | null => {
+  const c = index.get(cellKey('element_band', element, domain));
+  return c ? { cell: c, resolvedLevel: 'element_band' } : null;
+};


### PR DESCRIPTION
## 관련 이슈
Closes #527 (마스터 #523 Phase 1)

## 변경 내용
검증된·검증중 패턴 링크를 사주 축으로 모아 개인화 반응 프로필을 만드는 **파생 레이어**. 후속 기간 해석·예측 장부가 조인할 원료(#408 5-B 구체화).

- **이중계산 구조적 차단**: 링크당 정확히 1 source 셀 + 결정론 롤업(글자→십성→그룹). 조회는 단일 레벨(두 레벨 비합산). 천간/지지 글자는 동음이의 때문에 별도 축으로 분리.
- **winner's curse 차단**: 효과는 raw 비율이 아니라 shrunk 추정. 교란 링크 제외·약화 반영.
- 무증거 = 행 부재. 표시용 안정성 플래그(게이트 아님).
- 파생 테이블 user당 full-replace(트랜잭션). 주간 검증 엔진 말미 격리 호출 — 실패해도 검증 카드·발굴 무탈.
- 마이그 088 + ADR-0049 + 도메인 문서.

## 코드 리뷰 결과
- [x] 보안 감사 통과 — 동적 INSERT는 컬럼명 상수 + 전량 파라미터화(injection 불가), 로그는 카운트만
- [x] 타입 안전성 — any 없음, unknown + 타입 가드, tsc clean
- [x] 컨벤션 점검 — 네이밍·named export·import 순서·파일 분리
- [x] 코드 품질 — 순수 집계/DB I/O 분리, 결정론, 격리

## 테스트
- [x] 십성 매핑 결정론 스냅샷(천간10·지지12) + 이중계산 부재 불변식
- [x] 천간/지지 동음이의 별도 셀 + 단일 레벨 resolution(정지·fallback·비합산)
- [x] shrunk 효과·교란 제외·약화 min·안정성 전파·tier 게이트
- [x] 전체 843개 테스트 통과

## DoD (배포 후 다음 주간 run에서 확인)
`SELECT axis_level, count(*), sum(n_links) FROM saju_response_profile GROUP BY 1;` — 글자 레벨 합 == 편입 링크 수, provenance spot check. 집계는 주간 엔진(월요일)이 채우므로 prod 검증은 다음 run 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)