### PR TITLE
fix(insight): 신호 의미론 일괄 교정 — 실행 정합·측정 범위 정밀화 (#573)

### DIFF
--- a/db/migrations/101_signal_semantics.sql
+++ b/db/migrations/101_signal_semantics.sql
@@ -1,0 +1,164 @@
+-- 101: 신호 의미론 일괄 교정 (#573, ADR-0056)
+-- 배경: #572(100, ADR-0054)에서 후속으로 분리한 "타 도메인 신호 의미론 점검 6건"의 실행체.
+--   prod 실측(2026-07-04) 결과 6건 중 3건이 즉시 교정 대상, 3건은 무변경(문서화만)으로 확정.
+--   핵심 발견 = 스키마 드리프트로 인한 "좀비 신호": schedule_영화·schedule_이직의 sql_body가
+--   schedules.category(TEXT 컬럼)를 참조하는데 #394(2026-05-13, 04-migrate.sql)가 그 컬럼을 DROP하고
+--   category_id FK로 교체 → 두 신호가 7주째 실행 시 존재하지 않는 컬럼 참조로 죽어 있었다(링크 hit 0/miss 0).
+--   신호 정의가 catalog(DB)에 영속되므로 코드 리뷰·타입 체크로는 안 잡히고, 컬럼 rename/drop 마이그레이션이
+--   signal_defs.sql_body를 조용히 깨뜨린 클래스 사고.
+-- 구성:
+--   ① 은퇴 — 구 3개(schedule_영화·schedule_이직·expense_total) status='rejected' + 링크 archive.
+--   ② 신설 — 동명 재사용 2개(schedule_영화·schedule_이직, category_id JOIN + status='done' 재정의) +
+--      신명 1개(expense_discretionary = 자유지출만, 할부·고정비 제외). expense_total 계보는 의도적 단절.
+--   ③ 검증 DO 블록 — 신설 3 active / 구 3 rejected(관대 ≥) / 은퇴 신호 살아있는 링크 0 +
+--      신설 SQL 실행 스모크(각 sql_body를 user_id=1·오늘 날짜로 EXECUTE — 좀비 재발 방지의 핵심).
+-- 무변경(문서화만, docs/domains/insight.md §43): 완료율×미룸 기계 결합 / schedule_count_today 동명 2행(반대
+--   가설) / 수면 결측=0 / 루틴 미기록일=완료율 0(실측 결측 0건) / schedule_tax_keyword(title 기반 정상,
+--   생애 발화 0). 결측 전파 인프라는 #574에 편입.
+-- 안전: 파일 전체가 단일 암묵 트랜잭션(migrate.ts) — 검증 DO 블록이 RAISE 시 전체 롤백. 모든 변경 가역.
+--   신설 신호는 시드(source='seed')라 signal-sql-guard(LLM 전용) 비대상. 통계 스택·verdict·tier·임계치 불변
+--   — 100/086과 동일하게 *무엇을* 측정하는지(신호 정의)만 교정.
+--   prod 확인: 구 3신호에 confirmed 링크 0 → ADR-0048 D2 re-baseline 의무 미발생.
+
+-- ═══ ① 은퇴 — 구 3개 rejected + 링크 archive ═══════════════
+-- 085/099 부분 유니크 인덱스는 active/pending만 잡으므로 은퇴를 신설보다 먼저 실행(그래야 ②의 동명
+-- 신설이 인덱스에 안 걸린다). status='active' 조건 필수 — 기존 rejected 행(영화·이직 각 2행) 재처리 방지.
+-- expense_total은 rejected 0이라 조건 무관하나 일관성 위해 동일 가드.
+UPDATE signal_defs SET status = 'rejected'
+ WHERE user_id = 1 AND status = 'active'
+   AND name IN ('schedule_영화', 'schedule_이직', 'expense_total');
+
+-- 링크 archive: 방금 rejected로 내린 row만 잡도록 status='rejected' 조건 유지. 살아있는 링크
+-- (active/pending/weak/confirmed) 전부 archived — 재연결은 발굴 엔진(P5a) 다음 주간 스캔에 위임
+-- (086/100 전례). confirmed 링크가 있으면 sticky라 노출 사라지나, prod 확인 결과 confirmed 0.
+UPDATE pattern_links SET status = 'archived', updated_at = NOW()
+ WHERE status IN ('active', 'pending', 'weak', 'confirmed')
+   AND signal_id IN (SELECT id FROM signal_defs
+                      WHERE user_id = 1 AND status = 'rejected'
+                        AND name IN ('schedule_영화', 'schedule_이직', 'expense_total'));
+
+-- ① 검증
+DO $$
+DECLARE
+  old_rejected INT;
+BEGIN
+  SELECT count(*) INTO old_rejected FROM signal_defs
+   WHERE user_id = 1 AND status = 'rejected'
+     AND name IN ('schedule_영화', 'schedule_이직', 'expense_total');
+  -- 관대 비교(≥ 3): 영화·이직은 은퇴 전 이미 rejected 2행씩 존재(과거 재처리 흔적) → =3 강제면
+  -- 롤백된다(100 회고와 동일 함정). expense_total만 rejected 0이었으므로 최소 3개(방금 은퇴분)는 보장.
+  IF old_rejected < 3 THEN
+    RAISE EXCEPTION '[101①] 구 3신호 은퇴 실패 — rejected % (기대 ≥ 3)', old_rejected;
+  END IF;
+  RAISE NOTICE '[101①] 구 3신호 은퇴 + 링크 archive 완료 — rejected % 행', old_rejected;
+END $$;
+
+-- ═══ ② 신설 — 동명 재사용 2개 + 신명 1개 ═══════════════════
+-- 이름 재사용 근거: SIGNAL_LABEL_OVERRIDES/SIGNAL_MEASURE(insight-labels.ts)·테스트가 name 키라
+-- 무수정(영화·이직), 발굴·findEquivalentSignal은 active/pending만 보므로 rejected 구 row와 무충돌.
+-- signal_defs INSERT 컬럼은 086/100 참조: (user_id, name, kind, sql_body, value_type, direction,
+-- threshold, domain, description, source, status). $1=user_id, $2=날짜.
+
+-- schedule_영화: 좀비 부활 + done 재정의. 구 SQL이 참조하던 schedules.category(#394가 DROP)를
+-- category_id JOIN(categories.name='영화')으로 재작성 + status='done' 필터. "그 일정을 실제로 처리한 날".
+-- 실측 done 비율 영화 7/7일=100% → done 필터로 인한 손실 무시 가능.
+INSERT INTO signal_defs (user_id, name, kind, sql_body, value_type, direction, threshold, domain, description, source, status)
+VALUES (1, 'schedule_영화', 'sql',
+  $sql$SELECT COUNT(*) FROM schedules s JOIN categories c ON c.id = s.category_id WHERE s.user_id=$1 AND s.date=$2 AND c.name='영화' AND s.status='done'$sql$,
+  'continuous', 'above_abs', 1, 'schedule',
+  '영화 일정을 실제로 처리한 날 (category_id 기준, status=done)', 'seed', 'active')
+ON CONFLICT DO NOTHING;
+
+-- schedule_이직: 동일 구조(categories.name='이직'). 실측 done 비율 이직 39/41일=95% → 손실 무시 가능.
+INSERT INTO signal_defs (user_id, name, kind, sql_body, value_type, direction, threshold, domain, description, source, status)
+VALUES (1, 'schedule_이직', 'sql',
+  $sql$SELECT COUNT(*) FROM schedules s JOIN categories c ON c.id = s.category_id WHERE s.user_id=$1 AND s.date=$2 AND c.name='이직' AND s.status='done'$sql$,
+  'continuous', 'above_abs', 1, 'schedule',
+  '이직 일정을 실제로 처리한 날 (category_id 기준, status=done)', 'seed', 'active')
+ON CONFLICT DO NOTHING;
+
+-- expense_discretionary: expense_total 개명 재정의(신명 = 계보 단절). 자유지출만 측정 —
+--   할부 제외(COALESCE(is_installment,false)=false) + 고정비/통과비용 카테고리 제외.
+--   제외 목록: 구독·통신·공과금·보험·주거·세금 = 본인 재량 밖 고정지출 / '리커밋 택배' = 주문량 비례
+--   통과 비용(본인 행동 아님, 사용자 통찰). '리커밋 사업'은 유지 = 본인 사업 투자 결정(편재 유관).
+--   제외-목록 방식이라 새 카테고리는 기본 포함. COALESCE(SUM(amount),0)로 지출 0원인 날은 유효 0(ADR-0044).
+--   direction=above_avg·domain=expense·type='expense' 필터는 구 expense_total 그대로 승계
+--   (expenses.type은 030 원본 컬럼 — income 계열 행이 합계에 섞이지 않게 하는 필수 필터).
+INSERT INTO signal_defs (user_id, name, kind, sql_body, value_type, direction, threshold, domain, description, source, status)
+VALUES (1, 'expense_discretionary', 'sql',
+  $sql$SELECT COALESCE(SUM(amount),0) FROM expenses WHERE user_id=$1 AND date=$2 AND type='expense' AND COALESCE(is_installment,false)=false AND category NOT IN ('구독','구독료','통신','통신비','공과금','보험','주거','세금','리커밋 택배')$sql$,
+  'continuous', 'above_avg', NULL, 'expense',
+  '자유지출 총액 — 할부·고정비 제외', 'seed', 'active')
+ON CONFLICT DO NOTHING;
+
+-- ② 검증
+DO $$
+DECLARE
+  new_active INT;
+BEGIN
+  SELECT count(*) INTO new_active FROM signal_defs
+   WHERE user_id = 1 AND status = 'active'
+     AND name IN ('schedule_영화', 'schedule_이직', 'expense_discretionary');
+  IF new_active <> 3 THEN
+    RAISE EXCEPTION '[101②] 신설 3신호 active 수 이상 — % (기대 3)', new_active;
+  END IF;
+  RAISE NOTICE '[101②] 신설 3신호 active — schedule_영화·schedule_이직 재정의 + expense_discretionary 신명';
+END $$;
+
+-- ═══ ③ 정합 검증 + 신설 SQL 실행 스모크 ═══════════════════
+-- 카운트 검증 + 은퇴 신호 살아있는 링크 0 + 신설 3개 sql_body를 user_id=1·오늘로 EXECUTE.
+-- 스모크가 이 마이그레이션의 핵심: 좀비의 근본 원인은 sql_body의 컬럼 참조가 실제 스키마와 어긋난 것.
+-- 각 신설 SQL을 실제로 실행해 "에러 없이 숫자 1개 반환"을 증명하면, category_id JOIN·expenses 컬럼
+-- 참조가 현행 스키마와 맞음을 이 자리에서 확정한다(코드 리뷰가 놓친 스키마-SQL 정합을 런타임으로 봉인).
+DO $$
+DECLARE
+  new_active INT;
+  old_rejected INT;
+  dead_links INT;
+  smoke_val NUMERIC;
+  rec RECORD;
+  today TEXT := to_char((NOW() AT TIME ZONE 'Asia/Seoul')::date, 'YYYY-MM-DD');
+BEGIN
+  -- 카운트: 신설 3 active.
+  SELECT count(*) INTO new_active FROM signal_defs
+   WHERE user_id = 1 AND status = 'active'
+     AND name IN ('schedule_영화', 'schedule_이직', 'expense_discretionary');
+  IF new_active <> 3 THEN
+    RAISE EXCEPTION '[101③] 신설 신호 active 수 이상 — % (기대 3)', new_active;
+  END IF;
+
+  -- 카운트: 구 3 rejected(관대 ≥ 3 — 영화·이직 선재 rejected 존재).
+  SELECT count(*) INTO old_rejected FROM signal_defs
+   WHERE user_id = 1 AND status = 'rejected'
+     AND name IN ('schedule_영화', 'schedule_이직', 'expense_total');
+  IF old_rejected < 3 THEN
+    RAISE EXCEPTION '[101③] 구 신호 rejected 수 이상 — % (기대 ≥ 3)', old_rejected;
+  END IF;
+
+  -- 은퇴 3신호를 가리키는 살아있는 링크(active/pending/weak/confirmed)가 0이어야 함(전부 archive됨).
+  SELECT count(*) INTO dead_links
+    FROM pattern_links pl JOIN signal_defs s ON s.id = pl.signal_id
+   WHERE s.user_id = 1 AND s.status = 'rejected'
+     AND s.name IN ('schedule_영화', 'schedule_이직', 'expense_total')
+     AND pl.status IN ('active', 'pending', 'weak', 'confirmed');
+  IF dead_links <> 0 THEN
+    RAISE EXCEPTION '[101③] 은퇴 신호를 가리키는 미정리 링크 % 건', dead_links;
+  END IF;
+
+  -- 신설 SQL 실행 스모크: 각 active 신설 신호의 sql_body를 $1=user_id=1, $2='오늘'로 치환해 EXECUTE.
+  -- (pattern-match.ts runMetricSql와 동일 치환 규칙 — $1→'1', $2→'YYYY-MM-DD' 리터럴.)
+  -- 좀비 SQL이었다면 "column ... does not exist"로 여기서 즉시 RAISE → 전체 롤백(재발 구조적 차단).
+  FOR rec IN
+    SELECT name, sql_body FROM signal_defs
+     WHERE user_id = 1 AND status = 'active'
+       AND name IN ('schedule_영화', 'schedule_이직', 'expense_discretionary')
+  LOOP
+    EXECUTE replace(replace(rec.sql_body, '$1', '1'), '$2', quote_literal(today)) INTO smoke_val;
+    IF smoke_val IS NULL THEN
+      RAISE EXCEPTION '[101③] 신설 SQL 스모크 실패 — % 가 NULL 반환(숫자 기대)', rec.name;
+    END IF;
+    RAISE NOTICE '[101③] 스모크 OK — % → % (오늘 %)', rec.name, smoke_val, today;
+  END LOOP;
+
+  RAISE NOTICE '[101③] 정합 검증 완료 — 신설 3 active / 구 3 rejected / 은퇴 살아있는 링크 0 / 신설 SQL 실행 스모크 통과';
+END $$;

--- a/docs/adr/0056-signal-semantics-batch-correction.md
+++ b/docs/adr/0056-signal-semantics-batch-correction.md
@@ -1,0 +1,117 @@
+# 0056. 신호 의미론 일괄 교정 — 좀비 부활 + done 재정의 + 자유지출 개명
+
+- Status: Accepted
+- Date: 2026-07-04
+- Related: #573, ADR-0054(#572에서 후속 분리)
+- Tags: insight, data, statistics, process
+
+## Context
+
+#572([ADR-0054](0054-audit-net-displacement-and-trigger-writer.md))가 audit 신호 순변위 측정을 교정하면서, "타 도메인 신호 의미론 점검 6건"을 각각 가설 의미 결정이 필요하다는 이유로 후속 이슈(#573)로 분리했다. prod 실측(2026-07-04)으로 6건을 점검한 결과:
+
+1. **좀비 신호 발견 (schema drift).** `schedule_영화`·`schedule_이직`의 `sql_body`가 `schedules.category`(TEXT 컬럼)를 참조하는데, #394(2026-05-13)가 그 컬럼을 DROP하고 `category_id` FK로 교체했다. 두 신호는 7주째 "존재하지 않는 컬럼 참조"로 실행 시 죽어 있었다(링크 hit 0/miss 0). 신호 정의가 catalog(DB)에 영속되므로 코드 리뷰·타입 체크로 안 잡히고, 컬럼 rename/drop 마이그레이션이 `signal_defs.sql_body`를 조용히 깨뜨린 **클래스 사고**다.
+
+2. **`expense_total`의 측정 범위 부정확.** "총 지출"은 할부 회차·구독·통신·공과금 같은 고정지출을 다 합산한다. 사주 재성/편재 발현이 재량 소비 행동과 연관되는지를 재려면 본인이 그날 결정한 자유지출만 봐야 하는데, 고정비가 섞여 신호가 둔해진다. (실측: 할부 행만 168/912 = 18%.)
+
+3. **나머지 4건은 실측상 무변경.** 완료율×미룸 기계 결합(공존 쌍 0), `schedule_count_today` 동명 2행(의도된 반대 가설), 수면 결측=0시 기상(실측 결측 0건, 117/117 매일 기록), 루틴 미기록일=완료율 0(실측 결측 0건, 120/120 매일 기록), `schedule_tax_keyword`(title 기반 정상, 생애 발화 0). — 지금 손대면 실이익 없이 baseline만 흔든다.
+
+prod 확인 결과 구 3신호(영화·이직·expense_total)에 confirmed 링크 0 → [ADR-0048](0048-enrollment-clip-and-rebaseline.md) D2 re-baseline 의무는 미발생.
+
+## Decision
+
+네 가지를 결정한다. 통계 스택·verdict·tier·임계치는 불변 — [ADR-0054](0054-audit-net-displacement-and-trigger-writer.md)·[ADR-0046](0046-signal-seed-precision.md)과 동일하게 *무엇을* 측정하는지(신호 정의)만 교정한다.
+
+### 1. 영화·이직 = 좀비 부활 + `status='done'` 재정의
+
+깨진 `category='영화'`를 `categories.name='영화'` **category_id JOIN**으로 재작성하고, `status='done'` 필터를 추가한다. 의미를 "그 일정이 달력에 있던 날"에서 **"그 일정을 실제로 처리한 날"**로 명시적으로 좁힌다. 실측 done 비율(영화 7/7일=100%, 이직 39/41일=95%)이 done 필터로 인한 손실이 무시 가능함을 뒷받침한다.
+
+```sql
+-- schedule_영화 (schedule_이직 동일 구조, name='이직')
+SELECT COUNT(*) FROM schedules s JOIN categories c ON c.id = s.category_id
+ WHERE s.user_id=$1 AND s.date=$2 AND c.name='영화' AND s.status='done'
+```
+
+### 2. `expense_total` → `expense_discretionary` 개명 재정의
+
+자유지출만 측정한다. 할부 제외(`COALESCE(is_installment,false)=false`) + 고정비/통과비용 카테고리 제외.
+
+```sql
+SELECT COALESCE(SUM(amount),0) FROM expenses
+ WHERE user_id=$1 AND date=$2 AND COALESCE(is_installment,false)=false
+   AND category NOT IN ('구독','구독료','통신','통신비','공과금','보험','주거','세금','리커밋 택배')
+```
+
+- **제외 목록 정책 = 제외-목록(deny-list) 방식.** 새 카테고리는 기본 포함된다. 재량 지출은 다양하게 늘어날 수 있으므로 "포함할 것을 열거"보다 "제외할 고정지출을 열거"가 유지보수 부담이 낮다.
+- **'리커밋 사업'은 유지, '리커밋 택배'는 제외.** 사업 투자 결정은 본인 재량 행동(편재 유관)이라 신호에 포함하는 게 맞고, 택배는 주문량에 비례하는 통과 비용(본인 행동 아님)이라 제외한다(사용자 통찰).
+- `COALESCE(SUM(amount),0)` 유지 — 지출 0원인 날은 유효 0([ADR-0044](0044-discovery-measurement-validity.md)).
+- **신명(new name) = 계보 단절.** `expense_total`의 e-value 시계열은 승계하지 않는다(개명이 곧 새 신호). 측정 범위가 바뀐 시계열을 한 anytime-valid 과정에 섞으면 보장이 훼손된다.
+
+### 3. 결측 전파 인프라는 #574에 편입 (지금 안 함)
+
+수면·루틴 결측일이 "0"으로 강제 변환되는 문제(3항·6항의 근본 원인)는 실측 결측이 0건이라 지금 손댈 실이익이 없다. 결측 전파 인프라(실행기 NULL 보존 + COALESCE 제거)를 #574 설계에 넘긴다. 설계 스케치는 도메인 문서(§43)에 남긴다.
+
+### 4. 링크 처분 = archive만, 재연결은 발굴 엔진에 위임
+
+구 3신호의 살아있는 링크(active/pending/weak/confirmed)는 전부 archive만 한다. 재연결(새 정의의 신호를 시드에 다시 잇는 것)은 발굴 엔진(P5a)의 다음 주간 스캔에 맡긴다 — [086](../../db/migrations/086_signal_seed_precision.sql)/[100](../../db/migrations/100_audit_net_displacement.sql) 전례 그대로. 마이그레이션에서 링크를 수동 재생성하지 않는다.
+
+구현: 마이그레이션 [101](../../db/migrations/101_signal_semantics.sql)(은퇴 먼저 → 신설 나중, 085/099 부분 유니크 인덱스가 active/pending만 잡으므로). 라벨 레이어([insight-labels.ts](../../src/shared/insight-labels.ts)) 현행화 — 영화·이직은 override("… 처리한 날"), expense는 measure 맵 개명("자유지출").
+
+## Alternatives considered
+
+### A. 라벨만 고치고 SQL은 그대로
+
+- 장점: 변경 최소.
+- 단점: 좀비 SQL이 계속 죽어 있어 신호가 영영 발화 못 함. 라벨은 "무슨 뜻인지"만 바꾸고 "측정이 되는지"는 못 고친다.
+- 기각 이유: 근본 문제(스키마 드리프트)를 안 건드림. 좀비를 살리는 게 이 이슈의 핵심.
+
+### B. `expense_total` 분모를 고정지출 총액으로 나눠 비율화
+
+- 장점: 소비 성향을 상대화.
+- 단점: 고정지출이 월 단위라 일별 신호에 분모로 넣기 부적합, 임의 정규화 도입([ADR-0028](0028-pillar-level-and-threshold-pool.md) 임의값 배제 위반).
+- 기각 이유: 자유지출 "절대액 above_avg"가 이미 rolling baseline으로 상대화됨 — 별도 분모 불필요.
+
+### C. 결측 전파 인프라를 이번에 같이 구현
+
+- 장점: 3·6항까지 한 번에 완결.
+- 단점: `extractFirstNumber`(pattern-match.ts) NULL→0 강제, `MetricRunner` 타입 확장, 신호 SQL COALESCE 제거, 도메인 화이트리스트 opt-in — 하류 결측 처리([ADR-0044](0044-discovery-measurement-validity.md) `computeSignalSeries` raw null·`binarizeSqlSeries`·`buildContingency` inconclusive)는 완비돼 있으나 상류 변경 범위가 넓다.
+- 기각 이유: **실측 결측 0건**(수면 117/117, 루틴 120/120)이라 당장 동작 변화가 없다. 넓은 상류 변경을 이익 0인 채로 야간 배포에 싣지 않는다 — #574로 편입해 결측 표본이 실제로 생길 때 설계.
+
+### D. 6개 신호 전량 은퇴 후 재설계
+
+- 장점: 의미론을 백지에서 정리.
+- 단점: 4개는 무변경이 정답(실측 근거)이라 은퇴가 과잉. 발굴 재편·baseline 리셋 비용만 커짐.
+- 기각 이유: 실측이 "3 교정 / 3 무변경"을 명확히 가름 — 전량 은퇴는 실측을 무시하는 판단.
+
+### E. (선택한 안) 3 교정 + 3 무변경, 개명은 신명, 링크는 발굴 재연결
+
+- 장점: 실측 근거에 정확히 대응. 신규 통계 코드 0. baseline 교란 최소.
+- 단점: 발굴 재연결까지 신호가 잠시 링크 없이 뜸(관찰 필요).
+
+## Consequences
+
+### 장점
+
+- 좀비 2신호가 7주 만에 다시 발화 가능 — category_id 스키마와 정합.
+- 자유지출 신호가 고정비 잡음 제거로 재성/편재 가설에 더 예민.
+- 신규 통계 코드 0, 임계치·verdict·tier 불변 → 리스크 낮음.
+
+### 단점 / 제약
+
+- **발굴 재연결 관찰 필요.** 링크 archive 후 새 정의가 시드에 다시 붙는지는 다음 주간 발굴 스캔에서 확인해야 한다(즉시 노출 안 됨).
+- **`expense` 계보 단절은 의도.** `expense_total`의 과거 e-value·hit/miss는 `expense_discretionary`로 승계되지 않는다 — 개명이 새 신호이므로 축적을 처음부터 다시 쌓는다.
+- **스키마 드리프트 클래스 위험 상존.** 이번엔 영화·이직만 걸렸지만, 다른 `signal_defs.sql_body`가 미래의 컬럼 변경에 또 깨질 수 있다.
+
+### 후속 작업
+
+- [ ] **컬럼 rename/drop 마이그레이션 시 `signal_defs.sql_body` grep 의무 (재발 방지 규칙).** 도메인 문서 §43·[conventions.md](../conventions.md)에 명문화. 점검 쿼리 예: `SELECT name, sql_body FROM signal_defs WHERE sql_body ILIKE '%<드롭할 컬럼>%';` + 신설 SQL 실행 스모크(101 ③처럼 `EXECUTE`로 정합 증명).
+- [ ] 다음 주간 발굴 스캔에서 영화·이직·자유지출 신호의 재연결 여부 확인.
+- [ ] 결측 전파 인프라 #574 설계(실행기 NULL 보존 + COALESCE 제거 + 도메인 opt-in).
+
+---
+
+**참고 자료**
+
+- [ADR-0054](0054-audit-net-displacement-and-trigger-writer.md) — 이 이슈를 후속으로 분리한 audit 순변위 교정
+- [ADR-0044](0044-discovery-measurement-validity.md) — 데이터-존재 윈도우·유효 0 보존(하류 결측 처리 완비분)
+- [ADR-0048](0048-enrollment-clip-and-rebaseline.md) — re-baseline 의무 조건(confirmed 링크)
+- 마이그레이션 [101](../../db/migrations/101_signal_semantics.sql)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -161,6 +161,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0052](0052-weekly-insight-single-card-merge.md) | 주간 인사이트 단일 카드 통합 — routine 단독 발송 + 봇 검증 카드 은퇴 + posterior 노출 제거 | Accepted | 2026-06-16 | process, data, ux |
 | [0053](0053-signal-suggest-idempotency.md) | 월간 신호 제안 루틴 idempotency — DB 클레임 테이블 (최초 원자적 클레임, 재실행 중복 발송 차단) | Accepted | 2026-07-01 | data, process, reliability |
 | [0054](0054-audit-net-displacement-and-trigger-writer.md) | 일정 변경 audit 순변위 측정 + 기록 트리거 단일 계기 — 왕복 상쇄·30분 유예·FK 제거 로그화·tombstone·운명 view | Accepted | 2026-07-04 | data, process, reliability |
+| [0056](0056-signal-semantics-batch-correction.md) | 신호 의미론 일괄 교정 — 좀비 부활(schema drift) + done 재정의 + 자유지출 개명 + 결측 인프라 #574 편입 | Accepted | 2026-07-04 | insight, data, statistics, process |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/signal-seed-precision.md
+++ b/docs/design-notebook/signal-seed-precision.md
@@ -100,3 +100,40 @@ PR [#509](https://github.com/hyewon3938/slack-ai-agents/pull/509)로 ①②③�
 - **계획서의 전제도 리뷰 대상이다.** FK 동적 DROP이 `contype='f'`만으로 조회해 2개 FK(user_id→users, schedule_id→schedules) 중 아무거나 잡는 비결정 버그 — 구현 에이전트 잘못이 아니라 FK 1개를 전제한 계획서 자체의 누락이었고, 에이전트는 충실히 따랐을 뿐. 리뷰에서 원본 DDL(053)을 다시 폈기 때문에 잡혔다. `confrelid` 특정으로 교정.
 - **검증 엄격도는 "진짜 불변식"에만.** 스냅샷 NULL 0건 강제는 nullable `created_at`의 정상 상태를 부팅 롤백 사고로 만들 뻔했다 — "살아있는 일정 기준 백필 누락 0건"(JOIN 불변식)으로 교체. 반대로 rejected 카운트는 `≥3` 관대 검증이 정답이었음이 배포 전 preflight에서 실측 증명 — `audit_postponed_done`에 과거 재정의 흔적(rejected 3행)이 이미 있었고, `=3` 강제였다면 마이그레이션이 롤백됐다.
 - **배포 전 read-only preflight는 싸고 강하다.** FK 실재·created_at NULL 0·CHECK 1개·신호 선재 상태를 5쿼리로 확정하고 들어가니 "방어적으로 짰지만 실제로 어느 분기를 타는지"를 아는 상태로 배포. 검증은 배포 파이프라인 성공 + 업타임 체크(마이그레이션이 부팅 차단이라 기동=적용 증명)로 이중 확인.
+
+---
+
+## 3차: 신호 의미론 점검 (#573, 2026-07-04)
+
+- 이슈: [#573](https://github.com/hyewon3938/slack-ai-agents/issues/573)
+- 관련 ADR: [ADR-0056](../adr/0056-signal-semantics-batch-correction.md)
+- 관련 마이그레이션: [101](../../db/migrations/101_signal_semantics.sql)
+- 2차(#572)의 "포기/미룬" 6건을 prod 실측으로 처분
+
+### 결정 요약
+
+2차가 후속으로 넘긴 "타 도메인 신호 의미론 점검 6건"을 prod 실측(2026-07-04)으로 갈랐다 — **3건 교정 / 3건 무변경**. 실측이 판단을 대체한 케이스.
+
+1. **영화·이직 = 좀비 부활 + done 재정의.** 두 신호의 `sql_body`가 `schedules.category`(TEXT)를 참조하는데 #394(2026-05-13)가 그 컬럼을 DROP하고 `category_id` FK로 교체 → 7주째 실행 불능(링크 hit 0/miss 0). `category_id` JOIN으로 재작성 + `status='done'` 추가해 "실제 처리한 날"로 재정의.
+2. **`expense_total` → `expense_discretionary` 개명.** 자유지출만 측정(할부 제외 + 고정비 카테고리 제외).
+3. **나머지 4건 무변경.** 완료율×미룸 공존 쌍 0 / `schedule_count_today` 2행은 의도된 반대 가설 / 수면·루틴 결측 실측 0건 / `schedule_tax_keyword` title 기반 정상(생애 발화 0).
+
+### 분기점 (실측이 결정을 뒤집은 지점들)
+
+- **done 필터는 실측 100%/95%가 결정했다.** "달력에 있던 날"을 "실제 처리한 날"로 좁히면 발화가 줄어들 걱정이 있었으나, 실측 done 비율(영화 7/7일=100%, 이직 39/41일=95%)이 손실 무시 가능임을 증명 → 망설임 없이 done 필터 채택. 실측 없이 SQL만 봤으면 done 필터를 못 넣었을 것.
+- **택배 제외는 사용자 통찰이 갈랐다.** '리커밋 사업'과 '리커밋 택배'를 처음엔 둘 다 넣거나 둘 다 뺄지 애매했는데, 사용자가 "사업 투자는 본인 재량 결정(편재 유관)이지만 택배는 주문량 비례 통과 비용(본인 행동 아님)"이라 구분 — 사업 유지·택배 제외로 확정. 카테고리명만 봐선 안 나오는 도메인 지식.
+- **결측 인프라 편입이 분석 제안을 뒤집었다.** 초기 분석은 "수면 결측=0시 기상 / 루틴 미기록일=완료율 0"을 SQL·실행기 수정으로 즉시 고치자고 봤으나, 실측 결측이 0건(수면 117/117, 루틴 120/120 매일 기록)이라 지금 고쳐도 동작 변화가 없음이 드러남 → 넓은 상류 변경(실행기 NULL 보존)을 이익 0인 채로 싣지 않고 #574로 편입. "고칠 값어치가 있나"를 실측이 답함.
+
+### 좀비 발견 경위 (스키마 드리프트)
+
+`signal_defs.sql_body`는 catalog(DB)에 문자열로 영속된다 — TypeScript 타입 체크·코드 리뷰의 사각지대다. #394가 `schedules.category`를 드롭할 때 코드의 category 참조는 다 고쳤지만, DB에 잠자던 신호 SQL 2개는 아무도 grep하지 않았다. 7주 뒤 이 이슈의 prod 실측(링크 hit/miss 0 → sql_body 확인 → 존재하지 않는 컬럼 참조)에서야 드러남. **재발 방지 = 컬럼 rename/drop 마이그레이션 시 `signal_defs.sql_body` grep 의무 + 신설 SQL 실행 스모크**(101 ③이 각 신설 sql_body를 `EXECUTE`해 스키마 정합을 런타임으로 봉인).
+
+### 포기한 안 / 미룬 항목
+
+- **즉시 결측 전파 인프라 구현** — #574로 편입. 실측 결측 0건이라 당장 이익 0 + 상류 변경(`extractFirstNumber` NULL→0 강제, `MetricRunner` 타입, 신호 COALESCE 제거, 도메인 opt-in)이 넓음. 하류(ADR-0044 `computeSignalSeries` raw null·`binarizeSqlSeries`·`buildContingency` inconclusive)는 이미 완비 → #574는 상류만 열면 됨.
+- **고정비 카테고리 하드코딩 최소화** — 대신 사용자 확정 제외 목록을 그대로 씀. "카테고리 메타에 is_fixed 플래그를 두자"는 정규화 안도 있었으나, 목록이 짧고 안정적이며 deny-list라 새 카테고리 기본 포함이라 하드코딩 비용 < 스키마 확장 비용. 목록이 자주 흔들리면 그때 플래그화.
+- **`expense_total` 계보 승계(in-place SQL 교체)** — 기각, 신명으로 단절. 측정 범위가 바뀐 시계열을 한 e-value 과정에 섞으면 anytime-valid 훼손(2차 신호 처분과 동일 논리). confirmed 0이라 ADR-0048 re-baseline 의무는 미발생.
+
+### 회고
+
+(머지 후 채움)

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -2373,6 +2373,39 @@ db/migrations/  (마스터 #477 매트릭 중심 패턴 검증 — 2026-06)
 
 **`schedule_fate` view — 생성일 코호트 추적 기반** ([100](../../db/migrations/100_audit_net_displacement.sql) ⑥, #574 선행): 살아있는 일정(schedules) + 삭제 일정(tombstone) 합집합으로 생성일(KST `cohort_date`)·카테고리·순미룸 일수·최종 상태를 한 곳에 낸다. 한 번도 안 옮긴 채 완료된 일정도 코호트의 "잘 해결된" 쪽으로 포함(생존 편향 방지). 코호트 신호 정의·성숙 기간·e-value 정합은 [#574](https://github.com/hyewon3938/slack-ai-agents/issues/574)에서 설계 — 그 전에도 view로 ad-hoc·주간 리뷰 소비 가능. 삭제 이벤트는 소급 불가라 캡처 계층만 본 건에 포함(배포일부터 축적).
 
+### 43. 신호 의미론 일괄 교정 (#573, ADR-0056)
+
+#572(§42)가 후속으로 분리한 "타 도메인 신호 의미론 점검 6건"의 실행체. prod 실측(2026-07-04)으로 6건을 갈라 **3건 교정 / 3건 무변경**으로 처분했다. 핵심 발견은 **좀비 신호** — `schedule_영화`·`schedule_이직`의 `sql_body`가 `schedules.category`(TEXT 컬럼)를 참조하는데 [#394](../adr/0013-schedule-category-fk-migration.md)(2026-05-13)가 그 컬럼을 DROP하고 `category_id` FK로 교체 → 두 신호가 7주째 존재하지 않는 컬럼 참조로 죽어 있었다(링크 hit 0/miss 0). 통계 스택·verdict·tier·임계치 불변 — *무엇을* 측정하는지만 교정. 마이그레이션 [101](../../db/migrations/101_signal_semantics.sql). 상세 판단은 [ADR-0056](../adr/0056-signal-semantics-batch-correction.md) · [signal-seed-precision.md](../design-notebook/signal-seed-precision.md) 3차.
+
+**6항목 처분 표** (각: 실측 근거 → 처분):
+
+| # | 신호/사안 | 실측 근거 | 처분 |
+|---|-----------|-----------|------|
+| 1 | `schedule_영화`·`schedule_이직` | `category` 컬럼 드롭으로 7주째 실행 불능(hit 0/miss 0). done 비율 영화 7/7=100%·이직 39/41=95% | **교정**: `category_id` JOIN + `status='done'` 재정의 = "실제 처리한 날" |
+| 2 | 완료율×미룸 기계 결합 | 완료율+audit 신호가 같은 시드에 공존하는 쌍 0개 | **무변경**(문서화만) |
+| 3 | 수면 결측=0시 기상 | 수면 실측 결측 0건(117/117 매일 기록) | **무변경** — 결측 인프라 #574 편입 |
+| 4 | `expense_total` 고정비 발화 | "총 지출"이 할부·구독·통신·공과금 합산 — 할부 행만 168/912(18%) | **교정**: `expense_discretionary` 개명 = 자유지출만 |
+| 5 | `schedule_count_today` 동명 2행 | id 11 above_avg×life_dow_월 / id 12 below_avg×life_holiday = 의도된 반대 가설 | **무변경**(문서화만) |
+| 6 | 루틴 미기록일=완료율 0 | 루틴 실측 결측 0건(120/120 매일 기록) | **무변경** — 결측 인프라 #574 편입 |
+
+(추가로 `schedule_tax_keyword`는 title 기반이라 동작 정상, 생애 발화 0일 — 대기 상태.)
+
+**영화·이직 = 좀비 부활 + done 재정의** ([101](../../db/migrations/101_signal_semantics.sql) ②): 깨진 `category='영화'`를 `categories.name='영화'` category_id JOIN으로 재작성 + `status='done'` 필터 추가. 의미를 "달력에 있던 날"에서 "그 일정을 실제로 처리한 날"로 명시적으로 좁힌다. `above_abs` threshold=1·`domain='schedule'`·`source='seed'`는 구 정의 유지.
+
+**자유지출 개명 재정의** ([101](../../db/migrations/101_signal_semantics.sql) ②): `expense_total` → `expense_discretionary`(신명 = 계보 단절). 할부 제외(`COALESCE(is_installment,false)=false`) + 고정비/통과비용 카테고리 제외.
+
+- **제외 목록**: `구독·구독료·통신·통신비·공과금·보험·주거·세금·리커밋 택배`. **deny-list 방식이라 새 카테고리는 기본 포함** — 재량 지출이 다양하게 늘 수 있어 "포함 열거"보다 "제외할 고정지출 열거"가 유지보수 부담이 낮다.
+- **'리커밋 사업' 유지 / '리커밋 택배' 제외**: 사업 투자 결정은 본인 재량 행동(편재 유관)이라 포함, 택배는 주문량 비례 통과 비용(본인 행동 아님)이라 제외(사용자 통찰).
+- `COALESCE(SUM(amount),0)` 유지 — 지출 0원인 날은 유효 0([ADR-0044](../adr/0044-discovery-measurement-validity.md)). `direction='above_avg'`·`domain='expense'`는 구 정의 유지. 개명이라 `expense_total`의 e-value 시계열은 승계 안 함.
+
+**결측 인프라 #574 편입 설계 스케치**: 3·6항의 근본 원인(수면·루틴 결측일이 "0"으로 강제 변환)은 실측 결측 0건이라 지금 손대도 동작 변화 0 → #574로 미룬다. 상류 변경 스케치 — ⓐ `extractFirstNumber`([pattern-match.ts](../../src/shared/pattern-match.ts) 첫 행 첫 컬럼을 number로 좁히며 NULL을 0으로 강제하는 지점) null→0 강제 해제 + ⓑ `runMetricSql`/`MetricRunner`([pattern-match.ts](../../src/shared/pattern-match.ts)) 타입을 `number | null` 반환으로 확장 + ⓒ 대상 신호 SQL의 `COALESCE` 제거 + ⓓ 도메인 화이트리스트 opt-in(결측을 결측으로 흘릴 도메인만). **하류는 이미 완비** — [computeSignalSeries](../../src/shared/pattern-verification.ts) raw null 처리·[binarizeSqlSeries](../../src/shared/pattern-verification.ts)·`buildContingency` inconclusive가 [ADR-0044](../adr/0044-discovery-measurement-validity.md)에서 갖춰짐. #574는 상류만 열면 결측이 2×2에서 자연 제외된다.
+
+**링크 처분**: 구 3신호 살아있는 링크(active/pending/weak/confirmed)는 전부 archive만. 재연결은 발굴 엔진(P5a) 다음 주간 스캔에 위임([086](../../db/migrations/086_signal_seed_precision.sql)/[100](../../db/migrations/100_audit_net_displacement.sql) 전례) — 마이그레이션에서 링크 수동 재생성 안 함. prod 확인 결과 구 3신호 confirmed 링크 0 → [ADR-0048](../adr/0048-enrollment-clip-and-rebaseline.md) re-baseline 의무 미발생. 은퇴를 신설보다 먼저 실행 — 085/099 부분 유니크 인덱스가 active/pending만 잡으므로.
+
+**신설 SQL 실행 스모크** ([101](../../db/migrations/101_signal_semantics.sql) ③): 좀비의 근본 원인이 sql_body의 컬럼 참조가 실제 스키마와 어긋난 것이므로, 검증 DO 블록이 각 신설 sql_body를 `user_id=1`·오늘 날짜로 `EXECUTE`해 "에러 없이 숫자 반환"을 증명한다. category_id JOIN·expenses 컬럼 참조가 현행 스키마와 맞음을 마이그레이션 시점에 봉인 — 좀비 재발의 구조적 차단.
+
+> **스키마 드리프트 재발 방지 규칙**: `signal_defs.sql_body`는 catalog(DB) 문자열이라 TypeScript 타입 체크·코드 리뷰의 사각지대다. **컬럼 rename/drop 마이그레이션 시 `signal_defs.sql_body` grep 의무.** 점검 쿼리: `SELECT name, sql_body FROM signal_defs WHERE sql_body ILIKE '%<드롭할 컬럼>%';` — 걸리면 신호 SQL을 새 스키마로 재작성 + 실행 스모크(101 ③ 패턴)로 정합 증명.
+
 ## 부록 — e-value 게이트 설계 노트 (S-f)
 
 > [ADR-0034](../adr/0034-evalue-construction-replay-test-martingale.md) 본문은 불변(Accepted). 이 부록은 운영·후속 판단을 위한 **경계 조건 메모**로, ADR 결정을 바꾸지 않는다.

--- a/src/agents/insight/__tests__/hypothesis-cards.test.ts
+++ b/src/agents/insight/__tests__/hypothesis-cards.test.ts
@@ -31,9 +31,9 @@ describe('buildDiscoveryCandidateCard — 발굴 후보 맥락 카드', () => {
     seedDescription: '일운 천간 갑목(편재) → 일정/지출 폭증',
     seedLabel: '갑목(편재)',
     patternKind: 'saju',
-    signalName: 'expense_total',
-    signalDescription: 'N8_병화_편관_천간 시드의 expense_total 평가',
-    signalLabel: '총 지출 많음',
+    signalName: 'expense_discretionary',
+    signalDescription: 'N8_병화_편관_천간 시드의 expense_discretionary 평가',
+    signalLabel: '자유지출 많음',
     signalKind: 'sql',
     valueType: 'binary',
     rateActive: 0.75,
@@ -63,7 +63,7 @@ describe('buildDiscoveryCandidateCard — 발굴 후보 맥락 카드', () => {
     const text = sectionTexts(buildDiscoveryCandidateCard(makeCandidate()))[0] ?? '';
     expect(text).toContain('[사주]');
     expect(text).toContain('갑목(편재)'); // seedLabel (#542 접두 제거)
-    expect(text).toContain('총 지출 많음'); // signalLabel (#542 "평소보다" 제거)
+    expect(text).toContain('자유지출 많음'); // signalLabel (#573 expense_total→expense_discretionary)
     expect(text).toContain('새 패턴 후보');
     expect(text).toContain('24일 중 18일'); // 발현 = 분수
     expect(text).toContain('평소 25%'); // 비발현 = 비율
@@ -71,7 +71,7 @@ describe('buildDiscoveryCandidateCard — 발굴 후보 맥락 카드', () => {
     expect(text).toContain('인과 아님'); // caveat
     // 변수명·깨진 provenance 미노출 (#504 P2)
     expect(text).not.toContain('S1_갑목_편재_천간');
-    expect(text).not.toContain('expense_total');
+    expect(text).not.toContain('expense_discretionary');
     expect(text).not.toContain('평가');
   });
 
@@ -98,7 +98,7 @@ describe('buildDiscoveryCandidateCard — 발굴 후보 맥락 카드', () => {
         ),
       )[0] ?? '';
     expect(text).toContain('갑목(편재)'); // seedLabel
-    expect(text).toContain('총 지출 많음'); // signalLabel
+    expect(text).toContain('자유지출 많음'); // signalLabel
     expect(text).not.toContain('schedule_tax_keyword');
     expect(text).not.toContain('평가');
   });

--- a/src/shared/__tests__/insight-labels.test.ts
+++ b/src/shared/__tests__/insight-labels.test.ts
@@ -177,9 +177,9 @@ describe('signalLabel — sql seed 룰', () => {
   it('above_abs threshold=1 → 있음', () => {
     expect(
       signalLabel(
-        sig({ name: 'schedule_영화', domain: 'schedule', direction: 'above_abs', threshold: 1 }),
+        sig({ name: 'schedule_created', domain: 'schedule', direction: 'above_abs', threshold: 1 }),
       ),
-    ).toBe('영화 일정 있음');
+    ).toBe('등록한 일정 있음');
   });
 
   it('above_abs threshold>1 → N회 이상', () => {
@@ -227,6 +227,28 @@ describe('signalLabel — override / tag / llm', () => {
         }),
       ),
     ).toBe('병원비 지출(할부 제외)');
+  });
+
+  it('영화·이직 신호 override (#573 — status=done 재정의, direction·threshold 무시)', () => {
+    // above_abs 1이지만 "있음" 룰 대신 "처리한 날" 평어 override. 변수명·언더스코어 미노출.
+    const movie = signalLabel(
+      sig({ name: 'schedule_영화', domain: 'schedule', direction: 'above_abs', threshold: 1 }),
+    );
+    const job = signalLabel(
+      sig({ name: 'schedule_이직', domain: 'schedule', direction: 'above_abs', threshold: 1 }),
+    );
+    expect(movie).toBe('영화 일정 처리한 날');
+    expect(job).toBe('이직 일정 처리한 날');
+    expect(looksLikeIdentifier(movie)).toBe(false);
+    expect(looksLikeIdentifier(job)).toBe(false);
+  });
+
+  it('expense_discretionary 개명 (#573 — expense_total → 자유지출)', () => {
+    expect(
+      signalLabel(
+        sig({ name: 'expense_discretionary', domain: 'expense', direction: 'above_avg' }),
+      ),
+    ).toBe('자유지출 많음');
   });
 
   it('날짜 변경 방향 신호 override (#508 ① — direction·threshold 무시)', () => {

--- a/src/shared/insight-labels.ts
+++ b/src/shared/insight-labels.ts
@@ -138,7 +138,7 @@ const SIGNAL_MEASURE: Record<string, Measure> = {
   sleep_nap_count: { noun: '낮잠' },
   sleep_wake_hour: { noun: '기상 시각', hi: '늦음', lo: '이름' },
   // expense
-  expense_total: { noun: '총 지출' },
+  expense_discretionary: { noun: '자유지출' }, // #573: expense_total 개명 — 할부·고정비 제외
   expense_배달음식: { noun: '배달음식 지출' },
   expense_식재료: { noun: '식재료 지출' },
   expense_외식: { noun: '외식 지출' },
@@ -151,8 +151,8 @@ const SIGNAL_MEASURE: Record<string, Measure> = {
   schedule_count_today: { noun: '일정 수' },
   schedule_created: { noun: '등록한 일정' },
   schedule_done: { noun: '완료한 일정' },
-  schedule_영화: { noun: '영화 일정' },
-  schedule_이직: { noun: '이직 일정' },
+  // schedule_영화·schedule_이직은 "실제 처리한 날"(status=done) 의미라 방향 룰로 안 떨어짐 →
+  // SIGNAL_LABEL_OVERRIDES에서 전체 라벨 직접 지정(#573 ADR-0056).
 };
 
 /** 합성·모호 신호 — 룰로 안 떨어져 라벨 전체를 직접 지정(direction 무시). */
@@ -164,6 +164,9 @@ const SIGNAL_LABEL_OVERRIDES: Record<string, string> = {
   audit_postponed_done: '미룬 일정 처리',
   expense_hospital_excl_installment: '병원비 지출(할부 제외)',
   schedule_tax_keyword: '세금 관련 일정',
+  // #573 ADR-0056: category_id JOIN + status='done' 재정의 — "그 일정을 실제로 처리한 날".
+  schedule_영화: '영화 일정 처리한 날',
+  schedule_이직: '이직 일정 처리한 날',
 };
 
 /** diary 태그 enum → 한글 (diary-meta-extract.ts gloss 기반). */


### PR DESCRIPTION
## 관련 이슈
Closes #573

## 변경 내용
- **`schedule_영화`·`schedule_이직` 재작성**: 스키마 변경(#394 카테고리 FK 전환) 이후 실행되지 않던 신호 SQL을 `category_id` JOIN으로 교정 + `status='done'` 필터로 "실제 처리한 날" 재정의 (실측 done 비율 100%·95% — 손실 무시 가능)
- **`expense_total` → `expense_discretionary` 개명 재정의**: 할부(`is_installment`) + 고정성 카테고리 제외한 자유지출만 측정 — 신명으로 e-value 계보 단절 (측정 범위 변경 시계열 비혼합 원칙)
- **신설 SQL 실행 스모크**: 마이그레이션 검증 블록이 신설 `sql_body`를 실제 EXECUTE해 스키마 정합을 적용 시점에 증명 — 정의-스키마 어긋남 재발 구조적 차단
- **무변경 3건 문서화**: 완료율×미룸(위험 쌍 0)·동명 반대방향 2행(의도된 설계)·수면/루틴 결측(실측 0건 — 결측 인프라는 #574 편입)
- 라벨 레이어 현행화 + ADR-0056 + 도메인 문서 §43·design-notebook 3차

## 코드 리뷰 결과
- [x] 보안 감사 통과 (개인 데이터 값·크리덴셜 없음 — 카테고리명·행동 카운트만)
- [x] 마이그레이션 방어 검증 — 은퇴 우선 순서·관대 카운트(선재 rejected)·type 필터 승계(리뷰 교정)·실행 스모크
- [x] 타입 안전성 확인 (tsc clean)
- [x] 컨벤션 점검 완료

## 테스트
- [x] vitest 984 passed (53 files) — 라벨 오버라이드·개명 커버리지 포함
- [x] 마이그레이션 자기검증 — 배포 시 신설 3 active / 구 3 rejected / 링크 정리 / SQL 스모크 자동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)