### PR TITLE
fix(insight): 카드 버튼 클릭 후 제안 내용 보존

### DIFF
--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -1732,6 +1732,7 @@ P4a·P4b가 evidence-only로 남긴 결정론 feature 시드(강도 밴드·관�
 
 - `approveDiscoveryLink`/`dismissDiscoveryLink`(`WHERE id=$1 AND user_id=$2 AND status='pending'` 가드) 테스트 가능 코어. (P5a 시점엔 LLM 매트릭 승인 `METRIC_*`이 suspended였고, P5b [### 30](#30-매트릭-중심-패턴-검증--phase-5b-llm-신호-제안--검증실행-격리-491)에서 `signal_defs(source='llm')` 모델로 재구현됨.)
 - **노출 vs 믿음 분리**: 사람은 *진실*을 판정하지 않는다 — 게이트하는 건 노출·큐레이션("추적할 가치 있나"), 믿음("진짜인가")은 끝까지 e-value 트랙. 게이트 없이 느슨한 q 발견을 자동 활성하면 미검증 연관이 emerging tier로 조기 노출되므로, 사람 게이트가 그 노출만 막는다.
+- **카드 갱신 — 클릭 후 표시**: 승인/패스 모두 제안 본문 블록은 보존하고 `actions`(버튼) 블록만 제거한 뒤 처리 결과 안내 context를 덧붙인다(`resolveActionCard`, [slack.ts](../../src/shared/slack.ts)). 버튼 클릭 후에도 어떤 제안이었는지 카드에 남게 — DB 전이는 불변, 표시만 변경(#535). P5b LLM 신호 카드도 같은 헬퍼 재사용.
 
 **주간 cron 통합** ([weekly-verification.ts](../../src/cron/weekly-verification.ts) `surfaceDiscoveries`): 검증·persist·카드 발송 후 발굴 단계(검증과 독립 try-catch 격리 — 발굴 실패가 검증 결과를 막지 않게). 월요일 06:00 KST만 실행(`weeklyVerificationTask` 가드 상속).
 

--- a/src/agents/insight/__tests__/actions.test.ts
+++ b/src/agents/insight/__tests__/actions.test.ts
@@ -19,8 +19,13 @@ vi.mock('../../../shared/db.js', () => ({
   }),
 }));
 
-const { approveDiscoveryLink, dismissDiscoveryLink, approveLlmSignal, rejectLlmSignal } =
-  await import('../actions.js');
+const {
+  approveDiscoveryLink,
+  dismissDiscoveryLink,
+  approveLlmSignal,
+  rejectLlmSignal,
+  extractMessageBlocks,
+} = await import('../actions.js');
 
 beforeEach(() => {
   captured = [];
@@ -108,5 +113,28 @@ describe('rejectLlmSignal — pending → rejected', () => {
   it('해당 없음(0행)이면 null', async () => {
     nextRows = [];
     expect(await rejectLlmSignal(1, 99)).toBeNull();
+  });
+});
+
+describe('extractMessageBlocks — body.message.blocks 안전 추출', () => {
+  it('정상 body면 원본 blocks 배열을 반환한다', () => {
+    const blocks = [{ type: 'section', text: { type: 'mrkdwn', text: '제안 본문' } }];
+    expect(extractMessageBlocks({ message: { blocks } })).toEqual(blocks);
+  });
+
+  it('message가 없으면 []', () => {
+    expect(extractMessageBlocks({})).toEqual([]);
+  });
+
+  it('message.blocks가 배열이 아니면 []', () => {
+    expect(extractMessageBlocks({ message: { blocks: 'nope' } })).toEqual([]);
+    expect(extractMessageBlocks({ message: {} })).toEqual([]);
+  });
+
+  it('null·undefined·비객체 body면 [] (폴백)', () => {
+    expect(extractMessageBlocks(null)).toEqual([]);
+    expect(extractMessageBlocks(undefined)).toEqual([]);
+    expect(extractMessageBlocks('str')).toEqual([]);
+    expect(extractMessageBlocks(42)).toEqual([]);
   });
 });

--- a/src/agents/insight/actions.ts
+++ b/src/agents/insight/actions.ts
@@ -9,9 +9,10 @@
  */
 
 import type { App } from '@slack/bolt';
+import type { KnownBlock } from '@slack/types';
 import { query } from '../../shared/db.js';
 import { validateSignalSql } from '../../shared/signal-sql-guard.js';
-import { updateMessage } from '../../shared/slack.js';
+import { resolveActionCard, updateMessage } from '../../shared/slack.js';
 import { resolveUserId, DEFAULT_USER_ID } from '../../shared/user-resolver.js';
 import {
   DISCOVERY_APPROVE_ACTION_ID,
@@ -38,6 +39,14 @@ const extractRawValue = (body: unknown): string | null => {
   if (!first || typeof first !== 'object') return null;
   const value = (first as { value?: unknown }).value;
   return typeof value === 'string' ? value : null;
+};
+
+/** Slack action body에서 원본 메시지 블록 안전 추출 (없으면 빈 배열). */
+export const extractMessageBlocks = (body: unknown): KnownBlock[] => {
+  if (!body || typeof body !== 'object') return [];
+  const message = (body as { message?: { blocks?: unknown } }).message;
+  if (!message || !Array.isArray(message.blocks)) return [];
+  return message.blocks as KnownBlock[];
 };
 
 // ─── 발굴 승인/패스 — pending pattern_link status 전이 (테스트 가능 코어) ──
@@ -151,12 +160,13 @@ export const registerInsightActions = (app: App): void => {
       }
       const { channelId, messageTs } = extractChannelTs(body);
       if (channelId && messageTs) {
+        const notice = '✅ 추적 시작함 — 다음 주간 검증부터 off-day 대조로 진짜인지 가린다.';
         await updateMessage(
           client,
           channelId,
           messageTs,
-          '추적 시작 — 다음 주간 검증부터 off-day 대조로 진짜인지 가린다.',
-          [],
+          notice,
+          resolveActionCard(extractMessageBlocks(body), notice),
         );
       }
     } catch (error: unknown) {
@@ -176,7 +186,14 @@ export const registerInsightActions = (app: App): void => {
       await dismissDiscoveryLink(userId, payload.linkId);
       const { channelId, messageTs } = extractChannelTs(body);
       if (channelId && messageTs) {
-        await updateMessage(client, channelId, messageTs, '_후보 패스함 — 추적 안 함._', []);
+        const notice = '패스함 — 추적 안 함.';
+        await updateMessage(
+          client,
+          channelId,
+          messageTs,
+          notice,
+          resolveActionCard(extractMessageBlocks(body), notice),
+        );
       }
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -200,21 +217,24 @@ export const registerInsightActions = (app: App): void => {
       const { channelId, messageTs } = extractChannelTs(body);
       if (!channelId || !messageTs) return;
       if (signalId === null) {
+        const notice = '검증 실패 또는 이미 처리됨 — 활성화 안 됨.';
         await updateMessage(
           client,
           channelId,
           messageTs,
-          '_검증 실패 또는 이미 처리됨 — 활성화 안 됨._',
-          [],
+          notice,
+          resolveActionCard(extractMessageBlocks(body), notice),
         );
         return;
       }
+      const notice =
+        '✅ 측정 시작함 — 매일 이 신호를 재고, 다음 발굴에서 시드와 연결되면 off-day로 검정한다.';
       await updateMessage(
         client,
         channelId,
         messageTs,
-        '측정 시작 — 매일 이 신호를 재고, 다음 발굴에서 시드와 연결되면 off-day로 검정한다.',
-        [],
+        notice,
+        resolveActionCard(extractMessageBlocks(body), notice),
       );
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -233,7 +253,14 @@ export const registerInsightActions = (app: App): void => {
       await rejectLlmSignal(userId, payload.signalId);
       const { channelId, messageTs } = extractChannelTs(body);
       if (channelId && messageTs) {
-        await updateMessage(client, channelId, messageTs, '_신호 반려함 — 측정 안 함._', []);
+        const notice = '반려함 — 측정 안 함.';
+        await updateMessage(
+          client,
+          channelId,
+          messageTs,
+          notice,
+          resolveActionCard(extractMessageBlocks(body), notice),
+        );
       }
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/src/shared/__tests__/slack.test.ts
+++ b/src/shared/__tests__/slack.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import type { KnownBlock } from '@slack/types';
+import { resolveActionCard } from '../slack.js';
+
+describe('resolveActionCard — actions 블록만 제거 + 안내 context append', () => {
+  const sampleCard: KnownBlock[] = [
+    { type: 'section', text: { type: 'mrkdwn', text: '제안 본문' } },
+    { type: 'context', elements: [{ type: 'mrkdwn', text: '```SELECT 1```' }] },
+    {
+      type: 'actions',
+      elements: [
+        { type: 'button', text: { type: 'plain_text', text: '측정 시작' }, action_id: 'a' },
+        { type: 'button', text: { type: 'plain_text', text: '반려' }, action_id: 'b' },
+      ],
+    },
+  ];
+
+  it('actions 블록은 제거하고 본문(section·기존 context)은 그대로 보존한다', () => {
+    const out = resolveActionCard(sampleCard, '✅ 측정 시작함');
+    expect(out.some((b) => b.type === 'actions')).toBe(false);
+    expect(out[0]).toEqual(sampleCard[0]); // section 보존
+    expect(out[1]).toEqual(sampleCard[1]); // 기존 context 보존
+  });
+
+  it('안내 문구를 카드 맨 끝 context 블록으로 추가한다', () => {
+    const out = resolveActionCard(sampleCard, '✅ 측정 시작함');
+    expect(out[out.length - 1]).toEqual({
+      type: 'context',
+      elements: [{ type: 'mrkdwn', text: '✅ 측정 시작함' }],
+    });
+    // 본문 2 + 안내 1 = 3 (actions 1개 제거)
+    expect(out).toHaveLength(3);
+  });
+
+  it('빈 blocks 입력이면 안내 context 한 줄만 반환한다 (폴백 경로)', () => {
+    expect(resolveActionCard([], '패스함 — 추적 안 함.')).toEqual([
+      { type: 'context', elements: [{ type: 'mrkdwn', text: '패스함 — 추적 안 함.' }] },
+    ]);
+  });
+
+  it('원본 blocks 배열을 변형하지 않는다 (순수 함수)', () => {
+    resolveActionCard(sampleCard, '안내');
+    expect(sampleCard).toHaveLength(3);
+    expect(sampleCard[2]?.type).toBe('actions');
+  });
+});

--- a/src/shared/slack.ts
+++ b/src/shared/slack.ts
@@ -38,10 +38,16 @@ export const updateMessage = async (
   await client.chat.update({ channel, ts, text, blocks });
 };
 
-export const sendMessage = async (
-  say: SayFn,
-  text: string,
-): Promise<void> => {
+/**
+ * 인터랙션 카드 갱신용 — actions(버튼) 블록만 제거하고 처리 결과 안내 context를 덧붙인다.
+ * 제안 본문(section/context 등) 블록은 보존해 버튼 클릭 후에도 어떤 제안이었는지 남는다.
+ */
+export const resolveActionCard = (blocks: KnownBlock[], noticeText: string): KnownBlock[] => {
+  const kept = blocks.filter((b) => b.type !== 'actions');
+  return [...kept, { type: 'context', elements: [{ type: 'mrkdwn', text: noticeText }] }];
+};
+
+export const sendMessage = async (say: SayFn, text: string): Promise<void> => {
   await say(text);
 };
 


### PR DESCRIPTION
## 관련 이슈
Closes #535

## 변경 내용
- `#insight` 인터랙티브 카드(발굴 승인·LLM 신호 제안)가 버튼 클릭 시 메시지를 한 줄 안내로 통째 교체해, 이전에 어떤 제안이 왔는지 다시 볼 수 없던 문제를 수정
- 원본 메시지 블록에서 `actions`(버튼) 블록만 제거하고 처리 결과 안내 context를 덧붙이는 방식으로 변경 — **제안 본문은 보존, 버튼만 안내로 교체**
- 승인·패스·측정 시작·반려 4개 버튼 모두 적용 (긍정 액션은 ✅, 부정 액션은 평문)
- **DB 상태 전이 로직은 불변** — 메시지 표시 방식만 변경
- `resolveActionCard` 순수 헬퍼(`shared/slack.ts`): actions 블록 제거 + 안내 context append (두 카드 공용)
- `extractMessageBlocks` unknown 가드(`insight/actions.ts`): Slack action body에서 원본 블록 안전 추출 (실패 시 빈 배열 폴백)
- 도메인 문서(`docs/domains/insight.md`) 카드 갱신 동작 1줄 현행화

## 코드 리뷰 결과
- [x] 보안 감사 통과 (크리덴셜·env 없음, SQL 미변경, 외부 입력 unknown 가드)
- [x] 타입 안전성 확인 (`any` 0, `unknown`+가드, `KnownBlock`)
- [x] 컨벤션 점검 완료 (named export, import 순서, 에러 처리 경계)
- [x] 코드 품질 확인 (순수 헬퍼 분리, 기존 추출 가드 패턴과 일관)

## 테스트
- [x] `resolveActionCard`: actions 블록 제거 / 본문 블록 보존 / 안내 context append / 빈 입력 폴백 / 원본 불변
- [x] `extractMessageBlocks`: 정상 body → blocks / message 없음·비배열·null·비객체 → []
- [x] 기존 전이 코어 테스트 회귀 없음 (전체 904 테스트 통과)