### PR TITLE
refactor(insight): 구세대 개인 패턴 프롬프트 참조 제거

### DIFF
--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -69,6 +69,8 @@ life_themes:
   created_at TIMESTAMPTZ
 
 -- 사주 패턴 (cross-domain x 일운 상관 분석)
+-- > 2026-07-05 은퇴: 봇 프롬프트에서 미사용. 테이블·데이터는 이력으로 존치.
+-- > 역할은 profile_summary 실측 패턴 + pattern_links 검증축이 대체.
 saju_patterns:
   id SERIAL PK,
   user_id INTEGER,
@@ -139,20 +141,20 @@ weekly-fortune routine이 일운/월운/세운/대운을 생성. fortune_analyse
 - **detail 자동 진화**: 일기/대화에서 상황 변화 감지 시 detail 업데이트
 - 해결 시 `active = false`
 
-### 4. 사주 패턴 (saju_patterns)
-- 누적된 패턴은 시스템 프롬프트 조회에 계속 사용. 갱신 routine(구 `weekly-saju-review`)은 2026-05-26 비활성화 (마스터 #421 A1 신 routine 검증 후 archive 예정)
+### 4. 사주 패턴 (saju_patterns) — 🗑️ 봇 프롬프트 미사용 (2026-07-05)
+> 갱신 routine(구 `weekly-saju-review`)은 2026-05-26 비활성화. 봇 시스템 프롬프트(`buildInsightSystemPrompt`)에서도 2026-07-05 참조 제거 — 테이블·누적 row는 이력으로 존치, 새 조회 경로 없음. 역할은 `saju_profiles.profile_summary`(실측 패턴 포함) + 검증 시드 파이프라인(`pattern_links`)이 대체.
+
 - pattern_type: sipsin(십신) / ganji(특정 글자) / relation(합/형/충) / sibiunsung(십이운성)
 - **분석 도메인**: 일기, 수면, 지출, 일정, 루틴 (cross-domain 통합 분석, 28일 롤링 윈도우)
 - **evidence 표준 형식**: `{date, domain, summary, fortune_element, ...domain_specific}` — 도메인 추가(식사·운동 등) 시 마이그레이션 없이 확장 가능. 상세는 [ADR 0011](../adr/0011-saju-patterns-cross-domain.md) 참조
 - 같은 trigger_element가 여러 도메인에 발현하면 분리하지 않고 같은 row의 evidence에 누적
 - 감지 횟수 추적 (detection_count), 신뢰도 평가 (confidence)
 - 비활성화 시 `active = false`, `deactivated_at = NOW()`
-- **일일 종합 인사이트(§23)는 `saju_patterns`를 쓰지 않는다** — `saju_influence_summary` view(#477 P3: verified/emerging/recent 3-tier, ### 26)를 사용. `saju_patterns`는 시스템 프롬프트 조회 + weekly-fortune 관점 5 용으로만 잔존 (정리는 마스터 A A3 후속)
+- **일일 종합 인사이트(§23)는 `saju_patterns`를 쓰지 않는다** — `saju_influence_summary` view(#477 P3: verified/emerging/recent 3-tier, ### 26)를 사용.
 
 ### 5. 시스템 프롬프트 구성
 `buildInsightSystemPrompt()`가 실시간으로 아래 데이터를 로드하여 프롬프트에 주입:
 - 활성 life_themes (현재 삶의 맥락)
-- 활성 saju_patterns (확인된 개인 패턴)
 - 오늘/내일 fortune_analyses (일운 컨텍스트)
 - 십성 매핑표, 오행 상생상극, 사용자 원국 정보 (정적)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -29,7 +29,7 @@
 - 월운/세운 예측 장부 — 사전등록 → 사후 채점(방향 적중 + 실측 delta, Brier 금지). baseline 동결·절기 시간게이트 무인 자기검증 (`period_forecasts`, #531, 대운 비편입)
 - 일기 자동 저장 (`diary_entries`)
 - 삶의 테마 관리 (`life_themes`, 자동 진화)
-- 사주 패턴 누적 (`saju_patterns`, 28일 롤링 — 갱신 routine 2026-05-26 비활성화, 누적분만 시스템 프롬프트에 활용)
+- ~~사주 패턴 누적~~ (`saju_patterns` — 갱신 2026-05-26 중단, 봇 프롬프트 참조 2026-07-05 제거 #583. 테이블·누적분은 이력으로 존치, 역할은 프로필 요약 + `pattern_links` 검증축이 대체)
 - 사주 일일 매칭 시드 카탈로그 (`pattern_catalog`, Phase 3 — 결정론 매칭, 마스터 #434 Phase 1 rename per ADR-0026, 마스터 #434 Phase 2에서 6종 풀세트 161개 신규 시드 추가, Phase 2.5에서 `pillar_level` 차원 + `cumulative_pillar_count` trigger + 14 신규 시드 추가)
 - 일기 LLM enum 16종 추출 (`diary_meta_tags`, Phase 3)
 - 주간 사주 회고 카드 (`weekly-saju-review-v2`, 매주 월요일 08:00 KST `#insight` — 마스터 #421)

--- a/src/agents/insight/__tests__/prompt.test.ts
+++ b/src/agents/insight/__tests__/prompt.test.ts
@@ -7,9 +7,8 @@ vi.mock('../../../shared/db.js', () => ({
 
 // kst 모킹 — 결정론적 날짜
 vi.mock('../../../shared/kst.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../shared/kst.js')>(
-    '../../../shared/kst.js',
-  );
+  const actual =
+    await vi.importActual<typeof import('../../../shared/kst.js')>('../../../shared/kst.js');
   return {
     ...actual,
     getTodayISO: () => '2026-04-11',
@@ -34,8 +33,6 @@ describe('buildInsightSystemPrompt — 일주 앵커 가드레일', () => {
   it('"상단 앵커만 사용" 가드레일 문구를 포함한다', async () => {
     const prompt = await buildInsightSystemPrompt(1);
     expect(prompt).toMatch(/오늘 일주는 프롬프트 상단.*박힌 값만 사용/);
-    expect(prompt).toMatch(/saju_patterns 설명.*일주와 무관/);
-    expect(prompt).toMatch(/역산/);
   });
 
   it('일주 앵커가 프롬프트 초반(상위 30%)에 위치한다', async () => {

--- a/src/agents/insight/prompt.ts
+++ b/src/agents/insight/prompt.ts
@@ -37,36 +37,6 @@ const loadLifeThemes = async (userId: number): Promise<string> => {
   }
 };
 
-/** DB에서 활성 saju_patterns 조회 */
-const loadSajuPatterns = async (userId: number): Promise<string> => {
-  try {
-    const result = await query<{
-      pattern_type: string;
-      trigger_element: string;
-      description: string;
-      confidence: string | null;
-      detection_count: number;
-    }>(
-      `SELECT pattern_type, trigger_element, description, confidence, detection_count
-       FROM saju_patterns
-       WHERE active = true AND user_id = $1
-       ORDER BY detection_count DESC, created_at`,
-      [userId],
-    );
-    if (result.rows.length === 0) return '';
-
-    const lines = result.rows
-      .map(
-        (r) =>
-          `- [${r.pattern_type}] ${r.trigger_element}: ${r.description} (${r.detection_count}회 감지, ${r.confidence ?? '미평가'})`,
-      )
-      .join('\n');
-    return `\n\n## 확인된 개인 패턴 (saju_patterns)\n※ 아래 설명에 등장하는 천간/지지/합충 표현은 **패턴 성격 설명**일 뿐, 오늘의 일주와는 무관해. 거기서 일주를 역산하지 마.\n${lines}`;
-  } catch {
-    return '';
-  }
-};
-
 /** DB에서 오늘 일운 조회 → 프롬프트 주입용 (내일은 사용자가 물으면 DB 조회) */
 const loadFortuneContext = async (
   today: string,
@@ -128,14 +98,12 @@ export const buildInsightSystemPrompt = async (userId: number): Promise<string> 
   const todayPillar = getDayPillar(todayISO);
   const todayPillarStr = `${todayPillar.cheongan}${todayPillar.jiji}(${todayPillar.hanja})`;
 
-  const [lifeThemes, sajuPatterns, fortuneContext, profileContext, sajuMappingPrompt] =
-    await Promise.all([
-      loadLifeThemes(userId),
-      loadSajuPatterns(userId),
-      loadFortuneContext(todayISO, todayPillarStr, userId),
-      loadProfileContext(userId),
-      loadSajuMappingPrompt(userId),
-    ]);
+  const [lifeThemes, fortuneContext, profileContext, sajuMappingPrompt] = await Promise.all([
+    loadLifeThemes(userId),
+    loadFortuneContext(todayISO, todayPillarStr, userId),
+    loadProfileContext(userId),
+    loadSajuMappingPrompt(userId),
+  ]);
 
   return `너는 개인 일기 관리자이자 명리학 운세 전달자야.
 사용자의 일기와 고민을 기록하고, 저장된 분석(일운=fortune_analyses, 월/세/대운=period_interpretations)을 바탕으로 사주적 관점을 연결해주는 역할이야.
@@ -179,7 +147,6 @@ ${sajuMappingPrompt}
 
 ### 사주 연결 규칙 (⛔ 필수)
 - ⛔ **오늘 일주는 프롬프트 상단 "오늘 일주:"에 박힌 값만 사용**. 다른 일주로 바꿔 말하지 마. 계산/추론 금지.
-- ⛔ **saju_patterns 설명에 등장하는 천간/지지/합충 표현(예: 정화/병화/사해충/진술충)은 패턴 성격 설명일 뿐, 오늘의 일주와 무관**. 거기서 역산해서 일주를 만들어내지 마.
 - 오늘 일기 사주 코멘트: 프롬프트 하단 "오늘 일운" 데이터 기반으로만.
 - 과거/미래 일기: fortune_analyses에서 해당 날짜 조회해서 day_pillar 사용. 오늘 일운을 다른 날짜에 적용 금지.
 - 일운 데이터 없으면 사주 해석 없이 공감 위주로 응답.
@@ -201,9 +168,8 @@ ${sajuMappingPrompt}
 category: career/family/romance/health/finance/기타. detail에 상세 상황 기록.
 ⚠️ 일기에서 기존 테마 상황 변화 감지 시 detail 업데이트 (기존 맥락 유지, 최신만 추가).
 
-### 4. 사주 프로필/패턴 조회
+### 4. 사주 프로필 조회
 - saju_profiles: 원국, 격국, 용신, 대운
-- saju_patterns: 일기-일운 비교에서 감지된 구조적 반응 패턴 (active=true 조회)
 
 ## DB 스키마 (모든 테이블에 id SERIAL PK, created_at TIMESTAMPTZ)
 
@@ -212,9 +178,8 @@ category: career/family/romance/health/finance/기타. detail에 상세 상황 �
 - period_interpretations: user_id, period_type('wolun'/'seun'/'daeun'), period_start, period_end, pillar(간지 2자), narrative(TEXT, 월/세/대운 답변 근거), structured(JSONB) — period_type별 최신은 period_start DESC LIMIT 1
 - diary_entries: user_id, date(UNIQUE), content, updated_at
 - life_themes: user_id, theme, category, detail, active, source(user/auto), first_mentioned, mention_count
-- saju_patterns: user_id, pattern_type(sipsin/ganji/relation/sibiunsung), trigger_element, description, evidence(JSONB), active, detection_count, first_detected, last_detected, activated_at, deactivated_at, source(auto/user), confidence(high/medium/low), updated_at
 
 ## ⚠️ user_id 필터 (절대 규칙)
 모든 SELECT/INSERT/UPDATE/DELETE 쿼리에 반드시 user_id = ${userId} 조건을 포함해.
-${profileContext}${lifeThemes}${sajuPatterns}${fortuneContext}`;
+${profileContext}${lifeThemes}${fortuneContext}`;
 };


### PR DESCRIPTION
## 요약

동결 상태(2026-05\~)인 v1 패턴 테이블 `saju_patterns`의 봇 시스템 프롬프트 참조 제거. 테이블·데이터는 이력으로 존치.

- 프롬프트 로더(`loadSajuPatterns`)·"확인된 개인 패턴" 섹션·역산 방지 가이드·스키마 목록 행 제거
- 역할 대체: 프로필 요약(실측 패턴 포함) + `pattern_links` 검증축
- insight.md·features.md 은퇴 표기

## 검증

- [x] vitest 전체 스위트 984개 통과, tsc 클린
- [x] `grep -rn saju_patterns src/` → 0건

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)