### PR TITLE
feat(budget): 지출 전망 카드 개선 — 계획·실지출 이중 전망 (#552)

### DIFF
--- a/web/src/features/budget/components/runway-card.tsx
+++ b/web/src/features/budget/components/runway-card.tsx
@@ -11,6 +11,13 @@ function barHeight(projection: MonthProjection, maxRemaining: number): number {
   return Math.max(2, Math.round((projection.remaining / maxRemaining) * 100));
 }
 
+/** target 대비 gap(개월) — 양수면 여유, 음수면 부족. 두 인자 모두 'YYYY-MM'. */
+function monthsGap(runwayDate: string, targetDate: string): number {
+  const [ty, tm] = targetDate.split('-').map(Number);
+  const [ry, rm] = runwayDate.split('-').map(Number);
+  return Math.round(((ry - ty) * 12 + (rm - tm)) * 10) / 10;
+}
+
 export function RunwayCard() {
   const [runway, setRunway] = useState<RunwayProjectionResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -58,45 +65,68 @@ export function RunwayCard() {
     }
   }
 
-  // 실제 런웨이 vs 목표 비교
   const targetDate = runway.target_date;
-  let targetGapMonths: number | null = null;
-  if (targetDate) {
-    const [ty, tm] = targetDate.split('-').map(Number);
-    const [ry, rm] = runway.actual_runway_date.split('-').map(Number);
-    targetGapMonths = Math.round(((ry - ty) * 12 + (rm - tm)) * 10) / 10;
-  }
+  // 목표 대비 비교는 페이스 전망 기준 — 계획 전망은 배분상 항상 목표월에 수렴(동어반복)이라 정보가 없음.
+  const paceGapMonths = targetDate ? monthsGap(runway.pace_runway_date, targetDate) : null;
 
   return (
     <div className="space-y-3">
-      {/* 1. 실제 런웨이 카드 */}
+      {/* 1. 전망 카드 — 계획(목표 있을 때) / 페이스(항상) 병기 */}
       <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-        <div className="mb-1 flex items-center gap-1.5">
+        <div className="mb-2 flex items-center gap-1.5">
           <ArrowTrendingDownIcon size={15} />
-          <span className="text-xs font-semibold text-gray-500">실제 런웨이</span>
+          <span className="text-xs font-semibold text-gray-500">지출 전망</span>
         </div>
-        <div className="flex items-end gap-2 mb-1">
-          <span className="text-3xl font-bold text-gray-900">{runway.actual_runway_months}개월</span>
-          <span className="mb-0.5 text-sm text-gray-500">({runway.actual_runway_date}까지)</span>
-        </div>
+
+        {/* 계획 전망 (목표 있을 때만) */}
         {targetDate && (
-          <div className="flex items-center gap-2 mt-1">
-            <span className="text-xs text-gray-400">목표 {targetDate}</span>
-            {targetGapMonths !== null && (
-              <span className={`text-xs font-semibold ${targetGapMonths > 0 ? 'text-green-600' : targetGapMonths < 0 ? 'text-red-500' : 'text-gray-500'}`}>
-                {targetGapMonths > 0 ? `+${targetGapMonths}개월 여유` : targetGapMonths < 0 ? `${targetGapMonths}개월 부족` : '목표 달성'}
+          <div className="mb-3">
+            <div className="text-[11px] text-gray-400">계획 전망 · 목표 기간까지 배분 기준</div>
+            <div className="flex items-end gap-2">
+              <span className="text-2xl font-bold text-gray-900">
+                {runway.actual_runway_months}개월
               </span>
-            )}
+              <span className="mb-0.5 text-xs text-gray-500">
+                ({runway.actual_runway_date}까지)
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* 페이스 전망 (항상) */}
+        <div>
+          <div className="text-[11px] text-gray-400">페이스 전망 · 최근 실지출 기준</div>
+          <div className="flex items-end gap-2">
+            <span className={`font-bold text-gray-900 ${targetDate ? 'text-2xl' : 'text-3xl'}`}>
+              {runway.pace_runway_months}개월
+            </span>
+            <span className="mb-0.5 text-xs text-gray-500">({runway.pace_runway_date}까지)</span>
+          </div>
+        </div>
+
+        {/* 목표 대비 — 페이스 기준 */}
+        {targetDate && paceGapMonths !== null && (
+          <div className="mt-2 flex items-center gap-2 border-t border-gray-100 pt-2">
+            <span className="text-xs text-gray-400">목표 {targetDate}</span>
+            <span
+              className={`text-xs font-semibold ${paceGapMonths > 0 ? 'text-green-600' : paceGapMonths < 0 ? 'text-red-500' : 'text-gray-500'}`}
+            >
+              {paceGapMonths > 0
+                ? `페이스 +${paceGapMonths}개월 여유`
+                : paceGapMonths < 0
+                  ? `페이스 ${paceGapMonths}개월 부족`
+                  : '페이스 목표 도달'}
+            </span>
           </div>
         )}
         {!targetDate && (
-          <p className="mt-1 text-xs text-gray-400">
+          <p className="mt-2 text-xs text-gray-400">
             설정 탭에서 목표 기간을 설정하면 월별 예산이 자동 산정됩니다.
           </p>
         )}
       </div>
 
-      {/* 2. 월별 시뮬레이션 */}
+      {/* 2. 월별 시뮬레이션 — 목표 있으면 계획 배분, 없으면 페이스 */}
       {projections.length > 0 && (
         <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
           <button
@@ -105,6 +135,9 @@ export function RunwayCard() {
           >
             월별 시뮬레이션 {showProjections ? '접기' : '펼치기'} ({projections.length}개월)
           </button>
+          <p className="mb-2 text-[10px] text-gray-400">
+            {targetDate ? '목표 기간 배분 기준' : '최근 실지출 페이스 기준'}
+          </p>
 
           {/* 미니 바 차트 */}
           {!showProjections && (
@@ -152,8 +185,12 @@ export function RunwayCard() {
                           </span>
                         )}
                       </td>
-                      <td className="px-2 py-1.5 text-right text-gray-500">{formatAmount(p.free_budget)}</td>
-                      <td className="px-2 py-1.5 text-right font-medium text-gray-700">{formatAmount(p.remaining)}</td>
+                      <td className="px-2 py-1.5 text-right text-gray-500">
+                        {formatAmount(p.free_budget)}
+                      </td>
+                      <td className="px-2 py-1.5 text-right font-medium text-gray-700">
+                        {formatAmount(p.remaining)}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -172,8 +209,10 @@ export function RunwayCard() {
       <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
         <div className="grid grid-cols-2 gap-2 text-xs text-gray-500">
           <div>
-            <div className="text-gray-400">실시간 가용자금</div>
-            <div className="font-medium text-gray-700">{formatAmount(runway.effective_available)}</div>
+            <div className="text-gray-400">자금 (수기 기준)</div>
+            <div className="font-medium text-gray-700">
+              {formatAmount(runway.effective_available)}
+            </div>
           </div>
           <div>
             <div className="text-gray-400">월 고정비</div>
@@ -186,8 +225,10 @@ export function RunwayCard() {
             </div>
           )}
           <div>
-            <div className="text-gray-400">3개월 평균 지출</div>
-            <div className="font-medium text-gray-700">{formatAmount(runway.avg_variable_monthly)}</div>
+            <div className="text-gray-400">최근 3주기 평균 변동지출</div>
+            <div className="font-medium text-gray-700">
+              {formatAmount(runway.avg_variable_monthly)}
+            </div>
           </div>
         </div>
       </div>

--- a/web/src/features/budget/lib/facade.test.ts
+++ b/web/src/features/budget/lib/facade.test.ts
@@ -524,6 +524,61 @@ describe('getRunwayProjection', () => {
     expect(result.actual_runway_date).toBe('2026-08');
     expect(result.projections[0]!.installments).toBeGreaterThan(0);
   });
+
+  // #552 — 페이스(실지출) 전망 상시 병기
+  it('readAvgVariableMonthly 를 (userId, 3, 현재 결제월) 시그니처로 호출', async () => {
+    vi.mocked(readDistributableAssetBalance).mockResolvedValue(1_000_000);
+    // DEFAULT_NOW = 2026-04-10 21:00 KST → 현재 결제월 '2026-04'
+    await getRunwayProjection(1, DEFAULT_NOW);
+    expect(readAvgVariableMonthly).toHaveBeenCalledWith(1, 3, '2026-04');
+  });
+
+  it('pace_* 필드 + pace_projections 항상 존재 (target 유무 무관)', async () => {
+    vi.mocked(readDistributableAssetBalance).mockResolvedValue(1_000_000);
+    vi.mocked(readFixedCostsMonthlyTotal).mockResolvedValue(0);
+    vi.mocked(readAvgVariableMonthly).mockResolvedValue(200_000);
+    vi.mocked(readTargetMonth).mockResolvedValue('2026-06');
+
+    const result = await getRunwayProjection(1, DEFAULT_NOW);
+
+    expect(typeof result.pace_runway_months).toBe('number');
+    expect(typeof result.pace_runway_date).toBe('string');
+    expect(Array.isArray(result.pace_projections)).toBe(true);
+    // 페이스는 avgVariableMonthly(200_000)를 자유 지출로 소진
+    expect(result.pace_projections[0]!.free_budget).toBe(200_000);
+  });
+
+  it('target 있으면 plan_projections 채워지고 pace_projections 는 target 너머까지 이어짐', async () => {
+    // 자유 예산이 커서 페이스 소진이 느림 → target(2026-06)보다 페이스가 더 오래 감.
+    vi.mocked(readDistributableAssetBalance).mockResolvedValue(1_200_000);
+    vi.mocked(readFixedCostsMonthlyTotal).mockResolvedValue(0);
+    vi.mocked(readAvgVariableMonthly).mockResolvedValue(100_000); // 12개월치 페이스
+    vi.mocked(readTargetMonth).mockResolvedValue('2026-06'); // 계획은 3개월
+
+    const result = await getRunwayProjection(1, DEFAULT_NOW);
+
+    // 계획 전망: allocator 배분 → target월(2026-06)에 수렴
+    expect(result.plan_projections).not.toBeNull();
+    expect(result.actual_runway_date).toBe('2026-06');
+    // 페이스 전망: target과 독립 — 잔액이 target월 이후에도 이어짐 (동어반복 아님)
+    expect(result.pace_projections.length).toBeGreaterThan(result.plan_projections!.length);
+    expect(result.pace_runway_date > '2026-06').toBe(true);
+  });
+
+  it('target 없으면 plan_projections=null, actual_*=pace (하위호환)', async () => {
+    vi.mocked(readDistributableAssetBalance).mockResolvedValue(1_000_000);
+    vi.mocked(readFixedCostsMonthlyTotal).mockResolvedValue(0);
+    vi.mocked(readAvgVariableMonthly).mockResolvedValue(200_000);
+    vi.mocked(readTargetMonth).mockResolvedValue(null);
+
+    const result = await getRunwayProjection(1, DEFAULT_NOW);
+
+    expect(result.plan_projections).toBeNull();
+    // actual_* 는 페이스와 동일해야 함 (target 없을 때 primary=pace)
+    expect(result.actual_runway_months).toBe(result.pace_runway_months);
+    expect(result.actual_runway_date).toBe(result.pace_runway_date);
+    expect(result.projections).toEqual(result.pace_projections);
+  });
 });
 
 describe('getBudgetPreview', () => {

--- a/web/src/features/budget/lib/facade.ts
+++ b/web/src/features/budget/lib/facade.ts
@@ -42,6 +42,7 @@ export interface TodayAllocationResult extends DayAllocatorResult {
 }
 
 export interface RunwayProjectionResponse {
+  // 하위호환: actual_* / projections 는 (target ? 계획 : 페이스) — 기존 의미 불변.
   actual_runway_months: number;
   actual_runway_date: string;
   free_per_month: number | null;
@@ -50,6 +51,12 @@ export interface RunwayProjectionResponse {
   avg_variable_monthly: number;
   target_date: string | null;
   projections: MonthProjection[];
+  // 신규: 페이스 전망은 target 유무와 무관하게 항상 계산 (최근 실지출 기반).
+  pace_runway_months: number;
+  pace_runway_date: string;
+  // 신규: 계획 전망은 target 있을 때만 (allocator 배분 기준). 없으면 null.
+  plan_projections: MonthProjection[] | null;
+  pace_projections: MonthProjection[];
 }
 
 export interface BudgetPreviewResponse {
@@ -157,47 +164,54 @@ export async function getRunwayProjection(
   const cycle = getBillingCycle(now);
   const todayStr = formatKSTDate(now);
 
-  const [monthly, avgVariableMonthly, fixedMonthly, targetDate] = await Promise.all([
-    getMonthlyAllocation(userId, now),
-    readAvgVariableMonthly(userId, 3),
-    readFixedCostsMonthlyTotal(userId),
-    readTargetMonth(userId),
-  ]);
+  // 페이스 전망용 창: [현재 결제월, +120] — 시뮬레이션 maxMonths(120)를 넉넉히 덮음.
+  // target 유무와 무관하게 항상 조회 (페이스 전망은 target 너머까지 이어짐).
+  const paceWindowEnd = addBillingMonths(cycle.yearMonth, 120);
+  const [monthly, avgVariableMonthly, fixedMonthly, targetDate, pacePlanned, paceInstallmentLock] =
+    await Promise.all([
+      getMonthlyAllocation(userId, now),
+      readAvgVariableMonthly(userId, 3, cycle.yearMonth),
+      readFixedCostsMonthlyTotal(userId),
+      readTargetMonth(userId),
+      readPlannedExpenses(userId, cycle.yearMonth, paceWindowEnd),
+      readInstallmentLockByMonth(userId, cycle.yearMonth, paceWindowEnd),
+    ]);
 
   const totalAvailable = await computeTotalAvailable(userId, todayStr);
   const freePerMonth = monthly.freePerMonth;
 
-  let projResult;
-  if (targetDate && monthly.monthlyBudgets.length > 0) {
-    // target 있음 → allocator 결과 재사용 (정합성 보장)
-    projResult = projectFromAllocator(totalAvailable, monthly.monthlyBudgets, cycle.yearMonth);
-  } else {
-    // target 없음 → 평균 지출 기반 시뮬레이션. 할부 burn은 billing_month별 락 맵으로 조회
-    // (창 상한 없음 — 시뮬레이션 maxMonths(120)를 넉넉히 덮음).
-    const projectionWindowEnd = addBillingMonths(cycle.yearMonth, 120);
-    const [planned, installmentLockByMonth] = await Promise.all([
-      readPlannedExpenses(userId, cycle.yearMonth, cycle.yearMonth),
-      readInstallmentLockByMonth(userId, cycle.yearMonth, projectionWindowEnd),
-    ]);
-    projResult = projectRunway({
-      billingMonth: cycle.yearMonth,
-      totalAvailable,
-      fixedMonthly,
-      installmentLockByMonth,
-      plannedExpenses: planned,
-      freePerMonthEstimate: avgVariableMonthly,
-    });
-  }
+  // 페이스 전망 (항상): 최근 실지출(avgVariableMonthly)을 자유 지출 추정치로 소진 시뮬레이션.
+  const paceResult = projectRunway({
+    billingMonth: cycle.yearMonth,
+    totalAvailable,
+    fixedMonthly,
+    installmentLockByMonth: paceInstallmentLock,
+    plannedExpenses: pacePlanned,
+    freePerMonthEstimate: avgVariableMonthly,
+  });
+
+  // 계획 전망 (target 있을 때만): allocator 배분 결과 재사용 (정합성 보장 — target월에 잔액 0 수렴).
+  const planResult =
+    targetDate && monthly.monthlyBudgets.length > 0
+      ? projectFromAllocator(totalAvailable, monthly.monthlyBudgets, cycle.yearMonth)
+      : null;
+
+  // 하위호환: actual_* / projections = target 있으면 계획, 없으면 페이스 (기존 의미 유지).
+  const primary = planResult ?? paceResult;
 
   return {
-    actual_runway_months: projResult.actualRunwayMonths,
-    actual_runway_date: projResult.actualRunwayDate,
+    actual_runway_months: primary.actualRunwayMonths,
+    actual_runway_date: primary.actualRunwayDate,
     free_per_month: freePerMonth,
     effective_available: totalAvailable,
     fixed_monthly: fixedMonthly,
     avg_variable_monthly: avgVariableMonthly,
     target_date: targetDate,
-    projections: projResult.projections,
+    projections: primary.projections,
+    pace_runway_months: paceResult.actualRunwayMonths,
+    pace_runway_date: paceResult.actualRunwayDate,
+    plan_projections: planResult ? planResult.projections : null,
+    pace_projections: paceResult.projections,
   };
 }
 

--- a/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
@@ -6,6 +6,7 @@ vi.mock('@/lib/db', () => ({
 
 import { query } from '@/lib/db';
 import {
+  readAvgVariableMonthly,
   readExcludedSpent,
   readFlexibleSpent,
   readPlannedOverflow,
@@ -314,5 +315,53 @@ describe('readExcludedSpent (#549)', () => {
   it('행 없음 → 0', async () => {
     vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
     expect(await readExcludedSpent(1, '2026-04')).toBe(0);
+  });
+});
+
+describe('readAvgVariableMonthly (#552)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('완결된 결제주기 범위 [current-N, current)를 파라미터로 전달', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ avg_monthly: '0' }] } as Any);
+
+    // current='2026-07', months=3 → windowStart='2026-04', upper bound(exclusive)='2026-07'
+    await readAvgVariableMonthly(1, 3, '2026-07');
+
+    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    expect(params).toEqual([1, '2026-04', '2026-07']);
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    // 진행 중 주기는 제외 (< current), 하한은 포함 (>= windowStart)
+    expect(sql).toMatch(/billing_month\s*>=\s*\$2/i);
+    expect(sql).toMatch(/billing_month\s*<\s*\$3/i);
+  });
+
+  it('할부·예정연결 제외 + billing_month 단위 집계 (이중 계상 방지)', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ avg_monthly: '0' }] } as Any);
+
+    await readAvgVariableMonthly(1, 3, '2026-07');
+
+    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    // 할부 회차는 예측 시 락 맵으로 따로 burn → 평균에서 제외
+    expect(sql).toMatch(/is_installment\s*=\s*false/i);
+    // 예정지출 연결분도 예측에서 planned로 따로 반영 → 제외
+    expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
+    // 달력월 DATE_TRUNC가 아니라 billing_month 기준 그룹핑
+    expect(sql).toMatch(/GROUP BY billing_month/i);
+    expect(sql).not.toMatch(/DATE_TRUNC/i);
+    // 기본 필터 유지
+    expect(sql).toMatch(/exclude_from_budget\s*=\s*false/i);
+    expect(sql).toMatch(/type.*expense/i);
+  });
+
+  it('AVG 결과를 반올림해 반환', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ avg_monthly: '123456.7' }] } as Any);
+    expect(await readAvgVariableMonthly(1, 3, '2026-07')).toBe(123457);
+  });
+
+  it('행 없음 → 0', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    expect(await readAvgVariableMonthly(1, 3, '2026-07')).toBe(0);
   });
 });

--- a/web/src/features/budget/lib/repository/expenses-repo.ts
+++ b/web/src/features/budget/lib/repository/expenses-repo.ts
@@ -1,4 +1,5 @@
 import { query } from '@/lib/db';
+import { addBillingMonths } from '../billing/cycle';
 
 function subtractOneDay(dateStr: string): string {
   const d = new Date(`${dateStr}T00:00:00Z`);
@@ -121,20 +122,32 @@ export async function readPlannedOverflow(
   return Number(result.rows[0]?.overflow ?? 0);
 }
 
-/** 최근 N개월 변동 지출 월평균 (고정비 제외 일반 지출만) */
-export async function readAvgVariableMonthly(userId: number, months = 3): Promise<number> {
+// 최근 N개 '완결된' 결제주기의 자유(변동) 지출 월평균 — 페이스 전망의 freePerMonth 추정치.
+// - is_installment=false: 할부 회차는 예측 시 락 맵으로 따로 burn되므로 평균에 넣으면 이중 계상.
+// - planned_expense_id IS NULL: 예정지출 연결분도 예측에서 planned로 따로 반영 → 제외.
+// - billing_month 기준 [current-N, current): 결제주기 단위로 집계하고 진행 중 주기(부분)는 제외
+//   (달력월 DATE_TRUNC나 부분 주기가 평균을 끌어내리는 것 방지).
+export async function readAvgVariableMonthly(
+  userId: number,
+  months: number,
+  currentBillingMonth: string,
+): Promise<number> {
+  const windowStart = addBillingMonths(currentBillingMonth, -months);
   const result = await query<{ avg_monthly: string }>(
     `SELECT COALESCE(AVG(monthly_total), 0) AS avg_monthly
      FROM (
-       SELECT DATE_TRUNC('month', date) AS month, SUM(amount) AS monthly_total
+       SELECT billing_month, SUM(amount) AS monthly_total
        FROM expenses
        WHERE user_id = $1
-         AND date >= NOW() - ($2::text || ' months')::interval
-         AND exclude_from_budget = false
          AND COALESCE(type, 'expense') = 'expense'
-       GROUP BY 1
+         AND exclude_from_budget = false
+         AND is_installment = false
+         AND planned_expense_id IS NULL
+         AND billing_month >= $2
+         AND billing_month < $3
+       GROUP BY billing_month
      ) sub`,
-    [userId, months],
+    [userId, windowStart, currentBillingMonth],
   );
   return Math.round(Number(result.rows[0]?.avg_monthly ?? 0));
 }


### PR DESCRIPTION
## 배경

전망 카드에서 목표 기간이 설정된 경우, "전망" 수치가 배분 계획을 그대로 소진하는 계산이라 구조적으로 항상 목표 시점과 일치했다. 즉 목표를 세우면 전망이 목표를 그대로 되돌려주는 동어반복이 되어 "지금 페이스면 어떤가"라는 정보가 사라졌다.

## 변경

- **이중 전망 병기**: 계획 전망(배분 기준)과 별개로, 최근 실지출 페이스 기반 전망을 항상 계산해 함께 보여준다. 목표 대비 비교(여유/부족)를 페이스 전망 기준으로 전환해 실제로 의미 있는 신호가 되도록 했다.
- **facade 응답 확장(하위호환)**: 페이스 전망 필드와 계획/페이스 프로젝션 배열을 신규 추가하고, 기존 필드의 의미는 그대로 유지했다. 기존 응답을 쓰는 소비자는 영향 없음.
- **평균 변동지출 추정 교정**: 페이스 추정의 기준 산식에서 할부·예정지출 연결분을 제외하고, 완결된 결제주기 단위로 집계하도록 바꿔 이중 계상과 부분 주기 왜곡을 없앴다.
- **라벨 정리**: 실제 의미와 어긋나던 카드 문구를 정돈했다.

## 검증

- `web` 타입 체크 통과
- `web` / 루트 테스트 스위트 전체 통과 (repo 산식 파라미터 + 이중 전망 상시 계산 + 하위호환 케이스 추가)

Closes #552