### PR TITLE
feat(insight): 일기 메타 태그 어휘 확장 (22→26종)

### DIFF
--- a/db/migrations/102_diary_meta_tags_enum_expand_v2.sql
+++ b/db/migrations/102_diary_meta_tags_enum_expand_v2.sql
@@ -1,0 +1,32 @@
+-- diary_meta_tags enum 확장 (22 → 26)
+--   evaluation_exposure : 평가·시선 노출 상황 — 면접/발표/리뷰/마감 (관성 매핑)
+--   feeling_enough      : 충분함·인정 체감 (인성 매핑)
+--   palpitation         : 두근거림·심계 — health_complaint에서 세분 (화 채널)
+--   muscle_tension      : 결림·근막 긴장 — health_complaint에서 세분 (목 채널)
+
+ALTER TABLE diary_meta_tags
+  DROP CONSTRAINT IF EXISTS diary_meta_tags_tag_check;
+
+ALTER TABLE diary_meta_tags
+  ADD CONSTRAINT diary_meta_tags_tag_check
+  CHECK (tag IN (
+    'irritation','health_complaint','low_energy','mood_down',
+    'confidence_high','analytical_mode','deep_thought','rest',
+    'peaceful','mood_high','cooking','creating','talkative',
+    'nostalgia','anxiety','past_memory',
+    'wealth_awareness','self_observation','social_activity',
+    'physical_activity','task_completion','clumsy_overflow',
+    'evaluation_exposure','feeling_enough','palpitation','muscle_tension'
+  ));
+
+-- signal_defs 검증축 편입 (077 tag 신호 등록 패턴과 동일 — 전역 1개, 여러 시드가 공유)
+INSERT INTO signal_defs (user_id, name, kind, value_type, domain, tag_name, description, source, status)
+SELECT DISTINCT d.user_id, t.tag, 'tag', 'binary', 'diary_meta', t.tag, t.descr, 'seed', 'active'
+FROM diary_meta_tags d
+CROSS JOIN (VALUES
+  ('evaluation_exposure', '평가·시선 노출 상황 (면접/발표/리뷰/마감)'),
+  ('feeling_enough', '충분함·인정 체감'),
+  ('palpitation', '두근거림·심계'),
+  ('muscle_tension', '결림·근막 긴장')
+) AS t(tag, descr)
+ON CONFLICT (user_id, tag_name) WHERE kind = 'tag' DO NOTHING;

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -752,7 +752,7 @@ GROUP BY c.id;
 
 - `weekly-saju-review-v2` Routine — view 인터페이스 유지로 영향 없음 (Section 13)
 - `weekly-fortune` Routine + `fortune_analyses` 테이블 — 본 마스터 범위 외
-- `diary_meta_tags` enum 22종 — 마스터 #393 Phase 4 (그대로)
+- `diary_meta_tags` enum 26종 — 마스터 #393 Phase 4 + migration 102 (그대로)
 - fast path 명령어(`/일운`·`/월운`·`/세운`·`/대운`) — 그대로
 
 #### 다음 Phase
@@ -1464,7 +1464,7 @@ ALTER TABLE pattern_matches
 | `signal_defs` | 전역 신호 정의 (시드 무관) | `kind`(sql\|tag), `sql_body`·`direction`·`value_type`·`threshold`·`domain`·`window_days`(sql), `tag_name`(tag), `source`(seed\|llm), `status`(active\|pending\|rejected) |
 | `pattern_links` | (시드 × 신호) = 가설 + 누적 검증상태 | `seed_id`×`signal_id` UNIQUE, `source`(manual\|discovery\|llm), `status`(active\|pending\|weak\|confirmed\|rejected\|archived), `hit/miss/inconclusive_count`, `posterior_*`, 검증결과(`test_type`·`effect`·`p_value`·`q_value`·`e_value`·`test_detail`·`confound`) |
 
-- **신호 종류**: `kind=sql`(객관 SQL 측정, 1차) — 기존 매트릭 SQL + off-day 대조 판정(`direction`). `kind=tag`(일기 메타 22태그, 보조) — 그날 태그 존재 여부를 binary로 평가. 객관 SQL이 1차, 주관 태그가 보조 (ADR-0033 §5, 확증편향 방어).
+- **신호 종류**: `kind=sql`(객관 SQL 측정, 1차) — 기존 매트릭 SQL + off-day 대조 판정(`direction`). `kind=tag`(일기 메타 26태그, 보조) — 그날 태그 존재 여부를 binary로 평가. 객관 SQL이 1차, 주관 태그가 보조 (ADR-0033 §5, 확증편향 방어).
 - **검증결과 컬럼**(`e_value`·`test_detail`·`confound` 등)은 P1에서 **선언만** — 로직은 P2(주간 엔진)/P3(통계 증강). 헌장 ④ "후속 미루지 않기"에 따라 컬럼은 미리 둠.
 
 **이관 매핑** (077, 데이터 독립 검증 DO 블록이 DROP 전 대조 — 불일치 시 전체 롤백):
@@ -1940,7 +1940,7 @@ Phase 1이 측정을 고친 뒤 다음 병목은 가독성이었다. 프로액�
 순수 함수 [insight-labels.ts](../../src/shared/insight-labels.ts)(`seedLabel`·`signalLabel`)가 카드 조립 지점에서 라벨 문자열을 생성. 시드와 신호는 description 신뢰도가 정반대라 생성 규칙이 비대칭이다:
 
 - **시드 = description tail-strip.** 시드 description은 hand-authored라 접두가 곧 활성조건. 첫 `→`/`—` 앞만 취한다("일운 천간 갑목(편재) → 일정/지출 폭증" → "일운 천간 갑목(편재)", "갑술 60갑자일 — … 콤보 — 본인 일지 비화" → "갑술 60갑자일"). 십성 주석 "(편재)"은 보존(`(`는 구분자에서 제외), 예측절·내부 참조(ADR)·가설 꼬리표는 자동 탈락. 6종 trigger 구조 파싱 불필요.
-- **신호 = name+domain+direction 룰.** 신호 description은 깨진 provenance라 못 쓰고 metadata로 생성. 측정 명사는 `SIGNAL_MEASURE` 맵(한글접미 `expense_배달음식`→"배달음식 지출"), 방향은 룰(above_avg→"평소보다 많음", 율·시각은 높음/낮음·늦음/이름), 합성·모호 4개는 `SIGNAL_LABEL_OVERRIDES`("세금 관련 일정" 등), tag 신호는 diary 22태그 한글맵, llm 신호는 자작 description.
+- **신호 = name+domain+direction 룰.** 신호 description은 깨진 provenance라 못 쓰고 metadata로 생성. 측정 명사는 `SIGNAL_MEASURE` 맵(한글접미 `expense_배달음식`→"배달음식 지출"), 방향은 룰(above_avg→"평소보다 많음", 율·시각은 높음/낮음·늦음/이름), 합성·모호 4개는 `SIGNAL_LABEL_OVERRIDES`("세금 관련 일정" 등), tag 신호는 diary 26태그 한글맵, llm 신호는 자작 description.
 
 #### 2) 4개 표면 — hard / soft
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -31,7 +31,7 @@
 - 삶의 테마 관리 (`life_themes`, 자동 진화)
 - 사주 패턴 누적 (`saju_patterns`, 28일 롤링 — 갱신 routine 2026-05-26 비활성화, 누적분만 시스템 프롬프트에 활용)
 - 사주 일일 매칭 시드 카탈로그 (`pattern_catalog`, Phase 3 — 결정론 매칭, 마스터 #434 Phase 1 rename per ADR-0026, 마스터 #434 Phase 2에서 6종 풀세트 161개 신규 시드 추가, Phase 2.5에서 `pillar_level` 차원 + `cumulative_pillar_count` trigger + 14 신규 시드 추가)
-- 일기 LLM enum 16종 추출 (`diary_meta_tags`, Phase 3)
+- 일기 LLM enum 26종 추출 (`diary_meta_tags`, Phase 3 — 059·102 확장)
 - 주간 사주 회고 카드 (`weekly-saju-review-v2`, 매주 월요일 08:00 KST `#insight` — 마스터 #421)
 - 일일 종합 인사이트 (`daily-insight` routine, 매일 08:00 KST `#insight` — 오늘 사주 일운 + 검증된 개인 패턴 신뢰도별 종합, 마스터 A A3 #475)
 - 상세: [docs/domains/insight.md](./domains/insight.md)

--- a/src/cron/__tests__/diary-meta-extract.test.ts
+++ b/src/cron/__tests__/diary-meta-extract.test.ts
@@ -45,10 +45,10 @@ describe('parseTagResponse', () => {
     expect(parseTagResponse('["irritation",42,{"x":1},"rest"]')).toEqual(['irritation', 'rest']);
   });
 
-  it('허용 태그 전부 정상 통과 (22개)', () => {
+  it('허용 태그 전부 정상 통과 (26개)', () => {
     const all = JSON.stringify(DIARY_META_TAGS);
     expect(parseTagResponse(all).length).toBe(DIARY_META_TAGS.length);
-    expect(DIARY_META_TAGS.length).toBe(22);
+    expect(DIARY_META_TAGS.length).toBe(26);
   });
 });
 
@@ -90,7 +90,7 @@ describe('extractDiaryTags', () => {
     expect(messages).toHaveLength(2);
     expect(messages[0]?.role).toBe('system');
     expect(messages[1]?.role).toBe('user');
-    // 시스템 프롬프트에 enum 22개 모두 포함되어야 함 (LLM이 enum 외 출력하지 않도록)
+    // 시스템 프롬프트에 enum 26개 모두 포함되어야 함 (LLM이 enum 외 출력하지 않도록)
     const systemContent = messages[0]?.content as string;
     for (const tag of DIARY_META_TAGS) {
       expect(systemContent).toContain(tag);

--- a/src/cron/diary-meta-extract.ts
+++ b/src/cron/diary-meta-extract.ts
@@ -5,7 +5,7 @@
  *
  * 흐름:
  *   1) 오늘 diary_entries 로드
- *   2) LLM(Opus)에게 고정 enum 22개 중 해당되는 태그만 JSON 배열로 요청
+ *   2) LLM(Opus)에게 고정 enum 26개 중 해당되는 태그만 JSON 배열로 요청
  *   3) 결과 파싱 → enum 화이트리스트 필터 → diary_meta_tags UPSERT
  */
 
@@ -16,7 +16,7 @@ import { getYesterdayISO } from '../shared/kst.js';
 import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
 import type { LifeCronConfig } from './life-cron.js';
 
-/** 허용된 22개 enum (migration 053 + 059와 동기화 필수) */
+/** 허용된 26개 enum (migration 053 + 059 + 102와 동기화 필수) */
 export const DIARY_META_TAGS = [
   // 기존 16 (migration 053)
   'irritation',
@@ -42,6 +42,11 @@ export const DIARY_META_TAGS = [
   'physical_activity',
   'task_completion',
   'clumsy_overflow',
+  // 신규 4 (migration 102 — 신호 해상도 확장)
+  'evaluation_exposure',
+  'feeling_enough',
+  'palpitation',
+  'muscle_tension',
 ] as const;
 
 export type DiaryMetaTag = (typeof DIARY_META_TAGS)[number];
@@ -50,7 +55,7 @@ const TAG_SET = new Set<string>(DIARY_META_TAGS);
 
 const SYSTEM_PROMPT = `너는 일기 텍스트에서 정해진 enum 태그만 추출하는 분류기.
 
-허용된 태그 (이 22개 외엔 절대 출력 금지):
+허용된 태그 (이 26개 외엔 절대 출력 금지):
 - irritation: 짜증/화남/예민
 - health_complaint: 몸 아픔/통증/컨디션 난조 호소
 - low_energy: 무기력/피곤/늘어짐
@@ -74,11 +79,17 @@ const SYSTEM_PROMPT = `너는 일기 텍스트에서 정해진 enum 태그만 �
 - physical_activity: 운동·산책·외출·이동 (단순 외출도 포함)
 - task_completion: 업무·과제 처리/완료 (구체적 일을 마쳤다는 언급)
 - clumsy_overflow: 실수·물건 떨어뜨림·놓침·잊음
+- evaluation_exposure: 면접·발표·리뷰·시험·마감 등 평가받거나 시선에 노출된 상황이 있었던 날
+- feeling_enough: 뿌듯함, "이만하면 됐다", 성취를 스스로 인정하거나 인정받은 날
+- palpitation: 두근거림·심계·가슴 답답 등 심장 계열 신호
+- muscle_tension: 목·어깨·허리 결림, 뻐근함, 근육 긴장
+
+구분 규칙: 심장 계열 신호는 palpitation, 근육 결림은 muscle_tension을 쓰고, 그 외 신체 불편(두통·소화·감기 등)만 health_complaint로 분류.
 
 출력 규칙:
 - 출력은 오로지 JSON 배열만. 예: ["irritation","low_energy"]
 - 해당 없으면 빈 배열 [].
-- 추론·확장 금지. 위 22개 외 태그를 만들지 마.
+- 추론·확장 금지. 위 26개 외 태그를 만들지 마.
 - 설명·주석·코드블록 마커 출력 금지.`;
 
 const buildContext = (content: string): string =>

--- a/src/shared/insight-labels.ts
+++ b/src/shared/insight-labels.ts
@@ -193,6 +193,10 @@ const TAG_LABELS: Record<string, string> = {
   physical_activity: '운동·외출',
   task_completion: '일 완료',
   clumsy_overflow: '실수·덤벙',
+  evaluation_exposure: '평가 노출',
+  feeling_enough: '충분함 체감',
+  palpitation: '두근거림',
+  muscle_tension: '결림',
 };
 
 /** 미매핑 신호 fallback 도메인 명사 — raw 변수명 노출 0 불변식의 마지막 방어선. */


### PR DESCRIPTION
## 요약

일기 메타 태그 4종 추가 + 검증축 편입.

- 마이그 102: CHECK 26종 확장 + `signal_defs` tag 신호 4행(077 패턴, partial unique + ON CONFLICT 멱등)
- diary-meta-extract: 상수·추출 프롬프트 갱신 (심계/결림은 세분 태그 우선, 기타 신체 불편만 health_complaint)
- insight-labels: 카드 한글 라벨 4종 (raw 변수명 노출 0 불변식 유지)
- 테스트·insight.md·features.md 갱신

## 검증

- [x] vitest 전체 스위트 984개 통과, tsc 클린
- [ ] 머지 후 prod CHECK 제약·signal_defs 4행 확인

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)