### PR TITLE
feat(budget): 목표 기간 만료 임박 알림 (#554)

### DIFF
--- a/src/cron/__tests__/life-cron.test.ts
+++ b/src/cron/__tests__/life-cron.test.ts
@@ -6,6 +6,8 @@ import {
   timeToCron,
   calcRoutineStats,
   getBillingMonthForDate,
+  getTargetExpiryDate,
+  buildTargetExpiryWarning,
   RELOAD_DEBOUNCE_MS,
 } from '../life-cron.js';
 
@@ -37,6 +39,58 @@ describe('getBillingMonthForDate — 결제주기 경계 15일', () => {
   });
 });
 
+// ── 목표 기간 만료 알림: 만료일 산식 + 문구 (#554) ──
+
+describe('getTargetExpiryDate — 만료일 산식 (15일-시작 규칙)', () => {
+  it('target 2026-08 → 만료일 2026-08-14', () => {
+    expect(getTargetExpiryDate('2026-08')).toBe('2026-08-14');
+  });
+
+  it('target 2026-12 → 만료일 2026-12-14', () => {
+    expect(getTargetExpiryDate('2026-12')).toBe('2026-12-14');
+  });
+});
+
+describe('buildTargetExpiryWarning — 날짜 픽스처 (만료일 2026-08-14 기준)', () => {
+  it('target_date 없음 → null (안내 없음)', () => {
+    expect(buildTargetExpiryWarning(null, '2026-07-03')).toBeNull();
+  });
+
+  it('43일 전 → null (아직 여유, 무음)', () => {
+    expect(buildTargetExpiryWarning('2026-08', '2026-07-02')).toBeNull();
+  });
+
+  it('42일 전(6주 경계) → 임박 안내 (N=42)', () => {
+    const msg = buildTargetExpiryWarning('2026-08', '2026-07-03');
+    expect(msg).toContain('42일 뒤에 끝나');
+    expect(msg).toContain('2026-08');
+  });
+
+  it('7일 전 → 임박 안내 (N=7)', () => {
+    const msg = buildTargetExpiryWarning('2026-08', '2026-08-07');
+    expect(msg).toContain('7일 뒤에 끝나');
+  });
+
+  it('만료 다음날 → 정지 안내', () => {
+    const msg = buildTargetExpiryWarning('2026-08', '2026-08-15');
+    expect(msg).toContain('지났어');
+    expect(msg).toContain('멈춰');
+  });
+
+  it('만료일 당일(남은 일수 0) → 정지 안내', () => {
+    const msg = buildTargetExpiryWarning('2026-08', '2026-08-14');
+    expect(msg).toContain('지났어');
+  });
+
+  it('문구에 금액·재정 표현 없음 (기간·일수만)', () => {
+    const warn = buildTargetExpiryWarning('2026-08', '2026-08-07');
+    const expired = buildTargetExpiryWarning('2026-08', '2026-08-15');
+    for (const m of [warn, expired]) {
+      expect(m).not.toMatch(/원|만원|잔액|런웨이|금액|자산/);
+    }
+  });
+});
+
 describe('calcRoutineStats', () => {
   it('빈 배열', () => {
     const stats = calcRoutineStats([]);
@@ -49,10 +103,13 @@ describe('calcRoutineStats', () => {
 // ── CronScheduler reload debounce/mutex 테스트 ──
 
 // vi.hoisted로 mock 함수 선언 (vi.mock 호이스팅 대응)
-const { mockSchedule, mockQuery, mockConnect } = vi.hoisted(() => ({
+const { mockSchedule, mockQuery, mockConnect, mockTodayISO, mockDayOfWeek } = vi.hoisted(() => ({
   mockSchedule: vi.fn(() => ({ stop: vi.fn() })),
   mockQuery: vi.fn(),
   mockConnect: vi.fn(),
+  // 목표 기간 만료 알림 테스트에서 요일/오늘 날짜를 제어하기 위한 mock (기본값 유지)
+  mockTodayISO: vi.fn(() => '2026-03-12'),
+  mockDayOfWeek: vi.fn(() => 4),
 }));
 
 // node-cron mock
@@ -71,10 +128,10 @@ vi.mock('pg', () => {
 });
 
 vi.mock('../../shared/kst.js', () => ({
-  getTodayISO: () => '2026-03-12',
+  getTodayISO: () => mockTodayISO(),
   getYesterdayISO: () => '2026-03-11',
   getKSTTimeString: () => '09:00',
-  getKSTDayOfWeek: () => 4,
+  getKSTDayOfWeek: () => mockDayOfWeek(),
   formatDateShort: (d: string) => d,
   addDays: (d: string, n: number) => {
     const date = new Date(`${d}T12:00:00+09:00`);
@@ -88,6 +145,7 @@ import {
   CronScheduler,
   createTodayRecords,
   calcYesterdayFlexSpent,
+  warnTargetExpiryIfNear,
   type LifeCronConfig,
 } from '../life-cron.js';
 import type { UserMapping } from '../../shared/user-resolver.js';
@@ -370,5 +428,114 @@ describe('calcYesterdayFlexSpent — 웹 SSOT 정합', () => {
     });
     const spent = await calcYesterdayFlexSpent(1, YESTERDAY, BILLING);
     expect(spent).toBe(3000); // max(0, 5000-8000)=0
+  });
+});
+
+// ── warnTargetExpiryIfNear: 월요일 게이트 + 채널 라우팅 (#554) ──
+
+describe('warnTargetExpiryIfNear — 월요일 게이트 + 채널 라우팅', () => {
+  const MONDAY = 1;
+  const TUESDAY = 2;
+
+  /** budget_settings.target_date + 매핑 mock */
+  const setupExpiryMock = (targetDate: string | null, mappings: UserMapping[]): void => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (/budget_settings/.test(sql)) {
+        return Promise.resolve({ rows: [{ target_date: targetDate }] });
+      }
+      if (/slack_user_mappings/.test(sql)) {
+        return Promise.resolve({
+          rows: mappings.map((m) => ({
+            user_id: m.userId,
+            slack_user_id: m.slackUserId,
+            life_channel_id: m.lifeChannelId,
+            insight_channel_id: m.insightChannelId,
+          })),
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  };
+
+  const config: LifeCronConfig = {
+    channelId: 'C_FALLBACK',
+    llmClient: {} as LifeCronConfig['llmClient'],
+  };
+
+  const mapping = (over: Partial<UserMapping> = {}): UserMapping => ({
+    userId: 1,
+    slackUserId: 'U1',
+    lifeChannelId: 'C_LIFE',
+    insightChannelId: 'C_INSIGHT',
+    ...over,
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue({ release: vi.fn() });
+    await connectDB('postgresql://test@localhost/test');
+    // 기본: 임박(만료 2026-08-14, 오늘 7일 전)
+    mockTodayISO.mockReturnValue('2026-08-07');
+    mockDayOfWeek.mockReturnValue(MONDAY);
+  });
+
+  afterEach(() => {
+    mockTodayISO.mockReturnValue('2026-03-12');
+    mockDayOfWeek.mockReturnValue(4);
+  });
+
+  it('화요일 → 무음 (DB 조회조차 안 함)', async () => {
+    mockDayOfWeek.mockReturnValue(TUESDAY);
+    setupExpiryMock('2026-08', [mapping()]);
+    const app = createMockApp() as { client: { chat: { postMessage: ReturnType<typeof vi.fn> } } };
+
+    await warnTargetExpiryIfNear(app as never, config);
+
+    expect(app.client.chat.postMessage).not.toHaveBeenCalled();
+    const budgetQueries = mockQuery.mock.calls.filter((c) =>
+      /budget_settings/.test(c[0] as string),
+    );
+    expect(budgetQueries).toHaveLength(0);
+  });
+
+  it('월요일 + 임박(7일 전) → life 채널로 전송', async () => {
+    setupExpiryMock('2026-08', [mapping()]);
+    const app = createMockApp() as { client: { chat: { postMessage: ReturnType<typeof vi.fn> } } };
+
+    await warnTargetExpiryIfNear(app as never, config);
+
+    expect(app.client.chat.postMessage).toHaveBeenCalledTimes(1);
+    const arg = app.client.chat.postMessage.mock.calls[0][0] as { channel: string; text: string };
+    expect(arg.channel).toBe('C_LIFE');
+    expect(arg.text).toContain('7일 뒤에 끝나');
+  });
+
+  it('월요일 + life 채널 없음 → slackUserId(DM)로 폴백', async () => {
+    setupExpiryMock('2026-08', [mapping({ lifeChannelId: null })]);
+    const app = createMockApp() as { client: { chat: { postMessage: ReturnType<typeof vi.fn> } } };
+
+    await warnTargetExpiryIfNear(app as never, config);
+
+    const arg = app.client.chat.postMessage.mock.calls[0][0] as { channel: string };
+    expect(arg.channel).toBe('U1');
+  });
+
+  it('월요일 + 아직 여유(43일 전) → 무음', async () => {
+    mockTodayISO.mockReturnValue('2026-07-02');
+    setupExpiryMock('2026-08', [mapping()]);
+    const app = createMockApp() as { client: { chat: { postMessage: ReturnType<typeof vi.fn> } } };
+
+    await warnTargetExpiryIfNear(app as never, config);
+
+    expect(app.client.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('월요일 + target_date 없음 → 무음', async () => {
+    setupExpiryMock(null, [mapping()]);
+    const app = createMockApp() as { client: { chat: { postMessage: ReturnType<typeof vi.fn> } } };
+
+    await warnTargetExpiryIfNear(app as never, config);
+
+    expect(app.client.chat.postMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -336,6 +336,78 @@ export const getBillingMonthForDate = (isoDate: string): string => {
   return `${year}-${String(month).padStart(2, '0')}`;
 };
 
+// ─── 목표 기간 만료 임박 알림 (#554) ────────────────────
+
+/** 만료 임박 경고를 시작하는 남은 일수 (6주). */
+export const TARGET_EXPIRY_WARN_DAYS = 42;
+
+/** 두 날짜(YYYY-MM-DD) 사이의 일수 (to − from). */
+const diffDaysISO = (from: string, to: string): number => {
+  const msPerDay = 86_400_000;
+  const fromMs = new Date(`${from}T00:00:00+09:00`).getTime();
+  const toMs = new Date(`${to}T00:00:00+09:00`).getTime();
+  return Math.round((toMs - fromMs) / msPerDay);
+};
+
+/**
+ * 목표 기간(target_date 'YYYY-MM')의 만료일 = 그 달 결제 주기의 마지막 날.
+ * getBillingMonthForDate와 같은 15일-시작 규칙(전월 15일 ~ 당월 14일) → 만료일 = target_date 그 달 14일.
+ * (예: target '2026-08' → 만료일 '2026-08-14')
+ */
+export const getTargetExpiryDate = (targetDate: string): string => `${targetDate}-14`;
+
+/**
+ * 목표 기간 만료 임박/경과 안내 문구 생성 (순수 함수).
+ * - target_date 없음 → null (안내 없음)
+ * - 남은 일수 > 42(6주) → null (아직 여유)
+ * - 0 < 남은 일수 ≤ 42 → 임박 안내
+ * - 남은 일수 ≤ 0 (만료일 당일 포함 이후) → 정지 안내
+ * 금액·재정 상황 언급 없이 기간·일수만 사용.
+ */
+export const buildTargetExpiryWarning = (
+  targetDate: string | null,
+  today: string,
+): string | null => {
+  if (!targetDate) return null;
+
+  const expiry = getTargetExpiryDate(targetDate);
+  const remaining = diffDaysISO(today, expiry);
+
+  if (remaining > TARGET_EXPIRY_WARN_DAYS) return null;
+
+  if (remaining > 0) {
+    return `예산 목표 기간(${targetDate})이 ${remaining}일 뒤에 끝나. 끝나면 예산 계산이 멈추니까 대시보드 설정에서 연장해두자.`;
+  }
+
+  return '예산 목표 기간이 지났어. 연장 전까지 예산 계산이 멈춰 있어 — 설정에서 target 늘려줘.';
+};
+
+/**
+ * 월요일에만 목표 기간 만료 임박/경과를 채널로 안내 (주 1회 중복 방지, 별도 상태 저장 불필요).
+ * 채널: 매핑에 money 전용 채널이 없으므로 life 채널(없으면 DM)로 폴백.
+ * 아침 알림 본체에 영향 없도록 morningTask에서 try/catch로 격리 호출.
+ */
+export const warnTargetExpiryIfNear = async (app: App, config: LifeCronConfig): Promise<void> => {
+  // 월요일(1)에만 실행 → 주 1회.
+  if (getKSTDayOfWeek() !== 1) return;
+
+  const today = getTodayISO();
+
+  await forEachUser(config, 'life', '목표 기간 만료 알림', async (userId, channelId) => {
+    const result = await query<{ target_date: string | null }>(
+      'SELECT target_date FROM budget_settings WHERE user_id = $1',
+      [userId],
+    );
+    const targetDate = result.rows[0]?.target_date ?? null;
+
+    const message = buildTargetExpiryWarning(targetDate, today);
+    if (!message) return;
+
+    await postToChannel(app.client, channelId, message);
+    console.warn(`[Life Cron] 목표 기간 만료 알림 전송 (유저=${userId})`);
+  });
+};
+
 /**
  * 어제자 daily_budget_logs 누락 감지 → 직접 INSERT 백필.
  * - budget: 같은 billing_month의 직전 로그에서 복제 (allocation 로직 미복제 — 웹 없이는 재현 불가)
@@ -437,6 +509,14 @@ const morningTask = async (app: App, config: LifeCronConfig): Promise<void> => {
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : String(error);
     console.error('[Life Cron] 일별 예산 로그 백필 체크 실패:', msg);
+  }
+
+  // 목표 기간 만료 임박 알림 (월요일만, 주 1회) — 실패해도 아침 알림 본체에 영향 없게 격리
+  try {
+    await warnTargetExpiryIfNear(app, config);
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error('[Life Cron] 목표 기간 만료 알림 체크 실패:', msg);
   }
 
   await forEachUser(config, 'life', '아침 알림', async (userId, channelId) => {


### PR DESCRIPTION
## 배경

목표 기간이 만료되면 예산 계산이 정지되는데(#539 설계 수용), 임박 경고가 대시보드 안에만 있었다. 봇이 만료 전부터 채널로 미리 안내하도록 경량 체크를 추가한다.

## 변경

- 아침 크론(`morningTask`)에 만료 임박 체크 `warnTargetExpiryIfNear` 추가
  - **월요일에만 실행** → 주 1회 (별도 상태 저장 없이 요일 게이트로 중복 방지)
  - 백필 체크와 동일하게 `try/catch`로 격리 — 실패해도 아침 알림 본체에 영향 없음
- 만료일 산식은 기존 결제주기 규칙(`getBillingMonthForDate`, 15일-시작)과 통일 — 목표 기간 그 달 14일
- 남은 기간이 6주 이내면 임박 안내, 이미 지났으면 정지 안내
- 채널 라우팅: 사용자 매핑에 전용 채널이 있으면 그쪽, 없으면 DM 폴백
- 안내 문구는 기간·일수만 노출 (금액·수치 없음)

## 테스트

- 순수 함수(`buildTargetExpiryWarning`·`getTargetExpiryDate`) 분리 → 날짜 픽스처 검증
  - 6주 밖(무음) / 6주 경계 / 임박 / 만료일 당일·다음날(정지) / target 미설정
- `warnTargetExpiryIfNear` 요일 게이트 + 채널 라우팅(전용 채널 / DM 폴백) 통합 테스트
- `yarn tsc --noEmit`·`yarn vitest run`(945 tests) 전체 통과

## 완료 기준

- [x] 만료 임박 채널 알림 (기존 봇 크론에 경량 체크 추가)
- [x] 중복 알림 방지 (주 1회 수준)
- [x] 테스트

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)