### PR TITLE
feat(ops): 업타임 모니터링 이중화 — heartbeat dead-man's-switch (#577)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@ POSTGRES_PASSWORD=...              # docker-compose PostgreSQL 비밀번호
 # DB_PROXY_URL=https://...         # 봇 서버 DB 프록시 URL (예: https://db.leecommit.kr)
 # DB_PROXY_API_KEY=...             # 랜덤 키 생성: openssl rand -hex 32 (VM과 외부 환경 동일 값)
 
+# 업타임 heartbeat (dead-man's-switch — healthchecks.io)
+# 봇 프로세스가 5분마다 self/웹 헬스 확인 후 ping 송신. 세 값 모두 선택적(미설정 시 no-op).
+# - HC_PING_URL_BOT / HC_PING_URL_WEB: healthchecks.io check의 ping URL (형식 https://hc-ping.com/<uuid>)
+# - WEB_HEALTH_URL: 웹 헬스 엔드포인트 (200 + body "ok":true 검증)
+# HC_PING_URL_BOT=
+# HC_PING_URL_WEB=
+# WEB_HEALTH_URL=
+
 # DB 백업 (VM 호스트 crontab에서 사용)
 # R2_REMOTE=r2:slack-ai-agents-backup   # rclone remote 이름:R2 버킷명
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ flowchart LR
 - **봇·DB** — Oracle Cloud VM, Docker Compose로 app + PostgreSQL 17 운영
 - **DB Proxy** — 루프백 바인딩, 외부에선 Caddy HTTPS 경유로만 접근(DB 포트 미노출). 웹(Vercel)은 DB 직결 없이 이 프록시 API를 호출
 - **비동기 분석** — 주간 통계 검증·발굴은 node-cron(Asia/Seoul), LLM이 무거운 일일 종합 인사이트는 Claude 앱 routine으로 실시간 경로와 분리
-- **CI/CD** — main push → GitHub Actions → GHCR 이미지 빌드 → VM 재기동, 5분 간격 자체 업타임 모니터링
+- **CI/CD** — main push → GitHub Actions → GHCR 이미지 빌드 → VM 재기동
+- **업타임 모니터링 이중화** — 봇 프로세스가 5분마다 self·웹 헬스를 확인해 외부 dead-man's-switch로 heartbeat 송신(1차), GitHub Actions 폴링을 보조망으로 유지(2차)
 
 ### Public 저장소 다층 보안
 

--- a/docs/adr/0005-uptime-monitoring-github-actions.md
+++ b/docs/adr/0005-uptime-monitoring-github-actions.md
@@ -1,6 +1,6 @@
 # 0005. GitHub Actions 기반 자체 업타임 모니터링
 
-- Status: Accepted
+- Status: Superseded by [0055](0055-uptime-deadman-heartbeat.md)
 - Date: 2026-04-22
 - Related: #334
 - Tags: infra, observability

--- a/docs/adr/0055-uptime-deadman-heartbeat.md
+++ b/docs/adr/0055-uptime-deadman-heartbeat.md
@@ -1,0 +1,116 @@
+# 0055. 업타임 dead-man's-switch heartbeat (봇 프로세스 송신)
+
+- Status: Accepted
+- Date: 2026-07-04
+- Related: #577
+- Tags: infra, observability, reliability
+
+## Context
+
+[ADR-0005](0005-uptime-monitoring-github-actions.md)에서 GitHub Actions `schedule`(`*/5 * * * *`)로 봇·웹 헬스를 5분 간격 폴링하는 자체 업타임 모니터를 도입했다. 당시에도 "GitHub Actions cron은 정시성을 보장하지 않는다"는 제약을 알고 있었으나, 개인 프로젝트 SLA에서는 5\~10분 감지 지연을 수용 가능하다고 판단했다.
+
+2026-07-04 실제 실행 이력을 집계한 결과, 실효 주기가 애초 가정보다 크게 벌어져 있었다.
+
+- 최근 30일 · 298개 실행 표본 기준, 인접 실행 간격의 **중앙값이 약 2시간**, **최댓값 약 6시간**
+- 의도한 5분대(4\~6분) 간격으로 실행된 건은 **0건**
+- 원인은 GitHub Actions `schedule` 트리거의 구조적 스로틀링 — 공용 러너 부하에 따라 예약 실행이 큐잉·지연·병합되며, 특히 저부하 리포지터리의 고빈도 cron은 강하게 눌린다 (공식 문서에 "정시 실행 보장 안 됨" 명시)
+
+즉, 2차 방어선으로 두었던 폴링이 실질적으로는 **수 시간 단위 감지**만 제공하고 있었다. 봇이나 VM이 내려가도 다음 폴링이 돌 때까지 감지가 지연된다.
+
+### 제약 조건
+
+- **비용 0원 유지** — 개인 프로젝트, 월 고정비 최소화 (ADR-0005와 동일)
+- **정확한 5분 주기 감지** — 스로틀링에 종속되지 않는 송신 경로가 필요
+- **모니터는 대상 바깥에서 관측** — 업타임 모니터링 기본 원칙 (자기 참조 구조 회피)
+- **배포 파이프라인에 편승** — 별도 수동 인프라(호스트 crontab 등)를 늘리지 않는다
+- **점진 도입 안전성** — 외부 서비스(healthchecks.io) 가입 전에 코드가 먼저 배포돼도 무해해야 함
+
+## Decision
+
+**"봇 프로세스가 직접 송신하는 heartbeat + 외부 dead-man's-switch(healthchecks.io) 관측"으로 1차 방어선을 재구성하고, 기존 GitHub Actions 폴링은 2차 보조망으로 강등한다.**
+
+핵심은 **핑 송신자를 GitHub Actions가 아니라 봇 프로세스 자체로** 옮기는 것이다. 봇은 상시 상주하며 node-cron으로 정확한 5분 주기를 돌릴 수 있어, Actions `schedule`의 스로틀링에 종속되지 않는다.
+
+### 동작
+
+봇 프로세스가 5분마다(node-cron, 인프라 레벨 상주 태스크):
+
+1. **봇 self-health** — DB `SELECT 1` (기존 `GET /health`와 동일 의미론). 정상이면 `HC_PING_URL_BOT`으로 GET, 실패면 `HC_PING_URL_BOT + '/fail'`로 GET(즉시 알림)
+2. **웹 health** — `WEB_HEALTH_URL`을 fetch → HTTP 200 + body에 `"ok": true` 포함 검증 (기존 `uptime-check.yml`과 동일 의미론). 정상이면 `HC_PING_URL_WEB`, 실패면 `+ '/fail'`
+
+healthchecks.io는 이 ping이 **정해진 주기(권장 Period 5분, Grace 10\~15분) 안에 도착하지 않으면** 봇/VM이 내려간 것으로 보고 알림을 낸다. dead-man's-switch — "핑이 끊기는 것"이 곧 장애 신호다.
+
+### 설계 포인트
+
+- **세 env(`HC_PING_URL_BOT`·`HC_PING_URL_WEB`·`WEB_HEALTH_URL`)는 전부 선택적.** 미설정이면 부팅 로그 한 줄 남기고 완전 no-op → healthchecks.io 가입 전에 배포돼도 안전. `requireEnv` 사용 안 함.
+- **인프라 레벨 태스크.** DB(`notification_settings`) 기반 Life Cron 슬롯이 아니다. 부팅 진입점(`src/app.ts`)에서 DB 프록시와 나란히 `node-cron`으로 직접 등록.
+- **heartbeat는 어떤 경우에도 봇을 죽이지 않는다.** 모든 fetch에 타임아웃(\~10초) + try-catch. ping 전송 실패는 로그만 — 재시도 루프 없음(healthchecks.io grace가 흡수).
+- **헬스 판정 로직 재사용.** 봇은 기존 `/health`의 DB ping을, 웹은 기존 폴링의 body 검증을 그대로 미러링 → 두 경로의 "정상" 정의가 어긋나지 않는다.
+
+## Alternatives considered
+
+### A. GitHub Actions를 그대로 송신자로 사용 (healthchecks.io만 추가)
+
+- 장점: 기존 워크플로우 재사용, 봇 코드 변경 없음
+- 단점: 송신 주기가 Actions `schedule` 스로틀링에 그대로 종속 → dead-man's-switch의 grace를 아무리 늘려도 "핑이 늦게 오는 것"과 "장애로 핑이 안 오는 것"을 구분 못 함
+- 기각 이유: 스로틀링이 grace로 **전염**된다. 실효 주기가 수 시간인 송신자로는 짧은 감지 창을 만들 수 없음 — 문제의 원인을 그대로 끌고 감
+
+### B. VM 호스트 crontab + curl로 healthchecks.io ping
+
+- 장점: 봇 프로세스와 독립, 구현 단순
+- 단점: 배포 파이프라인 바깥의 수동 인프라 — 서버에 직접 붙어 등록·유지해야 하고, 코드 리뷰·버전 관리 대상에서 벗어남. VM 프로비저닝을 다시 하면 재설정 누락 위험
+- 기각 이유: "배포 파이프라인에 편승" 제약 위반. 봇 프로세스 송신이면 이미지 배포만으로 함께 굴러감
+
+### C. Better Stack 등 SaaS의 능동 폴링(HTTP 모니터)
+
+- 장점: 외부에서 능동적으로 헬스 엔드포인트를 찔러주므로 봇이 "정상인데 거짓 핑"을 보낼 여지가 없음. 무증상 실패 커버리지가 송신자 정직성에 의존하지 않음
+- 단점: 무료 티어 정책 변동 리스크, 계정·대시보드 추가 관리. 능동 폴링도 결국 봇 self-health의 판정 깊이(DB ping 여부 등)까지는 못 봄
+- 기각 이유: 차선. dead-man's-switch(수동 관측) 쪽이 비용·운영 부담이 더 낮고, "봇 프로세스가 살아서 스스로 헬스를 확인하고 송신한다"는 신호 자체가 더 강한 liveness 증거. 다만 능동 폴링의 무증상 실패 내성은 유효한 장점 — 향후 보완 후보로 남긴다
+
+### D. 현상 수용 (ADR-0005 유지, 아무것도 바꾸지 않음)
+
+- 장점: 작업 없음
+- 단점: 실효 감지 주기가 수 시간에 머묾
+- 기각 이유: 실측상 2차망만으로는 감지 창이 지나치게 넓음. 1차망 신설로 좁힐 여지가 명확
+
+### E. 봇 heartbeat 송신 + 외부 dead-man 관측 + GH Actions 보조망 유지 (선택)
+
+- 장점:
+  - 정확한 5분 주기 (node-cron, 스로틀링 비종속)
+  - 배포 파이프라인 편승 (이미지 배포로 함께 굴러감)
+  - 외부 관측자가 대상 바깥에 위치 (VM 다운 시에도 healthchecks.io가 핑 부재를 감지)
+  - 선택적 env → 점진 도입 안전
+  - 기존 폴링을 보조망으로 남겨 이중화 (healthchecks.io 자체 장애 커버)
+- 단점: 무증상 실패(봇이 살아있으나 헬스 판정이 거짓 양성) 커버리지가 self-health 정직성에 의존 → 헬스 판정 로직을 기존 엔드포인트와 동일하게 미러링해 완화
+
+## Consequences
+
+### 장점
+
+- 봇/VM 다운 감지 창이 수 시간 → 수 분(권장 grace 10\~15분) 수준으로 축소
+- 월 고정비 0원 유지 (healthchecks.io 무료 티어 범위)
+- heartbeat 로직이 코드로 버전 관리 + 단위 테스트 대상
+- 봇·웹 각각 독립 check → 어느 쪽 장애인지 분리 식별
+- 외부 서비스 미가입 상태에서도 안전(no-op) → 배포와 설정 시점을 분리 가능
+
+### 단점 / 제약
+
+- **healthchecks.io 의존 추가** — 무료 티어 정책 변동 리스크. 완화: 기존 GitHub Actions 폴링을 2차 보조망으로 유지
+- **무증상 실패는 여전히 한계** — 봇 프로세스는 살아있으나 헬스 판정이 실제 상태와 어긋나면 거짓 정상 핑 가능. 완화: 판정 의미론을 기존 헬스 엔드포인트와 일치. 능동 폴링(대안 C)이 필요해지면 재검토
+- **모니터 자체 정지 시나리오** — healthchecks.io가 내려가면 dead-man 관측이 멈춘다. 완화: 2차망(GH Actions)이 별도 경로로 잔존
+
+### 후속 작업
+
+- [ ] healthchecks.io에 봇·웹 check 2개 생성 (권장 Period 5분 / Grace 10\~15분)
+- [ ] 각 check의 ping URL을 VM `.env`에 `HC_PING_URL_BOT`·`HC_PING_URL_WEB`로 등록, `WEB_HEALTH_URL`도 함께 등록 → 재배포
+- [ ] 한 달 운영 후: dead-man 오탐 빈도 점검, grace 튜닝 필요 시 재평가
+- [ ] 무증상 실패 커버리지가 중요해지면 능동 폴링(Better Stack 등) 보완 검토
+
+---
+
+**참고**
+
+- [ADR-0005](0005-uptime-monitoring-github-actions.md) — 본 ADR이 supersede (2차 보조망으로 강등)
+- [GitHub Actions: Scheduled events](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule) — cron 정시성 미보장 명시
+- [healthchecks.io](https://healthchecks.io/) — dead-man's-switch 모니터링
+- Michael Nygard, *Documenting Architecture Decisions* (2011)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -111,7 +111,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0002](0002-v3-architecture-split.md) | v3 아키텍처 — Vercel 웹 + VM 봇 + managed DB | Accepted | 2026-03-12 | infra, architecture |
 | [0003](0003-self-hosted-postgres.md) | DB 자가 호스팅 전환 (Neon → VM PostgreSQL) | Accepted | 2026-04-06 | infra, data |
 | [0004](0004-db-proxy-api.md) | DB Proxy API 패턴 — Vercel→VM DB 직결 제거 | Accepted | 2026-04-09 | infra, security |
-| [0005](0005-uptime-monitoring-github-actions.md) | GitHub Actions 기반 자체 업타임 모니터링 | Accepted | 2026-04-22 | infra, observability |
+| [0005](0005-uptime-monitoring-github-actions.md) | GitHub Actions 기반 자체 업타임 모니터링 | Superseded by [0055](0055-uptime-deadman-heartbeat.md) | 2026-04-22 | infra, observability |
 | [0006](0006-modify-db-confirm-flow.md) | modify_db 대량 변경 확인 플로우 | Accepted | 2026-04-22 | security, llm, ux |
 | [0007](0007-flexible-spent-unified-definition.md) | 자유지출 정의 통일 — directFlex + plannedOverflow | Accepted | 2026-05-06 | data, budget |
 | [0008](0008-daily-budget-base-vs-recommended.md) | 일 예산 산정 모델 이중화 — 기준 일 예산 + 오늘 예산 | Accepted | 2026-05-06 | data, budget, ux |
@@ -161,6 +161,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0052](0052-weekly-insight-single-card-merge.md) | 주간 인사이트 단일 카드 통합 — routine 단독 발송 + 봇 검증 카드 은퇴 + posterior 노출 제거 | Accepted | 2026-06-16 | process, data, ux |
 | [0053](0053-signal-suggest-idempotency.md) | 월간 신호 제안 루틴 idempotency — DB 클레임 테이블 (최초 원자적 클레임, 재실행 중복 발송 차단) | Accepted | 2026-07-01 | data, process, reliability |
 | [0054](0054-audit-net-displacement-and-trigger-writer.md) | 일정 변경 audit 순변위 측정 + 기록 트리거 단일 계기 — 왕복 상쇄·30분 유예·FK 제거 로그화·tombstone·운명 view | Accepted | 2026-07-04 | data, process, reliability |
+| [0055](0055-uptime-deadman-heartbeat.md) | 업타임 dead-man's-switch heartbeat — 봇 프로세스 5분 송신 + 외부 관측, GH Actions 폴링 2차망 강등 | Accepted | 2026-07-04 | infra, observability, reliability |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -135,7 +135,7 @@
 | PostgreSQL | Oracle VM (Docker 컨테이너) |
 | 웹 | Vercel 자동 배포 (GitHub push → 빌드) |
 | 봇 배포 | GitHub Actions `Deploy` 워크플로우 (main push 자동 + 수동 트리거) |
-| 모니터링 | GitHub Actions 5분 폴링 ([docs/ops/health-monitoring.md](./ops/health-monitoring.md)) |
+| 모니터링 | 봇 heartbeat + healthchecks.io dead-man's-switch(1차) + GitHub Actions 폴링(2차) ([docs/ops/health-monitoring.md](./ops/health-monitoring.md)) |
 | DB 백업 | 매일 04:00 KST → Cloudflare R2 ([docs/ops/db-backup.md](./ops/db-backup.md)) |
 
 ## 마스터 히스토리 (최근)

--- a/docs/ops/health-monitoring.md
+++ b/docs/ops/health-monitoring.md
@@ -2,22 +2,25 @@
 
 ## 개요
 
-봇·웹의 liveness를 외부에서 주기적으로 점검하고, 장애 감지 시 Slack `#project` 채널로 즉시 알림을 보낸다.
+봇·웹의 liveness를 이중으로 감시하고, 장애 감지 시 Slack으로 알림을 보낸다.
 
-- 모니터링 주체: **GitHub Actions** (자체 구현)
-- 체크 간격: 5분 (GitHub cron 특성상 실제 5\~10분)
-- 설계 판단 근거: [docs/adr/0005-uptime-monitoring-github-actions.md](../adr/0005-uptime-monitoring-github-actions.md)
+| 방어선 | 주체 | 감지 주기 | 설계 근거 |
+|--------|------|-----------|-----------|
+| **1차망** | 봇 프로세스 heartbeat + [healthchecks.io](https://healthchecks.io/) dead-man's-switch | 정확한 5분 | [ADR-0055](../adr/0055-uptime-deadman-heartbeat.md) |
+| **2차망** | GitHub Actions 폴링 (보조) | 실효 수 시간일 수 있음 | [ADR-0005](../adr/0005-uptime-monitoring-github-actions.md) |
+
+핵심: **핑 송신자는 봇 프로세스 자체**다. 봇이 5분마다 자기·웹 헬스를 확인해 외부 dead-man's-switch로 ping을 보내고, 핑이 끊기면(=봇/VM 다운) healthchecks.io가 알린다. GitHub Actions `schedule`은 구조적 스로틀링으로 실효 주기가 수 시간까지 벌어질 수 있어(2026-07-04 실측), 정확한 5분을 보장하는 봇 송신을 1차로 두고 폴링은 보조망으로 남긴다.
 
 ## 엔드포인트
 
-### 공개 엔드포인트 (Uptime 모니터용)
+### 공개 엔드포인트 (모니터용)
 
 | URL | 용도 | 응답 |
 |-----|------|------|
 | `https://<봇-호스트>/health` | 봇 프로세스 + DB 연결 체크 | `{ ok: true }` or 503 |
 | `https://<웹-호스트>/api/health` | Vercel 웹 앱 liveness | `{ ok: true }` |
 
-모니터는 **HTTP 200 + 응답 body에 `"ok":true` 포함**인지 검증한다 (단순 200이 아니라 body 내용도 확인 → 캐시된 구형 응답 감지).
+"정상"의 정의는 **HTTP 200 + 응답 body에 `"ok":true` 포함**이다 (단순 200이 아니라 body 내용도 확인 → 캐시된 구형 응답 감지). 봇 heartbeat와 GitHub Actions 폴링이 같은 판정 의미론을 공유한다.
 
 ### 내부 엔드포인트 (운영자용)
 
@@ -30,7 +33,58 @@
 curl -H "Authorization: Bearer $DB_PROXY_API_KEY" https://<봇-호스트>/health/detail
 ```
 
-## GitHub Actions 모니터 구성
+---
+
+## 1차망 — 봇 heartbeat + healthchecks.io dead-man's-switch
+
+### 동작 원리
+
+봇 프로세스가 상주하며 **5분마다**(node-cron, 인프라 레벨 태스크):
+
+1. **봇 self-health** — DB `SELECT 1` 실행 (`GET /health`와 동일 의미론)
+   - 정상 → `HC_PING_URL_BOT`으로 GET
+   - 실패 → `HC_PING_URL_BOT + '/fail'`로 GET (즉시 알림)
+2. **웹 health** — `WEB_HEALTH_URL`을 fetch → HTTP 200 + body `"ok":true` 검증
+   - 정상 → `HC_PING_URL_WEB`으로 GET
+   - 실패 → `HC_PING_URL_WEB + '/fail'`로 GET (즉시 알림)
+
+healthchecks.io는 이 ping이 정해진 주기 안에 도착하지 않으면 장애로 보고 알림을 낸다. **dead-man's-switch** — "핑이 끊기는 것"이 곧 신호다.
+
+### 구현 위치
+
+- 모듈: `src/ops/uptime-heartbeat.ts` (named export `startUptimeHeartbeat`)
+- 등록: 부팅 진입점 `src/app.ts` (DB 프록시와 나란히)
+- **DB(`notification_settings`) 기반 Life Cron 슬롯이 아니다** — 인프라 레벨 상주 태스크
+
+### 안전 설계
+
+- **세 env 전부 선택적** — 하나라도 미설정이면 해당 대상은 스킵, 셋 다 없으면 부팅 로그 한 줄 남기고 완전 no-op. healthchecks.io 가입 전에 배포돼도 안전
+- **heartbeat는 봇을 죽이지 않는다** — 모든 fetch에 \~10초 타임아웃 + try-catch. ping 전송 실패는 로그만 (재시도 루프 없음 — healthchecks.io grace가 흡수)
+
+### 설정 절차
+
+1. **healthchecks.io check 2개 생성** — 봇용·웹용
+   - 권장 **Period 5분 / Grace 10\~15분** (봇 송신 주기 5분 + 네트워크·배포 지연 여유)
+   - 각 check의 **ping URL**을 확보 (형식: `https://hc-ping.com/<uuid>`)
+2. **VM `.env`에 등록** — 봇 서버 `.env`에 아래 3개 키 추가
+
+   | 키 | 값 |
+   |----|-----|
+   | `HC_PING_URL_BOT` | 봇 check ping URL |
+   | `HC_PING_URL_WEB` | 웹 check ping URL |
+   | `WEB_HEALTH_URL` | 웹 헬스 엔드포인트 (`https://<웹-호스트>/api/health`) |
+
+3. **재배포** — `gh workflow run deploy.yml` 또는 GitHub UI "Run workflow"
+   - 부팅 로그에서 `[Heartbeat] 업타임 heartbeat 시작 (5분 간격): 봇, 웹` 확인
+   - healthchecks.io 대시보드에서 최초 ping 수신 확인
+
+> 알림 채널(Slack 등) 연결은 healthchecks.io check의 Integration 설정에서 구성한다.
+
+---
+
+## 2차망 — GitHub Actions 폴링 (보조)
+
+봇 heartbeat가 1차망을 담당하므로 GitHub Actions 폴링은 **보조망**이다. healthchecks.io 자체 장애 등 1차망이 침묵하는 경우를 별도 경로로 커버한다.
 
 ### 파일 위치
 
@@ -38,9 +92,9 @@ curl -H "Authorization: Bearer $DB_PROXY_API_KEY" https://<봇-호스트>/health
 
 ### 동작 원리
 
-1. **5분마다 cron 트리거** (`*/5 * * * *`)
+1. **5분마다 cron 트리거** (`*/5 * * * *`) — 단, 실효 주기는 스로틀링으로 수 시간까지 벌어질 수 있음(아래 "알려진 한계" 참조)
 2. **Matrix strategy**로 봇·웹 잡을 병렬 실행
-3. 각 잡에서 **최대 2회 시도** (1차 실패 시 10초 대기 후 재시도)
+3. 각 잡에서 **최대 2회 시도** (1차 실패 시 10초 대기 후 재시도 — cry wolf 방지)
 4. **직전 완료 run**을 `workflow_run` API로 조회
 5. 상태 전이 판정:
 
@@ -54,17 +108,9 @@ curl -H "Authorization: Bearer $DB_PROXY_API_KEY" https://<봇-호스트>/health
 
 6. Slack Incoming Webhook으로 메시지 전송
 
-### 재시도 설계 — cry wolf 방지
+### 설정 — GitHub Variables / Secrets
 
-**2회 재시도** 는 일시적 네트워크 튐·배포 순간의 응답 지연 등을 흡수하기 위함. "실제 장애가 아닌데 알림이 오는" 상황(false alarm / cry wolf)이 반복되면 진짜 알림도 무시하게 된다.
-
-- 1차 실패 → 10초 대기 → 2차 시도
-- 2차도 실패해야 DOWN 판정
-- 1회 성공하면 즉시 up 판정 (재시도 없이 종료)
-
-## 설정 — GitHub Variables / Secrets
-
-### Variables (레포 설정 → Secrets and variables → Actions → Variables)
+**Variables** (레포 설정 → Secrets and variables → Actions → Variables)
 
 | 키 | 값 예시 |
 |----|---------|
@@ -73,42 +119,13 @@ curl -H "Authorization: Bearer $DB_PROXY_API_KEY" https://<봇-호스트>/health
 
 헬스체크 URL은 민감정보가 아니므로 Variables에 저장 (workflow 로그·PR 디프 등에 노출돼도 무해).
 
-### Secrets (동일 경로 → Secrets 탭)
+**Secrets** (동일 경로 → Secrets 탭)
 
 | 키 | 값 |
 |----|-----|
-| `SLACK_WEBHOOK_URL` | `#project` 채널 Incoming Webhook URL |
+| `SLACK_WEBHOOK_URL` | 알림 채널 Incoming Webhook URL |
 
 Slack webhook은 유출 시 스팸에 악용 가능 → Secret에 저장.
-
-### Slack Incoming Webhook 발급
-
-1. Slack [apps 관리](https://api.slack.com/apps) → 해당 앱 선택
-2. **Incoming Webhooks** 활성화
-3. **Add New Webhook to Workspace** → `#project` 채널 선택
-4. 생성된 URL을 `SLACK_WEBHOOK_URL` Secret에 등록
-
-## 운영 가이드
-
-### 알림 예시
-
-**다운 감지:**
-```
-🔴 봇 다운 감지
-URL: https://<봇-호스트>/health
-HTTP: 503
-시각 (KST): 2026-04-22 14:35
-재시도: 2회 후 실패
-[GitHub Actions run 보기]
-```
-
-**복구 확인:**
-```
-✅ 봇 복구 확인
-URL: https://<봇-호스트>/health
-시각 (KST): 2026-04-22 14:45
-[GitHub Actions run 보기]
-```
 
 ### 수동 실행
 
@@ -118,38 +135,48 @@ URL: https://<봇-호스트>/health
 gh workflow run uptime-check.yml
 ```
 
+---
+
+## 장애 시나리오별 감지 경로
+
+| 시나리오 | 1차망 (봇 heartbeat) | 2차망 (GH Actions) |
+|----------|----------------------|---------------------|
+| **VM 다운** (봇·DB 함께 정지) | ping 송신 중단 → healthchecks.io가 grace 초과 감지 | 봇 URL 폴링 실패 → DOWN (단, 실효 주기 늦음) |
+| **봇 프로세스 다운** (VM은 생존) | ping 송신 중단 → dead-man 감지 | 봇 URL 폴링 실패 → DOWN |
+| **웹 다운** (Vercel 장애) | 웹 헬스 실패 → `HC_PING_URL_WEB/fail` 즉시 알림 | 웹 URL 폴링 실패 → DOWN |
+| **DB만 다운** (봇 프로세스는 생존) | self-health `SELECT 1` 실패 → 봇 check `/fail` 즉시 알림 | 봇 `/health` 503 → DOWN |
+| **모니터 자체 정지** (healthchecks.io 장애) | 감지 불가 (1차망 침묵) | GH Actions가 독립 경로로 잔존 → 커버 |
+| **GitHub Actions 정지** | 1차망 정상 동작 (독립) | 감지 불가 |
+
+두 방어선이 서로의 단일 실패점을 덮는다. VM/봇/웹/DB 장애는 1차망이 정확한 5분 창으로 잡고, healthchecks.io 자체 장애는 2차망이 잔존 경로로 커버한다.
+
 ### 장애 대응 플로우
 
-1. Slack `#project` 알림 수신
+1. Slack 알림 수신 (healthchecks.io 또는 GitHub Actions)
 2. `/health/detail` 호출해서 컴포넌트별 상태 확인
    - `db.status: 'error'` → DB 컨테이너 로그 점검
    - `ok: false` + `db.status: 'ok'` → 봇 프로세스/네트워크 로그 점검
    - Vercel `/api/health` 장애 → Vercel 배포 상태 확인
-3. 원인에 따라 복구 → 다음 cron에서 RECOVERY 알림 자동 수신
+3. 원인에 따라 복구 → 봇 heartbeat 재개 시 healthchecks.io가 자동으로 up 처리
 
-### False alarm 발생 시
-
-1주일 이상 일시적 실패 알림이 반복되면:
-1. Actions 로그에서 해당 run의 curl 결과 확인
-2. 재시도 간격(현재 10초) · 재시도 횟수(현재 2회) 튜닝 검토
-3. 튜닝 시 본 문서와 `0005-uptime-monitoring-github-actions.md` 후속 ADR 동시 업데이트
+---
 
 ## 알려진 한계
 
-### 1. GitHub Actions cron 정시성 보장 안 됨
+### 1. GitHub Actions cron 실효 주기 (2차망)
 
-`*/5 * * * *` 은 "5분마다"가 아니라 "5분 간격을 희망"이다. GitHub 공식 문서에 명시된 제약으로, 부하에 따라 5\~10분 간격이 될 수 있다.
+`*/5 * * * *`은 "5분마다"가 아니라 "5분 간격을 희망"이다. GitHub 공식 문서에 명시된 스로틀링 제약으로, 실측(2026-07-04, 30일 표본)상 실효 주기가 수 시간까지 벌어질 수 있다.
 
-→ **개인 프로젝트 SLA로는 5\~10분 감지 지연 수용.** 초분 단위 SLA가 필요하면 별도 서비스 도입 필요.
+→ 이 때문에 정확한 5분 감지는 봇 heartbeat(**1차망**)이 담당한다. GitHub Actions는 보조망으로만 유지.
 
-### 2. Slack 웹소켓(Socket Mode) 연결 끊김 미감지
+### 2. 무증상 실패 (1차망 한계)
+
+봇 프로세스는 살아있으나 헬스 판정이 실제 상태와 어긋나 거짓 정상 ping을 보내는 경우.
+
+→ 완화: 봇 self-health를 기존 `/health`와, 웹 검증을 기존 폴링과 동일 의미론으로 미러링. 능동 폴링(대상 바깥에서 직접 찔러보는 방식)이 필요해지면 Better Stack 등 SaaS 보완 검토 (ADR-0055 대안 C).
+
+### 3. Slack 웹소켓(Socket Mode) 연결 끊김 미감지
 
 프로세스는 살아있어 `/health`는 200을 반환하지만, Slack 메시지 응답은 불가능한 상태.
 
-→ 향후 개선: Bolt 앱 `client.ping()` 결과를 DB Proxy의 `/health/detail`에 반영. 본 ADR 범위 바깥.
-
-### 3. GitHub Actions 자체 장애 시 모니터링 정지
-
-GitHub 인프라가 다운되면 업타임 모니터도 멈춘다.
-
-→ GitHub 자체가 다운되는 시나리오는 본 프로젝트 SLA 범위 밖. 외부 보조 모니터가 필요하면 Better Stack 등 SaaS 추가 검토.
+→ 향후 개선: Bolt 앱 `client.ping()` 결과를 `/health/detail`에 반영. 현재 범위 바깥.

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { setPostModifyHook, setConfirmCardSender } from './shared/sql-tools.js';
 import { buildConfirmModifyCard } from './agents/life/blocks.js';
 import { postBlockMessage } from './shared/slack.js';
 import { startDBProxy } from './db-proxy.js';
+import { startUptimeHeartbeat } from './ops/uptime-heartbeat.js';
 
 const app = new App({
   token: CONFIG.slack.botToken,
@@ -77,6 +78,9 @@ const startApp = async (): Promise<void> => {
 
   // DB 프록시 서버 (웹 대시보드용 — Vercel → HTTPS → VM → DB)
   startDBProxy();
+
+  // 업타임 dead-man's-switch heartbeat (인프라 레벨 — 5분 간격 외부 ping)
+  startUptimeHeartbeat();
 
   await app.start();
   // eslint-disable-next-line no-console

--- a/src/ops/__tests__/uptime-heartbeat.test.ts
+++ b/src/ops/__tests__/uptime-heartbeat.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// 업타임 heartbeat 판정 로직 단위 테스트 (#577).
+// 검증 축:
+//  ① 봇 헬스 pass(SELECT 1 성공) → base ping URL / fail → base + '/fail'
+//  ② 웹 헬스 200 + body "ok":true → base ping URL / 그 외(비200·body 불일치·타임아웃) → '/fail'
+//  ③ env 미설정 → 해당 대상 완전 no-op (fetch 미호출)
+//  ④ ping 전송 실패는 삼켜서 heartbeat가 예외를 밖으로 던지지 않음
+
+const mockQuery = vi.fn();
+
+vi.mock('../../shared/db.js', () => ({
+  query: (...a: unknown[]) => mockQuery(...a),
+}));
+
+const { checkBotHealth, checkWebHealth, sendPing, runHeartbeatOnce, loadHeartbeatConfig } =
+  await import('../uptime-heartbeat.js');
+
+const okResponse = (body: string): Response =>
+  ({ status: 200, text: () => Promise.resolve(body) }) as unknown as Response;
+
+const statusResponse = (status: number, body = ''): Response =>
+  ({ status, text: () => Promise.resolve(body) }) as unknown as Response;
+
+describe('checkBotHealth — db-proxy /health 동일 의미론(SELECT 1)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('DB SELECT 1 성공 → true', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    expect(await checkBotHealth()).toBe(true);
+    expect(mockQuery).toHaveBeenCalledWith('SELECT 1');
+  });
+
+  it('DB 오류 → false (예외를 밖으로 던지지 않음)', async () => {
+    mockQuery.mockRejectedValue(new Error('connection refused'));
+    expect(await checkBotHealth()).toBe(false);
+  });
+});
+
+describe('checkWebHealth — uptime-check.yml 동일 의미론(200 + "ok":true)', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('200 + body {"ok":true} → true', async () => {
+    fetchMock.mockResolvedValue(okResponse('{"ok":true}'));
+    expect(await checkWebHealth('https://web.example/api/health')).toBe(true);
+  });
+
+  it('200 + 공백 포함 "ok" : true → true (정규식 유연 매칭)', async () => {
+    fetchMock.mockResolvedValue(okResponse('{ "ok" : true }'));
+    expect(await checkWebHealth('https://web.example/api/health')).toBe(true);
+  });
+
+  it('200 + body {"ok":false} → false', async () => {
+    fetchMock.mockResolvedValue(okResponse('{"ok":false}'));
+    expect(await checkWebHealth('https://web.example/api/health')).toBe(false);
+  });
+
+  it('503 (body는 ok:true여도) → false — 상태코드 우선', async () => {
+    fetchMock.mockResolvedValue(statusResponse(503, '{"ok":true}'));
+    expect(await checkWebHealth('https://web.example/api/health')).toBe(false);
+  });
+
+  it('fetch 예외(타임아웃 등) → false (밖으로 던지지 않음)', async () => {
+    fetchMock.mockRejectedValue(new Error('The operation was aborted'));
+    expect(await checkWebHealth('https://web.example/api/health')).toBe(false);
+  });
+});
+
+describe('sendPing — healthy → base URL / unhealthy → /fail', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('healthy=true → base URL로 GET', async () => {
+    fetchMock.mockResolvedValue(statusResponse(200));
+    await sendPing('https://hc-ping.example/uuid', true, '봇');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://hc-ping.example/uuid');
+    expect(init.method).toBe('GET');
+  });
+
+  it('healthy=false → base + "/fail"로 GET', async () => {
+    fetchMock.mockResolvedValue(statusResponse(200));
+    await sendPing('https://hc-ping.example/uuid', false, '봇');
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe('https://hc-ping.example/uuid/fail');
+  });
+
+  it('ping 전송 실패 → 예외를 삼킴 (throw 안 함)', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    await expect(sendPing('https://hc-ping.example/uuid', true, '봇')).resolves.toBeUndefined();
+  });
+});
+
+describe('runHeartbeatOnce — 설정된 대상만 처리', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockResolvedValue(statusResponse(200, '{"ok":true}'));
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('세 값 전부 설정 + 전부 정상 → 봇 base + 웹 base 각각 1회 ping', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ ok: 1 }] });
+    await runHeartbeatOnce({
+      botPingUrl: 'https://hc-ping.example/bot',
+      webPingUrl: 'https://hc-ping.example/web',
+      webHealthUrl: 'https://web.example/api/health',
+    });
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    // 웹 헬스 GET 1회 + 봇 ping + 웹 ping = fetch 3회 (봇 헬스는 DB query라 fetch 아님)
+    expect(urls).toContain('https://hc-ping.example/bot');
+    expect(urls).toContain('https://hc-ping.example/web');
+    expect(urls.some((u) => u.endsWith('/fail'))).toBe(false);
+  });
+
+  it('봇 헬스 실패 → 봇 ping은 "/fail"', async () => {
+    mockQuery.mockRejectedValue(new Error('db down'));
+    await runHeartbeatOnce({
+      botPingUrl: 'https://hc-ping.example/bot',
+      webPingUrl: '',
+      webHealthUrl: '',
+    });
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(urls).toContain('https://hc-ping.example/bot/fail');
+  });
+
+  it('env 미설정(빈 문자열) → 완전 no-op (fetch·query 미호출)', async () => {
+    await runHeartbeatOnce({ botPingUrl: '', webPingUrl: '', webHealthUrl: '' });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('웹 ping URL만 있고 webHealthUrl 없으면 → 웹 스킵 (봇만 처리)', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ ok: 1 }] });
+    await runHeartbeatOnce({
+      botPingUrl: 'https://hc-ping.example/bot',
+      webPingUrl: 'https://hc-ping.example/web',
+      webHealthUrl: '',
+    });
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(urls).toContain('https://hc-ping.example/bot');
+    expect(urls).not.toContain('https://hc-ping.example/web');
+  });
+});
+
+describe('loadHeartbeatConfig — env 미설정 시 빈 문자열', () => {
+  const saved = {
+    bot: process.env['HC_PING_URL_BOT'],
+    web: process.env['HC_PING_URL_WEB'],
+    health: process.env['WEB_HEALTH_URL'],
+  };
+
+  afterEach(() => {
+    if (saved.bot === undefined) delete process.env['HC_PING_URL_BOT'];
+    else process.env['HC_PING_URL_BOT'] = saved.bot;
+    if (saved.web === undefined) delete process.env['HC_PING_URL_WEB'];
+    else process.env['HC_PING_URL_WEB'] = saved.web;
+    if (saved.health === undefined) delete process.env['WEB_HEALTH_URL'];
+    else process.env['WEB_HEALTH_URL'] = saved.health;
+  });
+
+  it('미설정이면 세 값 모두 빈 문자열', () => {
+    delete process.env['HC_PING_URL_BOT'];
+    delete process.env['HC_PING_URL_WEB'];
+    delete process.env['WEB_HEALTH_URL'];
+    expect(loadHeartbeatConfig()).toEqual({ botPingUrl: '', webPingUrl: '', webHealthUrl: '' });
+  });
+
+  it('설정되면 그 값을 읽음', () => {
+    process.env['HC_PING_URL_BOT'] = 'https://hc-ping.example/bot';
+    process.env['HC_PING_URL_WEB'] = 'https://hc-ping.example/web';
+    process.env['WEB_HEALTH_URL'] = 'https://web.example/api/health';
+    expect(loadHeartbeatConfig()).toEqual({
+      botPingUrl: 'https://hc-ping.example/bot',
+      webPingUrl: 'https://hc-ping.example/web',
+      webHealthUrl: 'https://web.example/api/health',
+    });
+  });
+});

--- a/src/ops/uptime-heartbeat.ts
+++ b/src/ops/uptime-heartbeat.ts
@@ -1,0 +1,141 @@
+/**
+ * 업타임 dead-man's-switch heartbeat (인프라 레벨).
+ *
+ * 봇 프로세스가 5분마다 자기 헬스와 웹 헬스를 확인하고, 정상이면 healthchecks.io로
+ * ping을 송신한다. 외부 dead-man's-switch가 이 ping이 끊기는 것(=봇/VM 다운)을 관측해
+ * 알림을 낸다. GitHub Actions schedule의 실효 주기가 수 시간까지 벌어질 수 있어, 정확한
+ * 5분 주기를 보장하는 프로세스 내부 송신으로 감지 지연을 좁힌다.
+ *
+ * - DB(notification_settings) 기반 Life Cron 슬롯이 아니다 — 인프라 레벨 상주 태스크.
+ * - 세 env(HC_PING_URL_BOT / HC_PING_URL_WEB / WEB_HEALTH_URL)는 전부 선택적.
+ *   미설정이면 부팅 로그 한 줄 남기고 완전 no-op (healthchecks.io 가입 전 배포돼도 안전).
+ * - 모든 fetch에 타임아웃 + try-catch. heartbeat는 어떤 경우에도 봇을 죽이지 않는다.
+ *   ping 전송 실패는 로그만 (재시도 루프 없음 — healthchecks.io grace가 흡수).
+ */
+
+import cron from 'node-cron';
+import { query } from '../shared/db.js';
+
+/** heartbeat cron 주기 (5분) */
+const HEARTBEAT_CRON = '*/5 * * * *';
+
+/** 외부 요청 타임아웃 (ms) */
+const FETCH_TIMEOUT_MS = 10_000;
+
+/** 웹 헬스 body 검증 — uptime-check.yml과 동일 의미론 ("ok": true 포함) */
+const WEB_OK_PATTERN = /"ok"\s*:\s*true/;
+
+export interface HeartbeatConfig {
+  /** 봇 self-health용 healthchecks.io ping URL (미설정 시 봇 핑 스킵) */
+  botPingUrl: string;
+  /** 웹 health용 healthchecks.io ping URL (미설정 시 웹 핑 스킵) */
+  webPingUrl: string;
+  /** 웹 헬스 엔드포인트 URL (미설정 시 웹 체크 스킵) */
+  webHealthUrl: string;
+}
+
+/** CONFIG 없이 env에서 직접 읽는다 (전부 선택적 — requireEnv 사용 금지) */
+export const loadHeartbeatConfig = (): HeartbeatConfig => ({
+  botPingUrl: process.env['HC_PING_URL_BOT'] ?? '',
+  webPingUrl: process.env['HC_PING_URL_WEB'] ?? '',
+  webHealthUrl: process.env['WEB_HEALTH_URL'] ?? '',
+});
+
+/**
+ * 봇 self-health 판정 — db-proxy.ts GET /health와 동일 의미론(DB SELECT 1).
+ * 성공 시 true, 실패 시 false. 예외를 밖으로 던지지 않는다.
+ */
+export const checkBotHealth = async (): Promise<boolean> => {
+  try {
+    await query('SELECT 1');
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * 웹 health 판정 — uptime-check.yml과 동일 의미론(HTTP 200 + body "ok": true).
+ * 성공 시 true, 실패/타임아웃 시 false. 예외를 밖으로 던지지 않는다.
+ */
+export const checkWebHealth = async (webHealthUrl: string): Promise<boolean> => {
+  try {
+    const response = await fetch(webHealthUrl, {
+      method: 'GET',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (response.status !== 200) return false;
+    const body = await response.text();
+    return WEB_OK_PATTERN.test(body);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * healthchecks.io ping 송신.
+ * healthy면 baseUrl로, 아니면 baseUrl + '/fail'로 GET (즉시 알림).
+ * 전송 실패는 로그만 남기고 삼킨다 (재시도 없음).
+ */
+export const sendPing = async (baseUrl: string, healthy: boolean, label: string): Promise<void> => {
+  const url = healthy ? baseUrl : `${baseUrl}/fail`;
+  try {
+    await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.warn(`[Heartbeat] ${label} ping 전송 실패 (무시): ${msg}`);
+  }
+};
+
+/**
+ * 1회 heartbeat 실행 — 봇/웹 헬스 확인 후 각각 ping 송신.
+ * 설정된 항목만 처리한다. 어떤 예외도 밖으로 던지지 않는다 (봇 안정성 보호).
+ */
+export const runHeartbeatOnce = async (config: HeartbeatConfig): Promise<void> => {
+  try {
+    if (config.botPingUrl) {
+      const healthy = await checkBotHealth();
+      await sendPing(config.botPingUrl, healthy, '봇');
+    }
+
+    if (config.webPingUrl && config.webHealthUrl) {
+      const healthy = await checkWebHealth(config.webHealthUrl);
+      await sendPing(config.webPingUrl, healthy, '웹');
+    }
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`[Heartbeat] 실행 오류 (무시): ${msg}`);
+  }
+};
+
+/**
+ * heartbeat 크론 등록. 부팅 진입점에서 1회 호출.
+ * ping URL이 하나도 설정되지 않았으면 no-op (로그 한 줄).
+ */
+export const startUptimeHeartbeat = (): void => {
+  const config = loadHeartbeatConfig();
+
+  const botEnabled = config.botPingUrl.length > 0;
+  const webEnabled = config.webPingUrl.length > 0 && config.webHealthUrl.length > 0;
+
+  if (!botEnabled && !webEnabled) {
+    console.log('[Heartbeat] HC_PING_URL_BOT/WEB 미설정 — 업타임 heartbeat 비활성화');
+    return;
+  }
+
+  cron.schedule(
+    HEARTBEAT_CRON,
+    () => {
+      void runHeartbeatOnce(config);
+    },
+    { timezone: 'Asia/Seoul' },
+  );
+
+  const targets: string[] = [];
+  if (botEnabled) targets.push('봇');
+  if (webEnabled) targets.push('웹');
+  console.log(`[Heartbeat] 업타임 heartbeat 시작 (5분 간격): ${targets.join(', ')}`);
+};


### PR DESCRIPTION
## 관련 이슈
Closes #577

## 변경 내용
- **봇 프로세스 heartbeat** (`src/ops/uptime-heartbeat.ts`): 5분 간격으로 self 헬스(DB 체크)·웹 헬스(상태·body 검증)를 확인하고 외부 dead-man's-switch(healthchecks.io)로 ping 송신 — 정상은 base URL, 이상은 `/fail`(즉시 알림)
- **점진 도입 안전**: 관련 env 3종 전부 선택적 — 미설정 시 no-op (외부 서비스 설정 전 배포 무해)
- **기존 GitHub Actions 폴링은 2차 보조망으로 유지** (워크플로우 무변경)
- ADR-0055 (ADR-0005 supersede) + `docs/ops/health-monitoring.md` 전면 현행화

## 코드 리뷰 결과
- [x] 보안 감사 통과 — 실제 도메인·크리덴셜 없음 (placeholder만), env 값 미포함
- [x] 타입 안전성 확인 (tsc clean)
- [x] 안정성 — 전체 경로 타임아웃 + 예외 삼킴 (heartbeat가 봇 프로세스에 영향 없음)
- [x] 컨벤션 점검 완료

## 테스트
- [x] vitest 982 passed (신규 16종 포함: 헬스 판정 의미론 미러링·/fail 라우팅·no-op·예외 처리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)