### PR TITLE
fix(schedule): #545 밀린 일정 카운트 task 타입만 집계 (정의 단일화)

### DIFF
--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -188,6 +188,8 @@ weekly-fortune routine이 일운/월운/세운/대운을 생성. fortune_analyse
 | weeklyRegression | weekly | routine | 잔소리 | 지난주 ≥90% → 이번주 ≤60% |
 | spottyPattern | night | routine | 잔소리 | 7일 중 3\~4일 산발 빠짐 |
 
+> `overdueAlert`의 밀린 일정 수는 `src/shared/life-queries.ts`의 `countOverdueTasks`(task 타입만, event 제외)를 단일 소스로 계산 — #life 아침 잔소리·일정 맥락과 동일 정의. 상세는 [schedule.md](schedule.md) "밀린 일정" 참조.
+
 #### 동적 노출
 
 - 매일 morning(09:05) / night(23:55): priority ≥5인 패턴 최대 3개, 같은 도메인은 priority 최상위 1개만

--- a/docs/domains/schedule.md
+++ b/docs/domains/schedule.md
@@ -150,6 +150,12 @@ features/schedule/
 - 별도 `use-backlog.ts` 훅으로 관리
 - 백로그에서 날짜 지정으로 이동 가능, 반대도 가능 (`handleMoveToBacklog`)
 
+### 밀린 일정 (overdue)
+- 정의: `status='todo'` + 과거 날짜(`date < today`, `date IS NULL` 제외) + **task 타입만**
+- event 타입(약속·여행·정보 등)은 완료 체크 대상이 아니라 `status='todo'`로 영구 잔존 → 날짜만 과거로 밀려 무한 카운트됨. 따라서 밀린 일정 집계에서 제외
+- `category_type`은 child 우선(`c.type`), 없으면 parent(`p.type`), 둘 다 없으면 `'task'` (`COALESCE(c.type, p.type, 'task') = 'task'`)
+- **단일 소스**: `src/shared/life-queries.ts`의 `countOverdueTasks(today, userId)` — 아침 크론 잔소리(insights `detectOverdue`)와 일정 맥락(`queryScheduleContext`)이 공유. 정의가 두 곳에 갈라져 event 타입이 오집계되던 문제를 헬퍼 단일화로 해소
+
 ## 관련 Slack 에이전트
 
 - **채널**: #life

--- a/src/shared/__tests__/insights.test.ts
+++ b/src/shared/__tests__/insights.test.ts
@@ -65,7 +65,7 @@ const setupQueryMock = (overrides: Record<string, MockRow[]> = {}): void => {
     // slotGap: 시간대별 달성률
     'time_slot.*GROUP BY.*time_slot.*HAVING': [],
     // overdue: 밀린 일정
-    "status = 'todo'.*date < ": [{ overdue_count: 0 }],
+    "status = 'todo'.*date < ": [{ count: '0' }],
     // categorySkew: 카테고리 편향
     'window_schedules.*top_category': [],
     // drift: 수면 드리프트
@@ -331,7 +331,7 @@ describe('detectWeekComparison', () => {
 describe('detectOverdue', () => {
   it('밀린 일정 3건 이상이면 감지', async () => {
     setupQueryMock({
-      "status = 'todo'.*date < ": [{ overdue_count: 5 }],
+      "status = 'todo'.*date < ": [{ count: '5' }],
     });
 
     const result = defined(await detectOverdue('2026-03-15', 1));
@@ -343,7 +343,7 @@ describe('detectOverdue', () => {
 
   it('밀린 일정 2건이면 null', async () => {
     setupQueryMock({
-      "status = 'todo'.*date < ": [{ overdue_count: 2 }],
+      "status = 'todo'.*date < ": [{ count: '2' }],
     });
 
     const result = await detectOverdue('2026-03-15', 1);
@@ -352,7 +352,7 @@ describe('detectOverdue', () => {
 
   it('밀린 일정 0건이면 null', async () => {
     setupQueryMock({
-      "status = 'todo'.*date < ": [{ overdue_count: 0 }],
+      "status = 'todo'.*date < ": [{ count: '0' }],
     });
 
     const result = await detectOverdue('2026-03-15', 1);
@@ -602,7 +602,7 @@ describe('pickMorningNudges (priority threshold + domain dedupe + max items)', (
       // streak: morning, priority = streak * 2 = 10 (routine)
       'grp = 0': [{ name: '유산균 먹기', streak: '5' }],
       // overdue: morning, priority 7 (schedule)
-      "status = 'todo'.*date < ": [{ overdue_count: 4 }],
+      "status = 'todo'.*date < ": [{ count: '4' }],
     });
 
     const insights = await pickMorningNudges('2026-03-15', 1);
@@ -631,7 +631,7 @@ describe('pickMorningNudges (priority threshold + domain dedupe + max items)', (
   it('최대 3개만 반환 (도메인은 routine/sleep/schedule 3종)', async () => {
     setupQueryMock({
       'grp = 0': [{ name: '유산균 먹기', streak: '5' }], // routine, prio 10
-      "status = 'todo'.*date < ": [{ overdue_count: 5 }], // schedule, prio 7
+      "status = 'todo'.*date < ": [{ count: '5' }], // schedule, prio 7
     });
 
     const insights = await pickMorningNudges('2026-03-15', 1);

--- a/src/shared/__tests__/life-queries.test.ts
+++ b/src/shared/__tests__/life-queries.test.ts
@@ -27,6 +27,7 @@ import {
   createRecord,
   completeRecord,
   queryTodaySchedules,
+  countOverdueTasks,
   updateScheduleStatus,
   postponeSchedule,
 } from '../life-queries.js';
@@ -123,7 +124,9 @@ describe('queryActiveTemplates', () => {
     const result = await queryActiveTemplates(TEST_USER_ID);
     expect(result).toHaveLength(1);
     expect(result[0]?.name).toBe('운동');
-    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('routine_templates'), [TEST_USER_ID]);
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('routine_templates'), [
+      TEST_USER_ID,
+    ]);
   });
 });
 
@@ -198,7 +201,10 @@ describe('completeRecord', () => {
   it('UPDATE completed = true 실행', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
     await completeRecord(42, TEST_USER_ID);
-    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('completed = true'), [42, TEST_USER_ID]);
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('completed = true'), [
+      42,
+      TEST_USER_ID,
+    ]);
   });
 });
 
@@ -223,6 +229,28 @@ describe('queryTodaySchedules', () => {
     const result = await queryTodaySchedules('2026-03-08', TEST_USER_ID);
     expect(result).toHaveLength(1);
     expect(result[0]?.title).toBe('회의');
+  });
+});
+
+describe('countOverdueTasks', () => {
+  it('task 타입만 집계하는 정식 정의로 밀린 일정 수 반환 (회귀 가드)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: '3' }] });
+
+    const count = await countOverdueTasks('2026-03-08', TEST_USER_ID);
+    expect(count).toBe(3);
+
+    // 이번 버그 원인: task 타입 필터 누락 → event 타입이 밀린 일정에 무한 편입.
+    // 이 필터가 SQL에서 사라지면 재발하므로 명시적으로 가드한다.
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("COALESCE(c.type, p.type, 'task') = 'task'");
+    expect(sql).toContain("s.status = 'todo'");
+    expect(sql).toContain('s.date < $1');
+    expect(params).toEqual(['2026-03-08', TEST_USER_ID]);
+  });
+
+  it('결과 행이 없으면 0', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    expect(await countOverdueTasks('2026-03-08', TEST_USER_ID)).toBe(0);
   });
 });
 

--- a/src/shared/insights.ts
+++ b/src/shared/insights.ts
@@ -5,6 +5,7 @@
  */
 
 import { query } from './db.js';
+import { countOverdueTasks } from './life-queries.js';
 import { INSIGHT_THRESHOLDS } from './insight-thresholds.js';
 
 // ─── 타입 ───────────────────────────────────────────────
@@ -274,21 +275,10 @@ export const detectWeekComparison = async (
 
 // ─── 감지: 밀린 일정 ────────────────────────────────────
 
-interface OverdueRow {
-  overdue_count: number;
-}
-
 export const detectOverdue = async (today: string, userId: number): Promise<Insight | null> => {
   const { minCount } = INSIGHT_THRESHOLDS.overdueAlert;
   try {
-    const result = await query<OverdueRow>(
-      `SELECT COUNT(*)::int AS overdue_count
-       FROM schedules
-       WHERE status = 'todo' AND date < $1 AND date IS NOT NULL AND user_id = $2`,
-      [today, userId],
-    );
-
-    const count = result.rows[0]?.overdue_count ?? 0;
+    const count = await countOverdueTasks(today, userId);
     if (count < minCount) return null;
 
     return {

--- a/src/shared/life-context.ts
+++ b/src/shared/life-context.ts
@@ -5,6 +5,7 @@
  */
 
 import { query } from './db.js';
+import { countOverdueTasks } from './life-queries.js';
 import { getTodayISO, getYesterdayISO } from './kst.js';
 
 // ─── 타입 ───────────────────────────────────────────────
@@ -276,17 +277,8 @@ const queryScheduleContext = async ({ today, userId }: DateParams): Promise<stri
     parts.push(`내일 ${tomorrowCount}건`);
   }
 
-  // 밀린 일정 (어제 이전 + todo 상태 + task 타입만)
-  const overdueResult = await query<ScheduleCountRow>(
-    `SELECT COUNT(*)::text as count
-     FROM schedules s
-     LEFT JOIN categories c ON c.id = s.category_id
-     LEFT JOIN categories p ON p.id = c.parent_id
-     WHERE s.status = 'todo' AND s.date < $2 AND s.date IS NOT NULL AND s.user_id = $1
-       AND COALESCE(c.type, p.type, 'task') = 'task'`,
-    [userId, today],
-  );
-  const overdueCount = Number(overdueResult.rows[0]?.count ?? 0);
+  // 밀린 일정 (task 타입만) — 공유 헬퍼 countOverdueTasks로 단일화
+  const overdueCount = await countOverdueTasks(today, userId);
   if (overdueCount > 0) {
     parts.push(`밀린 일정 ${overdueCount}건`);
   }

--- a/src/shared/life-queries.ts
+++ b/src/shared/life-queries.ts
@@ -235,6 +235,26 @@ export const queryBacklogSchedules = async (userId: number): Promise<ScheduleRow
     )
   ).rows;
 
+/**
+ * 밀린 일정(task 타입) 건수.
+ * 정식 정의: status='todo' + 과거 날짜(date < today, NULL 제외) + task 타입만.
+ * event 타입(약속·여행·정보 등, 완료 대상 아님)은 제외 — 무한 누적 방지.
+ * category_type은 child 우선(c.type), 없으면 parent(p.type), 둘 다 없으면 'task'.
+ * 아침 잔소리(detectOverdue)와 일정 맥락(queryScheduleContext) 공유 단일 소스.
+ */
+export const countOverdueTasks = async (today: string, userId: number): Promise<number> => {
+  const result = await query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count
+       FROM schedules s
+       LEFT JOIN categories c ON c.id = s.category_id
+       LEFT JOIN categories p ON p.id = c.parent_id
+      WHERE s.status = 'todo' AND s.date < $1 AND s.date IS NOT NULL AND s.user_id = $2
+        AND COALESCE(c.type, p.type, 'task') = 'task'`,
+    [today, userId],
+  );
+  return Number(result.rows[0]?.count ?? 0);
+};
+
 /** 일정을 특정 날짜로 이동 */
 export const moveScheduleToDate = async (
   id: number,


### PR DESCRIPTION
## 관련 이슈
Closes #545

## 문제
아침 크론 잔소리의 "밀린 일정 N건"이 매일 +1씩 증가하며 실제 밀린 할 일과 무관하게 과다 집계됐다.

원인: 완료 체크 대상이 아닌 **event 타입** 일정(약속·정보 메모 등)은 `status='todo'`로 영구 잔존하는데, 밀린 일정 카운트가 이를 걸러내지 못하고 포함시킴. 날짜만 과거로 밀리며 무한 누적.

근본 원인은 "밀린 일정" 정의가 두 곳(`detectOverdue`, `queryScheduleContext`)에 분리돼 한쪽에만 task 타입 필터가 있던 drift.

## 변경 내용
- `src/shared/life-queries.ts`: 공유 헬퍼 `countOverdueTasks(today, userId)` 추출 — `status='todo'` + 과거 날짜 + `COALESCE(c.type, p.type, 'task') = 'task'`(task 타입만)
- `detectOverdue`(insights) / `queryScheduleContext`(life-context) 인라인 쿼리 제거 → 헬퍼 위임 (정의 단일화)
- 회귀 가드 테스트: 헬퍼 SQL에 task 타입 필터가 포함되는지 명시 검증 (이번 버그 재발 방지)
- 도메인 문서: `schedule.md` 밀린 일정 정의 섹션 신설, `insight.md` §8 overdueAlert 카운트 소스 각주

부수 효과: `detectOverdue`는 `overdueAlert` 신호 평가기로도 재사용되므로, 헬퍼 교정으로 잔소리 정확도 + off-day 패턴 통계 정확도가 함께 개선된다.

## 코드 리뷰 결과
- [x] 보안 감사 통과 (SQL 파라미터화 $1/$2, 하드코딩·개인정보 없음)
- [x] 타입 안전성 확인 (`any` 없음, 반환 타입 명시)
- [x] 컨벤션 점검 완료 (named export, 헬퍼 배치)
- [x] 코드 품질 확인 (정의 단일화로 중복 제거)

## 테스트
- [x] `countOverdueTasks` 회귀 가드 (task 타입 필터 검증 + 빈 결과 0)
- [x] 기존 `detectOverdue` / `buildLifeContext` 테스트 그린
- [x] 전체 스위트 901 passed, `tsc` strict 그린