### PR TITLE
refactor(insight): 주간 패턴 검증 카드 가독성 개선

### DIFF
--- a/src/agents/insight/__tests__/hypothesis-cards.test.ts
+++ b/src/agents/insight/__tests__/hypothesis-cards.test.ts
@@ -12,6 +12,12 @@ import {
   type DiscoveryCardInput,
 } from '../hypothesis-cards.js';
 import type { LinkVerification, Verdict } from '../../../shared/pattern-verification.js';
+import type {
+  ConfoundData,
+  SuspectedConfounder,
+  AdjustedConfounder,
+  ConfoundVerdict,
+} from '../../../shared/confound.js';
 
 const makeLink = (overrides: Partial<LinkVerification> = {}): LinkVerification => ({
   linkId: 1,
@@ -87,26 +93,30 @@ describe('buildVerificationBlocks — 빈 링크', () => {
 });
 
 describe('buildVerificationBlocks — verified (검증됨)', () => {
-  it('confirmed 링크는 ✅ + 검증됨 + off-day 대조(자연어) + 보조 줄(확신도) 노출', () => {
+  it('confirmed 링크는 ✅ 확정 + 핵심 2줄(효과·표본·확신) — 변수명·진행바·q·CI 미노출', () => {
     const blocks = buildVerificationBlocks(
       '2026-06-01',
       [makeLink({ nextStatus: 'confirmed' })],
       [],
     );
-    const t = sectionTexts(blocks).find((x) => x.includes('✅'));
+    // 요약 줄에도 ✅가 들어가므로 본문 고유 키워드(평소보다)로 항목 섹션을 집는다.
+    const t = sectionTexts(blocks).find((x) => x.includes('평소보다'));
     expect(t).toBeDefined();
+    expect(t).toContain('✅');
     expect(t).toContain('[사주]');
     expect(t).toContain('밤잠 평소보다 많음'); // signalLabel
     expect(t).toContain('일운 천간 갑목(편재)'); // seedLabel
     expect(t).not.toContain('sleep_night_minutes'); // 변수명 미노출 (#504)
     expect(t).not.toContain('S1_갑목_편재_천간');
-    expect(t).toContain('검증됨');
-    expect(t).toContain('25일 중 20일'); // 발현 = 분수(표본 작음 정직하게)
-    expect(t).toContain('평소 20%'); // 비발현 = 비율
-    expect(t).toContain('4.0배');
-    // 이탤릭 보조 줄: 확정 증거 + 확신도(credibleInterval 재사용, 표시 파생)
-    expect(t).toContain('확정 증거');
-    expect(t).toContain('확신도 78%');
+    expect(t).toContain('확정'); // tier 결론
+    expect(t).toContain('평소보다 4.0배'); // 효과크기
+    expect(t).toContain('(20/25일)'); // 표본 = 발현 분수(작은 표본 정직하게)
+    expect(t).toContain('확신 78%'); // 확신도(단일값)
+    // 압축으로 제거된 요소
+    expect(t).not.toContain('확정 증거'); // e-value 보조 줄 제거
+    expect(t).not.toContain('░'); // 진행바 제거
+    expect(t).not.toContain('우연 가능성'); // q값 제거
+    expect(t).not.toContain('%]'); // 추정범위(CI) 제거 ([사주] 라벨의 '['와 구분)
   });
 
   it('verified가 있으면 tier 범례 컨텍스트가 붙는다', () => {
@@ -124,39 +134,35 @@ describe('buildVerificationBlocks — verified (검증됨)', () => {
 });
 
 describe('buildVerificationBlocks — emerging (검증중)', () => {
-  it('active + effect leaning + n충분 → 🌱 + 확정까지 진행바 + 보조 줄(확신도)', () => {
+  it('active + effect leaning + n충분 → 🌱 + 핵심 2줄(효과·표본·확신), 진행바·추세 없음', () => {
     const blocks = buildVerificationBlocks(
       '2026-06-01',
       [makeLink({ nextStatus: 'active', eValue: 7 })],
       [],
     );
-    const t = sectionTexts(blocks).find((x) => x.includes('🌱'));
+    const t = sectionTexts(blocks).find((x) => x.includes('평소보다'));
     expect(t).toBeDefined();
-    expect(t).toContain('검증중');
-    expect(t).toContain('확정까지');
-    expect(t).toContain('7.0/20');
-    expect(t).toContain('확신도'); // 이탤릭 보조 줄
+    expect(t).toContain('🌱');
+    expect(t).toContain('평소보다 4.0배');
+    expect(t).toContain('(20/25일)');
+    expect(t).toContain('확신 78%');
+    // 압축으로 제거된 요소
+    expect(t).not.toContain('확정까지'); // 진행바 라벨 제거
+    expect(t).not.toContain('░'); // 진행바 제거
+    expect(t).not.toContain('/20'); // e-value 분모 제거
+    expect(t).not.toContain('지난주'); // 주간추세 제거
   });
 
-  it('prevEValues 있으면 주간대비 추세(오르는 중) 표기', () => {
-    const prev = new Map<number, number>([[1, 3.1]]);
-    const blocks = buildVerificationBlocks(
-      '2026-06-01',
-      [makeLink({ nextStatus: 'active', eValue: 7 })],
-      [],
-      prev,
-    );
-    const t = sectionTexts(blocks).find((x) => x.includes('🌱'));
-    expect(t).toContain('지난주 3.1 → 오르는 중');
-  });
-
-  it('effect 약하면(emerging 미달) 🌱 안 뜸', () => {
+  it('effect 약하면(emerging 미달) 항목 안 뜸 — 판정 보류로 카운트', () => {
     const blocks = buildVerificationBlocks(
       '2026-06-01',
       [makeLink({ nextStatus: 'active', effect: 1.0, verdict: 'inconclusive' })],
       [],
     );
-    expect(sectionTexts(blocks).some((x) => x.includes('🌱'))).toBe(false);
+    // 요약 줄 이모지와 구분 위해 항목 본문 키워드(평소보다)로 검사
+    expect(sectionTexts(blocks).some((x) => x.includes('평소보다'))).toBe(false);
+    const summary = sectionTexts(blocks).find((t) => t.includes('패턴 검증'));
+    expect(summary).toContain('나머지 1');
   });
 });
 
@@ -179,9 +185,81 @@ describe('buildVerificationBlocks — 요약 + reject', () => {
     expect(summary).toContain('검증됨 1');
     expect(summary).toContain('검증중 1');
     expect(summary).toContain('기각 1');
-    const rejectText = texts.find((t) => t.includes('✗'));
+    // 요약 줄에도 ✗가 들어가므로 reject 본문 고유 키워드(차이 없음)로 집는다.
+    const rejectText = texts.find((t) => t.includes('차이 없음'));
     expect(rejectText).toContain('총 지출 평소보다 많음');
     expect(rejectText).not.toContain('expense_total');
+  });
+});
+
+describe('buildVerificationBlocks — 교란 caveat (inline, 압축)', () => {
+  const susp = (seedId: number): SuspectedConfounder => ({
+    seedId,
+    seedName: `Z${seedId}`,
+    overlap: 0.6,
+    effectZX: 1.5,
+    nCofire: 12,
+  });
+  const adj = (verdict: ConfoundVerdict): AdjustedConfounder => ({
+    seedId: 99,
+    adjEffect: 1.1,
+    nCofire: 35,
+    verdict,
+  });
+  // emerging으로 뜨는 링크(effect 4.0·nActive 25·active) — 항목 둘째 줄 끝에 caveat가 붙음
+  const cardText = (cf: Map<number, ConfoundData>, kind: 'saju' | 'life_signal' = 'saju') =>
+    sectionTexts(
+      buildVerificationBlocks(
+        '2026-06-01',
+        [makeLink({ nextStatus: 'active', patternKind: kind })],
+        [],
+        cf,
+      ),
+    ).find((x) => x.includes('평소보다'));
+
+  it('suspected만(조정 게이트 미달) → "다른 기운과 겹침" (시드 이름 미노출)', () => {
+    const cf = new Map<number, ConfoundData>([
+      [1, { scannedAt: '2026-06-01', suspected: [susp(2), susp(3)] }],
+    ]);
+    const t = cardText(cf);
+    expect(t).toContain('⚠️ 다른 기운과 겹침');
+    expect(t).not.toContain('Z2'); // 교란 시드 이름 일반화(노출 0)
+  });
+
+  it('explained_away → "겹친 기운 빼면 효과 사라짐"', () => {
+    const cf = new Map<number, ConfoundData>([
+      [
+        1,
+        {
+          scannedAt: '2026-06-01',
+          suspected: [susp(2)],
+          adjusted: [adj('explained_away')],
+          explainedAway: true,
+        },
+      ],
+    ]);
+    expect(cardText(cf)).toContain('⚠️ 겹친 기운 빼면 효과 사라짐');
+  });
+
+  it('attenuated → "겹친 기운 빼면 약해짐"', () => {
+    const cf = new Map<number, ConfoundData>([
+      [1, { scannedAt: '2026-06-01', suspected: [susp(2)], adjusted: [adj('attenuated')] }],
+    ]);
+    expect(cardText(cf)).toContain('⚠️ 겹친 기운 빼면 약해짐');
+  });
+
+  it('survives(조정 후 유지)는 긍정이라 caveat 생략 — ⚠️ 없음', () => {
+    const cf = new Map<number, ConfoundData>([
+      [1, { scannedAt: '2026-06-01', suspected: [susp(2)], adjusted: [adj('survives')] }],
+    ]);
+    expect(cardText(cf)).not.toContain('⚠️');
+  });
+
+  it('life_signal 시드는 "기운" 대신 "요인"', () => {
+    const cf = new Map<number, ConfoundData>([
+      [1, { scannedAt: '2026-06-01', suspected: [susp(2)] }],
+    ]);
+    expect(cardText(cf, 'life_signal')).toContain('⚠️ 다른 요인과 겹침');
   });
 });
 

--- a/src/agents/insight/hypothesis-cards.ts
+++ b/src/agents/insight/hypothesis-cards.ts
@@ -11,7 +11,6 @@ import type { LinkVerification } from '../../shared/pattern-verification.js';
 import type { ConfoundData } from '../../shared/confound.js';
 import type { DiscoveryCandidate } from './hypothesis-discovery.js';
 import { INSIGHT_THRESHOLDS } from '../../shared/insight-thresholds.js';
-import { credibleInterval } from '../../shared/bayesian-posterior.js';
 
 const KIND_LABEL: Record<'saju' | 'life_signal', string> = {
   saju: '[사주]',
@@ -70,14 +69,6 @@ const offDayPhrase = (nActive: number, hit: number, rateOff: number, effect: num
  */
 const activationClause = (seedLabel: string): string =>
   /[날일](\s*\([^)]*\))?$/.test(seedLabel) ? seedLabel : `${seedLabel} 켜진 날`;
-
-/** 확신도 보조 절: "확신도 78% [62%–89%]" — CI는 credibleInterval 재사용(표시 파생, 검증 로직 무관). */
-const confidencePhrase = (alpha: number, beta: number, p: number): string => {
-  const ci = credibleInterval(alpha, beta);
-  const lo = formatPosterior(ci.lower);
-  const hi = formatPosterior(ci.upper);
-  return `확신도 ${formatPosterior(p)} [${lo}–${hi}]`;
-};
 
 // ─── P5a 발굴 후보 카드 빌더 ──────────────────────────────
 
@@ -183,81 +174,59 @@ export const isEmerging = (l: LinkVerification): boolean =>
   l.effect >= V.emergingMinEffect &&
   l.nActive >= V.emergingMinActive;
 
-/** e-value 진행바 (0 → threshold). */
-const evalueBar = (e: number, threshold: number): string => {
-  const ratio = Number.isFinite(e) ? Math.max(0, Math.min(1, e / threshold)) : 0;
-  const filled = Math.round(ratio * 7);
-  return '█'.repeat(filled) + '░'.repeat(7 - filled);
-};
+/**
+ * 검증중/검증됨 공통 둘째 줄(들여쓰기) — 핵심 3개만: 효과크기·표본·확신도.
+ * 진행바·우연확률(q)·추정범위(CI)·주간추세는 가독성 위해 카드에서 제외(DB·주간 스냅샷엔 보존).
+ */
+const statLine = (l: LinkVerification): string =>
+  `   평소보다 ${mult(l.effect)} (${l.a}/${l.nActive}일) · 확신 ${formatPosterior(l.posteriorP)}`;
 
-/** verified(검증됨) 한 줄 — 결론 위주(자연어 본문) + 이탤릭 보조 줄(확정 증거·우연 가능성·확신도). */
-const verifiedLine = (l: LinkVerification): string =>
-  `• ✅ ${KIND_LABEL[l.patternKind]} ${activationClause(l.seedLabel)} *${l.signalLabel}* — ` +
-  `${offDayPhrase(l.nActive, l.a, l.rateOff, l.effect)}. 검증됨\n` +
-  `_확정 증거 e ${l.eValue.toFixed(1)} (20 넘어 확정) · 우연 가능성 q ${formatPValue(l.qValue)} · ` +
-  `${confidencePhrase(l.posteriorAlpha, l.posteriorBeta, l.posteriorP)}_`;
+/** verified(검증됨) — 첫 줄 결론(확정) + 둘째 줄 핵심 통계 + 교란 caveat(있으면 inline). */
+const verifiedLine = (l: LinkVerification, confoundByLink: Map<number, ConfoundData>): string =>
+  `✅ ${KIND_LABEL[l.patternKind]} ${activationClause(l.seedLabel)} → *${l.signalLabel}* · 확정\n` +
+  statLine(l) +
+  confoundCaveat(l, confoundByLink);
 
-/** emerging(검증중) 한 줄 — 진행도 강조(자연어 본문) + 이탤릭 보조 줄(확정까지 진행바·추세·우연·확신도). */
-const emergingLine = (l: LinkVerification, prevE: number | undefined): string => {
-  const bar = evalueBar(l.eValue, V.evalueThreshold);
-  const cur = l.eValue;
-  let trend = '';
-  if (prevE !== undefined && Number.isFinite(prevE)) {
-    if (cur > prevE) trend = ` (지난주 ${prevE.toFixed(1)} → 오르는 중)`;
-    else if (cur < prevE) trend = ` (지난주 ${prevE.toFixed(1)} → 주춤)`;
-    else trend = ` (지난주 ${prevE.toFixed(1)} → 그대로)`;
-  }
-  return (
-    `• 🌱 ${KIND_LABEL[l.patternKind]} ${activationClause(l.seedLabel)} *${l.signalLabel}* — ` +
-    `${offDayPhrase(l.nActive, l.a, l.rateOff, l.effect)}. 검증중\n` +
-    `_확정까지 ${bar} ${cur.toFixed(1)}/${V.evalueThreshold}${trend} · ` +
-    `우연 가능성 q ${formatPValue(l.qValue)} · ` +
-    `${confidencePhrase(l.posteriorAlpha, l.posteriorBeta, l.posteriorP)}_`
-  );
-};
+/** emerging(검증중) — 첫 줄 패턴 + 둘째 줄 핵심 통계 + 교란 caveat(있으면 inline). */
+const emergingLine = (l: LinkVerification, confoundByLink: Map<number, ConfoundData>): string =>
+  `🌱 ${KIND_LABEL[l.patternKind]} ${activationClause(l.seedLabel)} → *${l.signalLabel}*\n` +
+  statLine(l) +
+  confoundCaveat(l, confoundByLink);
 
 const rejectLine = (l: LinkVerification): string =>
-  `• ✗ ${KIND_LABEL[l.patternKind]} ${l.seedLabel} × ${l.signalLabel} — ` +
-  `켜진 날이나 아닌 날이나 비슷 (${mult(l.effect)}). 기각`;
+  `✗ ${KIND_LABEL[l.patternKind]} ${l.seedLabel} × ${l.signalLabel} — 차이 없음`;
 
 /**
- * 교란 caveat 한 줄(있으면) — P6 marginal 플래그(ADR-0041) → P7 다변량 조정(ADR-0042).
- * - adjusted 있음(게이트 통과·조정함): verdict별(explained_away 어부지리 / attenuated 약화 / survives 유지).
- * - adjusted 없음(게이트 미달): P6 marginal 공존 의심.
- * 조정 교란 이름은 suspected(seedName 보유)에서 seedId로 join. verified/emerging 라인에만 덧붙임.
+ * 교란 caveat(inline, 압축) — 둘째 줄 끝에 " · ⚠️ …" 한 구절로 append.
+ * P6 marginal 플래그(ADR-0041) → P7 다변량 조정(ADR-0042). verdict별:
+ * - explained_away(어부지리)·attenuated(약화)만 ⚠️ 노출. survives(유지)는 긍정이라 압축 모드 생략.
+ * - 조정 게이트 미달(adjusted 없고 suspected만)이면 공존 의심.
+ * 시드 이름은 노출하지 않고 일반화("다른 기운/요인") — 카드 폭 방어 + 변수명 누출 0(#504 P2).
  */
-const confoundCaveat = (
-  l: LinkVerification,
-  confoundByLink: Map<number, ConfoundData>,
-  seedLabelById: Map<number, string>,
-): string => {
+const confoundCaveat = (l: LinkVerification, confoundByLink: Map<number, ConfoundData>): string => {
   const data = confoundByLink.get(l.linkId);
   if (!data) return '';
   const { suspected, adjusted } = data;
-  // 교란 시드도 변수명 대신 라벨로 (#504 P2). 미상이면 중립 표현(raw 이름·시드#id 미노출).
-  const labelOf = (seedId: number): string => seedLabelById.get(seedId) ?? '다른 시드';
-
+  const noun = l.patternKind === 'saju' ? '기운' : '요인';
   if (adjusted && adjusted.length > 0) {
-    const uniq = [...new Set(adjusted.map((a) => labelOf(a.seedId)))].join(', ');
     switch (adjusted[0]?.verdict) {
       case 'explained_away':
-        return `\n  ⚠️ ${uniq} 시드가 같이 켜지는 날이 많아서, 그거 빼고 보면 효과 사라짐 (어부지리 의심)`;
+        return ` · ⚠️ 겹친 ${noun} 빼면 효과 사라짐`;
       case 'attenuated':
-        return `\n  ⚠️ ${uniq} 같이 켜지는 영향 빼면 효과 약해짐`;
+        return ` · ⚠️ 겹친 ${noun} 빼면 약해짐`;
       default:
-        return `\n  · ${uniq} 같이 켜져도 효과 유지`;
+        return ''; // survives — 긍정, 압축 모드에선 생략
     }
   }
-
   if (suspected.length === 0) return '';
-  return `\n  ⚠️ ${suspected.map((s) => labelOf(s.seedId)).join(', ')} 시드가 자주 같이 켜져서 영향 섞였을 수 있음`;
+  return ` · ⚠️ 다른 ${noun}과 겹침`;
 };
 
 const TIER_LEGEND =
-  '_✅ 검증됨 = 증거 충분해 확정(우연 아님, 단 연관이지 인과 아님) · ' +
-  '🌱 검증중 = 경향은 보이나 확정 전(확정까지 진행도 표시) · ' +
-  '✗ 기각 = 켜진 날이나 아닌 날이나 비슷 · ' +
-  '⚠️ 교란 = 같이 켜지는 다른 시드 영향 의심_';
+  '_✅ 검증됨 = 우연 아님(연관이지 인과 아님) · ' +
+  '🌱 검증중 = 경향 있지만 확정 전 · ' +
+  '✗ 기각 = 차이 없음 · ' +
+  '⚠️ = 다른 패턴과 겹쳐 효과 불확실_';
 
 /**
  * 포화 시드 양방향 가드 알림(#508 ③, ADR-0046) — 주간 카드 말미 context 한 줄.
@@ -321,15 +290,14 @@ export const buildRebaselineNotice = (s: RebaselineSummary): KnownBlock[] => {
 
 /**
  * 주간 검증 리포트 — 시드 영향력 + 3-tier 검증 현황(검증됨/검증중/기각).
- * 검증중(emerging)은 e-value 진행바로 "쌓이는 중"을 정직하게 프레이밍(ADR-0035). discovery는 P5.
+ * 항목은 핵심 2줄(첫 줄 결론 + 둘째 줄 효과크기·표본·확신도·교란). 진행바·q·CI·주간추세는
+ * 가독성 위해 카드에서 제외(DB·주간 스냅샷엔 보존). discovery는 P5.
  */
 export const buildVerificationBlocks = (
   weekStart: string,
   links: LinkVerification[],
   seedInfluence: SeedInfluenceRow[],
-  prevEValues: Map<number, number> = new Map(),
   confoundByLink: Map<number, ConfoundData> = new Map(),
-  seedLabelById: Map<number, string> = new Map(),
 ): KnownBlock[] => {
   const blocks: KnownBlock[] = [
     {
@@ -357,16 +325,16 @@ export const buildVerificationBlocks = (
   const others = links.length - verified.length - emerging.length - rejects.length;
 
   const summaryParts = [
-    `검증됨 ${verified.length}`,
-    `검증중 ${emerging.length}`,
-    `기각 ${rejects.length}`,
+    `🌱 검증중 ${emerging.length}`,
+    `✅ 검증됨 ${verified.length}`,
+    `✗ 기각 ${rejects.length}`,
   ];
-  if (others > 0) summaryParts.push(`판정 보류 ${others}`);
+  if (others > 0) summaryParts.push(`나머지 ${others} 데이터 모으는 중`);
   blocks.push({
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text: `*이번 주 패턴 검증 (가설 ${links.length}개)*\n${summaryParts.join(' · ')}`,
+      text: `*이번 주 패턴 검증* · 가설 ${links.length}개\n${summaryParts.join(' · ')}`,
     },
   });
 
@@ -375,9 +343,7 @@ export const buildVerificationBlocks = (
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: verified
-          .map((l) => verifiedLine(l) + confoundCaveat(l, confoundByLink, seedLabelById))
-          .join('\n'),
+        text: verified.map((l) => verifiedLine(l, confoundByLink)).join('\n\n'),
       },
     });
   }
@@ -387,13 +353,7 @@ export const buildVerificationBlocks = (
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: emerging
-          .map(
-            (l) =>
-              emergingLine(l, prevEValues.get(l.linkId)) +
-              confoundCaveat(l, confoundByLink, seedLabelById),
-          )
-          .join('\n'),
+        text: emerging.map((l) => emergingLine(l, confoundByLink)).join('\n\n'),
       },
     });
   }

--- a/src/cron/weekly-verification.ts
+++ b/src/cron/weekly-verification.ts
@@ -191,25 +191,6 @@ const persistConfound = async (userId: number, r: ConfoundResult): Promise<void>
   ]);
 };
 
-/** 직전 주(들) 링크별 e_value — emerging 진행바 "지난주 → 이번주" delta용 (link당 최신 1행). */
-const loadPrevWeekEValues = async (
-  userId: number,
-  weekStart: string,
-): Promise<Map<number, number>> => {
-  const res = await query<{ link_id: number; e_value: string | null }>(
-    `SELECT DISTINCT ON (link_id) link_id, e_value
-       FROM link_weekly_stats
-      WHERE user_id = $1 AND week_start < $2
-      ORDER BY link_id, week_start DESC`,
-    [userId, weekStart],
-  );
-  const m = new Map<number, number>();
-  for (const r of res.rows) {
-    if (r.e_value !== null) m.set(r.link_id, Number(r.e_value));
-  }
-  return m;
-};
-
 /**
  * 시드 영향력 top N (credible interval lower bound 정렬).
  * pattern_summary(시드 메타 + active 여부) + pattern_links(α/β 합산, active|confirmed)에서 산출.
@@ -430,15 +411,6 @@ const processUser = async (
 
   const results = await verifyUserLinks(userId, today);
 
-  // 직전 주 e_value 먼저 로드(이번 주 스냅샷 쓰기 전 — delta가 과거만 반영하게).
-  let prevEValues = new Map<number, number>();
-  try {
-    prevEValues = await loadPrevWeekEValues(userId, weekStart);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[Verification] 직전주 e_value 로드 실패 user=${userId}: ${msg}`);
-  }
-
   let persisted = 0;
   for (const l of results) {
     // per-link 격리(#434 Phase 8a) — 한 링크 UPDATE 실패가 전체를 막지 않게.
@@ -511,26 +483,7 @@ const processUser = async (
     console.error(`[Confound] user=${userId} 교란 플래그 실패: ${msg}`);
   }
 
-  // 교란 caveat용 시드 라벨 맵(#504 P2, ADR-0045) — 실패해도 카드는 무탈(빈 맵 → 중립 표현).
-  let seedLabelById = new Map<number, string>();
-  try {
-    const allSeeds = await loadActiveSeeds(userId);
-    seedLabelById = new Map(
-      allSeeds.map((s) => [s.id, seedLabel({ name: s.name, description: s.description })]),
-    );
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[Verification] 시드 라벨 맵 로드 실패 user=${userId}: ${msg}`);
-  }
-
-  const blocks = buildVerificationBlocks(
-    weekStart,
-    results,
-    seedInfluence,
-    prevEValues,
-    confoundByLink,
-    seedLabelById,
-  );
+  const blocks = buildVerificationBlocks(weekStart, results, seedInfluence, confoundByLink);
   // 포화 가드 알림을 카드 말미에 append(#508 ③) — 변수명 미노출 라벨.
   blocks.push(
     ...buildHygieneNotice(


### PR DESCRIPTION
## 배경
주간 패턴 검증 리포트 카드에서 항목 한 건이 여러 줄에 걸쳐 다수의 지표를 한꺼번에 노출해 한눈에 읽기 어렵던 문제 개선.

## 변경
- 검증중/검증됨 항목을 **2줄 구조**로 단순화 (첫 줄 결론 + 둘째 줄 핵심 지표: 효과크기·표본·확신도)
- 시각적 진행바와 보조 통계 표시(우연확률·추정범위·주간추세)는 카드에서 제외 — **데이터 자체는 DB·주간 스냅샷에 그대로 보존**
- 교란 안내 문구를 inline 한 구절로 압축 (판정 종류별 분기)
- 요약 줄에 상태 아이콘 + 보류 항목 표현 정리

## 범위
- 검증 로직(통계 확정 게이트·다중비교 보정·교란 조정)은 **불변** — 표현 레이어만 변경
- 교란 안내 분기 회귀 테스트 추가

## 검증
- 테스트 908개 통과, 타입체크·lint 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)