### PR TITLE
fix(insight): 교란 탐지에 데이터-존재 윈도우 적용 (#556)

### DIFF
--- a/db/migrations/097_deactivate_retired_slot.sql
+++ b/db/migrations/097_deactivate_retired_slot.sql
@@ -1,0 +1,16 @@
+-- 097: 은퇴 크론 슬롯 행 비활성 (#556)
+-- pillarLevelDistributionReview는 #508(ADR-0046)에서 은퇴 — 누적 시드 강도 밴드 위임으로 분포 리뷰
+-- 무의미해져 핸들러(SLOT_TASKS)에서 제거됨. loadAndSchedule는 미등록 슬롯을 graceful skip(taskFn 없으면
+-- continue)하므로 DB row가 active로 남아도 무해하나, 설정 잔재라 비활성으로 정리(가역 — 단일 행 UPDATE).
+
+UPDATE notification_settings SET active = false
+ WHERE slot_name = 'pillarLevelDistributionReview';
+
+DO $$
+DECLARE
+  got INT;
+BEGIN
+  SELECT count(*) INTO got FROM notification_settings
+   WHERE slot_name = 'pillarLevelDistributionReview' AND active = false;
+  RAISE NOTICE '[097] pillarLevelDistributionReview 비활성 % 행', got;
+END $$;

--- a/src/shared/__tests__/confound.test.ts
+++ b/src/shared/__tests__/confound.test.ts
@@ -45,6 +45,13 @@ describe('computeOverlap', () => {
   it('S 발현 0이면 {0, 0}', () => {
     expect(computeOverlap(act([]), act(['d0', 'd1']))).toEqual({ overlap: 0, nCofire: 0 });
   });
+
+  it('windowStart 이전 날은 분자·분모 양쪽에서 제외 (#556 데이터-존재 클립)', () => {
+    // S={d0..d3}, Z={d0,d1,d8}. windowStart='d1' → d0 제외 → S발현 {d1,d2,d3}=3, cofire {d1}=1.
+    const r = computeOverlap(act(['d0', 'd1', 'd2', 'd3']), act(['d0', 'd1', 'd8']), 'd1');
+    expect(r.nCofire).toBe(1); // {d1} (d0 클립)
+    expect(r.overlap).toBeCloseTo(1 / 3); // 1/3 (분모도 d0 제외)
+  });
 });
 
 // ─── flagConfoundersForLink ──────────────────────────────
@@ -127,6 +134,46 @@ describe('flagConfoundersForLink', () => {
   });
 });
 
+// ─── #556 데이터-존재 윈도우 클립 (검증 엔진 #504 ADR-0044와 동일) ────
+
+describe('flagConfoundersForLink 데이터-존재 클립', () => {
+  // 데이터 시작 이전(d0..d3)은 '빈 과거' — S·Z 비활성, X 비pass(fail)로만 채워져 Z↔X 2×2의
+  // 비발현·실패(d 셀)를 부풀린다 → rateOff 하락 → effectZX 인플레(가짜 교란 flag).
+  // 클립 후엔 데이터 구간(d4..d9)만으로 effectZX가 정직하게 낮아진다.
+  const S = act(['d4', 'd5', 'd6']); // S 발현 = 데이터 구간에만
+  const Z: ConfoundCandidate = { seedId: 9, seedName: 'Z', act: act(['d4', 'd5', 'd6', 'd7']) };
+  // X: Z 발현일 d4·d5·d6 pass, off일 중 d8만 pass(rateOff 유한하게). d0..d3(빈 과거)는 fail.
+  const X = sig(['d4', 'd5', 'd6', 'd8']);
+  // minEffectZX를 두 값 사이(2.0)로 → 클립 유무가 flag 판정을 뒤집는다.
+  const Tclip: ConfoundThresholds = {
+    minOverlap: 0.6,
+    minCofireDays: 3,
+    minEffectZX: 2.0,
+    topN: 3,
+  };
+
+  it('클립 없으면 빈 과거가 effectZX를 부풀려 flag(비교 기준)', () => {
+    // no clip: Z발현 a=3,b=1(d7 fail); Z off c=1(d8),d=5(d0..d3+d9) → rateOff=1/6 → effect≈4.5 ≥ 2.0.
+    const r = flagConfoundersForLink(1, S, X, [Z], 'today', Tclip);
+    expect(r.suspected).toHaveLength(1);
+    expect(r.suspected[0]?.effectZX).toBeCloseTo(4.5);
+  });
+
+  it('데이터 시작(d4) 클립 시 effectZX 정직화 → 미flag', () => {
+    // seedStartById로 Z의 데이터 시작 'd4' 주입: d0..d3 제외 → Z off {d8,d9} c=1,d=1 → rateOff=0.5 →
+    // effect=1.5 < 2.0 → 컷. overlap(=1.0)·nCofire(=3)는 양쪽 동일 → effectZX만 판정 뒤집음.
+    const seedStartById = new Map<number, string | null>([[9, 'd4']]);
+    const r = flagConfoundersForLink(1, S, X, [Z], 'today', Tclip, null, seedStartById);
+    expect(r.suspected).toHaveLength(0);
+  });
+
+  it('baseStart(신호·시드 데이터 시작 합성)로도 동일 클립', () => {
+    // baseStart='d4' 경로(신호 X 또는 시드 S 데이터 시작이 d4인 케이스) — seedStartById 없이도 컷.
+    const r = flagConfoundersForLink(1, S, X, [Z], 'today', Tclip, 'd4');
+    expect(r.suspected).toHaveLength(0);
+  });
+});
+
 // ─── P7 다변량 분리 (Mantel-Haenszel 조정 — ADR-0042) ────
 
 // 큰 윈도우 합성 빌더 — 게이트(nCofire≥30)·층 viability를 충족하도록 셀을 정확히 깐다.
@@ -205,6 +252,26 @@ describe('buildStrata', () => {
     expect(sum('c')).toBe(flat.c);
     expect(sum('d')).toBe(flat.d);
   });
+
+  it('windowStart 이전 날은 층 배정 전 제외 → 셀 합 = 클립된 2×2 (#556)', () => {
+    const b = buildN(8);
+    const aS = b.m([0, 3]);
+    const aZ = b.m([0, 1], [4, 5]);
+    const x = b.s([0, 2], [4, 6]);
+    // windowStart='d2' → d0,d1 제외. 층 합이 같은 windowStart로 클립한 flat 2×2와 일치해야 함.
+    const strata = buildStrata(aS, x, [cand(2, aZ)], 'd2');
+    const sum = (k: 'a' | 'b' | 'c' | 'd') => strata.reduce((acc, st) => acc + st[k], 0);
+    const flat = buildContingency(aS, x, 'd2');
+    expect(sum('a')).toBe(flat.a);
+    expect(sum('b')).toBe(flat.b);
+    expect(sum('c')).toBe(flat.c);
+    expect(sum('d')).toBe(flat.d);
+    // 클립 전(d0,d1 포함)과 셀 합이 실제로 다름을 확인(no-op 아님).
+    const flatNoClip = buildContingency(aS, x);
+    expect(flat.a + flat.b + flat.c + flat.d).toBeLessThan(
+      flatNoClip.a + flatNoClip.b + flatNoClip.c + flatNoClip.d,
+    );
+  });
 });
 
 describe('adjustConfounders', () => {
@@ -274,5 +341,43 @@ describe('adjustConfounders', () => {
     const adj = r?.adjusted ?? [];
     expect(adj).toHaveLength(1); // joint(2 교란) 포기 → 단일 Z
     expect(adj[0]?.seedId).toBe(1); // 가장 강한 Z1
+  });
+
+  it('baseStart 클립이 빈 과거를 marginal·층화에서 제거 (#556)', () => {
+    // explained_away 픽스처를 +20 시프트하고 d000..d019를 빈 과거(S·Z off, X fail)로 채운다.
+    // 프로덕션 날짜(ISO YYYY-MM-DD)는 zero-pad라 문자열 < 비교가 숫자 순서와 일치 → 라벨도 zero-pad(3자리).
+    // baseStart='d020'로 클립하면 시프트 안 한 원본과 동일한 explained_away RR≈1.0가 나와야 한다.
+    const N = 140;
+    const days = Array.from({ length: N }, (_, i) => `d${String(i).padStart(3, '0')}`);
+    const set = (...ranges: [number, number][]): Set<string> => {
+      const s = new Set<string>();
+      for (const [lo, hi] of ranges)
+        for (let i = lo; i <= hi; i++) s.add(`d${String(i).padStart(3, '0')}`);
+      return s;
+    };
+    const m = (...ranges: [number, number][]): Map<string, boolean> => {
+      const on = set(...ranges);
+      return new Map(days.map((d) => [d, on.has(d)]));
+    };
+    const s = (...ranges: [number, number][]): DaySeries => {
+      const on = set(...ranges);
+      return new Map(days.map((d) => [d, on.has(d)]));
+    };
+    const actZ = m([20, 79]); // 원본 [0,59] +20
+    const aS = m([20, 59], [80, 99]); // 원본 [0,39]∪[60,79] +20
+    const x = s([20, 55], [60, 77], [80, 81], [100, 103]); // 원본 [0,35]∪[40,57]∪[60,61]∪[80,83] +20
+    const candById = new Map([[2, cand(2, actZ)]]);
+    const seedStartById = new Map<number, string | null>([[2, 'd020']]);
+    const clipped = adjustConfounders(
+      { actS: aS, sigX: x, suspected: [susp(2, 40)], candById, baseStart: 'd020', seedStartById },
+      AT,
+    );
+    expect(clipped?.explainedAway).toBe(true);
+    expect(clipped?.adjusted[0]?.verdict).toBe('explained_away');
+    expect(clipped?.adjusted[0]?.adjEffect).toBeCloseTo(1.0);
+
+    // 클립 없이 돌리면 빈 과거(d000..d019)의 off·fail이 셀을 부풀려 RR이 1.0에서 벗어난다(no-op 아님 확인).
+    const noClip = adjustConfounders({ actS: aS, sigX: x, suspected: [susp(2, 40)], candById }, AT);
+    expect(noClip?.adjusted[0]?.adjEffect ?? NaN).not.toBeCloseTo(1.0);
   });
 });

--- a/src/shared/confound.ts
+++ b/src/shared/confound.ts
@@ -23,6 +23,10 @@ import {
   verifyContingency,
   computeSignalSeries,
   computeSeedActivationSeries,
+  computeUserDataStarts,
+  signalDataStart,
+  seedDataStart,
+  maxDate,
   type SignalDef,
   type SignalDirection,
   type DaySeries,
@@ -102,14 +106,18 @@ export interface ConfoundCandidate {
 /**
  * S 발현일 대비 Z 공동발현 비율 + 공동발현일 수.
  * overlap = |{d: actS[d] ∧ actZ[d]}| / |{d: actS[d]}|. S 발현 0이면 {0, 0}.
+ * windowStart(#556): 데이터-존재 구간 시작 이전 날은 빈 과거라 집계 제외
+ * (검증 엔진 buildContingency와 동일 클립 — S·Z 둘 다 데이터를 가진 구간만).
  */
 export const computeOverlap = (
   actS: Map<string, boolean>,
   actZ: Map<string, boolean>,
+  windowStart: string | null = null,
 ): { overlap: number; nCofire: number } => {
   let sActive = 0;
   let inter = 0;
   for (const [date, active] of actS) {
+    if (windowStart !== null && date < windowStart) continue; // 데이터-존재 윈도우 밖(빈 과거)
     if (!active) continue;
     sActive++;
     if (actZ.get(date)) inter++;
@@ -122,6 +130,10 @@ export const computeOverlap = (
  * 후보 Z(≠ S)가 둘 다 만족하면 의심: (a) overlap≥minOverlap ∧ nCofire≥minCofireDays(노이즈 바닥),
  * (b) Z↔X 연관 effectZX≥minEffectZX (기존 2×2 재사용). overlap 내림차순 정렬 후 topN cap.
  * (a)만으론 신호와 무관한 겹침 시드까지 다 잡혀 노이즈 폭발 → (b) 필수(ADR-0041 §2).
+ *
+ * 데이터-존재 윈도우(#556, 검증 엔진 #504 ADR-0044와 동일 클립): overlap·nCofire(Z×S)와 Z×X 2×2는
+ * Z가 끼는 계산이라 windowStart = max(baseStart, seedStart_Z)로 클립(각 후보의 시드 데이터 시작일을
+ * baseStart에 합성). baseStart = max(seedStart_S, signalStart_X). seedStartById에 시작일 없으면 클립 없음.
  */
 export const flagConfoundersForLink = (
   seedId: number,
@@ -130,13 +142,16 @@ export const flagConfoundersForLink = (
   candidates: ConfoundCandidate[],
   today: string,
   t: ConfoundThresholds,
+  baseStart: string | null = null,
+  seedStartById: Map<number, string | null> = new Map(),
 ): ConfoundData => {
   const suspected: SuspectedConfounder[] = [];
   for (const z of candidates) {
     if (z.seedId === seedId) continue; // 자기 제외
-    const { overlap, nCofire } = computeOverlap(actS, z.act);
+    const zStart = maxDate(baseStart, seedStartById.get(z.seedId) ?? null);
+    const { overlap, nCofire } = computeOverlap(actS, z.act, zStart);
     if (overlap < t.minOverlap || nCofire < t.minCofireDays) continue;
-    const v = verifyContingency(buildContingency(z.act, sigX));
+    const v = verifyContingency(buildContingency(z.act, sigX, zStart));
     if (!Number.isFinite(v.effect) || v.effect < t.minEffectZX) continue;
     suspected.push({
       seedId: z.seedId,
@@ -156,14 +171,17 @@ export const flagConfoundersForLink = (
  * 게이트 통과 교란들의 값 조합으로 윈도우 일자를 층으로 나눠 각 층의 (시드 S × 신호 X) 2×2 산출.
  * confounders k개 → 최대 2^k 층(발현 조합별, 빈 조합은 생성 안 됨). actS 부분집합에 buildContingency
  * 호출 = P6와 같은 프리미티브 재사용(새 통계 코어 0).
+ * windowStart(#556): 빈 과거 일자는 층 배정 전에 제외(검증 엔진 buildContingency와 동일 클립).
  */
 export const buildStrata = (
   actS: Map<string, boolean>,
   sigX: DaySeries,
   confounders: ConfoundCandidate[],
+  windowStart: string | null = null,
 ): Contingency[] => {
   const byKey = new Map<string, Map<string, boolean>>();
   for (const [date, active] of actS) {
+    if (windowStart !== null && date < windowStart) continue; // 데이터-존재 윈도우 밖(빈 과거)
     const key = confounders.map((z) => (z.act.get(date) ? '1' : '0')).join('');
     let sub = byKey.get(key);
     if (!sub) {
@@ -172,7 +190,7 @@ export const buildStrata = (
     }
     sub.set(date, active);
   }
-  return [...byKey.values()].map((sub) => buildContingency(sub, sigX));
+  return [...byKey.values()].map((sub) => buildContingency(sub, sigX, windowStart));
 };
 
 /** 층 viability — 각 층 n_k ≥ minCell AND S발현·S비발현 양쪽 존재(MH 풀링이 서는 데이터). */
@@ -211,11 +229,13 @@ const selectStrata = (
   sigX: DaySeries,
   pairs: { g: SuspectedConfounder; z: ConfoundCandidate }[],
   t: ConfoundAdjustThresholds,
+  windowStart: string | null = null,
 ): StrataSelection | undefined => {
   const jointStrata = buildStrata(
     actS,
     sigX,
     pairs.map((p) => p.z),
+    windowStart,
   );
   if (allStrataViable(jointStrata, t.minStratumCell)) {
     return { strata: jointStrata, controlled: pairs.map((p) => p.g) };
@@ -226,19 +246,25 @@ const selectStrata = (
   for (const p of pairs) {
     if (p.g.overlap * p.g.effectZX > best.g.overlap * best.g.effectZX) best = p;
   }
-  const singleStrata = buildStrata(actS, sigX, [best.z]);
+  const singleStrata = buildStrata(actS, sigX, [best.z], windowStart);
   if (allStrataViable(singleStrata, t.minStratumCell)) {
     return { strata: singleStrata, controlled: [best.g] };
   }
   return undefined;
 };
 
-/** P7 조정 패스 입력 — flagConfoundersForLink 결과 + 후보 활성 시리즈 색인(시리즈 in-hand 공유). */
+/**
+ * P7 조정 패스 입력 — flagConfoundersForLink 결과 + 후보 활성 시리즈 색인(시리즈 in-hand 공유).
+ * 데이터-존재 윈도우(#556): baseStart = max(seedStart_S, signalStart_X). seedStartById로 게이트 통과 Z의
+ * 시드 시작일을 층화 windowStart 합성에 사용(둘 다 없으면 클립 없음 = 기존 동작).
+ */
 export interface AdjustInput {
   actS: Map<string, boolean>;
   sigX: DaySeries;
   suspected: SuspectedConfounder[];
   candById: Map<number, ConfoundCandidate>;
+  baseStart?: string | null;
+  seedStartById?: Map<number, string | null>;
 }
 
 /**
@@ -261,10 +287,16 @@ export const adjustConfounders = (
     .filter((p): p is { g: SuspectedConfounder; z: ConfoundCandidate } => p.z !== undefined);
   if (pairs.length === 0) return undefined;
 
-  // marginal(조정 전) rate ratio — 같은 2×2 프리미티브.
-  const marginal = verifyContingency(buildContingency(input.actS, input.sigX)).effect;
+  // 데이터-존재 윈도우(#556): 층화·marginal은 Z가 끼므로 baseStart에 통제 Z의 시드 시작일도 max 합성.
+  const baseStart = input.baseStart ?? null;
+  const seedStartById = input.seedStartById ?? new Map<number, string | null>();
+  let windowStart = baseStart;
+  for (const p of pairs) windowStart = maxDate(windowStart, seedStartById.get(p.g.seedId) ?? null);
 
-  const sel = selectStrata(input.actS, input.sigX, pairs, t);
+  // marginal(조정 전) rate ratio — 같은 2×2 프리미티브(같은 windowStart로 클립).
+  const marginal = verifyContingency(buildContingency(input.actS, input.sigX, windowStart)).effect;
+
+  const sel = selectStrata(input.actS, input.sigX, pairs, t, windowStart);
   if (!sel) return undefined;
 
   const rr = mantelHaenszelRR(sel.strata);
@@ -342,8 +374,13 @@ export const flagConfounds = async (userId: number, today: string): Promise<Conf
     buildNameIdMap('branches_master'),
   ]);
 
+  // 데이터-존재 윈도우(#556, 검증 엔진 #504 ADR-0044와 동일 클립): 유저 라이프 테이블별 첫 기록일 1회 산출.
+  // 신호·시드별 데이터 시작일을 여기서 계산해 두면 링크마다 max로 합성 → 빈 과거를 비발현/fail로 세지 않음.
+  const dataStarts = await computeUserDataStarts(userId);
+
   // 후보 = 모든 active 시드. 활성 시리즈는 시드당 1회(strength_band 2-pass 캐시 공유).
   const seeds = await loadActiveSeeds(userId);
+  const seedStartById = new Map(seeds.map((s) => [s.id, seedDataStart(s, dataStarts)]));
   const ctxCache = new Map<string, DailyContext | null>();
   const strengthCache = new Map<string, Map<string, number>>();
   const cutCache = new Map<string, BandCuts>();
@@ -374,9 +411,9 @@ export const flagConfounds = async (userId: number, today: string): Promise<Conf
     }
   }
 
-  // 링크에 등장한 신호 시리즈(신호당 1회).
-  // TODO(#504 후속): 데이터-존재 윈도우(computeUserDataStarts) 미적용 — P7 교란 조정은 dormant
-  // (annotate-only, verdict 불변)라 라이브 영향 없음. 활성화 전 verifyUserLinks와 동일 클립 경유 필요.
+  // 링크에 등장한 신호 시리즈(신호당 1회). 검증 엔진과 동일하게 각 신호를 자기 도메인 데이터 시작일
+  // 기준으로 계산 → 빈 과거의 COALESCE 0이 "발현 안 함=fail"로 새거나 rolling baseline을 오염시키는
+  // 측정 아티팩트 차단(#556 — #504 ADR-0044 데이터-존재 클립을 교란 엔진 P6/P7에도 적용).
   const signalIds = [...new Set(linkRes.rows.map((r) => r.signal_id))];
   const signalRes = await query<SignalDefRow>(
     `SELECT id, name, kind, source, sql_body, value_type, direction, threshold, tag_name, window_days, domain
@@ -384,9 +421,13 @@ export const flagConfounds = async (userId: number, today: string): Promise<Conf
       WHERE user_id = $1 AND id = ANY($2::int[]) AND status = 'active'`,
     [userId, signalIds],
   );
+  const signalStartById = new Map<number, string | null>();
   const signalSeriesById = new Map<number, DaySeries>();
   for (const row of signalRes.rows) {
-    const r = await computeSignalSeries(userId, toSignalDef(row), windowDates);
+    const signal = toSignalDef(row);
+    const start = signalDataStart(signal.domain, dataStarts);
+    signalStartById.set(row.id, start);
+    const r = await computeSignalSeries(userId, signal, windowDates, start);
     signalSeriesById.set(row.id, r.series);
   }
 
@@ -395,9 +436,29 @@ export const flagConfounds = async (userId: number, today: string): Promise<Conf
     const actS = seedActById.get(row.seed_id);
     const sigX = signalSeriesById.get(row.signal_id);
     if (!actS || !sigX) continue;
+    // 데이터-존재 윈도우(#556): 링크(S×X) 기본 클립 = max(시드 S 데이터 시작, 신호 X 데이터 시작).
+    // Z가 끼는 계산(overlap·nCofire·Z×X·층화)은 flagConfoundersForLink/adjustConfounders 내부에서
+    // 각 후보 Z의 시드 시작일을 baseStart에 추가로 max 합성한다(enrollment 클립은 검증 확정 게이트
+    // 전용 — 교란 P6/P7은 annotate-only marginal이라 적용 안 함).
+    const baseStart = maxDate(
+      seedStartById.get(row.seed_id) ?? null,
+      signalStartById.get(row.signal_id) ?? null,
+    );
     // P6 플래그 → P7 조정(게이트 통과 시만). 시리즈 in-hand 공유(재계산 0).
-    const confound = flagConfoundersForLink(row.seed_id, actS, sigX, candidates, today, T);
-    const adj = adjustConfounders({ actS, sigX, suspected: confound.suspected, candById }, T);
+    const confound = flagConfoundersForLink(
+      row.seed_id,
+      actS,
+      sigX,
+      candidates,
+      today,
+      T,
+      baseStart,
+      seedStartById,
+    );
+    const adj = adjustConfounders(
+      { actS, sigX, suspected: confound.suspected, candById, baseStart, seedStartById },
+      T,
+    );
     if (adj) {
       confound.adjusted = adj.adjusted;
       confound.explainedAway = adj.explainedAway;


### PR DESCRIPTION
## 배경

교란 탐지 엔진(P6 후보 플래그 + P7 다변량 분리)이 검증 엔진과 달리 데이터-존재 윈도우 클립을 경유하지 않아, 기록 시작 이전의 빈 과거 구간이 비발현·실패일로 집계되던 입력 편향이 있었다. 이 편향은 비발현일 통과율을 왜곡해 rate ratio를 부풀리고 overlap 분모를 늘려, 실제로는 무관한 후보가 교란으로 잡힐 수 있는 여지를 남긴다.

## 변경

- 교란 후보 탐지의 overlap·공동발현일 수·후보↔신호 2×2와 다변량 분리의 층화·기준 rate ratio 계산에 검증 엔진(#504 ADR-0044)과 동일한 데이터-존재 윈도우 클립을 적용.
- 신호 시리즈를 각 도메인의 데이터 시작일 기준으로 계산해 rolling baseline 오염 차단.
- 링크 기본 클립 = max(시드 시작, 신호 시작). 제3변수가 개입하는 계산은 해당 후보의 시드 시작일도 max로 합성.
- **판정 로직·임계치는 불변** — 입력 창만 교정(annotate 단계 입력 품질 정렬).
- 은퇴한 크론 슬롯의 설정 행을 비활성화하는 마이그레이션 추가(가역 단일 UPDATE).
- 단위 테스트 확장: 빈 과거가 존재할 때 클립 전후 집계 차이를 고정.

## 검증

- `yarn tsc --noEmit` 통과
- `yarn vitest run` 전체 통과 (교란 엔진 25 케이스, 신규 클립 테스트 포함)

Closes #556