### PR TITLE
fix(budget): 할부 지출 예산 플래그 정합성 정리 (#549)

### DIFF
--- a/db/migrations/095_installment_exclude_normalize.sql
+++ b/db/migrations/095_installment_exclude_normalize.sql
@@ -1,0 +1,28 @@
+-- 095: 할부 exclude 플래그 정규화 — 할부는 항상 묶인 돈 (#549, #539/ADR 0051)
+--
+-- #539(ADR 0051) 계약: 할부 회차는 목표 기간 창 안에서 "묶인 돈"(reservation)이며
+-- exclude_from_budget 토글은 일반(비할부) 지출 전용이다. #539에서 할부 exclude 토글을
+-- 제거했지만 그 이전에 exclude=true로 기록된 기존 할부 행(미래 회차)은 정리하지 않아
+-- 집계마다 이 플래그에 흔들렸다(요약 카드 "할부" 표시 ≠ 실제 락, 정산 스냅샷 분해 왜곡).
+--
+-- forward-only. UPDATE는 (is_installment=true AND exclude=true) 조합에만 국한한다.
+
+-- 1) 정규화: 할부 행의 exclude 플래그 무효화 (할부는 예외 없이 묶인 돈).
+UPDATE expenses
+   SET exclude_from_budget = false
+ WHERE COALESCE(is_installment, false) = true
+   AND COALESCE(exclude_from_budget, false) = true;
+
+-- 2) 재발 차단: 할부이면서 예산 제외인 조합을 제약으로 금지.
+ALTER TABLE expenses
+  ADD CONSTRAINT expenses_installment_not_excluded
+  CHECK (NOT (COALESCE(is_installment, false) AND COALESCE(exclude_from_budget, false)));
+
+DO $$
+DECLARE
+  leftover INT;
+BEGIN
+  SELECT count(*) INTO leftover FROM expenses
+   WHERE COALESCE(is_installment, false) AND COALESCE(exclude_from_budget, false);
+  RAISE NOTICE '[095] 정규화 후 할부 exclude 잔여 행 % (0이어야 정상)', leftover;
+END $$;

--- a/web/src/features/budget/lib/__tests__/query-month-summary.test.ts
+++ b/web/src/features/budget/lib/__tests__/query-month-summary.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  query: vi.fn(),
+  queryOne: vi.fn(),
+}));
+vi.mock('../repository/expenses-repo', () => ({
+  readFlexibleSpent: vi.fn(),
+  readTodayFlexSpent: vi.fn(),
+}));
+
+import { query, queryOne } from '@/lib/db';
+import { readFlexibleSpent } from '../repository/expenses-repo';
+import { queryMonthSummary } from '../queries';
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
+type Any = any;
+
+// queryMonthSummary가 발행하는 query() 호출 순서 (queryOne은 별도 mock):
+//   [0] total, [1] byCategory, [2] queryFixedCosts,
+//   [3] installmentTotal, [4] incomeTotal, [5] queryPlannedExpenses
+// queryOne 호출: [0] variableTotal
+function primeQueries(opts?: { installmentTotal?: string; variableTotal?: string }) {
+  vi.mocked(query)
+    .mockResolvedValueOnce({ rows: [{ total: '100000' }] } as Any) // total
+    .mockResolvedValueOnce({ rows: [] } as Any) // byCategory
+    .mockResolvedValueOnce({ rows: [] } as Any) // queryFixedCosts
+    .mockResolvedValueOnce({ rows: [{ total: opts?.installmentTotal ?? '0' }] } as Any) // installment
+    .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any) // income
+    .mockResolvedValueOnce({ rows: [] } as Any); // planned
+  vi.mocked(queryOne).mockResolvedValueOnce({
+    total: opts?.variableTotal ?? '0',
+  } as Any);
+  vi.mocked(readFlexibleSpent).mockResolvedValueOnce(0);
+}
+
+describe('queryMonthSummary — 할부 exclude 플래그 정합성 (#549)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('할부 합계 쿼리에 exclude_from_budget 필터가 없어야 함 (락 집합과 동일)', async () => {
+    primeQueries();
+
+    await queryMonthSummary(1, '2026-04');
+
+    // query 호출 [3]이 할부 합계 (is_installment=true, exclude 필터 없음)
+    const installmentSql = vi.mocked(query).mock.calls[3]![0] as string;
+    expect(installmentSql).toMatch(/is_installment\s*=\s*true/i);
+    expect(installmentSql).not.toMatch(/exclude_from_budget/i);
+  });
+
+  it('자유 지출(변동) 쿼리에 is_installment=false 필터가 있어야 함 (할부 분리)', async () => {
+    primeQueries();
+
+    await queryMonthSummary(1, '2026-04');
+
+    const variableSql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+    expect(variableSql).toMatch(/is_installment\s*=\s*false/i);
+    expect(variableSql).toMatch(/exclude_from_budget\s*=\s*false/i);
+  });
+
+  it('할부/변동 합계는 DB가 반환한 값을 그대로 반영 (exclude 플래그 조합과 무관)', async () => {
+    primeQueries({ installmentTotal: '300000', variableTotal: '45000' });
+
+    const summary = await queryMonthSummary(1, '2026-04');
+
+    // 정규화 이후 할부는 exclude 값과 무관하게 전부 installment_total에 집계된다.
+    expect(summary.installment_total).toBe(300000);
+    // 변동 지출은 할부를 제외한 자유 지출만.
+    expect(summary.variable_total).toBe(45000);
+  });
+
+  it('daily_avg는 variableTotal(할부 제외) 기준으로 산출', async () => {
+    primeQueries({ variableTotal: '310000' });
+
+    const summary = await queryMonthSummary(1, '2026-04');
+
+    // 변동 지출이 양수면 daily_avg > 0 (결제주기 일수로 나눈 정수)
+    expect(summary.variable_total).toBe(310000);
+    expect(summary.daily_avg).toBeGreaterThan(0);
+  });
+});

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -294,22 +294,24 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
     count: Number(r.count),
   }));
 
-  // 자유 지출 합계 (exclude_from_budget=false인 것만)
+  // 자유 지출 합계 (exclude_from_budget=false인 비할부만).
+  // 할부는 묶인 돈이라 자유지출·일평균(daily_avg)에서 분리 (#539/ADR 0051, #549).
   const variableResult = await queryOne<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0) as total FROM expenses
      WHERE user_id = $1 AND billing_month = $2
        AND exclude_from_budget = false
+       AND is_installment = false
        AND COALESCE(type, 'expense') = 'expense'`,
     [userId, yearMonth],
   );
   const variableTotal = Number(variableResult?.total ?? 0);
 
-  // 할부 합계 (예산 포함인 것 중 is_installment=true)
+  // 할부 합계 (is_installment=true인 것 전부 — 락 계산 readInstallmentLockByMonth와 동일 집합).
+  // exclude 필터 없음: 할부는 예외 없이 묶인 돈이라 표시가 실제 락과 어긋나면 안 됨 (#549).
   const installmentResult = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0) as total FROM expenses
      WHERE user_id = $1 AND billing_month = $2
        AND is_installment = true
-       AND exclude_from_budget = false
        AND COALESCE(type, 'expense') = 'expense'`,
     [userId, yearMonth],
   );

--- a/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
@@ -6,6 +6,7 @@ vi.mock('@/lib/db', () => ({
 
 import { query } from '@/lib/db';
 import {
+  readExcludedSpent,
   readFlexibleSpent,
   readPlannedOverflow,
   readTodayFlexSpent,
@@ -286,5 +287,32 @@ describe('readTotalCycleSpent (#539)', () => {
   it('행 없음 → 0', async () => {
     vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
     expect(await readTotalCycleSpent(1, '2026-04')).toBe(0);
+  });
+});
+
+describe('readExcludedSpent (#549)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('제외 지출은 일반(비할부) 지출만 — is_installment=false 필터 포함', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '20000' }] } as Any);
+
+    const result = await readExcludedSpent(1, '2026-04');
+
+    expect(result).toBe(20000);
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    // 할부는 묶인 돈으로 따로 집계되므로 제외 지출에서 빠져야 함
+    expect(sql).toMatch(/is_installment\s*=\s*false/i);
+    expect(sql).toMatch(/exclude_from_budget\s*=\s*true/i);
+    expect(sql).toMatch(/billing_month\s*=\s*\$2/i);
+    expect(sql).toMatch(/type.*expense/i);
+    expect(params).toEqual([1, '2026-04']);
+  });
+
+  it('행 없음 → 0', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    expect(await readExcludedSpent(1, '2026-04')).toBe(0);
   });
 });

--- a/web/src/features/budget/lib/repository/expenses-repo.ts
+++ b/web/src/features/budget/lib/repository/expenses-repo.ts
@@ -48,6 +48,9 @@ export async function readTotalCycleSpent(userId: number, billingMonth: string):
   return Number(result.rows[0]?.total ?? 0);
 }
 
+// 제외 지출 = 일반(비할부) 지출 중 예산 미포함분만 (#539/ADR 0051, #549).
+// 할부는 exclude 대상이 아니라 묶인 돈으로 따로 집계되므로 여기서 제외해야
+// 정산 스냅샷 분해(총 결제분 = 자유 + 할부 + 제외)가 왜곡되지 않는다.
 export async function readExcludedSpent(userId: number, billingMonth: string): Promise<number> {
   const result = await query<{ total: string }>(
     `SELECT COALESCE(SUM(amount), 0)::text AS total
@@ -55,6 +58,7 @@ export async function readExcludedSpent(userId: number, billingMonth: string): P
      WHERE user_id = $1
        AND COALESCE(type, 'expense') = 'expense'
        AND exclude_from_budget = true
+       AND is_installment = false
        AND billing_month = $2`,
     [userId, billingMonth],
   );


### PR DESCRIPTION
Closes #549

## 배경

할부 지출은 목표 기간 창 안에서 "묶인 돈"으로 취급하고, 예산 제외(exclude) 플래그는 일반(비할부) 지출 전용이라는 계약이 이전에 정립됐다(#539). 그런데 그 계약 이전에 기록된 일부 할부 행에 예산 제외 플래그가 남아 있어, 집계 경로마다 이 플래그에 흔들리는 표시 불일치가 있었다. 이번 변경은 기존 데이터를 계약에 맞게 정규화하고, 관련 집계 쿼리와 DB 제약으로 정합성을 고정한다.

## 변경 사항

- **마이그레이션 095**: 할부 행의 예산 제외 플래그를 정규화하고, "할부이면서 예산 제외" 조합을 금지하는 CHECK 제약을 추가해 재발을 차단(forward-only, 조건 국한 UPDATE).
- **`queryMonthSummary`**:
  - 할부 합계에서 예산 제외 필터 제거 — 할부 락 계산과 동일한 집합을 보게 해 요약 카드의 "할부" 표시가 실제 락과 일치.
  - 자유 지출(변동)·일평균 산출에서 할부를 분리(`is_installment = false`) — 묶인 돈이 자유 지출로 섞이지 않게.
- **`readExcludedSpent`**: 제외 지출을 일반(비할부) 지출로 한정 — 정산 스냅샷 분해(총 결제분 = 자유 + 할부 + 제외)가 왜곡되지 않도록.
- 관련 테스트 추가(`query-month-summary.test.ts`, `expenses-repo.test.ts`의 `readExcludedSpent`).

## 동작 변화 고지

정규화로 일부 할부 회차의 예산 제외 플래그가 해제되면서, 카테고리 한도의 사용 횟수(used_count) 집계에 해당 할부의 첫 회차가 이제 정상적으로 포함될 수 있다. 이는 원래 의도된 동작(#543)의 회복이지만, 화면상 카운트 표시가 이전과 달라질 수 있음.

## 테스트

- 웹 `yarn tsc --noEmit`: 통과
- 웹 `yarn vitest run`: 25개 파일 275개 통과
- 루트 `yarn vitest run`: 51개 파일 901개 통과

머지 후 별도 검증은 오케스트레이터가 수행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)