### PR TITLE
fix(insight): #546 월간 신호 제안 idempotency 하드닝 (마이그 094 + ADR-0053)

### DIFF
--- a/db/migrations/094_signal_suggest_runs.sql
+++ b/db/migrations/094_signal_suggest_runs.sql
@@ -1,0 +1,33 @@
+-- 094: 월간 신호 제안 발송 기록 (idempotency 테이블) — #546, ADR-0053
+-- monthly-signal-suggest Routine(월 1일 09:30 KST, LLM 기반, repo 밖 로컬 SKILL) 의존 테이블.
+--
+-- 원리: Routine 최초 액션에서 INSERT ON CONFLICT (user_id, month_start) DO NOTHING RETURNING id.
+-- 같은 달 두 번째 실행이면 RETURNING이 비어서 Routine이 후보 생성·발송 전에 즉시 종료 → 중복 카드 차단.
+-- Routine 재실행·스케줄러 중복 fire·프롬프트 중복 호출 어떤 원인이든 원자적으로 하나만 승리.
+-- (기존 saju_weekly_reviews(062) idempotency 패턴과 동일 결. 최초-클레임 선택 근거는 ADR-0053.)
+
+CREATE TABLE IF NOT EXISTS signal_suggest_runs (
+  id          SERIAL PRIMARY KEY,
+  user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  month_start DATE NOT NULL,                              -- 해당 월 1일 (DATE_TRUNC('month', ...)::date)
+  posted_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, month_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_signal_suggest_runs_user_month
+  ON signal_suggest_runs(user_id, month_start DESC);
+
+COMMENT ON TABLE signal_suggest_runs IS
+  'monthly-signal-suggest Routine의 idempotency 기록. UNIQUE (user_id, month_start)로 같은 달 중복 발송 차단 (#546, ADR-0053).';
+
+DO $$
+DECLARE
+  has_table INT;
+  has_unique INT;
+BEGIN
+  SELECT count(*) INTO has_table FROM information_schema.tables
+   WHERE table_name = 'signal_suggest_runs';
+  SELECT count(*) INTO has_unique FROM pg_constraint
+   WHERE conname LIKE '%signal_suggest_runs%' AND contype = 'u';
+  RAISE NOTICE '[094] signal_suggest_runs 테이블 % / UNIQUE 제약 %', has_table, has_unique;
+END $$;

--- a/docs/adr/0053-signal-suggest-idempotency.md
+++ b/docs/adr/0053-signal-suggest-idempotency.md
@@ -1,0 +1,88 @@
+# 0053. 월간 신호 제안 루틴 idempotency — DB 클레임 테이블
+
+- Status: Accepted
+- Date: 2026-07-01
+- Related: #546
+- Tags: data, process, reliability
+
+## Context
+
+`monthly-signal-suggest`는 매월 1일 09:30 KST 실행되는 LLM 기반 Claude 앱 routine(repo 밖 SKILL)이다. 누적 라이프 데이터(카운트·태그·평균만)로 새 측정 신호(`signal_defs` source=llm status=pending)를 0\~5개 생성·INSERT하고 후보별 승인 카드를 #insight에 발송한다 (#477 P5b, ADR-0040).
+
+발송 중복이 관측됐다: 카드가 발송·승인된 뒤 동일 내용이 재발송. `signal_defs`에는 중복 행이 없어(발송만 2회) 원인은 후보 생성이 아니라 **발송 계층**이다.
+
+- 기존 idempotency는 SKILL 1단계의 **소프트 체크**(이번 달 `signal_defs` 카운트 조회 후 cnt>0이면 종료)로만 존재.
+- LLM이 프롬프트 스텝을 100% 이행한다는 보장이 없고, 재실행·부분 재시도 시 이미 pending인 카드를 다시 발송할 수 있다. 발송 계층에 **원자적 하드 가드가 없다**.
+- 동일 프로젝트의 `weekly-saju-review-v2`는 이미 `saju_weekly_reviews`(마이그 062) `UNIQUE` 제약 + `INSERT ON CONFLICT ... RETURNING` 패턴으로 중복 발송을 막고 있다 — 재사용 가능한 선례.
+
+## Decision
+
+DB 클레임 테이블로 원자적 월별 실행 클레임을 도입한다.
+
+1. 신규 테이블 `signal_suggest_runs(user_id, month_start DATE, posted_at)` `UNIQUE(user_id, month_start)` — 062 패턴과 동일 결.
+2. routine의 **최초 DB 액션**을 원자적 클레임으로 교체:
+
+```sql
+INSERT INTO signal_suggest_runs (user_id, month_start)
+VALUES ($1, DATE_TRUNC('month', (NOW() AT TIME ZONE 'Asia/Seoul'))::date)
+ON CONFLICT (user_id, month_start) DO NOTHING
+RETURNING id
+```
+
+RETURNING이 비면 "이번 달 이미 실행됨" 출력 후 **즉시 종료**. 값이 있으면 진행.
+
+3. 클레임을 **최초 액션**으로 두어, 두 번째 실행은 후보 생성(LLM 토큰)·INSERT·발송 이전에 종료 → 중복 발송·중복 행·중복 LLM 비용 모두 차단.
+4. 보조 가드: SKILL 5단계에 "후보별 카드는 정확히 1회 발송, 실패해도 재시도 루프 금지" 명시 — 단일 실행 내 발송 tool 중복 호출 모드 보완.
+
+## Alternatives considered
+
+### A. 소프트 카운트 체크 유지·강화 (`signal_defs` 월별 조회)
+
+- 장점: 스키마 변경 없음
+- 단점: 원자성 없음(동시 두 실행이 둘 다 통과 가능), LLM 이행 의존 그대로
+- 기각: 이번 사고의 원인 계층을 그대로 둠
+
+### B. 카드 발송을 봇 코드로 이관 (결정론적 100% 차단)
+
+- 장점: routine은 후보 생성·INSERT만, 발송은 봇이 UNIQUE·트랜잭션으로 완전 보장
+- 단점: P5b 발송 아키텍처(ADR-0040) 변경 + #477 헌장(생성/판정/발송 역할 배치) 재검토 필요, 범위 과대
+- 기각(보류): 월 1회 저빈도라 현 시점 과투자. 재발 지속 시 별도 마스터로 승격
+
+### C. `signal_defs (user_id, name)` UNIQUE 제약
+
+- 장점: 중복 후보 행 방지
+- 단점: 이번 문제(중복 발송)는 못 막음(행은 이미 1개). rejected 재제안 노이즈와도 별개 축
+- 기각: 문제 영역 불일치
+
+### 클레임 시점: 최초 액션(선택) vs 발송 성공 후 기록
+
+- 발송 성공 후 기록(ADR-0052 weekly-review가 택한 방식)은 미발송 주 수동 재실행을 보장하지만, 두 실행이 모두 성공하면 중복 발송을 못 막는다.
+- signal-suggest는 **중복 방지가 최우선**이고 월간 신호 제안은 출력 연속성-critical이 아니므로(0건 발송도 정상 결과), 최초-클레임을 택해 중복을 확실히 막는다. 대가로 클레임 후 크래시 시 그 달은 건너뜀(burned month) — 저빈도·저손실이라 수용. (weekly-review와 반대 선택인 이유 = 카드 성격 차이: 회고 카드는 연속성 필수, 신호 제안은 선택적.)
+
+## Consequences
+
+### 장점
+
+- 재실행·스케줄러 중복 fire·프롬프트 중복 호출 어떤 원인이든 원자적으로 하나만 승리 → 중복 발송·행·LLM 비용 차단.
+- 기존 062 idempotency 패턴 재사용 → 일관성, 온보딩 비용 낮음.
+
+### 단점 / 제약
+
+- 여전히 routine이 클레임 스텝을 실행해야 효력. 이를 위해 클레임을 **최초·필수 액션**으로 배치(프롬프트 구조로 강제). 코드 레벨 100% 강제는 대안 B 필요.
+- 클레임 후 조기 크래시 시 해당 월 스킵(burned month). 월간·저손실이라 수용, 다음 달 자동 복구.
+- 단일 실행 내 LLM 발송 tool 중복 호출 모드는 클레임으로 못 막음 → SKILL 5단계 "1회 발송" 가드로 보완.
+
+### 후속 작업
+
+- [ ] 마이그 094 `signal_suggest_runs` + prod 적용
+- [ ] SKILL 1단계 원자적 클레임으로 교체(최초 액션), 5단계 1회 발송 가드
+- [ ] `docs/domains/insight.md` P5b 섹션에 idempotency 테이블 반영
+- [ ] (별도) rejected 재제안 노이즈 억제는 분리 이슈
+
+---
+
+**참고 자료**
+
+- ADR-0040 — `monthly-signal-suggest` (P5b LLM 신호 제안)
+- [ADR-0052](0052-weekly-insight-single-card-merge.md) — weekly-review idempotency(발송 성공 기준) 대비
+- 마이그 062 `saju_weekly_reviews` — 동일 idempotency 패턴 원형

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -158,6 +158,8 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0049](0049-response-profile-aggregation.md) | 개인화 가중치 집계 레이어 — saju_response_profile (글자→십성→그룹 단일레벨 + element_band, 이중계산 구조적 차단 + shrunk 효과) | Accepted | 2026-06-13 | insight, statistics, architecture, saju |
 | [0050](0050-verifiability-ladder-and-forecast-ledger.md) | 검증가능성 사다리 + 예측 장부 — 상위 주기(월/세/대운) 해석의 인식 지위 (일운 실증 / 월운 축적-실증 / 세운 장부한정 / 대운 비실증, 전이 가설 미검증 라벨) | Accepted | 2026-06-13 | insight, statistics, saju, architecture |
 | [0051](0051-budget-model-simplification-runway-locked.md) | 예산 모델 단순화 — 자금 단일화 + 목표기간 기준 묶인 돈 일괄 처리 (reservation/depletion 분리, 건별 토글 제거, ADR 0015·0018 supersede) | Accepted | 2026-06-16 | data, budget |
+| [0052](0052-weekly-insight-single-card-merge.md) | 주간 인사이트 단일 카드 통합 — routine 단독 발송 + 봇 검증 카드 은퇴 + posterior 노출 제거 | Accepted | 2026-06-16 | process, data, ux |
+| [0053](0053-signal-suggest-idempotency.md) | 월간 신호 제안 루틴 idempotency — DB 클레임 테이블 (최초 원자적 클레임, 재실행 중복 발송 차단) | Accepted | 2026-07-01 | data, process, reliability |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -1775,7 +1775,7 @@ LLM이 새 측정 신호(`signal_defs`, `kind='sql'`, `source='llm'`)를 월간 
 
 **P5a vs P5b 경계** (겹침 없음): 발굴(P5a) = *기존 신호*를 시드와 off-day로 연결(가설 발견) / LLM(P5b) = *새 신호*를 생성(측정 정의). 둘 다 같은 승인 게이트(pending→active) + 통계가 심판(헌장 ①). LLM은 생성만, 판정은 통계.
 
-**월간 routine** (`monthly-signal-suggest`, 로컬 SKILL·repo 외): 매월 09:30 KST Opus([ADR-0027](../adr/0027-llm-async-work-as-claude-app-routines.md)). 입력 풀 = 라이프 메트릭 표(카운트·평균만, **금액 제외**) + 시드 description + 기존 active/rejected 신호(중복·재제안 관리). 텍스트 원문 0(헌장 v2 ①). 생성 계약 = 단일 SELECT·`user_id=$1`·화이트리스트 테이블·`value_type`/`direction` 지정. idempotency(이번 달 `source='llm'` 존재 시 종료) + cap 월 5. 등록 INSERT는 DB proxy `validateProxySQL` 통과, 임베드 `sql_body`는 게이트 #1/#2가 심판.
+**월간 routine** (`monthly-signal-suggest`, 로컬 SKILL·repo 외): 매월 09:30 KST Opus([ADR-0027](../adr/0027-llm-async-work-as-claude-app-routines.md)). 입력 풀 = 라이프 메트릭 표(카운트·평균만, **금액 제외**) + 시드 description + 기존 active/rejected 신호(중복·재제안 관리). 텍스트 원문 0(헌장 v2 ①). 생성 계약 = 단일 SELECT·`user_id=$1`·화이트리스트 테이블·`value_type`/`direction` 지정. idempotency = 최초 액션에서 `signal_suggest_runs` 원자적 클레임(`INSERT ... ON CONFLICT (user_id, month_start) DO NOTHING RETURNING` → 빈 결과면 후보 생성·발송 전에 즉시 종료). 재실행·스케줄러 중복 fire 어떤 원인이든 하나만 승리 — 마이그 [094](../../db/migrations/094_signal_suggest_runs.sql), 선택 근거·weekly(062) 대비 최초-클레임 이유는 [ADR-0053](../adr/0053-signal-suggest-idempotency.md). cap 월 5. 등록 INSERT는 DB proxy `validateProxySQL` 통과, 임베드 `sql_body`는 게이트 #1/#2가 심판.
 
 ### 31. 매트릭 중심 패턴 검증 — Phase 6 (교란 플래그: 공동발현 시드 marginal 탐지, #493)
 


### PR DESCRIPTION
## 관련 이슈
Closes #546

## 문제
월간 측정 신호 제안 카드가 Routine 재실행 시 동일 내용으로 중복 발송될 수 있었다. idempotency가 프롬프트 소프트 체크로만 존재해 하드 가드가 없었던 것이 원인 (DB 후보 행은 중복 생성되지 않고 발송만 중복).

## 변경 내용
- **마이그레이션 094** `signal_suggest_runs (user_id, month_start) UNIQUE` idempotency 테이블 추가
- Routine 최초 액션이 `INSERT ... ON CONFLICT (user_id, month_start) DO NOTHING RETURNING` → 빈 결과면 후보 생성·발송 전에 즉시 종료. 재실행·스케줄러 중복 fire 어떤 원인이든 원자적으로 하나만 승리 (기존 `saju_weekly_reviews`(062) 패턴과 동일 결)
- **ADR-0053**: claim-first 선택 근거 + weekly(record-after, ADR-0052) 대비 카드 성격별 idempotency 분기 기록
- `insight.md` §30 월간 routine idempotency 서술 갱신

## ⚠️ 배포 시퀀싱 (중요)
Routine 정의(`monthly-signal-suggest` SKILL)는 **repo 밖 로컬 파일**이라 이 PR에 미포함. 순서 준수 필요:
1. 이 PR 머지 → 배포 → 마이그 094 prod 적용 (테이블 생성)
2. **그 후** SKILL 1단계를 원자적 클레임으로 갱신 (테이블 존재 전제)
3. 다음 실행(8/1) 또는 수동 Run으로 idempotency 동작 확인

## 코드 리뷰 결과
- [x] 보안 감사 통과 (마이그 FK `user_id`만, 시크릿·개인정보·하드코딩 없음)
- [x] 마이그레이션 번호 유일성 확인 (094)
- [x] 컨벤션 점검 완료 (062 idempotency 패턴 미러 + 검증 DO 블록)
- [x] 결정 기록 ADR-0053

## 테스트
- [x] `yarn build` strict 그린
- [x] 전체 스위트 899 passed
- [x] 마이그레이션 SQL: `CREATE TABLE IF NOT EXISTS` + `UNIQUE` + 검증 NOTICE (idempotent DDL)