### PR TITLE
fix(insight): 기각 이력 신호 재생성 가드 (#557)

### DIFF
--- a/db/migrations/098_signal_defs_pending_identity.sql
+++ b/db/migrations/098_signal_defs_pending_identity.sql
@@ -1,0 +1,40 @@
+-- 098: 신호 재생성 가드 — active/pending 부분 unique 인덱스 (#557)
+-- 배경: 085가 active sql 신호에 부분 unique 인덱스(uq_signal_defs_sql_active)를 걸어 동일 측정
+--   신호의 재-active를 막았으나 status='pending'은 인덱스 밖이었다. monthly-signal-suggest routine(repo 밖)이
+--   동일 정의를 pending으로 INSERT하면 인덱스에 걸리지 않고 슬쩍 들어와 승인 카드로 노출된다(피로 + m-인플레).
+-- 변경: 같은 시맨틱 키의 부분 unique 인덱스를 status IN ('active','pending')으로 확장 신설. 085 인덱스와
+--   공존(active만 vs active+pending) — 085는 active 재삽입, 098은 active/pending 간 중복까지 구조적 차단.
+-- 키: 085와 동일 (user_id, name, sql_body, value_type, direction, COALESCE(threshold,-1),
+--   COALESCE(domain,''), COALESCE(window_days,-1)). NULL은 센티널로 distinct 방지. tag 신호는
+--   077 uq_signal_defs_tag(user, tag)가 이미 전역 1개를 보장하므로 sql 신호만 대상.
+-- 안전(방어적): prod에 이미 active/pending 동일 정의가 있으면 CREATE UNIQUE INDEX가 실패해 마이그레이션
+--   전체가 롤백된다. 사전에 위반을 세어 있으면 NOTICE만 내고 인덱스 생성을 건너뛴다(데이터 dedup은 별도
+--   후속 — 링크 FK repoint 위험을 야간 배포에 싣지 않는다). 위반 0이면 인덱스 생성. 멱등(IF NOT EXISTS).
+
+DO $$
+DECLARE
+  dup_cnt INT;
+BEGIN
+  -- active/pending sql 신호 중 동일 시맨틱 키가 2벌 이상인 그룹의 잉여 수.
+  SELECT COALESCE(sum(cnt - 1), 0) INTO dup_cnt FROM (
+    SELECT count(*) AS cnt FROM signal_defs
+     WHERE kind = 'sql' AND status IN ('active', 'pending')
+     GROUP BY user_id, name, sql_body, value_type, direction,
+              COALESCE(threshold, '-1'::numeric), COALESCE(domain, ''), COALESCE(window_days, -1)
+    HAVING count(*) > 1
+  ) g;
+
+  IF dup_cnt <> 0 THEN
+    RAISE NOTICE '[098] active/pending sql 신호 동일 정의 중복 % 건 잔존 → 인덱스 생성 건너뜀(코드 가드로 방어, dedup은 후속)', dup_cnt;
+  ELSE
+    EXECUTE $ix$
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_signal_defs_sql_active_pending
+        ON signal_defs (
+          user_id, name, sql_body, value_type, direction,
+          COALESCE(threshold, '-1'::numeric), COALESCE(domain, ''), COALESCE(window_days, -1)
+        )
+        WHERE kind = 'sql' AND status IN ('active', 'pending')
+    $ix$;
+    RAISE NOTICE '[098] active/pending sql 신호 부분 unique 인덱스 생성 완료';
+  END IF;
+END $$;

--- a/db/migrations/099_signal_defs_pending_identity.sql
+++ b/db/migrations/099_signal_defs_pending_identity.sql
@@ -1,4 +1,4 @@
--- 098: 신호 재생성 가드 — active/pending 부분 unique 인덱스 (#557)
+-- 099: 신호 재생성 가드 — active/pending 부분 unique 인덱스 (#557)
 -- 배경: 085가 active sql 신호에 부분 unique 인덱스(uq_signal_defs_sql_active)를 걸어 동일 측정
 --   신호의 재-active를 막았으나 status='pending'은 인덱스 밖이었다. monthly-signal-suggest routine(repo 밖)이
 --   동일 정의를 pending으로 INSERT하면 인덱스에 걸리지 않고 슬쩍 들어와 승인 카드로 노출된다(피로 + m-인플레).

--- a/src/agents/insight/__tests__/actions.test.ts
+++ b/src/agents/insight/__tests__/actions.test.ts
@@ -70,33 +70,71 @@ describe('dismissDiscoveryLink — pending → archived', () => {
   });
 });
 
-describe('approveLlmSignal — pending → active (게이트 #1 재검증, ADR-0040)', () => {
-  it('검증 통과 sql_body면 active 전이 + signalId 반환', async () => {
+describe('approveLlmSignal — pending → active (게이트 #1 재검증, ADR-0040 + 재생성 가드 #557)', () => {
+  /** 승인 대상 pending 신호의 identity SELECT 응답. */
+  const pendingRow = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+    sql_body: 'SELECT count(*) FROM schedules WHERE user_id = $1 AND date = $2',
+    name: 'schedule_completion_rate',
+    kind: 'sql',
+    direction: 'above_avg',
+    threshold: null,
+    tag_name: null,
+    ...over,
+  });
+
+  it('검증 통과 + 동일 정의 없음이면 active 전이 + signalId 반환', async () => {
     resultQueue = [
-      { rows: [{ sql_body: 'SELECT count(*) FROM schedules WHERE user_id = $1 AND date = $2' }] },
-      { rows: [{ id: 88 }] },
+      { rows: [pendingRow()] }, // identity SELECT
+      { rows: [] }, // findEquivalentSignal → absent
+      { rows: [{ id: 88 }] }, // UPDATE
     ];
     const out = await approveLlmSignal(1, 88);
     expect(out).toBe(88);
-    expect(captured).toHaveLength(2);
-    expect(captured[0]?.sql).toMatch(/SELECT sql_body FROM signal_defs/);
+    expect(captured).toHaveLength(3);
+    expect(captured[0]?.sql).toMatch(/SELECT sql_body, name, kind, direction, threshold, tag_name/);
     expect(captured[0]?.sql).toMatch(/status = 'pending' AND source = 'llm'/);
-    expect(captured[1]?.sql).toMatch(/UPDATE signal_defs SET status = 'active'/);
-    expect(captured[1]?.sql).toMatch(/source = 'llm'/); // llm만
-    expect(captured[1]?.params).toEqual([88, 1]); // [signalId, userId]
+    // findEquivalentSignal은 자신 제외(excludeId=signalId).
+    expect(captured[1]?.sql).toMatch(/SELECT id, status FROM signal_defs/);
+    expect(captured[1]?.params?.[7]).toBe(88);
+    expect(captured[2]?.sql).toMatch(/UPDATE signal_defs SET status = 'active'/);
+    expect(captured[2]?.sql).toMatch(/source = 'llm'/); // llm만
+    expect(captured[2]?.params).toEqual([88, 1]); // [signalId, userId]
   });
 
-  it('검증 실패 sql_body면 활성화 거부(UPDATE 안 함, null)', async () => {
-    resultQueue = [{ rows: [{ sql_body: 'SELECT sum(value) FROM assets WHERE user_id = $1' }] }];
+  it('검증 실패 sql_body면 활성화 거부(equiv 조회·UPDATE 안 함, null)', async () => {
+    resultQueue = [
+      { rows: [pendingRow({ sql_body: 'SELECT sum(value) FROM assets WHERE user_id = $1' })] },
+    ];
     const out = await approveLlmSignal(1, 88);
     expect(out).toBeNull();
-    expect(captured).toHaveLength(1); // SELECT만, UPDATE 미실행
+    expect(captured).toHaveLength(1); // identity SELECT만, equiv·UPDATE 미실행
+  });
+
+  it('기각 이력 동일 정의만 존재 → 활성화 거부(UPDATE 안 함, null)', async () => {
+    resultQueue = [
+      { rows: [pendingRow()] }, // identity SELECT
+      { rows: [{ id: 3, status: 'rejected' }] }, // findEquivalentSignal → skip_rejected
+    ];
+    const out = await approveLlmSignal(1, 88);
+    expect(out).toBeNull();
+    expect(captured).toHaveLength(2); // equiv까지, UPDATE 미실행
+    expect(captured[1]?.sql).toMatch(/SELECT id, status FROM signal_defs/);
+  });
+
+  it('다른 active 동일 정의 존재(중복) → 활성화 거부(null)', async () => {
+    resultQueue = [
+      { rows: [pendingRow()] },
+      { rows: [{ id: 42, status: 'active' }] }, // findEquivalentSignal → reuse
+    ];
+    const out = await approveLlmSignal(1, 88);
+    expect(out).toBeNull();
+    expect(captured).toHaveLength(2); // UPDATE 미실행
   });
 
   it('pending/llm/본인 아님(SELECT 0행)이면 null', async () => {
     resultQueue = [{ rows: [] }];
     expect(await approveLlmSignal(1, 99)).toBeNull();
-    expect(captured).toHaveLength(1); // UPDATE 미시도
+    expect(captured).toHaveLength(1); // equiv·UPDATE 미시도
   });
 });
 

--- a/src/agents/insight/actions.ts
+++ b/src/agents/insight/actions.ts
@@ -11,6 +11,7 @@
 import type { App } from '@slack/bolt';
 import type { KnownBlock } from '@slack/types';
 import { query } from '../../shared/db.js';
+import { findEquivalentSignal } from '../../shared/signal-defs.js';
 import { validateSignalSql } from '../../shared/signal-sql-guard.js';
 import { resolveActionCard, updateMessage } from '../../shared/slack.js';
 import { resolveUserId, DEFAULT_USER_ID } from '../../shared/user-resolver.js';
@@ -90,22 +91,54 @@ export const dismissDiscoveryLink = async (
 /**
  * LLM 신호 승인 — 게이트 #1 정적 재검증 통과 시에만 pending → active (#477 P5b).
  * 저장된 sql_body도 불신: 승인 시점에 validateSignalSql 재실행, 실패하면 활성화 거부(미승인 = 실행 0).
+ *
+ * 재생성 가드(#557): monthly-signal-suggest routine(repo 밖)이 기각 이력이 있는 동일 정의를 다시
+ * pending으로 INSERT할 수 있다 — SKILL 프롬프트가 그걸 걸러도 봇 승인 게이트가 최종 방어선이다.
+ * 승격 직전 findEquivalentSignal(자신 제외)로 동일 측정 정의를 확인:
+ *   - 다른 active/pending 동일 정의가 있으면 중복 활성화 거부(reuse).
+ *   - rejected 동일 정의만 있으면 기각 재활성화 거부(skip_rejected) — 사람이 기각한 걸 조용히 되살리지 않는다.
+ *
  * 가드: 본인(user_id=$2) + pending + source='llm'만. @returns 활성화된 signalId, 아니면 null.
  */
 export const approveLlmSignal = async (
   userId: number,
   signalId: number,
 ): Promise<number | null> => {
-  const sel = await query<{ sql_body: string | null }>(
-    `SELECT sql_body FROM signal_defs
+  const sel = await query<{
+    sql_body: string | null;
+    name: string;
+    kind: 'sql' | 'tag';
+    direction: string | null;
+    threshold: string | null;
+    tag_name: string | null;
+  }>(
+    `SELECT sql_body, name, kind, direction, threshold, tag_name FROM signal_defs
        WHERE id = $1 AND user_id = $2 AND status = 'pending' AND source = 'llm'`,
     [signalId, userId],
   );
-  const sql = sel.rows[0]?.sql_body;
-  if (!sql) return null;
+  const row = sel.rows[0];
+  const sql = row?.sql_body;
+  if (!row || !sql) return null;
   const err = validateSignalSql(sql);
   if (err) {
     console.warn(`[Insight Action] llm_signal 승인 거부(검증 실패) id=${signalId}: ${err}`);
+    return null;
+  }
+  const eq = await findEquivalentSignal(
+    userId,
+    {
+      name: row.name,
+      kind: row.kind,
+      direction: row.direction,
+      threshold: row.threshold === null ? null : Number(row.threshold),
+      tagName: row.tag_name,
+      sqlBody: row.sql_body,
+    },
+    signalId,
+  );
+  if (eq.decision !== 'absent') {
+    const why = eq.decision === 'reuse' ? '동일 정의 이미 활성/대기' : '기각 이력 재활성화 차단';
+    console.warn(`[Insight Action] llm_signal 승인 거부(${why}) id=${signalId}`);
     return null;
   }
   const res = await query<{ id: number }>(

--- a/src/shared/__tests__/pattern-verification.test.ts
+++ b/src/shared/__tests__/pattern-verification.test.ts
@@ -38,8 +38,9 @@ vi.mock('../db.js', () => ({
     if (/FROM signal_defs/i.test(s) && /WHERE id = \$1 AND user_id = \$2/i.test(s)) {
       return { rows: signalRow ? [signalRow] : [] }; // 대상 신호 로드
     }
-    if (/FROM signal_defs/i.test(s) && /direction = \$4/i.test(s)) {
-      return { rows: mirrorRows }; // 거울 존재 조회
+    // findEquivalentSignal(#557) 거울 존재 조회 — id·status 컬럼, IS NOT DISTINCT FROM 매칭.
+    if (/SELECT id, status FROM signal_defs/i.test(s) && /IS NOT DISTINCT FROM/i.test(s)) {
+      return { rows: mirrorRows };
     }
     throw new Error(`[fixture] unexpected SQL: ${s.slice(0, 60)}`);
   }),

--- a/src/shared/__tests__/signal-defs.test.ts
+++ b/src/shared/__tests__/signal-defs.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── db mock — findEquivalentSignal의 단일 SELECT를 캡처하고 rows를 되돌린다 ──
+interface EquivRow {
+  id: number;
+  status: 'active' | 'pending' | 'rejected';
+}
+let equivRows: EquivRow[];
+let captured: Array<{ sql: string; params: readonly unknown[] }>;
+
+const resetDb = (): void => {
+  equivRows = [];
+  captured = [];
+};
+resetDb();
+
+vi.mock('../db.js', () => ({
+  query: vi.fn(async (sql: string, params?: readonly unknown[]) => {
+    captured.push({ sql, params: params ?? [] });
+    return { rows: equivRows };
+  }),
+}));
+
+import { findEquivalentSignal, type SignalIdentity } from '../signal-defs.js';
+
+const sqlIdentity = (over: Partial<SignalIdentity> = {}): SignalIdentity => ({
+  name: 'schedule_completion_rate',
+  kind: 'sql',
+  direction: 'above_avg',
+  threshold: null,
+  tagName: null,
+  sqlBody: 'SELECT 1',
+  ...over,
+});
+
+describe('findEquivalentSignal', () => {
+  beforeEach(() => resetDb());
+
+  it('동일 정의 부재 → absent (생성 허용)', async () => {
+    equivRows = [];
+    const res = await findEquivalentSignal(1, sqlIdentity());
+    expect(res.decision).toBe('absent');
+  });
+
+  it('active 동일 정의 존재 → reuse (그 id 반환, 재생성 금지)', async () => {
+    equivRows = [{ id: 42, status: 'active' }];
+    const res = await findEquivalentSignal(1, sqlIdentity());
+    expect(res).toEqual({ decision: 'reuse', signalId: 42, status: 'active' });
+  });
+
+  it('pending 동일 정의 존재 → reuse', async () => {
+    equivRows = [{ id: 7, status: 'pending' }];
+    const res = await findEquivalentSignal(1, sqlIdentity());
+    expect(res).toEqual({ decision: 'reuse', signalId: 7, status: 'pending' });
+  });
+
+  it('rejected 동일 정의만 존재 → skip_rejected (기각 재생성 차단)', async () => {
+    equivRows = [
+      { id: 3, status: 'rejected' },
+      { id: 9, status: 'rejected' },
+    ];
+    const res = await findEquivalentSignal(1, sqlIdentity());
+    expect(res.decision).toBe('skip_rejected');
+  });
+
+  it('active + rejected 혼재 → reuse가 rejected보다 우선', async () => {
+    equivRows = [
+      { id: 3, status: 'rejected' },
+      { id: 42, status: 'active' },
+    ];
+    const res = await findEquivalentSignal(1, sqlIdentity());
+    expect(res.decision).toBe('reuse');
+    if (res.decision === 'reuse') expect(res.signalId).toBe(42);
+  });
+
+  it('active 여러 벌 → active 우선 + MIN id 선택', async () => {
+    equivRows = [
+      { id: 50, status: 'pending' },
+      { id: 30, status: 'active' },
+      { id: 20, status: 'active' },
+    ];
+    const res = await findEquivalentSignal(1, sqlIdentity());
+    expect(res.decision).toBe('reuse');
+    if (res.decision === 'reuse') {
+      expect(res.status).toBe('active');
+      expect(res.signalId).toBe(20); // active 중 MIN id
+    }
+  });
+
+  it('동일성 쿼리는 user_id 격리 + name·kind·direction·threshold·tag_name·sql_body(IS NOT DISTINCT FROM) 매칭', async () => {
+    equivRows = [];
+    await findEquivalentSignal(1, sqlIdentity({ threshold: 5, direction: 'below_avg' }));
+    const rec = captured[0];
+    expect(rec?.sql).toMatch(/FROM signal_defs/);
+    expect(rec?.sql).toMatch(/user_id = \$1/);
+    expect(rec?.sql).toMatch(/direction IS NOT DISTINCT FROM \$4/);
+    expect(rec?.sql).toMatch(/threshold IS NOT DISTINCT FROM \$5/);
+    expect(rec?.sql).toMatch(/tag_name IS NOT DISTINCT FROM \$6/);
+    expect(rec?.sql).toMatch(/sql_body IS NOT DISTINCT FROM \$7/);
+    // 파라미터 순서: [userId, name, kind, direction, threshold, tagName, sqlBody, excludeId]
+    expect(rec?.params?.[0]).toBe(1);
+    expect(rec?.params?.[2]).toBe('sql');
+    expect(rec?.params?.[3]).toBe('below_avg');
+    expect(rec?.params?.[4]).toBe(5);
+    expect(rec?.params?.[7]).toBeNull(); // excludeId 미지정
+  });
+
+  it('excludeId 지정 시 자기 자신 제외 조건 포함', async () => {
+    equivRows = [];
+    await findEquivalentSignal(1, sqlIdentity(), 88);
+    const rec = captured[0];
+    expect(rec?.sql).toMatch(/id <> \$8/);
+    expect(rec?.params?.[7]).toBe(88);
+  });
+
+  it('tag 신호도 동일 헬퍼로 판정 (tag_name 매칭, sql_body는 양쪽 NULL)', async () => {
+    equivRows = [{ id: 12, status: 'active' }];
+    const res = await findEquivalentSignal(
+      1,
+      sqlIdentity({ kind: 'tag', direction: null, sqlBody: null, tagName: 'flow' }),
+    );
+    expect(res.decision).toBe('reuse');
+    const rec = captured[0];
+    expect(rec?.params?.[2]).toBe('tag');
+    expect(rec?.params?.[5]).toBe('flow');
+    expect(rec?.params?.[6]).toBeNull(); // sqlBody
+  });
+});

--- a/src/shared/pattern-verification.ts
+++ b/src/shared/pattern-verification.ts
@@ -14,6 +14,7 @@
  */
 
 import { query } from './db.js';
+import { findEquivalentSignal } from './signal-defs.js';
 import { addDays } from './kst.js';
 import {
   fisherExact,
@@ -545,20 +546,20 @@ export const ensureMirrorSignalDef = async (
     return { outcome: 'ineligible', mirrorSignalId: null };
   }
 
-  // 같은 측정 정의(name·sql·threshold·domain) + 반전 direction 행 조회. NULL threshold/domain은 IS NOT DISTINCT FROM으로 매칭.
-  const existing = await query<{ status: string }>(
-    `SELECT status FROM signal_defs
-      WHERE user_id = $1 AND kind = 'sql' AND source = 'seed' AND name = $2
-        AND sql_body = $3 AND direction = $4
-        AND threshold IS NOT DISTINCT FROM $5
-        AND domain IS NOT DISTINCT FROM $6`,
-    [userId, row.name, row.sql_body, mirror, row.threshold, row.domain],
-  );
-  if (existing.rows.some((r) => r.status === 'active' || r.status === 'pending')) {
+  // 같은 측정 정의(name·kind·threshold·sql) + 반전 direction 신호가 이미 있으면 재생성 금지 (#557 공통 가드).
+  // NULL threshold는 IS NOT DISTINCT FROM으로 매칭. active/pending → 재사용(exists), rejected만 → 스킵.
+  const eq = await findEquivalentSignal(userId, {
+    name: row.name,
+    kind: 'sql',
+    direction: mirror,
+    threshold: row.threshold === null ? null : Number(row.threshold),
+    tagName: null,
+    sqlBody: row.sql_body,
+  });
+  if (eq.decision === 'reuse') {
     return { outcome: 'exists', mirrorSignalId: null };
   }
-  if (existing.rows.length > 0) {
-    // active/pending은 없고 rejected 이력만 존재 — 되살리지 않는다(재기각 방지).
+  if (eq.decision === 'skip_rejected') {
     console.warn(
       `[MirrorSignal] user=${userId} signal=${signalId} 거울(${row.name} ${mirror}) 기각 이력만 존재 — 생성 스킵`,
     );

--- a/src/shared/signal-defs.ts
+++ b/src/shared/signal-defs.ts
@@ -1,0 +1,106 @@
+/**
+ * signal_defs 재생성 가드 — #557 (2026-07 감사 S7).
+ *
+ * 배경: 077이 pattern_metrics(시드별 행)를 signal_defs로 1:1 이관하며 동일 측정 신호가 시드 수만큼
+ *   중복 생성됐고(085에서 dedup + active 부분 unique 인덱스로 정리), 이후에도 자동 생성 경로가
+ *   "기각 이력이 있는 동일 정의"를 조용히 다시 만들 여지가 남았다. 같은 가설이 기각→재등장→기각
+ *   루프를 돌면 승인 카드 피로 + 통계 가족 m-인플레이션을 만든다.
+ *
+ * findEquivalentSignal: 자동 생성 직전에 "이미 같은 측정을 하는 신호가 있는가"를 판정한다.
+ *   - active/pending 동일 정의 존재 → 재사용(reuse) — 새 INSERT 금지.
+ *   - rejected 동일 정의만 존재 → 스킵(skip_rejected) + warn — 기각의 의미를 보존(사람이 명시적으로
+ *     재도전할 때만 되살린다).
+ *   - 부재 → 생성 허용(absent).
+ *
+ * 동일성 기준(#555 ensureMirrorSignalDef 조회 기준과 일치): (name, direction, kind, threshold, tag_name)
+ *   — NULL은 IS NOT DISTINCT FROM으로 매칭 — 에 더해 sql 신호는 sql_body 포함. user_id로 격리(교차 유저
+ *   신호를 동일 정의로 오인하지 않게). source(seed/llm)는 판정에서 제외한다 — "무엇을 측정하는가"는
+ *   측정 정의이지 누가 제안했는가가 아니다(같은 측정을 llm이 다시 제안해도 중복).
+ *
+ * 이 헬퍼는 앱(TS) 생성 경로의 방어선이다. monthly-signal-suggest routine(repo 밖)의 pending INSERT는
+ * DB Proxy로 raw SQL이 들어오므로 이 헬퍼를 경유하지 않는다 — 그 경로는 봇 승인 게이트(approveLlmSignal)
+ * + DB 부분 unique 인덱스가 최종 방어선이다.
+ */
+
+import { query } from './db.js';
+
+/** 재생성 판정 대상 신호의 측정 정의. NULL 필드는 IS NOT DISTINCT FROM으로 매칭된다. */
+export interface SignalIdentity {
+  name: string;
+  kind: 'sql' | 'tag';
+  direction: string | null;
+  threshold: number | null;
+  tagName: string | null;
+  /** sql 신호의 본문. tag 신호는 null. */
+  sqlBody: string | null;
+}
+
+export type EquivalentDecision =
+  /** active/pending 동일 정의가 이미 있다 — 재사용(새 INSERT 금지). */
+  | { decision: 'reuse'; signalId: number; status: 'active' | 'pending' }
+  /** rejected 동일 정의만 있다 — 생성 스킵(기각 의미 보존). */
+  | { decision: 'skip_rejected' }
+  /** 동일 정의 없음 — 생성 허용. */
+  | { decision: 'absent' };
+
+interface EquivalentRow {
+  id: number;
+  status: 'active' | 'pending' | 'rejected';
+}
+
+/**
+ * 같은 측정 정의(SignalIdentity)를 가진 신호가 이미 있는지 판정한다 (#557).
+ *   - active/pending이 있으면 그중 하나를 재사용 대상으로 반환(active 우선, 그다음 MIN id).
+ *   - active/pending은 없고 rejected만 있으면 skip_rejected.
+ *   - 하나도 없으면 absent.
+ * user_id로 격리 — 교차 유저 신호는 동일 정의로 보지 않는다.
+ * excludeId — 자기 자신 제외(승인 게이트에서 승격 대상 pending 행이 자신과 매칭되는 것 방지).
+ */
+export const findEquivalentSignal = async (
+  userId: number,
+  identity: SignalIdentity,
+  excludeId?: number,
+): Promise<EquivalentDecision> => {
+  const res = await query<EquivalentRow>(
+    `SELECT id, status FROM signal_defs
+      WHERE user_id = $1
+        AND name = $2
+        AND kind = $3
+        AND direction IS NOT DISTINCT FROM $4
+        AND threshold IS NOT DISTINCT FROM $5
+        AND tag_name IS NOT DISTINCT FROM $6
+        AND sql_body IS NOT DISTINCT FROM $7
+        AND ($8::int IS NULL OR id <> $8)`,
+    [
+      userId,
+      identity.name,
+      identity.kind,
+      identity.direction,
+      identity.threshold,
+      identity.tagName,
+      identity.sqlBody,
+      excludeId ?? null,
+    ],
+  );
+  const rows = res.rows;
+  const reusable = rows
+    .filter((r) => r.status === 'active' || r.status === 'pending')
+    .sort((a, b) => {
+      // active 우선, 그다음 MIN id — 재사용 대상 안정적 선택.
+      if (a.status !== b.status) return a.status === 'active' ? -1 : 1;
+      return a.id - b.id;
+    });
+  const chosen = reusable[0];
+  if (chosen) {
+    return {
+      decision: 'reuse',
+      signalId: chosen.id,
+      status: chosen.status as 'active' | 'pending',
+    };
+  }
+  if (rows.length > 0) {
+    // active/pending은 없고 rejected 이력만 존재 — 되살리지 않는다.
+    return { decision: 'skip_rejected' };
+  }
+  return { decision: 'absent' };
+};


### PR DESCRIPTION
Closes #557

## 배경

동일 측정 정의가 status만 다른 채로 여러 벌 존재하고(기각 이력 포함), 자동 생성 경로가 "기각된 것과 동일한 정의"를 조용히 다시 만들 여지가 남아 있었다. 같은 가설이 기각→재등장→기각 루프를 돌면 승인 카드 피로 + 통계 가족 m-인플레이션을 만든다. 이 PR은 재생성 경로에 공통 가드를 심고, #555에서 도입된 기각-스킵 로직을 그 가드로 일원화한다.

## 조사 — signal_defs 생성 경로 전수 (`grep -rn "INSERT INTO signal_defs" src web scripts db`)

| 경로 | 위치 | 성격 | 가드 대상 |
|------|------|------|-----------|
| 077 이관 INSERT | `db/migrations/077_*.sql` | 일회성 (pattern_metrics → signal_defs 1:1) | N (이미 실행됨) |
| 086 시드 정밀화 INSERT | `db/migrations/086_*.sql` | 일회성 시드 | N |
| 거울 신호 보장 (#555) | `src/shared/pattern-verification.ts` `ensureMirrorSignalDef` | 런타임 자동 생성 (역방향 종결 시) | ✅ 헬퍼로 일원화 |
| LLM 신호 제안 pending INSERT | `monthly-signal-suggest` routine (repo 밖, DB Proxy 경유 raw SQL) | 무인 야간 생성 | ⛔ TS에서 직접 가드 불가 → 승인 게이트 + DB 인덱스가 방어선 |
| 발굴 엔진 (P5a) | `src/agents/insight/hypothesis-discovery.ts` | `pattern_links`만 INSERT, `signal_defs`는 SELECT(active)만 | 해당 없음 |

- **repo 내 런타임 signal_defs INSERT는 `ensureMirrorSignalDef` 단 하나**였다. 발굴 엔진은 기존 active 신호를 링크할 뿐 새 신호를 만들지 않는다.
- **LLM 신호 pending INSERT는 repo 밖 routine이 DB Proxy로 raw SQL을 보내는 구조**라 TS 헬퍼를 경유하지 않는다. 따라서 이 경로의 최종 방어선은 (a) 봇 승인 게이트(`approveLlmSignal`)와 (b) DB 부분 unique 인덱스다.
- 기존 방어: 마이그 085가 active sql 신호에 부분 unique 인덱스(`uq_signal_defs_sql_active`)를 이미 걸어 뒀으나 **`status='pending'`은 인덱스 밖**이었다 — routine이 동일 정의를 pending으로 밀어 넣으면 인덱스에 안 걸리고 승인 카드로 노출되는 틈이 남아 있었다.
- 중복 벌들은 077이 시드별 행을 신호로 1:1 이관하며 생긴 것(측정 정의는 같고 시드만 다름). 085에서 dedup 후 잉여를 rejected 처리한 이력이 있어, "동일 정의 N벌 중 일부 rejected" 형태가 남아 있다.

## 변경

### 1. 공통 헬퍼 `findEquivalentSignal` (`src/shared/signal-defs.ts`)

자동 생성 직전 "이미 같은 측정을 하는 신호가 있는가"를 판정:
- active/pending 동일 정의 존재 → `reuse` (새 INSERT 금지, 기존 행 id 반환)
- rejected 동일 정의만 존재 → `skip_rejected` (생성 스킵, 기각 의미 보존)
- 부재 → `absent` (생성 허용)

동일성 기준: `(name, direction, kind, threshold, tag_name)` + sql 신호는 `sql_body` 포함, NULL은 `IS NOT DISTINCT FROM`. `user_id` 격리(교차 유저 신호 오인 방지) + `excludeId`(승인 게이트에서 자기 자신 제외). source(seed/llm)는 판정에서 제외 — "무엇을 측정하는가"는 측정 정의이지 누가 제안했는가가 아니다.

### 2. 적용 지점

- **`ensureMirrorSignalDef` (#555)**: 자체 기각-스킵 조회를 이 헬퍼로 일원화. 동작 동일(active/pending → exists, rejected만 → skipped_rejected).
- **`approveLlmSignal`**: 승격(pending→active) 직전 가드 추가. SQL 재검증 통과 후 `findEquivalentSignal(자신 제외)`로 확인 — 다른 active/pending 동일 정의(중복)거나 rejected 동일 정의(재활성화)면 활성화 거부. **routine이 만든 pending에 대한 봇 쪽 최종 방어선.**

### 3. 마이그레이션 098 (채택)

085의 부분 unique 인덱스 키를 그대로 쓰되 `status IN ('active','pending')`으로 확장한 `uq_signal_defs_sql_active_pending`을 신설. active/pending 간 동일 정의 중복을 구조적으로 차단(pending으로 슬쩍 들어오는 틈을 막음).

**방어적 작성**: prod에 이미 active/pending 동일 정의가 있으면 `CREATE UNIQUE INDEX`가 실패해 마이그레이션 전체가 롤백되므로, DO 블록으로 위반을 먼저 세어 있으면 NOTICE만 내고 인덱스 생성을 건너뛴다. 데이터 dedup(링크 FK repoint)은 야간 배포에 싣지 않고 별도 후속으로 남긴다. prod DB 직접 접속 없이 작성.

### repo 밖 routine (monthly-signal-suggest SKILL)

이 PR에서 **SKILL 파일은 수정하지 않는다**(git 밖 + 무인 야간 작업 리스크). 봇 쪽 승인/등록 경로 가드(`approveLlmSignal`)와 DB 인덱스(098)가 최종 방어선이다. "SKILL 프롬프트에 기각 이력 신호 제외 지시 추가"는 아침 확인 목록용 권고로 남긴다.

## 검증

- `yarn tsc --noEmit` 통과
- `yarn vitest run` — 942 tests / 52 files 통과 (신규 `signal-defs.test.ts` 11 케이스 + `actions`/`pattern-verification` 갱신 포함)
- `yarn lint` — 신규/수정 소스 warning 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
