### PR TITLE
feat(schedule): 월간 뷰 사주 일주 표시

### DIFF
--- a/docs/domains/schedule.md
+++ b/docs/domains/schedule.md
@@ -92,6 +92,7 @@ features/schedule/
 │   ├── schedule-card.tsx       # 일정 카드 UI
 │   ├── schedule-form.tsx       # 일정 생성/수정 폼 (모달)
 │   ├── status-badge.tsx        # 상태 뱃지 컴포넌트
+│   ├── saju-pillar-label.tsx   # 사주 일주 라벨 (월/주 뷰 공용)
 │   └── action-menu.tsx         # 일정 컨텍스트 메뉴 (수정/삭제/미루기 등)
 ├── hooks/
 │   ├── use-schedules.ts        # 메인 일정 상태 관리 + CRUD + 필터링 + 폴링
@@ -133,12 +134,15 @@ features/schedule/
 - 3가지 뷰: month / week / day
 - 초기 뷰: 모바일(< 768px) = day, 데스크톱 = week
 - 15초 폴링 (탭 활성 시), 탭 복귀 시 날짜 갱신
-- 사주 일주 표시 (2026-05-26, #427): 주간·일간 뷰 날짜 셀에 일주(천간+지지) 한자+한글 병기
-  - 계산: `web/src/lib/saju.ts` `getDayPillar(dateStr)` — 봇 `src/shared/saju-calendar.ts`의 복제본 (순수 함수, ~50줄). 동기화 책임은 [ADR-0021](../adr/0021-web-shared-saju-code-duplication.md)
-  - 표시 형식: `庚子 경자` 한 줄 (한자 명조체 `font-serif` + 한글), `flex-wrap`으로 좁아지면 두 줄 자동 분리
-  - 적용 위치: `week-view.tsx` 데스크탑 grid 날짜 셀 + 모바일 세로 리스트 카드, `day-view.tsx` 헤더 옆
-  - 색상: 오늘 `text-blue-600`, 그 외 `text-gray-500` (day-view 헤더는 항상 `text-blue-600`)
-  - 컴포넌트: `SajuPillarLabel`은 week-view.tsx 내부 정의 (재사용 범위가 한 파일이라 별도 분리 안 함)
+- 사주 일주 표시 (2026-05-26 #427, 월간 뷰 확장 2026-07-03): 월·주·일 모든 뷰 날짜 셀에 일주(천간+지지) 한자+한글 병기
+  - 계산: `web/src/lib/saju.ts` `getDayPillar(dateStr)` — 봇 `src/shared/saju-calendar.ts`의 복제본 (순수 함수, \~50줄). 동기화 책임은 [ADR-0021](../adr/0021-web-shared-saju-code-duplication.md)
+  - 표시 형식: `庚子 경자` (한자 `font-medium` + 한글)
+    - 주·일 뷰: `text-[11px]` + `flex-wrap`(좁아지면 두 줄 자동 분리)
+    - 월간 뷰: `compact` 모드 — `text-[9px] sm:text-[10px]` + `whitespace-nowrap`(한 줄 고정). 좁은 모바일 셀에서 헤더 높이를 예측 가능하게 유지해 스패닝 바와 겹치지 않게
+  - 적용 위치: `month-view.tsx` 날짜 셀(숫자 아래) + `week-view.tsx` 데스크탑 grid 셀·모바일 리스트 카드 + `day-view.tsx` 헤더 옆(자체 배지)
+  - 색상: 오늘 `text-blue-600`, 이번 달 아님(월간 뷰) `text-gray-300`, 그 외 `text-gray-500` (day-view 헤더는 항상 `text-blue-600`)
+  - 컴포넌트: `SajuPillarLabel` (`saju-pillar-label.tsx`) — 월·주 뷰 공용. `today`/`dimmed`/`compact`/`align` prop으로 뷰별 변형. day-view는 헤더용 자체 배지 사용
+  - 월간 뷰는 일주 라벨 한 줄만큼 `DATE_ROW_HEIGHT`를 34→44로 올려 스패닝 바 시작 위치를 라벨 아래로 내림
 
 ### 필터링
 - 카테고리 필터 (상위 + 하위 카테고리)

--- a/web/src/features/schedule/components/month-view.tsx
+++ b/web/src/features/schedule/components/month-view.tsx
@@ -22,6 +22,7 @@ import {
 import { ScheduleCard } from './schedule-card';
 import { DroppableDay } from './droppable-day';
 import { DraggableCard } from './draggable-card';
+import { SajuPillarLabel } from './saju-pillar-label';
 
 interface MonthViewProps {
   currentDate: Date;
@@ -36,7 +37,8 @@ interface MonthViewProps {
 const DAY_NAMES = ['월', '화', '수', '목', '금', '토', '일'];
 const MAX_VISIBLE = 3;
 const LANE_HEIGHT = 22;
-const DATE_ROW_HEIGHT = 34;
+// 날짜 숫자 + 사주 일주 라벨 한 줄까지 포함한 헤더 높이. 스패닝 바가 라벨을 가리지 않도록 여유 포함.
+const DATE_ROW_HEIGHT = 44;
 
 export function MonthView({
   currentDate,
@@ -100,20 +102,30 @@ export function MonthView({
                     !isCurrentMonth ? 'bg-gray-50/50' : 'bg-white hover:bg-blue-50/30'
                   } ${selected ? 'ring-2 ring-inset ring-blue-400' : ''}`}
                 >
-                  <div
-                    className={`mb-1.5 flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium ${
-                      today
-                        ? 'bg-blue-500 text-white'
-                        : !isCurrentMonth
-                          ? 'text-gray-300'
-                          : dayOfWeek === 0
-                            ? 'text-red-500'
-                            : dayOfWeek === 6
-                              ? 'text-blue-500'
-                              : 'text-gray-700'
-                    }`}
-                  >
-                    {format(day, 'd')}
+                  <div className="mb-1.5">
+                    <div
+                      className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium ${
+                        today
+                          ? 'bg-blue-500 text-white'
+                          : !isCurrentMonth
+                            ? 'text-gray-300'
+                            : dayOfWeek === 0
+                              ? 'text-red-500'
+                              : dayOfWeek === 6
+                                ? 'text-blue-500'
+                                : 'text-gray-700'
+                      }`}
+                    >
+                      {format(day, 'd')}
+                    </div>
+                    <SajuPillarLabel
+                      dateStr={dateStr}
+                      today={today}
+                      dimmed={!isCurrentMonth}
+                      compact
+                      align="start"
+                      className="mt-0.5"
+                    />
                   </div>
 
                   {/* 스패닝 바 공간 확보 */}

--- a/web/src/features/schedule/components/saju-pillar-label.tsx
+++ b/web/src/features/schedule/components/saju-pillar-label.tsx
@@ -1,0 +1,44 @@
+import { getDayPillar } from '@/lib/saju';
+
+interface SajuPillarLabelProps {
+  dateStr: string;
+  /** 오늘이면 파란색 강조 */
+  today?: boolean;
+  /** 이번 달이 아닌 날(월간 뷰의 이전/다음 달 흐림 처리) */
+  dimmed?: boolean;
+  /** 월간 뷰용 소형 표기: 더 작은 글씨 + 한 줄 고정(좁은 셀에서도 높이 예측 가능) */
+  compact?: boolean;
+  /** 정렬 — 기본 center(주/일 뷰), start(월 뷰 날짜 셀) */
+  align?: 'center' | 'start';
+  className?: string;
+}
+
+/**
+ * 사주 일주(천간+지지) 라벨. 한자 + 한글 병기.
+ * 월/주/일 캘린더 뷰의 날짜 셀에서 공용 (계산: lib/saju.ts getDayPillar).
+ */
+export function SajuPillarLabel({
+  dateStr,
+  today = false,
+  dimmed = false,
+  compact = false,
+  align = 'center',
+  className = '',
+}: SajuPillarLabelProps) {
+  const pillar = getDayPillar(dateStr);
+  const color = today ? 'text-blue-600' : dimmed ? 'text-gray-300' : 'text-gray-500';
+  return (
+    <div
+      className={`flex items-baseline gap-x-1 leading-tight ${color} ${
+        align === 'center' ? 'justify-center' : 'justify-start'
+      } ${
+        compact
+          ? 'flex-nowrap overflow-hidden whitespace-nowrap text-[9px] sm:text-[10px]'
+          : 'flex-wrap text-[11px]'
+      } ${className}`}
+    >
+      <span className="font-medium">{pillar.hanja}</span>
+      <span>{pillar.hangul}</span>
+    </div>
+  );
+}

--- a/web/src/features/schedule/components/week-view.tsx
+++ b/web/src/features/schedule/components/week-view.tsx
@@ -13,7 +13,6 @@ import {
 import type { CategoryRow } from '@/lib/types';
 import { getCategoryStyle } from '@/lib/types';
 import { getTodayISO } from '@/lib/kst';
-import { getDayPillar } from '@/lib/saju';
 import {
   computeWeekLayout,
   WEEK_START,
@@ -23,6 +22,7 @@ import { StatusBadge } from './status-badge';
 import { DroppableDay } from './droppable-day';
 import { DraggableCard } from './draggable-card';
 import { ActionMenu } from './action-menu';
+import { SajuPillarLabel } from './saju-pillar-label';
 
 interface WeekViewProps {
   currentDate: Date;
@@ -472,28 +472,6 @@ function WeekSpanBar({
           <div className="mx-auto h-full w-0.5 rounded bg-gray-200" />
         </div>
       )}
-    </div>
-  );
-}
-
-function SajuPillarLabel({
-  dateStr,
-  today,
-  className = '',
-}: {
-  dateStr: string;
-  today: boolean;
-  className?: string;
-}) {
-  const pillar = getDayPillar(dateStr);
-  return (
-    <div
-      className={`flex flex-wrap items-baseline justify-center gap-x-1 text-[11px] leading-tight ${
-        today ? 'text-blue-600' : 'text-gray-500'
-      } ${className}`}
-    >
-      <span className="font-medium">{pillar.hanja}</span>
-      <span>{pillar.hangul}</span>
     </div>
   );
 }


### PR DESCRIPTION
## 개요

일정 대시보드 **월간 뷰**의 모든 날짜 셀에도 사주 일주(천간+지지)를 표시한다. 지금까지는 주·일 뷰에만 있어서, 한 달 전체를 한눈에 볼 때 일주가 보이지 않았다. 데스크탑·모바일 모두 적용.

## 변경 내용

- **월간 뷰 일주 표시**: 날짜 숫자 아래에 `庚子 경자` 형식으로 한자+한글 병기
- **compact 모드**: 좁은 월간 셀(특히 모바일)에 맞춰 `text-[9px] sm:text-[10px]` + 한 줄 고정(`whitespace-nowrap`). 헤더 높이를 예측 가능하게 유지해 스패닝 바와 겹치지 않게
- **컴포넌트 분리**: `SajuPillarLabel`을 `week-view.tsx` 내부 정의에서 공용 컴포넌트(`saju-pillar-label.tsx`)로 추출. `today`/`dimmed`/`compact`/`align` prop으로 뷰별 변형 (주·일 뷰 렌더링은 기존과 동일)
- **레이아웃**: 스패닝 바 시작 위치를 일주 라벨 아래로 내리기 위해 `DATE_ROW_HEIGHT` 34→44
- **색 규칙**: 주·일 뷰와 통일 — 오늘 파랑, 이전/다음 달 흐림, 그 외 회색

## 검증

- `tsc --noEmit` 통과
- 데스크탑·모바일(375px) 렌더 확인 — 좁은 셀에서도 한 줄 유지, 스패닝 바·일정 카드와 겹침 없음
- 주·일 뷰 회귀 없음(공용 컴포넌트 기본값이 기존 클래스와 동일)
- 문서: `docs/domains/schedule.md` 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)