### PR TITLE
fix(budget): 카테고리 한도 카운트에서 예산 미포함 지출 제외

### DIFF
--- a/web/src/features/budget/lib/repository/__tests__/category-limits-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/category-limits-repo.test.ts
@@ -43,6 +43,8 @@ describe('category-limits-repo', () => {
       expect(sql).toMatch(/COUNT/i);
       expect(sql).toMatch(/billing_month/);
       expect(sql).toMatch(/is_installment = false OR e\.installment_num = 1/);
+      // 예산 미포함(exclude_from_budget=true) 건은 카운트 제외
+      expect(sql).toMatch(/COALESCE\(e\.exclude_from_budget, false\) = false/);
       // userId, billingMonth 파라미터 전달 확인
       expect(vi.mocked(query).mock.calls[0]![1]).toEqual([1, '2026-05']);
     });

--- a/web/src/features/budget/lib/repository/category-limits-repo.ts
+++ b/web/src/features/budget/lib/repository/category-limits-repo.ts
@@ -3,7 +3,7 @@ import type { CategoryLimitRow, CategoryLimitWithUsage } from '../types';
 
 /**
  * 카테고리 한도 + 현재 주기 사용 횟수 조회.
- * used_count는 expenses에서 live 집계 — 할부는 1회차만 카운트, income 제외.
+ * used_count는 expenses에서 live 집계 — 할부는 1회차만 카운트, income 제외, 예산 미포함(exclude) 제외.
  */
 export async function readCategoryLimitsWithUsage(
   userId: number,
@@ -20,6 +20,7 @@ export async function readCategoryLimitsWithUsage(
            AND e.billing_month = $2
            AND e.category = cl.category
            AND e.type = 'expense'
+           AND COALESCE(e.exclude_from_budget, false) = false
            AND (e.is_installment = false OR e.installment_num = 1)
        ), 0) AS used_count
      FROM category_limits cl


### PR DESCRIPTION
## 변경 내용

카테고리 한도(주기당 N회) 카운트에서 **예산 미포함(exclude_from_budget=true) 지출을 제외**한다.

- `readCategoryLimitsWithUsage`의 `used_count` 서브쿼리에 `COALESCE(e.exclude_from_budget, false) = false` 필터 추가
- 예산 미포함으로 설정한 건은 한도 횟수에 카운트되지 않음 (사용자 요청)
- 할부 1회차만 카운트하는 기존 로직(구매 횟수 집계)은 그대로 유지

## 테스트
- [x] 카운트 SQL에 exclude 필터 포함 검증 추가
- [x] category-limits-repo 11 테스트 통과
- [x] tsc 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)