### PR TITLE
feat(budget): 결제주기 정산 견고화 — 누락 보정 + 고정비 기록 보장 (#551)

### DIFF
--- a/web/src/app/api/cron/monthly-settlement/route.ts
+++ b/web/src/app/api/cron/monthly-settlement/route.ts
@@ -14,7 +14,12 @@ export async function GET(request: Request) {
 
   const now = new Date();
   const userIds = await listAllUserIds();
-  const results: Array<{ userId: number; settled: boolean; yearMonth?: string; error?: string }> = [];
+  const results: Array<{
+    userId: number;
+    settled: boolean;
+    yearMonths?: string[];
+    error?: string;
+  }> = [];
 
   for (const userId of userIds) {
     try {
@@ -22,7 +27,9 @@ export async function GET(request: Request) {
       results.push({
         userId,
         settled: result.settled,
-        ...(result.snapshot && { yearMonth: result.snapshot.year_month }),
+        ...(result.snapshots.length > 0 && {
+          yearMonths: result.snapshots.map((s) => s.year_month),
+        }),
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -287,15 +287,16 @@ describe('runSettlementIfDue', () => {
     expect(vi.mocked(saveSnapshotIfAbsent).mock.calls[0]?.[1]?.year_month).toBe('2026-02');
   });
 
-  it('(c-cap) 장기 미스라도 최대 3개월까지만 소급 (최근 3개, 오래된 순)', async () => {
+  it('(c-cap) 장기 미스라도 오래된 순 최대 3개월만 소급 — 다음 실행이 이어서 따라잡음', async () => {
     // 진행중=2026-04, 직전 종료=2026-03. 최신 스냅샷 2025-09 → 6개월 밀렸지만 cap=3.
     vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2025-09'));
     vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
 
     const result = await runSettlementIfDue(1, DEFAULT_NOW);
 
-    // 최근 3개월 = 2026-01, 2026-02, 2026-03
-    expect(result.snapshots.map((s) => s.year_month)).toEqual(['2026-01', '2026-02', '2026-03']);
+    // 오래된 순 3개월 = 2025-10, 2025-11, 2025-12.
+    // (최신 우선으로 자르면 정산 후 latest가 전진해 옛 주기가 영구 탈락 — 히스토리 구멍 방지)
+    expect(result.snapshots.map((s) => s.year_month)).toEqual(['2025-10', '2025-11', '2025-12']);
     expect(saveSnapshotIfAbsent).toHaveBeenCalledTimes(3);
   });
 
@@ -380,10 +381,11 @@ describe('listUnsettledMonths', () => {
     expect(months).toEqual(['2026-01', '2026-02', '2026-03']);
   });
 
-  it('cap 초과 → 최근 3개월만', async () => {
+  it('cap 초과 → 오래된 순 3개월만 (자기치유: 정산되면 latest 전진 → 다음 실행이 이어받음)', async () => {
+    // latest=2025-06, lastEnded=2026-03 → 9개월 밀림. 오래된 순으로 자른다.
     vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2025-06'));
     const months = await listUnsettledMonths(1, DEFAULT_NOW);
-    expect(months).toEqual(['2026-01', '2026-02', '2026-03']);
+    expect(months).toEqual(['2025-07', '2025-08', '2025-09']);
   });
 });
 

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -28,6 +28,7 @@ vi.mock('./repository/settings-repo', () => ({
   readTargetMonth: vi.fn(),
   upsertTargetDate: vi.fn(),
 }));
+vi.mock('./fixed-cost-ensure', () => ({ ensureFixedCostExpenses: vi.fn() }));
 
 import {
   getMonthlyAllocation,
@@ -35,8 +36,10 @@ import {
   getRunwayProjection,
   getBudgetPreview,
   runSettlementIfDue,
+  listUnsettledMonths,
 } from './facade';
 import { readLatestSnapshot, saveSnapshotIfAbsent } from './snapshot/monthly-snapshot-repo';
+import { ensureFixedCostExpenses } from './fixed-cost-ensure';
 import {
   readDistributableAssetBalance,
   applyAssetDeduction,
@@ -75,6 +78,26 @@ function setupCommonMocks() {
   vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: false });
   vi.mocked(applyAssetDeduction).mockResolvedValue([]);
   vi.mocked(applyAssetIncrease).mockResolvedValue([]);
+  vi.mocked(ensureFixedCostExpenses).mockResolvedValue(0);
+}
+
+// StoredSnapshot 최소 스텁 — readLatestSnapshot 반환값용 (year_month 만 실질적으로 참조됨)
+function storedSnapshot(yearMonth: string, availableAtEnd = 0) {
+  return {
+    id: 1,
+    user_id: 1,
+    year_month: yearMonth,
+    sealed_at: `${yearMonth}-16T00:00:00Z`,
+    allocated_budget: 0,
+    fixed_total: 0,
+    installment_total: 0,
+    planned_total: 0,
+    flexible_spent: 0,
+    excluded_spent: 0,
+    income_total: 0,
+    available_at_start: 0,
+    available_at_end: availableAtEnd,
+  };
 }
 
 describe('getMonthlyAllocation', () => {
@@ -151,19 +174,8 @@ describe('runSettlementIfDue', () => {
     setupCommonMocks();
   });
 
-  it('정산일(14일)이 아니면 settled=false', async () => {
-    const result = await runSettlementIfDue(1, DEFAULT_NOW); // April 10
-
-    expect(result.settled).toBe(false);
-    expect(saveSnapshotIfAbsent).not.toHaveBeenCalled();
-  });
-
-  it('정산일(14일)이고 스냅샷 신규 → settled=true + 스냅샷 반환', async () => {
-    // April 15 12:00 UTC = April 15 21:00 KST → yesterday=April 14 → shouldSettle=true, targetMonth='2026-04'
-    // range.to = '2026-04-14' (cycle 15→14 boundary)
-    // targetEnd = new Date('2026-04-14T12:00:00Z') = Apr 14 21:00 KST → billing cycle '2026-04' ✓
-    const settlementNow = new Date('2026-04-15T12:00:00Z');
-
+  // 스냅샷 없음(초회) 기준 — DEFAULT_NOW(4/10, 진행중 주기 2026-04)의 직전 종료 주기는 2026-03.
+  it('스냅샷 신규 → settled=true + snapshots 배열에 대상 월 반환', async () => {
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
     vi.mocked(readFlexibleSpent).mockResolvedValue(300_000);
@@ -171,16 +183,14 @@ describe('runSettlementIfDue', () => {
     vi.mocked(readIncomeTotal).mockResolvedValue(2_000_000);
     vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
 
-    const result = await runSettlementIfDue(1, settlementNow);
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
 
     expect(result.settled).toBe(true);
-    expect(result.snapshot).toBeDefined();
-    expect(result.snapshot?.year_month).toBe('2026-04');
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.snapshots[0]?.year_month).toBe('2026-03');
   });
 
   it('available_at_end = availableAtStart + income - totalSpent (전체 결제분, 자산 미참조)', async () => {
-    const settlementNow = new Date('2026-04-15T12:00:00Z');
-
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
     vi.mocked(readFlexibleSpent).mockResolvedValue(300_000);
@@ -189,17 +199,15 @@ describe('runSettlementIfDue', () => {
     vi.mocked(readTotalCycleSpent).mockResolvedValue(350_000);
     vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
 
-    const result = await runSettlementIfDue(1, settlementNow);
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
 
     // availableAtStart = 5_000_000 (자산 fallback)
     // availableAtEnd = 5_000_000 + 200_000 - 350_000(totalSpent) = 4_850_000
-    expect(result.snapshot?.available_at_end).toBe(4_850_000);
-    expect(result.snapshot?.available_at_start).toBe(5_000_000);
+    expect(result.snapshots[0]?.available_at_end).toBe(4_850_000);
+    expect(result.snapshots[0]?.available_at_start).toBe(5_000_000);
   });
 
   it('snapshot 신규 저장 시 자산 차감 = 전체 결제분(totalSpent), 증액 = income (분리)', async () => {
-    const settlementNow = new Date('2026-04-15T12:00:00Z');
-
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
     vi.mocked(readFlexibleSpent).mockResolvedValue(300_000);
@@ -208,15 +216,13 @@ describe('runSettlementIfDue', () => {
     vi.mocked(readTotalCycleSpent).mockResolvedValue(350_000);
     vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
 
-    await runSettlementIfDue(1, settlementNow);
+    await runSettlementIfDue(1, DEFAULT_NOW);
 
     expect(applyAssetDeduction).toHaveBeenCalledWith(1, 350_000); // totalSpent
     expect(applyAssetIncrease).toHaveBeenCalledWith(1, 200_000); // income
   });
 
   it('정산 차감액은 flex+excluded가 아니라 전체 결제분(totalSpent) — 할부 회차 결제 포함', async () => {
-    const settlementNow = new Date('2026-04-15T12:00:00Z');
-
     vi.mocked(readLatestSnapshot).mockResolvedValue(null);
     vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
     vi.mocked(readFlexibleSpent).mockResolvedValue(300_000);
@@ -226,33 +232,158 @@ describe('runSettlementIfDue', () => {
     vi.mocked(readTotalCycleSpent).mockResolvedValue(500_000);
     vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
 
-    const result = await runSettlementIfDue(1, settlementNow);
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
 
     // 차감은 totalSpent 기준 (등록시점 차감 폐지 → 결제 시 한 번만 빠짐)
     expect(applyAssetDeduction).toHaveBeenCalledWith(1, 500_000);
     // 장부도 totalSpent 기준: 5_000_000 + 0 - 500_000 = 4_500_000
-    expect(result.snapshot?.available_at_end).toBe(4_500_000);
+    expect(result.snapshots[0]?.available_at_end).toBe(4_500_000);
     // snapshot 분해 필드는 여전히 flex/excluded 분리 기록
-    expect(result.snapshot?.flexible_spent).toBe(300_000);
-    expect(result.snapshot?.excluded_spent).toBe(50_000);
+    expect(result.snapshots[0]?.flexible_spent).toBe(300_000);
+    expect(result.snapshots[0]?.excluded_spent).toBe(50_000);
   });
 
-  it('snapshot 재실행(saved=false) 시 자산 변동 호출 없음 — idempotency', async () => {
-    const settlementNow = new Date('2026-04-15T12:00:00Z');
+  // ─── #551 catch-up 시나리오 ────────────────────────────
 
-    vi.mocked(readLatestSnapshot).mockResolvedValue(null);
-    vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
-    vi.mocked(readFlexibleSpent).mockResolvedValue(300_000);
-    vi.mocked(readExcludedSpent).mockResolvedValue(50_000);
-    vi.mocked(readIncomeTotal).mockResolvedValue(200_000);
-    // 이미 같은 yearMonth 저장됨 — UNIQUE 제약으로 saved=false
-    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: false });
+  it('(a) 정상 실행 — 최신 스냅샷이 직전 종료 주기면 무동작(settled=false)', async () => {
+    // DEFAULT_NOW(4/10) 진행중=2026-04, 직전 종료=2026-03. 이미 2026-03 스냅샷 존재 → 정산 대상 없음.
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2026-03'));
 
-    const result = await runSettlementIfDue(1, settlementNow);
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
 
     expect(result.settled).toBe(false);
+    expect(result.snapshots).toHaveLength(0);
+    expect(saveSnapshotIfAbsent).not.toHaveBeenCalled();
+    expect(ensureFixedCostExpenses).not.toHaveBeenCalled();
+  });
+
+  it('(b) 크론 미스 후 늦게 실행 → 밀린 주기 자동 보정', async () => {
+    // 진행중=2026-04, 직전 종료=2026-03. 최신 스냅샷은 2026-02(2026-03 정산이 누락됨).
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2026-02'));
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
+
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
+
+    expect(result.settled).toBe(true);
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.snapshots[0]?.year_month).toBe('2026-03');
+    // 정산 직전 고정비 보장 호출
+    expect(ensureFixedCostExpenses).toHaveBeenCalledWith(1, '2026-03');
+  });
+
+  it('(c) 두 달 연속 미스 → 오래된 순으로 순차 2건 보정', async () => {
+    // 진행중=2026-04, 직전 종료=2026-03. 최신 스냅샷은 2026-01 → 2026-02, 2026-03 두 주기 밀림.
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2026-01'));
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
+
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
+
+    expect(result.snapshots.map((s) => s.year_month)).toEqual(['2026-02', '2026-03']);
+    expect(saveSnapshotIfAbsent).toHaveBeenCalledTimes(2);
+    // 각 월마다 고정비 보장 호출
+    expect(ensureFixedCostExpenses).toHaveBeenCalledWith(1, '2026-02');
+    expect(ensureFixedCostExpenses).toHaveBeenCalledWith(1, '2026-03');
+    // 오래된 순 보장 — 첫 저장이 2026-02
+    expect(vi.mocked(saveSnapshotIfAbsent).mock.calls[0]?.[1]?.year_month).toBe('2026-02');
+  });
+
+  it('(c-cap) 장기 미스라도 최대 3개월까지만 소급 (최근 3개, 오래된 순)', async () => {
+    // 진행중=2026-04, 직전 종료=2026-03. 최신 스냅샷 2025-09 → 6개월 밀렸지만 cap=3.
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2025-09'));
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
+
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
+
+    // 최근 3개월 = 2026-01, 2026-02, 2026-03
+    expect(result.snapshots.map((s) => s.year_month)).toEqual(['2026-01', '2026-02', '2026-03']);
+    expect(saveSnapshotIfAbsent).toHaveBeenCalledTimes(3);
+  });
+
+  it('(d) 재실행 멱등 — 이미 저장된 주기는 saved=false → 자산 이중 변동 없음', async () => {
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2026-02'));
+    vi.mocked(readIncomeTotal).mockResolvedValue(200_000);
+    vi.mocked(readTotalCycleSpent).mockResolvedValue(350_000);
+    // UNIQUE(user, year_month) 충돌 → saved=false
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: false });
+
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
+
+    expect(result.settled).toBe(false);
+    expect(result.snapshots).toHaveLength(0);
     expect(applyAssetDeduction).not.toHaveBeenCalled();
     expect(applyAssetIncrease).not.toHaveBeenCalled();
+  });
+
+  it('(e) 스냅샷 전무 → 직전 1개만 정산 (초회 대량 소급 방지)', async () => {
+    // 최신 스냅샷 없음. 직전 종료 주기(2026-03) 1개만.
+    vi.mocked(readLatestSnapshot).mockResolvedValue(null);
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
+
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
+
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.snapshots[0]?.year_month).toBe('2026-03');
+    expect(saveSnapshotIfAbsent).toHaveBeenCalledTimes(1);
+  });
+
+  it('(f) 고정비 미생성 상태 → 정산 전 ensure 호출로 totalSpent 반영', async () => {
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2026-02'));
+    vi.mocked(readDistributableAssetBalance).mockResolvedValue(5_000_000);
+    vi.mocked(saveSnapshotIfAbsent).mockResolvedValue({ saved: true });
+
+    // ensure 가 고정비 행을 생성한 뒤라야 readTotalCycleSpent 가 그 금액을 포함한다.
+    // ensure 호출 후 totalSpent 가 커지는 순서를 모의: ensure 를 총지출 조회의 선행 조건으로 검증.
+    let ensured = false;
+    vi.mocked(ensureFixedCostExpenses).mockImplementation(async () => {
+      ensured = true;
+      return 1;
+    });
+    vi.mocked(readTotalCycleSpent).mockImplementation(async () => (ensured ? 400_000 : 0));
+
+    const result = await runSettlementIfDue(1, DEFAULT_NOW);
+
+    expect(ensureFixedCostExpenses).toHaveBeenCalledWith(1, '2026-03');
+    // ensure 후 조회되어 고정비 포함 총지출(400_000)이 차감에 반영
+    expect(applyAssetDeduction).toHaveBeenCalledWith(1, 400_000);
+    expect(result.snapshots[0]?.year_month).toBe('2026-03');
+  });
+});
+
+describe('listUnsettledMonths', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    setupCommonMocks();
+  });
+
+  it('스냅샷 전무 → 직전 종료 주기 1개', async () => {
+    vi.mocked(readLatestSnapshot).mockResolvedValue(null);
+    const months = await listUnsettledMonths(1, DEFAULT_NOW); // 진행중 2026-04
+    expect(months).toEqual(['2026-03']);
+  });
+
+  it('최신이 직전 종료 주기 → 빈 배열 (정산 대상 없음)', async () => {
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2026-03'));
+    const months = await listUnsettledMonths(1, DEFAULT_NOW);
+    expect(months).toEqual([]);
+  });
+
+  it('최신이 직전 종료 주기보다 미래(방어) → 빈 배열', async () => {
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2026-05'));
+    const months = await listUnsettledMonths(1, DEFAULT_NOW);
+    expect(months).toEqual([]);
+  });
+
+  it('여러 주기 밀림 → (latest, lastEnded] 오래된 순', async () => {
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2025-12'));
+    const months = await listUnsettledMonths(1, DEFAULT_NOW);
+    // 2026-01, 2026-02, 2026-03 (cap 3 이내)
+    expect(months).toEqual(['2026-01', '2026-02', '2026-03']);
+  });
+
+  it('cap 초과 → 최근 3개월만', async () => {
+    vi.mocked(readLatestSnapshot).mockResolvedValue(storedSnapshot('2025-06'));
+    const months = await listUnsettledMonths(1, DEFAULT_NOW);
+    expect(months).toEqual(['2026-01', '2026-02', '2026-03']);
   });
 });
 

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -1,9 +1,16 @@
-import { getBillingCycle, getBillingRange, calcCycleDays, addBillingMonths } from './billing/cycle';
+import {
+  getBillingCycle,
+  getBillingRange,
+  getCurrentBillingMonth,
+  calcCycleDays,
+  addBillingMonths,
+} from './billing/cycle';
 import { calcAllocatedDays } from './allocator/proration';
 import { allocateMonthlyBudgets } from './allocator/month-allocator';
 import { allocateTodayBudget } from './allocator/day-allocator';
 import { projectRunway, projectFromAllocator } from './allocator/runway-projection';
-import { detectSettlementTrigger, buildSettlementSnapshot } from './settlement/settle';
+import { buildSettlementSnapshot } from './settlement/settle';
+import { ensureFixedCostExpenses } from './fixed-cost-ensure';
 
 import {
   readDistributableAssetBalance,
@@ -243,16 +250,49 @@ export async function getBudgetPreview(
   };
 }
 
-/** 월 경계 정산 (Phase 4 cron 진입점) */
-export async function runSettlementIfDue(
-  userId: number,
-  now: Date,
-): Promise<{ settled: boolean; snapshot?: SettlementSnapshot }> {
-  const trigger = detectSettlementTrigger(now);
-  if (!trigger.shouldSettle || !trigger.targetMonth) {
-    return { settled: false };
+/** catch-up 정산 상한 — 크론 장기 미실행 시에도 한 번에 최대 이 개수까지만 소급 (폭주 방지) */
+const MAX_CATCHUP_MONTHS = 3;
+
+/**
+ * 정산이 필요한(=아직 스냅샷이 없는) 종료된 결제주기 목록을 오래된 순으로 반환.
+ *
+ * - `current`(진행 중 주기)는 아직 안 끝났으므로 제외.
+ * - 최신 스냅샷이 있으면 그 다음 달부터 `current` 직전까지를 후보로 삼되, 최근 최대 3개월만 (cap).
+ * - 스냅샷이 하나도 없으면 직전 종료 주기 1개만 (초회 대량 소급 방지 — 기존 동작 보존).
+ */
+export async function listUnsettledMonths(userId: number, now: Date): Promise<string[]> {
+  const current = getCurrentBillingMonth(now);
+  const lastEnded = addBillingMonths(current, -1); // current 직전 = 마지막으로 끝난 주기
+
+  const latest = (await readLatestSnapshot(userId))?.year_month;
+
+  // 스냅샷 전무 → 직전 1개만
+  if (!latest) return [lastEnded];
+
+  // 이미 최신까지(또는 그 이상) 정산됨 → 없음
+  if (latest >= lastEnded) return [];
+
+  // (latest, lastEnded] 구간을 오래된 순으로 수집
+  const months: string[] = [];
+  let cursor = addBillingMonths(latest, 1);
+  while (cursor <= lastEnded) {
+    months.push(cursor);
+    cursor = addBillingMonths(cursor, 1);
   }
-  const targetMonth = trigger.targetMonth;
+
+  // cap: 가장 최근 MAX_CATCHUP_MONTHS 개만 (오래된 순 유지)
+  return months.slice(-MAX_CATCHUP_MONTHS);
+}
+
+/** 단일 결제주기 정산 — 고정비 보장 후 스냅샷 저장 + (신규 시) 자산 변동 */
+async function settleMonth(
+  userId: number,
+  targetMonth: string,
+): Promise<SettlementSnapshot | null> {
+  // 정산 직전 고정비 자동 기록 보장 — 대시보드 조회 부수효과에 의존하지 않고 여기서 확정.
+  // (과거 월도 ensureFixedCostExpenses 의 expenseDate<=today 필터로 전부 생성됨)
+  await ensureFixedCostExpenses(userId, targetMonth);
+
   const range = getBillingRange(targetMonth);
 
   const [flex, excluded, income, totalSpent] = await Promise.all([
@@ -267,7 +307,8 @@ export async function runSettlementIfDue(
   const alloc = await getMonthlyAllocation(userId, targetEnd);
   const monthlyBudget = alloc.monthlyBudgets.find((m) => m.yearMonth === targetMonth);
   if (!monthlyBudget) {
-    return { settled: false };
+    console.warn(`[settlement] user ${userId} ${targetMonth}: allocator에 대상 월 없음 → skip`);
+    return null;
   }
 
   const prevSnapshot = await readLatestSnapshot(userId);
@@ -296,5 +337,37 @@ export async function runSettlementIfDue(
     await applyAssetIncrease(userId, income);
   }
 
-  return { settled: result.saved, snapshot };
+  // 금액 로그 금지 — 월·신규저장 여부(불리언)만 기록.
+  console.info(`[settlement] user ${userId} ${targetMonth}: saved=${result.saved}`);
+
+  return result.saved ? snapshot : null;
+}
+
+/**
+ * 월 경계 정산 (Phase 4 cron 진입점).
+ *
+ * 매일 실행되며, 아직 정산 안 된 종료 주기가 있으면 오래된 순으로 순차 정산한다(catch-up).
+ * 크론이 특정 날짜에 실패해도 다음 실행에서 자동 보정되며, `saveSnapshotIfAbsent` 멱등성으로
+ * 재실행 시 자산 이중 변동은 발생하지 않는다.
+ */
+export async function runSettlementIfDue(
+  userId: number,
+  now: Date,
+): Promise<{ settled: boolean; snapshots: SettlementSnapshot[] }> {
+  const targetMonths = await listUnsettledMonths(userId, now);
+  if (targetMonths.length === 0) {
+    return { settled: false, snapshots: [] };
+  }
+
+  const catchUp = targetMonths.length > 1;
+  console.info(`[settlement] user ${userId}: 대상 ${targetMonths.length}개월 catch-up=${catchUp}`);
+
+  const snapshots: SettlementSnapshot[] = [];
+  // 오래된 순 순차 처리 — available_at_start 체인이 직전 스냅샷의 available_at_end 를 참조하므로 순서 중요.
+  for (const targetMonth of targetMonths) {
+    const snapshot = await settleMonth(userId, targetMonth);
+    if (snapshot) snapshots.push(snapshot);
+  }
+
+  return { settled: snapshots.length > 0, snapshots };
 }

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -257,7 +257,7 @@ const MAX_CATCHUP_MONTHS = 3;
  * 정산이 필요한(=아직 스냅샷이 없는) 종료된 결제주기 목록을 오래된 순으로 반환.
  *
  * - `current`(진행 중 주기)는 아직 안 끝났으므로 제외.
- * - 최신 스냅샷이 있으면 그 다음 달부터 `current` 직전까지를 후보로 삼되, 최근 최대 3개월만 (cap).
+ * - 최신 스냅샷이 있으면 그 다음 달부터 `current` 직전까지를 후보로 삼되, 오래된 순 최대 3개월만 (cap).
  * - 스냅샷이 하나도 없으면 직전 종료 주기 1개만 (초회 대량 소급 방지 — 기존 동작 보존).
  */
 export async function listUnsettledMonths(userId: number, now: Date): Promise<string[]> {
@@ -280,8 +280,9 @@ export async function listUnsettledMonths(userId: number, now: Date): Promise<st
     cursor = addBillingMonths(cursor, 1);
   }
 
-  // cap: 가장 최근 MAX_CATCHUP_MONTHS 개만 (오래된 순 유지)
-  return months.slice(-MAX_CATCHUP_MONTHS);
+  // cap: 오래된 순 최대 MAX_CATCHUP_MONTHS 개 — 매일 실행되는 크론이 순서대로 따라잡는 자기치유 cap.
+  // (최신 우선으로 자르면 정산 후 latest가 잘린 옛 주기를 건너뛰어 영구 탈락 — 히스토리에 구멍)
+  return months.slice(0, MAX_CATCHUP_MONTHS);
 }
 
 /** 단일 결제주기 정산 — 고정비 보장 후 스냅샷 저장 + (신규 시) 자산 변동 */

--- a/web/src/features/budget/lib/fixed-cost-ensure.ts
+++ b/web/src/features/budget/lib/fixed-cost-ensure.ts
@@ -1,0 +1,70 @@
+import { query } from '@/lib/db';
+import { getTodayISO } from '@/lib/kst';
+import { resolveFixedCostExpenseDate } from './billing/fixed-cost-date';
+import { getBillingMonthForExpense } from './billing/card-billing';
+import type { FixedCostRow } from './types';
+
+// 고정비 조회 + 자동 기록.
+// facade(정산)와 queries(대시보드 조회) 양쪽에서 쓰이며, queries 가 facade 를 import 하므로
+// 이 로직을 queries 에 두면 facade → queries → facade 순환이 생긴다. 별도 모듈로 분리해 순환을 끊는다.
+// (이 파일은 facade / queries 를 import 하지 않는다.)
+
+/** 고정비 목록 (active 먼저) */
+export async function queryFixedCosts(userId: number): Promise<FixedCostRow[]> {
+  const { rows } = await query<FixedCostRow>(
+    `SELECT id, name, amount, category, is_variable, day_of_month, active, memo
+     FROM fixed_costs WHERE user_id = $1 ORDER BY active DESC, category, name`,
+    [userId],
+  );
+  return rows;
+}
+
+/**
+ * 고정비 자동 기록: 결제일(day_of_month)이 설정된 활성 고정비에 대해
+ * 해당 결제주기 내에 지출 기록이 없으면 자동 생성.
+ */
+export async function ensureFixedCostExpenses(userId: number, yearMonth: string): Promise<number> {
+  const fixedCosts = await queryFixedCosts(userId);
+  const activeCostsWithDay = fixedCosts.filter((fc) => fc.active && fc.day_of_month);
+
+  if (activeCostsWithDay.length === 0) return 0;
+
+  const todayStr = getTodayISO();
+
+  const candidates = activeCostsWithDay
+    .map((fc) => {
+      const expenseDate = resolveFixedCostExpenseDate(yearMonth, fc.day_of_month!);
+      return { fc, expenseDate };
+    })
+    .filter((c) => c.expenseDate <= todayStr)
+    .map((c) => ({
+      ...c,
+      billingMonth: getBillingMonthForExpense(c.expenseDate, '현대카드'),
+    }));
+
+  if (candidates.length === 0) return 0;
+
+  const result = await query(
+    `INSERT INTO expenses
+       (user_id, date, amount, category, description, payment_method, source, memo, type, exclude_from_budget, billing_month)
+     SELECT $1, d.date, d.amount, d.category, d.description, '현대카드', 'fixed', d.memo, 'expense', true, d.billing_month
+     FROM UNNEST(
+       $2::date[], $3::numeric[], $4::text[], $5::text[], $6::text[], $7::text[]
+     ) AS d(date, amount, category, description, memo, billing_month)
+     WHERE NOT EXISTS (
+       SELECT 1 FROM expenses e
+       WHERE e.user_id = $1 AND e.source = 'fixed' AND e.date = d.date AND e.description = d.description
+     )`,
+    [
+      userId,
+      candidates.map((c) => c.expenseDate),
+      candidates.map((c) => c.fc.amount),
+      candidates.map((c) => c.fc.category ?? '기타'),
+      candidates.map((c) => c.fc.name),
+      candidates.map((c) => `고정비 자동 기록 (fixed_cost_id: ${c.fc.id})`),
+      candidates.map((c) => c.billingMonth),
+    ],
+  );
+
+  return result.rowCount ?? 0;
+}

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -2,9 +2,9 @@ import { query, queryOne } from '@/lib/db';
 import { getTodayISO } from '@/lib/kst';
 import { getTodayAllocation } from './facade';
 import { getCurrentBillingMonth, getBillingRange, calcCycleDays } from './billing/cycle';
-import { resolveFixedCostExpenseDate } from './billing/fixed-cost-date';
 import { getBillingMonthForExpense } from './billing/card-billing';
 import { readFlexibleSpent, readTodayFlexSpent } from './repository/expenses-repo';
+import { queryFixedCosts, ensureFixedCostExpenses } from './fixed-cost-ensure';
 import type {
   ExpenseRow,
   FixedCostRow,
@@ -14,6 +14,10 @@ import type {
   PlannedExpenseRow,
   DailyBudgetLog,
 } from './types';
+
+// 고정비 조회·자동기록은 순환 import(queries → facade → queries) 방지를 위해 별도 모듈로 이동.
+// 기존 import 경로 호환을 위해 여기서 재수출한다.
+export { queryFixedCosts, ensureFixedCostExpenses };
 
 // ─── 지출 CRUD ───────────────────────────────────────
 
@@ -362,16 +366,6 @@ export async function queryMonthSummary(userId: number, yearMonth: string): Prom
 
 // ─── 고정비 ───────────────────────────────────────────
 
-/** 고정비 목록 (active 먼저) */
-export async function queryFixedCosts(userId: number): Promise<FixedCostRow[]> {
-  const { rows } = await query<FixedCostRow>(
-    `SELECT id, name, amount, category, is_variable, day_of_month, active, memo
-     FROM fixed_costs WHERE user_id = $1 ORDER BY active DESC, category, name`,
-    [userId],
-  );
-  return rows;
-}
-
 /** 고정비 수정 */
 const FIXED_COST_COLUMNS = new Set([
   'name',
@@ -423,56 +417,6 @@ export async function deleteFixedCost(userId: number, id: number): Promise<boole
     userId,
   ]);
   return (result.rowCount ?? 0) > 0;
-}
-
-/**
- * 고정비 자동 기록: 결제일(day_of_month)이 설정된 활성 고정비에 대해
- * 해당 결제주기 내에 지출 기록이 없으면 자동 생성.
- */
-export async function ensureFixedCostExpenses(userId: number, yearMonth: string): Promise<number> {
-  const fixedCosts = await queryFixedCosts(userId);
-  const activeCostsWithDay = fixedCosts.filter((fc) => fc.active && fc.day_of_month);
-
-  if (activeCostsWithDay.length === 0) return 0;
-
-  const todayStr = getTodayISO();
-
-  const candidates = activeCostsWithDay
-    .map((fc) => {
-      const expenseDate = resolveFixedCostExpenseDate(yearMonth, fc.day_of_month!);
-      return { fc, expenseDate };
-    })
-    .filter((c) => c.expenseDate <= todayStr)
-    .map((c) => ({
-      ...c,
-      billingMonth: getBillingMonthForExpense(c.expenseDate, '현대카드'),
-    }));
-
-  if (candidates.length === 0) return 0;
-
-  const result = await query(
-    `INSERT INTO expenses
-       (user_id, date, amount, category, description, payment_method, source, memo, type, exclude_from_budget, billing_month)
-     SELECT $1, d.date, d.amount, d.category, d.description, '현대카드', 'fixed', d.memo, 'expense', true, d.billing_month
-     FROM UNNEST(
-       $2::date[], $3::numeric[], $4::text[], $5::text[], $6::text[], $7::text[]
-     ) AS d(date, amount, category, description, memo, billing_month)
-     WHERE NOT EXISTS (
-       SELECT 1 FROM expenses e
-       WHERE e.user_id = $1 AND e.source = 'fixed' AND e.date = d.date AND e.description = d.description
-     )`,
-    [
-      userId,
-      candidates.map((c) => c.expenseDate),
-      candidates.map((c) => c.fc.amount),
-      candidates.map((c) => c.fc.category ?? '기타'),
-      candidates.map((c) => c.fc.name),
-      candidates.map((c) => `고정비 자동 기록 (fixed_cost_id: ${c.fc.id})`),
-      candidates.map((c) => c.billingMonth),
-    ],
-  );
-
-  return result.rowCount ?? 0;
 }
 
 // ─── 자산 ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #551

## 배경

결제주기 정산이 특정 하루에만 트리거되어, 그날 스케줄러가 실패하면 해당 주기 정산이 영구 누락되는 구조였다. 또 고정비 자동 기록이 대시보드 조회 부수효과에만 의존해, 정산 시점에 미생성분이 남으면 집계가 과소 계상될 수 있었다. 정산 신뢰성을 높이는 선제 개선.

## 변경 내용

- **catch-up 정산**: 트리거를 "정산 대상(미정산 종료 주기) 존재 여부" 기준으로 재설계. 매일 실행 시 밀린 주기를 오래된 순으로 순차 보정하며, 한 번에 최대 3주기까지만 소급(폭주 방지).
- **초회 안전장치**: 스냅샷이 하나도 없을 때는 직전 종료 주기 1개만 정산해 초회 대량 소급을 막고 기존 동작을 보존.
- **고정비 기록 보장**: 각 주기 정산 직전에 고정비 자동 기록 보장 호출을 추가 — 조회 타이밍에 좌우되지 않고 정산 경로에서 확정.
- **모듈 분리**: 고정비 조회·자동기록 로직을 별도 모듈(`fixed-cost-ensure.ts`)로 추출해 순환 import를 차단. 기존 import 경로는 재수출로 호환 유지.
- **멱등성**: 신규 스냅샷 저장 시에만 자산이 변동되도록 하는 기존 가드를 유지해 재실행 시 이중 반영을 방지. 로깅은 월·불리언만(수치 미포함).
- **반환 확장**: 정산 결과를 복수 스냅샷 대응 형태로 확장하고 크론 응답에 반영.

## 테스트

- 신규 시나리오 6종: 정상 무동작 / 미스 후 보정 / 두 주기 순차 보정 / 소급 상한 / 재실행 멱등 / 초회 단건 / 고정비 보장.
- 트리거 목록 유틸 단위 테스트 5종 추가.
- `web/`: `yarn tsc --noEmit` 통과, vitest 285 전부 통과.
- 루트: vitest 910 전부 통과.
- 인증(Bearer) 로직 불변 — 응답 형태만 변경.