### PR TITLE
feat(insight): 역방향 링크 종결 규칙 + 반대 방향 가설 재제안 (#555)

### DIFF
--- a/src/cron/weekly-verification.ts
+++ b/src/cron/weekly-verification.ts
@@ -24,6 +24,7 @@ import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.j
 import {
   verifyUserLinks,
   computeStrengthCutpoints,
+  ensureMirrorSignalDef,
   type LinkVerification,
   type StrengthCutpoint,
 } from '../shared/pattern-verification.js';
@@ -351,6 +352,16 @@ const processUser = async (
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[Verification] 링크 persist 실패 link=${l.linkId}: ${msg}`);
     }
+    // 역방향 종결(#555) — 반대 방향 신호 정의 보장(발굴 엔진 위임). persist와 독립 격리:
+    // 거울 보장 실패가 다른 링크·검증을 막지 않게(신호 정의는 없어도 검증은 무탈). 링크는 만들지 않음.
+    if (l.verdict === 'direction_mismatch' && l.nextStatus === 'rejected') {
+      try {
+        await ensureMirrorSignalDef(userId, l.signalId);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[MirrorSignal] user=${userId} link=${l.linkId} 거울 보장 실패: ${msg}`);
+      }
+    }
   }
 
   // 포화 시드 양방향 가드(#508 ③, ADR-0046) — 검정 불가 시드 자동 archive ⟷ 탈포화 부활.
@@ -365,8 +376,9 @@ const processUser = async (
 
   const verified = results.filter((l) => l.nextStatus === 'confirmed').length;
   const rejects = results.filter((l) => l.verdict === 'reject').length;
+  const dirMismatch = results.filter((l) => l.verdict === 'direction_mismatch').length; // 역방향 종결(#555)
   console.warn(
-    `[Verification] user=${userId} 링크 ${results.length} (persist ${persisted}) verified ${verified} reject ${rejects}`,
+    `[Verification] user=${userId} 링크 ${results.length} (persist ${persisted}) verified ${verified} reject ${rejects} 역방향 ${dirMismatch}`,
   );
   // 가족별 BH 집합 크기(m) 관측 — 발굴 승인 누적에 따른 가족 m-인플레이션 추적(#523 P0, §2-5).
   const familyTally = results.reduce<Map<string, number>>(

--- a/src/shared/__tests__/pattern-verification.test.ts
+++ b/src/shared/__tests__/pattern-verification.test.ts
@@ -1,4 +1,50 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── db mock — ensureMirrorSignalDef만 query를 사용(그 외 테스트는 순수 함수라 미접근) ──
+interface FakeSignalRow {
+  id: number;
+  name: string;
+  kind: 'sql' | 'tag';
+  source: 'seed' | 'llm';
+  sql_body: string | null;
+  value_type: 'binary' | 'continuous' | null;
+  direction: string | null;
+  threshold: string | null;
+  tag_name: string | null;
+  window_days: number | null;
+  domain: string | null;
+  description: string | null;
+}
+let signalRow: FakeSignalRow | null; // id로 조회되는 대상 신호
+let mirrorRows: Array<{ status: string }>; // 거울 존재 조회 결과
+let inserts: Array<{ sql: string; params: readonly unknown[] }>;
+let nextInsertId: number;
+
+const resetDb = (): void => {
+  signalRow = null;
+  mirrorRows = [];
+  inserts = [];
+  nextInsertId = 999;
+};
+resetDb();
+
+vi.mock('../db.js', () => ({
+  query: vi.fn(async (sql: string, params?: readonly unknown[]) => {
+    const s = sql.trim();
+    if (/^INSERT INTO signal_defs/i.test(s)) {
+      inserts.push({ sql: s, params: params ?? [] });
+      return { rows: [{ id: nextInsertId }] };
+    }
+    if (/FROM signal_defs/i.test(s) && /WHERE id = \$1 AND user_id = \$2/i.test(s)) {
+      return { rows: signalRow ? [signalRow] : [] }; // 대상 신호 로드
+    }
+    if (/FROM signal_defs/i.test(s) && /direction = \$4/i.test(s)) {
+      return { rows: mirrorRows }; // 거울 존재 조회
+    }
+    throw new Error(`[fixture] unexpected SQL: ${s.slice(0, 60)}`);
+  }),
+}));
+
 import {
   buildWindowDates,
   binarizeSqlSeries,
@@ -8,6 +54,7 @@ import {
   verifyContingency,
   classifyVerdict,
   statusForVerdict,
+  ensureMirrorSignalDef,
   familyOf,
   bhFdrByFamily,
   signalDataStart,
@@ -189,6 +236,23 @@ describe('classifyVerdict', () => {
   it('effect 충분하나 q 비유의 → inconclusive (confirm 아님)', () => {
     expect(classifyVerdict({ nActive: 40, effect: 2.0 }, 0.5)).toBe('inconclusive');
   });
+
+  // ── direction_mismatch (#555) ──
+  it('nActive ≥ 30 & effect ≤ 0.77(명확한 역방향) → direction_mismatch', () => {
+    expect(classifyVerdict({ nActive: 40, effect: 0.5 }, 0.5)).toBe('direction_mismatch');
+  });
+
+  it('effect 0.77 경계 → direction_mismatch (이하 포함)', () => {
+    expect(classifyVerdict({ nActive: 40, effect: 0.77 }, 0.5)).toBe('direction_mismatch');
+  });
+
+  it('effect 0.9(게이트 위·reject 밴드 밖) → inconclusive (역방향 아님)', () => {
+    expect(classifyVerdict({ nActive: 40, effect: 0.9 }, 0.5)).toBe('inconclusive');
+  });
+
+  it('nActive < 30 이면 역방향이어도 insufficient 우선', () => {
+    expect(classifyVerdict({ nActive: 20, effect: 0.3 }, 0.5)).toBe('insufficient');
+  });
 });
 
 // ─── buildDaySequence ────────────────────────────────────
@@ -225,6 +289,14 @@ describe('buildDaySequence', () => {
 describe('statusForVerdict', () => {
   it('active + reject → rejected (e 무관, 정당한 제거)', () => {
     expect(statusForVerdict('reject', 'active', 1)).toBe('rejected');
+  });
+
+  it('active + direction_mismatch → rejected (역방향 종결, #555)', () => {
+    expect(statusForVerdict('direction_mismatch', 'active', 1)).toBe('rejected');
+  });
+
+  it('confirmed는 direction_mismatch에도 sticky (엔진이 재검증 안 함)', () => {
+    expect(statusForVerdict('direction_mismatch', 'confirmed', 1)).toBe('confirmed');
   });
 
   it('active + confirm & e≥20 → confirmed (verified 승격)', () => {
@@ -590,5 +662,101 @@ describe('splitHalvesConsistent', () => {
 
   it('너무 짧으면(<minPerHalf*2) null', () => {
     expect(splitHalvesConsistent([o(true, true), o(false, false)])).toBeNull();
+  });
+});
+
+// ─── ensureMirrorSignalDef (#555) ────────────────────────
+
+describe('ensureMirrorSignalDef', () => {
+  const sqlSignal = (over: Partial<FakeSignalRow> = {}): FakeSignalRow => ({
+    id: 10,
+    name: 'sig_above',
+    kind: 'sql',
+    source: 'seed',
+    sql_body: 'SELECT 1',
+    value_type: 'continuous',
+    direction: 'above_avg',
+    threshold: null,
+    tag_name: null,
+    window_days: 28,
+    domain: 'sleep',
+    description: '설명',
+    ...over,
+  });
+
+  beforeEach(() => resetDb());
+
+  it('above_avg 신호 & 거울 없음 → below_avg 신호 생성', async () => {
+    signalRow = sqlSignal({ direction: 'above_avg' });
+    mirrorRows = [];
+    const res = await ensureMirrorSignalDef(1, 10);
+    expect(res.outcome).toBe('created');
+    expect(res.mirrorSignalId).toBe(999);
+    expect(inserts).toHaveLength(1);
+    // INSERT는 direction만 반전(below_avg), status='active', pattern_links 생성 없음.
+    expect(inserts[0]?.params).toContain('below_avg');
+    expect(inserts[0]?.sql).toMatch(/INSERT INTO signal_defs/);
+    expect(inserts[0]?.sql).not.toMatch(/pattern_links/);
+  });
+
+  it('below_avg 신호 → above_avg 방향으로 반전 생성', async () => {
+    signalRow = sqlSignal({ name: 'sig_below', direction: 'below_avg' });
+    mirrorRows = [];
+    const res = await ensureMirrorSignalDef(1, 10);
+    expect(res.outcome).toBe('created');
+    expect(inserts[0]?.params).toContain('above_avg');
+  });
+
+  it('거울이 active로 이미 존재 → no-op(exists)', async () => {
+    signalRow = sqlSignal();
+    mirrorRows = [{ status: 'active' }];
+    const res = await ensureMirrorSignalDef(1, 10);
+    expect(res.outcome).toBe('exists');
+    expect(res.mirrorSignalId).toBeNull();
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('거울이 pending으로 존재 → no-op(exists)', async () => {
+    signalRow = sqlSignal();
+    mirrorRows = [{ status: 'pending' }];
+    const res = await ensureMirrorSignalDef(1, 10);
+    expect(res.outcome).toBe('exists');
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('기각 이력만 존재(active/pending 없음) → 생성 스킵(skipped_rejected)', async () => {
+    signalRow = sqlSignal();
+    mirrorRows = [{ status: 'rejected' }];
+    const res = await ensureMirrorSignalDef(1, 10);
+    expect(res.outcome).toBe('skipped_rejected');
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('above_abs 신호 → 반전 대상 아님(ineligible)', async () => {
+    signalRow = sqlSignal({ direction: 'above_abs' });
+    const res = await ensureMirrorSignalDef(1, 10);
+    expect(res.outcome).toBe('ineligible');
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('tag 신호 → 방향 없음(ineligible)', async () => {
+    signalRow = sqlSignal({ kind: 'tag', direction: null, sql_body: null, tag_name: 'flow' });
+    const res = await ensureMirrorSignalDef(1, 10);
+    expect(res.outcome).toBe('ineligible');
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('llm 출신 신호 → 대상 아님(ineligible, seed만 거울 보장)', async () => {
+    signalRow = sqlSignal({ source: 'llm' });
+    const res = await ensureMirrorSignalDef(1, 10);
+    expect(res.outcome).toBe('ineligible');
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('신호 없음(교차 유저·삭제) → ineligible', async () => {
+    signalRow = null;
+    const res = await ensureMirrorSignalDef(1, 10);
+    expect(res.outcome).toBe('ineligible');
+    expect(inserts).toHaveLength(0);
   });
 });

--- a/src/shared/insight-thresholds.ts
+++ b/src/shared/insight-thresholds.ts
@@ -69,6 +69,10 @@ export const INSIGHT_THRESHOLDS = {
     minRateRatio: 1.3, // confirm 최소 효과크기 (발현일 pass율 / 비발현일 pass율)
     rejectRatioLow: 0.95, // reject 효과크기 하한 (연관 없음 판정 밴드)
     rejectRatioHigh: 1.05, // reject 효과크기 상한
+    // #555: 역방향 종결 게이트. ≈ 1/minRateRatio(1.3). effect ≤ 이 값 & 발현일 ≥ minActiveDays →
+    // direction_mismatch 종결(reject 밴드도 confirm도 못 걸리던 사각지대 해소). 반대 방향 가설은 신호
+    // 정의 보장(ensureMirrorSignalDef)으로 발굴 엔진(P5a)에 위임 — 여기서 링크는 만들지 않음(ADR-0039 2층 분리).
+    directionMismatchMaxEffect: 0.77,
     // ── P3 통계 증강 (ADR-0034 e-value, ADR-0035 등급별 노출) ──
     evalueAlpha: 0.05, // e-value 확정 게이트 유의수준
     evalueThreshold: 20, // = 1/evalueAlpha. e_value ≥ 20 → 'confirmed' 승격(verified tier)

--- a/src/shared/pattern-verification.ts
+++ b/src/shared/pattern-verification.ts
@@ -68,7 +68,9 @@ export type LinkLifecycleStatus =
   | 'rejected'
   | 'archived';
 
-export type Verdict = 'confirm' | 'reject' | 'insufficient' | 'inconclusive';
+// direction_mismatch(#555): 충분한 표본에서 명확한 역방향(effect ≤ directionMismatchMaxEffect).
+// reject(무연관)와 lifecycle은 같이 'rejected'로 종결하되 사유를 분리 — reject=무연관, direction_mismatch=역방향.
+export type Verdict = 'confirm' | 'reject' | 'insufficient' | 'inconclusive' | 'direction_mismatch';
 
 /** 신호 일자 시리즈: pass=true / fail=false / 측정불가=null(2×2에서 제외). */
 export type DaySeries = Map<string, boolean | null>;
@@ -453,10 +455,14 @@ export const verifyContingency = (cont: Contingency): ContingencyVerification =>
 
 /**
  * verdict 분류 (provisional). confirm은 P3 e-value 전까지 승격 안 함(statusForVerdict 참조).
- *   confirm:      nActive≥MIN & q≤CONFIRM_Q & effect≥MIN_RATE_RATIO
- *   reject:       nActive≥MIN & effect∈[REJECT_LOW, REJECT_HIGH] (연관 없음)
- *   insufficient: nActive<MIN 또는 effect 산출 불가(off일 0)
- *   inconclusive: 그 외(데이터는 충분하나 판정 보류)
+ *   confirm:            nActive≥MIN & q≤CONFIRM_Q & effect≥MIN_RATE_RATIO
+ *   direction_mismatch: nActive≥MIN & effect≤DIRECTION_MISMATCH_MAX (명확한 역방향 — #555)
+ *   reject:             nActive≥MIN & effect∈[REJECT_LOW, REJECT_HIGH] (연관 없음)
+ *   insufficient:       nActive<MIN 또는 effect 산출 불가(off일 0)
+ *   inconclusive:       그 외(데이터는 충분하나 판정 보류)
+ *
+ * direction_mismatch는 reject 밴드보다 먼저 판정한다(#555). 게이트(≤0.77)와 reject 밴드(0.95~1.05)는
+ * 겹치지 않지만, 역방향은 "무연관"이 아니라 "반대 방향 신호"이므로 사유를 분리해 종결한다.
  */
 export const classifyVerdict = (
   v: Pick<ContingencyVerification, 'nActive' | 'effect'>,
@@ -464,13 +470,15 @@ export const classifyVerdict = (
 ): Verdict => {
   if (v.nActive < V.minActiveDays || !Number.isFinite(v.effect)) return 'insufficient';
   if (Number.isFinite(q) && q <= V.confirmQ && v.effect >= V.minRateRatio) return 'confirm';
+  if (v.effect <= V.directionMismatchMaxEffect) return 'direction_mismatch';
   if (v.effect >= V.rejectRatioLow && v.effect <= V.rejectRatioHigh) return 'reject';
   return 'inconclusive';
 };
 
 /**
  * P3 status 전이 정책 (ADR-0034 e-value 게이트). verified tier = status='confirmed'.
- *   - reject(반증, 충분한 데이터) → 'rejected' (정당한 제거).
+ *   - reject·direction_mismatch(충분한 데이터의 종결) → 'rejected' (정당한 제거).
+ *     둘 다 rejected lifecycle이지만 사유는 test_detail.verdict로 구분(별도 status enum·DB CHECK 불변, #555).
  *   - confirm & e_value ≥ 1/α(=20) → 'confirmed' (verified tier 승격). optional stopping 안전.
  *   - 그 외(confirm이나 e<20, inconclusive, insufficient) → 'active' 유지(emerging은 view가 분류).
  *   - confirmed는 sticky — verifyUserLinks가 active만 재검증하므로 한번 승격되면 동결(금딱지).
@@ -482,9 +490,103 @@ export const statusForVerdict = (
   eValue: number,
 ): LinkLifecycleStatus => {
   if (current !== 'active') return current;
-  if (verdict === 'reject') return 'rejected';
+  if (verdict === 'reject' || verdict === 'direction_mismatch') return 'rejected';
   if (verdict === 'confirm' && eValue >= V.evalueThreshold) return 'confirmed';
   return 'active';
+};
+
+// ─── 거울 신호 보장 (#555) ────────────────────────────────
+// 역방향 종결(direction_mismatch)로 링크를 버릴 때 정보까지 버리지 않도록, 반대 방향 신호 "정의"를
+// 보장한다. 신호 정의 생성은 측정 정의일 뿐 믿음이 아니다(ADR-0039 2층 분리) — 링크 생성·검증은
+// 발굴 엔진(P5a)의 기존 게이트가 담당하므로 여기서 pattern_links는 만들지 않는다. 다음 주 발굴 스캔이
+// (시드 × 거울신호) 쌍을 자연히 후보로 집어 올린다.
+
+/** above_avg ↔ below_avg 반전. 그 외 direction은 반전 대상 아님(null). */
+const mirrorDirection = (direction: SignalDirection | null): SignalDirection | null => {
+  if (direction === 'above_avg') return 'below_avg';
+  if (direction === 'below_avg') return 'above_avg';
+  return null;
+};
+
+export type MirrorSignalOutcome = 'created' | 'exists' | 'skipped_rejected' | 'ineligible';
+
+export interface MirrorSignalResult {
+  outcome: MirrorSignalOutcome;
+  /** 생성됐을 때만 non-null — 새 signal_defs.id. */
+  mirrorSignalId: number | null;
+}
+
+/**
+ * 종결된 링크의 신호에 대해 반대 방향(above_avg↔below_avg) 신호 정의를 보장한다 (#555).
+ *   - 대상: kind='sql' AND direction ∈ {above_avg, below_avg} 인 신호만.
+ *     (above_abs/below_abs는 절대 임계라 반전이 임계 의미와 일치하지 않고, tag/flag_present는 방향이 없다 → ineligible.)
+ *   - 거울 = 같은 (name, sql_body, threshold, domain, kind, source='seed')에 direction만 반전한 행.
+ *   - 거울이 status IN ('active','pending')으로 이미 있으면 no-op('exists').
+ *   - 기각 이력만 있으면(active/pending 없음) 생성 스킵('skipped_rejected', 로그) — 재기각을 되살리지 않는다.
+ *   - 없으면 status='active'로 INSERT('created'). pattern_links는 만들지 않는다(발굴 엔진 위임).
+ * INSERT 컬럼 구성은 signal_defs 기존 생성 경로(마이그 086 등)를 따른다.
+ * user_id 가드 — 교차 유저 신호 생성 차단.
+ */
+export const ensureMirrorSignalDef = async (
+  userId: number,
+  signalId: number,
+): Promise<MirrorSignalResult> => {
+  const res = await query<SignalDefRow>(
+    `SELECT id, name, kind, source, sql_body, value_type, direction, threshold, tag_name, window_days, domain, description
+       FROM signal_defs
+      WHERE id = $1 AND user_id = $2`,
+    [signalId, userId],
+  );
+  const row = res.rows[0];
+  if (!row) return { outcome: 'ineligible', mirrorSignalId: null };
+
+  const mirror = mirrorDirection(row.direction);
+  if (row.kind !== 'sql' || row.source !== 'seed' || mirror === null || row.sql_body === null) {
+    return { outcome: 'ineligible', mirrorSignalId: null };
+  }
+
+  // 같은 측정 정의(name·sql·threshold·domain) + 반전 direction 행 조회. NULL threshold/domain은 IS NOT DISTINCT FROM으로 매칭.
+  const existing = await query<{ status: string }>(
+    `SELECT status FROM signal_defs
+      WHERE user_id = $1 AND kind = 'sql' AND source = 'seed' AND name = $2
+        AND sql_body = $3 AND direction = $4
+        AND threshold IS NOT DISTINCT FROM $5
+        AND domain IS NOT DISTINCT FROM $6`,
+    [userId, row.name, row.sql_body, mirror, row.threshold, row.domain],
+  );
+  if (existing.rows.some((r) => r.status === 'active' || r.status === 'pending')) {
+    return { outcome: 'exists', mirrorSignalId: null };
+  }
+  if (existing.rows.length > 0) {
+    // active/pending은 없고 rejected 이력만 존재 — 되살리지 않는다(재기각 방지).
+    console.warn(
+      `[MirrorSignal] user=${userId} signal=${signalId} 거울(${row.name} ${mirror}) 기각 이력만 존재 — 생성 스킵`,
+    );
+    return { outcome: 'skipped_rejected', mirrorSignalId: null };
+  }
+
+  const ins = await query<{ id: number }>(
+    `INSERT INTO signal_defs
+        (user_id, name, kind, sql_body, value_type, direction, threshold, domain, window_days, description, source, status)
+     VALUES ($1, $2, 'sql', $3, $4, $5, $6, $7, $8, $9, 'seed', 'active')
+     RETURNING id`,
+    [
+      userId,
+      row.name,
+      row.sql_body,
+      row.value_type,
+      mirror,
+      row.threshold,
+      row.domain,
+      row.window_days,
+      row.description ?? '',
+    ],
+  );
+  const mirrorSignalId = ins.rows[0]?.id ?? null;
+  console.warn(
+    `[MirrorSignal] user=${userId} signal=${signalId} 거울 신호 생성(${row.name} ${row.direction}→${mirror}) id=${mirrorSignalId}`,
+  );
+  return { outcome: 'created', mirrorSignalId };
 };
 
 // ─── FDR 가족 분리 (#477 P4a, ADR-0037) ──────────────────


### PR DESCRIPTION
Closes #555

## 배경

off-day 대조 검증에서 판정 밴드에 사각지대가 있었다. 효과크기(rate ratio)가 confirm 하한(1.3) 미만이면서 무연관 판정 밴드(0.95~1.05)에도 들지 않는 **명확한 역방향** 링크는, 표본이 충분히 쌓여도 어느 종결 조건에도 걸리지 않아 무기한 active로 남는다.

## 변경

- **판정 확장**: `direction_mismatch` verdict 추가. 발현일 표본이 충분(≥ 최소 발현일)하고 효과크기가 역방향 게이트(≈ 1/1.3) 이하이면 종결로 분류한다. 무연관 밴드보다 먼저 판정하되, "무연관"이 아니라 "반대 방향"이므로 사유를 분리해 기록한다.
- **상태 전이**: 역방향 종결은 기존 종결과 동일한 lifecycle(rejected)로 통합한다. 별도 status enum·DB 제약을 늘리지 않고, 종결 사유는 검증 상세(test_detail)로 구분한다.
- **반대 방향 신호 정의 보장**: 역방향으로 종결한 신호에 대해 방향만 뒤집은 신호 **정의**를 보장한다(기존 정의가 있으면 no-op, 기각 이력만 있으면 생성 스킵). 신호 정의는 측정 정의일 뿐 believe가 아니므로, 링크 생성·검증은 기존 발굴 게이트에 위임한다(2층 분리 유지) — 여기서 링크는 만들지 않는다.
- **훅**: 주간 검증 엔진의 링크 종결 지점에 per-link 격리로 연결(한 링크의 보장 실패가 다른 링크·검증을 막지 않음) + 관측 로그.
- 마이그레이션 없음(새 status·통계 코어 0). 임계치는 튜닝 노브로 단일 지점에 추가.

## 동작

다음 월요일 주간 실행에서 조건을 충족하는 역방향 링크가 종결되고, 반대 방향 거울 신호가 다음 주 발굴 스캔 풀에 들어간다. 이후 발굴 엔진이 (기존 시드 × 거울 신호) 쌍을 기존 게이트로 재평가한다.

## 검증

- `yarn tsc --noEmit` 통과
- `yarn vitest run` 전체 통과 (931 passed) — 판정 분기·상태 전이·거울 신호 보장(생성/no-op/스킵/비대상) 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)