### PR TITLE
fix(cron): 일별 예산 로그 백필 산식 단일화 (#550)

### DIFF
--- a/src/cron/__tests__/life-cron.test.ts
+++ b/src/cron/__tests__/life-cron.test.ts
@@ -2,13 +2,38 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── 순수 유틸 테스트 ──
 
-import { timeToCron, calcRoutineStats, RELOAD_DEBOUNCE_MS } from '../life-cron.js';
+import {
+  timeToCron,
+  calcRoutineStats,
+  getBillingMonthForDate,
+  RELOAD_DEBOUNCE_MS,
+} from '../life-cron.js';
 
 describe('timeToCron', () => {
   it('HH:MM → 크론 표현식', () => {
     expect(timeToCron('09:00')).toBe('0 9 * * *');
     expect(timeToCron('13:30')).toBe('30 13 * * *');
     expect(timeToCron('22:05')).toBe('5 22 * * *');
+  });
+});
+
+// ── getBillingMonthForDate: 결제주기 경계 (웹 billing/cycle.ts와 15일 통일) ──
+
+describe('getBillingMonthForDate — 결제주기 경계 15일', () => {
+  it('14일 → 당월 (경계 직전)', () => {
+    expect(getBillingMonthForDate('2026-07-14')).toBe('2026-07');
+  });
+
+  it('15일 → 다음 달 (경계 당일, 기존 16일 버그 케이스)', () => {
+    expect(getBillingMonthForDate('2026-07-15')).toBe('2026-08');
+  });
+
+  it('16일 → 다음 달', () => {
+    expect(getBillingMonthForDate('2026-07-16')).toBe('2026-08');
+  });
+
+  it('12월 15일 → 연 넘김 (다음 해 1월)', () => {
+    expect(getBillingMonthForDate('2026-12-15')).toBe('2027-01');
   });
 });
 
@@ -59,7 +84,12 @@ vi.mock('../../shared/kst.js', () => ({
 }));
 
 import { connectDB } from '../../shared/db.js';
-import { CronScheduler, createTodayRecords, type LifeCronConfig } from '../life-cron.js';
+import {
+  CronScheduler,
+  createTodayRecords,
+  calcYesterdayFlexSpent,
+  type LifeCronConfig,
+} from '../life-cron.js';
 import type { UserMapping } from '../../shared/user-resolver.js';
 
 /** notification_settings 쿼리 mock 설정 */
@@ -113,9 +143,7 @@ describe('CronScheduler reload debounce', () => {
 
     await connectDB('postgresql://test@localhost/test');
 
-    setupSettingsMock([
-      { slot_name: 'morning', label: '아침', time_value: '09:00', active: true },
-    ]);
+    setupSettingsMock([{ slot_name: 'morning', label: '아침', time_value: '09:00', active: true }]);
 
     const app = createMockApp();
     const config: LifeCronConfig = {
@@ -130,9 +158,7 @@ describe('CronScheduler reload debounce', () => {
     mockQuery.mock.calls.length = 0;
 
     // 리로드용 settings mock 재설정
-    setupSettingsMock([
-      { slot_name: 'morning', label: '아침', time_value: '09:30', active: true },
-    ]);
+    setupSettingsMock([{ slot_name: 'morning', label: '아침', time_value: '09:30', active: true }]);
   });
 
   afterEach(() => {
@@ -155,8 +181,8 @@ describe('CronScheduler reload debounce', () => {
     await vi.advanceTimersByTimeAsync(RELOAD_DEBOUNCE_MS);
 
     // loadAndSchedule 1회만 실행됨 (notification_settings 쿼리 1회)
-    const settingsQueries = mockQuery.mock.calls.filter(
-      (call) => /notification_settings/.test(call[0] as string),
+    const settingsQueries = mockQuery.mock.calls.filter((call) =>
+      /notification_settings/.test(call[0] as string),
     );
     expect(settingsQueries).toHaveLength(1);
   });
@@ -169,8 +195,8 @@ describe('CronScheduler reload debounce', () => {
     vi.advanceTimersByTime(RELOAD_DEBOUNCE_MS * 2);
 
     // destroy 시점 이후 notification_settings 쿼리 없음
-    const settingsQueries = mockQuery.mock.calls.filter(
-      (call) => /notification_settings/.test(call[0] as string),
+    const settingsQueries = mockQuery.mock.calls.filter((call) =>
+      /notification_settings/.test(call[0] as string),
     );
     expect(settingsQueries).toHaveLength(0);
   });
@@ -199,9 +225,13 @@ describe('createTodayRecords — 매일 빈도 start_date 가드', () => {
     await connectDB('postgresql://test@localhost/test');
   });
 
-  const setupTemplateMock = (
-    template: { id: number; name: string; time_slot: string; frequency: string; start_date: string },
-  ): void => {
+  const setupTemplateMock = (template: {
+    id: number;
+    name: string;
+    time_slot: string;
+    frequency: string;
+    start_date: string;
+  }): void => {
     mockQuery.mockImplementation((sql: string) => {
       if (/FROM routine_templates/.test(sql)) {
         return Promise.resolve({ rows: [template] });
@@ -218,21 +248,29 @@ describe('createTodayRecords — 매일 빈도 start_date 가드', () => {
 
   it('매일 빈도 + start_date 미래 → 기록 생성하지 않음', async () => {
     setupTemplateMock({
-      id: 99, name: '미래 루틴', time_slot: '낮', frequency: '매일', start_date: '2026-04-21',
+      id: 99,
+      name: '미래 루틴',
+      time_slot: '낮',
+      frequency: '매일',
+      start_date: '2026-04-21',
     });
 
     const created = await createTodayRecords('2026-04-20', 1);
     expect(created).toBe(0);
 
-    const inserts = mockQuery.mock.calls.filter(
-      (call) => /INSERT INTO routine_records/.test(call[0] as string),
+    const inserts = mockQuery.mock.calls.filter((call) =>
+      /INSERT INTO routine_records/.test(call[0] as string),
     );
     expect(inserts).toHaveLength(0);
   });
 
   it('매일 빈도 + start_date = 오늘 → 기록 생성', async () => {
     setupTemplateMock({
-      id: 99, name: '오늘 시작', time_slot: '낮', frequency: '매일', start_date: '2026-04-21',
+      id: 99,
+      name: '오늘 시작',
+      time_slot: '낮',
+      frequency: '매일',
+      start_date: '2026-04-21',
     });
 
     const created = await createTodayRecords('2026-04-21', 1);
@@ -241,10 +279,96 @@ describe('createTodayRecords — 매일 빈도 start_date 가드', () => {
 
   it('매일 빈도 + start_date 과거 → 기록 생성', async () => {
     setupTemplateMock({
-      id: 99, name: '진행 중', time_slot: '밤', frequency: '매일', start_date: '2026-04-01',
+      id: 99,
+      name: '진행 중',
+      time_slot: '밤',
+      frequency: '매일',
+      start_date: '2026-04-01',
     });
 
     const created = await createTodayRecords('2026-04-21', 1);
     expect(created).toBe(1);
+  });
+});
+
+// ── calcYesterdayFlexSpent: 웹 readTodayFlexSpent SSOT 정합 ──
+// spent = directFlex(어제, 비할부) + max(0, overflow(어제까지) - overflow(그제까지)).
+
+describe('calcYesterdayFlexSpent — 웹 SSOT 정합', () => {
+  const YESTERDAY = '2026-07-10';
+  const DAY_BEFORE = '2026-07-09';
+  const BILLING = '2026-07';
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue({ release: vi.fn() });
+    await connectDB('postgresql://test@localhost/test');
+  });
+
+  /**
+   * directFlex 쿼리(`date = $2::date`)와 overflow 쿼리(`planned_expenses`)를 구분해 mock.
+   * overflow는 upToDate($3) 값에 따라 어제까지/그제까지 누적을 다르게 반환.
+   */
+  const setupSpentMock = (opts: {
+    direct: number;
+    overflowByDate: Record<string, number>;
+  }): void => {
+    mockQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      if (/planned_expenses/.test(sql)) {
+        const upTo = String(params?.[2] ?? '');
+        const overflow = opts.overflowByDate[upTo] ?? 0;
+        return Promise.resolve({ rows: [{ overflow: String(overflow) }] });
+      }
+      if (/date = \$2::date/.test(sql)) {
+        return Promise.resolve({ rows: [{ total: String(opts.direct) }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  };
+
+  it('(a) 일반 지출만 → directFlex 그대로, overflow 0', async () => {
+    setupSpentMock({ direct: 12000, overflowByDate: {} });
+    const spent = await calcYesterdayFlexSpent(1, YESTERDAY, BILLING);
+    expect(spent).toBe(12000);
+  });
+
+  it('(b) 할부·예정연결·exclude는 directFlex SQL에서 제외 (WHERE 절 고정)', async () => {
+    setupSpentMock({ direct: 0, overflowByDate: {} });
+    await calcYesterdayFlexSpent(1, YESTERDAY, BILLING);
+
+    const directCall = mockQuery.mock.calls.find((c) => /date = \$2::date/.test(c[0] as string));
+    expect(directCall).toBeDefined();
+    const directSql = directCall?.[0] as string;
+    expect(directSql).toMatch(/is_installment = false/);
+    expect(directSql).toMatch(/exclude_from_budget = false/);
+    expect(directSql).toMatch(/planned_expense_id IS NULL/);
+  });
+
+  it('(c) 예정지출 초과 발생일 → overflow 증가분만 가산', async () => {
+    // 그제까지 누적 초과 0, 어제까지 누적 초과 5000 → 증가분 5000
+    setupSpentMock({
+      direct: 3000,
+      overflowByDate: { [DAY_BEFORE]: 0, [YESTERDAY]: 5000 },
+    });
+    const spent = await calcYesterdayFlexSpent(1, YESTERDAY, BILLING);
+    expect(spent).toBe(8000); // 3000 + 5000
+  });
+
+  it('(c-2) 초과가 이미 그제 발생 → 어제 증가분 0 (중복 가산 방지)', async () => {
+    setupSpentMock({
+      direct: 3000,
+      overflowByDate: { [DAY_BEFORE]: 5000, [YESTERDAY]: 5000 },
+    });
+    const spent = await calcYesterdayFlexSpent(1, YESTERDAY, BILLING);
+    expect(spent).toBe(3000); // overflow 증가분 0
+  });
+
+  it('(d) overflow 감소(환불·조정) → max(0, ...)로 음수 방어', async () => {
+    setupSpentMock({
+      direct: 3000,
+      overflowByDate: { [DAY_BEFORE]: 8000, [YESTERDAY]: 5000 },
+    });
+    const spent = await calcYesterdayFlexSpent(1, YESTERDAY, BILLING);
+    expect(spent).toBe(3000); // max(0, 5000-8000)=0
   });
 });

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -30,6 +30,7 @@ import {
   getEffectiveTodayISO,
   getKSTTimeString,
   getKSTDayOfWeek,
+  addDays,
 } from '../shared/kst.js';
 import {
   DEFAULT_USER_ID,
@@ -258,13 +259,74 @@ export const createTodayRecords = async (
 
 // ─── 일별 예산 로그 자동 백필 (Vercel cron 누락 방어) ──
 
-/** 결제일 사이클(16일 시작)을 적용해 해당 날짜의 billing_month 'YYYY-MM' 반환 */
-const getBillingMonthForDate = (isoDate: string): string => {
+/**
+ * 예정지출별 누적 사용량이 예산을 초과한 부분의 합 (upToDate까지).
+ * Σ max(0, used(p) - p.amount). 웹 readPlannedOverflow(ADR-0007 SSOT)의 복제본.
+ */
+const queryPlannedOverflow = async (
+  userId: number,
+  billingMonth: string,
+  upToDate: string,
+): Promise<number> => {
+  const result = await query<{ overflow: string }>(
+    `SELECT COALESCE(SUM(GREATEST(used - budget, 0)), 0)::text AS overflow
+     FROM (
+       SELECT p.amount AS budget, COALESCE(SUM(e.amount), 0) AS used
+       FROM planned_expenses p
+       LEFT JOIN expenses e
+         ON e.planned_expense_id = p.id
+         AND e.user_id = p.user_id
+         AND e.billing_month = $2
+         AND e.date <= $3
+       WHERE p.user_id = $1
+       GROUP BY p.id, p.amount
+     ) sub`,
+    [userId, billingMonth, upToDate],
+  );
+  return Number(result.rows[0]?.overflow ?? 0);
+};
+
+/**
+ * 어제자 자유 지출 = directFlex(어제) + max(0, overflow(어제까지) - overflow(그제까지)).
+ * 웹 readTodayFlexSpent(ADR-0007 SSOT)의 복제본 — 할부 전액 제외, 예정지출 초과분만 일별 증가분으로 가산.
+ * 웹 정의 변경 시 이 함수 + queryPlannedOverflow + 테스트를 동기화할 것.
+ */
+export const calcYesterdayFlexSpent = async (
+  userId: number,
+  yesterday: string,
+  billingMonth: string,
+): Promise<number> => {
+  const dayBefore = addDays(yesterday, -1);
+  const [directResult, yesterdayOverflow, dayBeforeOverflow] = await Promise.all([
+    query<{ total: string }>(
+      `SELECT COALESCE(SUM(amount), 0)::text AS total
+       FROM expenses
+       WHERE user_id = $1
+         AND COALESCE(type, 'expense') = 'expense'
+         AND exclude_from_budget = false
+         AND planned_expense_id IS NULL
+         AND date = $2::date
+         AND is_installment = false`,
+      [userId, yesterday],
+    ),
+    queryPlannedOverflow(userId, billingMonth, yesterday),
+    queryPlannedOverflow(userId, billingMonth, dayBefore),
+  ]);
+  const direct = Number(directResult.rows[0]?.total ?? 0);
+  const dailyOverflow = Math.max(0, yesterdayOverflow - dayBeforeOverflow);
+  return direct + dailyOverflow;
+};
+
+/**
+ * 결제일 사이클(전월 15일 ~ 당월 14일)을 적용해 해당 날짜의 billing_month 'YYYY-MM' 반환.
+ * 웹 billing/cycle.ts getCurrentBillingMonth와 동일 규칙 (15일부터 다음 달) — 변경 시 양쪽 동기화.
+ */
+export const getBillingMonthForDate = (isoDate: string): string => {
   const [yStr, mStr, dStr] = isoDate.split('-');
   let year = Number(yStr);
   let month = Number(mStr);
   const day = Number(dStr);
-  if (day >= 16) {
+  if (day >= 15) {
     month += 1;
     if (month > 12) {
       month = 1;
@@ -276,8 +338,9 @@ const getBillingMonthForDate = (isoDate: string): string => {
 
 /**
  * 어제자 daily_budget_logs 누락 감지 → 직접 INSERT 백필.
- * - budget: 같은 billing_month의 직전 로그에서 복제 (allocation 로직 미복제)
- * - spent: 기존 saveDailyBudgetLog와 동일한 SQL로 직접 계산
+ * - budget: 같은 billing_month의 직전 로그에서 복제 (allocation 로직 미복제 — 웹 없이는 재현 불가)
+ * - spent: 웹 readTodayFlexSpent(ADR-0007 SSOT)의 복제본 = directFlex(비할부) + 일별 plannedOverflow 증가분.
+ *   웹 정의 변경 시 이 함수 + 테스트를 동기화할 것.
  * - 백필 발생 시 #project 채널로 Slack 알림
  */
 const backfillYesterdayBudgetLogIfMissing = async (app: App): Promise<void> => {
@@ -309,23 +372,7 @@ const backfillYesterdayBudgetLogIfMissing = async (app: App): Promise<void> => {
       }
       const budget = prevBudget.budget;
 
-      const budgetStartRow = await query<{ updated_at: string }>(
-        'SELECT updated_at::text FROM budget_settings WHERE user_id = $1',
-        [userId],
-      );
-      const budgetStartAt = budgetStartRow.rows[0]?.updated_at ?? '9999-12-31T00:00:00Z';
-
-      const spentRow = await query<{ spent: string }>(
-        `SELECT COALESCE(SUM(amount), 0)::text AS spent
-         FROM expenses
-         WHERE user_id = $1 AND date = $2
-           AND (is_installment = false OR (is_installment = true AND created_at >= $3))
-           AND exclude_from_budget = false
-           AND COALESCE(type, 'expense') = 'expense'
-           AND planned_expense_id IS NULL`,
-        [userId, yesterday, budgetStartAt],
-      );
-      const spent = Number(spentRow.rows[0]?.spent ?? 0);
+      const spent = await calcYesterdayFlexSpent(userId, yesterday, billingMonth);
       const saved = budget - spent;
 
       await query(


### PR DESCRIPTION
Closes #550

## 배경

봇의 일별 예산 로그 백필(`backfillYesterdayBudgetLogIfMissing`)이 웹 대시보드의 정식 정의(ADR-0007 SSOT)와 두 지점에서 어긋나 있었다. 웹(`web/`)과 봇(`src/`)은 별도 프로젝트라 함수 공유가 불가능해, ADR-0021 선례대로 정의를 복제하되 테스트로 고정하는 방식으로 정합화했다.

## 변경

1. **결제주기 경계 통일** — `getBillingMonthForDate`의 다음 달 전환 기준을 웹 `billing/cycle.ts` `getCurrentBillingMonth`와 동일하게 맞춤. 경계 당일자 백필이 어긋난 billing_month로 들어가던 문제 해소.
2. **spent 산식 정렬** — 웹 `readTodayFlexSpent` 정의를 그대로 복제:
   `directFlex(비할부) + max(0, plannedOverflow(당일까지) - plannedOverflow(전일까지))`
   - `queryPlannedOverflow` / `calcYesterdayFlexSpent` 헬퍼로 추출.
   - allocation 재현은 웹 없이는 불가 → budget 복제 한계는 주석에 명시 유지.
3. **주석 정정 3곳** — 경계 규칙, spent 산식 출처(웹 SSOT 복제본 + 동기화 의무), 함수 doc.

## 테스트

- `getBillingMonthForDate` 경계 케이스 (경계 직전/당일/다음날/연 넘김)
- `calcYesterdayFlexSpent` 산식: 일반 지출 / 할부·예정연결·exclude 제외(WHERE 절 고정) / overflow 증가분 가산 / 중복 가산 방지 / 음수 방어
- `yarn tsc --noEmit` 통과
- `yarn vitest run` 전체 통과 (51 files, 910 tests)
- lint 0 errors (신규 경고 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)