### PR TITLE
feat(insight): 월간 신호 제안 누락 fallback 슬롯 (#466 일부)

### DIFF
--- a/db/migrations/104_signal_suggest_fallback_slot.sql
+++ b/db/migrations/104_signal_suggest_fallback_slot.sql
@@ -1,0 +1,18 @@
+-- 104: 월간 신호 제안 누락 fallback 알림 슬롯 (#466, ADR-0058)
+-- routine(monthly-signal-suggest, 월 1일 09:30 repo 밖 SKILL)이 그 달 안 돌면 신호 제안 조용히 누락.
+-- 봇이 월 2일 11:00에 signal_suggest_runs(월 클레임) row 존재를 확인 → 없으면 "수동 실행해줘" 알림만.
+-- (row = 최초 클레임이라 발송 성공 아님. row 없음 = 그 달 미실행만 확실 감지 — ADR-0058/0053.)
+-- (slot_name source of truth = notification_settings — SLOT_TASKS 키와 어긋나면 스케줄 누락.)
+-- 매일 등록되지만 signalSuggestFallbackTask 내부에서 월 2일만 실행(weeklyReviewFallback 동일 패턴).
+
+INSERT INTO notification_settings (slot_name, time_value, label, active)
+VALUES ('signalSuggestFallback', '11:00', '월간 신호 제안 누락 알림', true)
+ON CONFLICT (slot_name) DO NOTHING;
+
+DO $$
+DECLARE
+  got INT;
+BEGIN
+  SELECT count(*) INTO got FROM notification_settings WHERE slot_name = 'signalSuggestFallback';
+  RAISE NOTICE '[104] signalSuggestFallback slot % 행 (월 2일 11:00)', got;
+END $$;

--- a/docs/adr/0058-signal-suggest-missing-fallback.md
+++ b/docs/adr/0058-signal-suggest-missing-fallback.md
@@ -1,0 +1,85 @@
+# 0058. 월간 신호 제안 누락 fallback 알림 — row-존재 감지
+
+- Status: Accepted
+- Date: 2026-07-08
+- Related: #466 (마스터 #434 Phase 6 follow-up), [ADR-0052](0052-weekly-insight-single-card-merge.md), [ADR-0053](0053-signal-suggest-idempotency.md), [ADR-0040](0040-llm-signal-sql-validation-and-execution-isolation.md)
+- Tags: reliability, process, insight
+
+## Context
+
+`monthly-signal-suggest`는 매월 1일 09:30 KST 실행되는 LLM 기반 Claude 앱 routine(repo 밖 SKILL)이다 (#477 P5b, ADR-0040). 그런데 이 routine이 실패하거나 앱이 그 시각에 안 켜져 **아예 안 돌면 그 달 신호 제안이 조용히 누락**된다 — 감지·알림 안전망이 전무하다. 실제로 봇 사이드에는 `signal_suggest_runs`를 읽는 코드가 하나도 없다.
+
+이 안전망 부재는 #466 검토 항목 중 "routine 실패 fallback 경로"로, 회고 본체(승인률·거절률 분포)와 달리 **표본 축적과 무관하게 지금 해소 가능**하다.
+
+선례가 있다: `weekly-saju-review-v2`도 repo 밖 routine이고, 봇 사이드 fallback 슬롯(`weeklyReviewFallback`, [ADR-0052](0052-weekly-insight-single-card-merge.md), 월 10:00)이 `saju_weekly_reviews` row 존재를 확인해 미발송 주에 "수동 실행해줘" 알림만 발송한다. 같은 패턴을 재사용할 수 있다.
+
+**단, 의미론 차이가 핵심이다.**
+
+| | `saju_weekly_reviews` (weekly) | `signal_suggest_runs` (monthly) |
+|---|---|---|
+| row 기록 시점 | 발송 성공 후 | **최초 액션 클레임** (발송 전, ADR-0053) |
+| row 존재 의미 | "이번 주 카드 나감" | "이번 달 routine이 최소 1스텝 실행됨" |
+| row 없음 의미 | 미발송 | **그 달 routine이 아예 안 돎** |
+
+즉 `signal_suggest_runs`의 row는 발송 성공을 뜻하지 않는다. 클레임 직후 크래시하면 row는 있는데 발송 0건인 "burned month"가 되고(ADR-0053이 저빈도·저손실로 수용), 게다가 후보 0건 발송도 정상 결과다. 그래서 **row 있음만으로 "정상"이라 단정할 수 없고, row 없음만이 확실한 실패 신호**다.
+
+## Decision
+
+봇 사이드에 daily 등록 + 월 2일 내부 가드 슬롯 `signalSuggestFallback`을 추가하고, `signal_suggest_runs`의 **row-존재(`SELECT EXISTS`)로 "그 달 routine 미실행"을 감지**해 `#insight`에 수동 실행 알림만 발송한다. 봇이 제안을 대신 생성·발송하지 않는다.
+
+1. **감지 대상 = "그 달 최초 클레임 스텝조차 실행 안 됨"** (= 스케줄러/앱 완전 실패). 가장 흔한 조용한 실패 모드.
+2. **2일 가드** (`getKSTDayOfMonth() !== 2` early return): 1일 정상 실행이면 2일엔 이미 row → no-op. 1일에 앱이 꺼졌다 당일/익일 늦게 밀려 실행돼도 2일 체크 전 row가 생기면 no-op(헛알림 억제). 2일까지도 row 없으면 진짜 누락으로 판정.
+3. **알림만 (대신 발송 안 함)**: ADR-0052 Alt B(봇이 반쪽 카드 생성) 기각을 계승. LLM 신호 생성은 봇 능력 밖이므로 봇이 할 수 있는 건 사용자에게 수동 재실행을 알리는 것뿐.
+
+## Alternatives considered
+
+### A. burned month까지 감지 (row 있는데 발송 0건 구분)
+
+- `signal_suggest_runs`에 발송완료/후보수 컬럼을 추가하거나 SKILL(repo 밖) 계약을 바꿔 "발송 완료"를 별도 마킹해야 한다.
+- ADR-0053이 burned month를 "월간·저손실이라 수용, 다음 달 자동 복구"로 **명시 결정**했다 → 지금 감지 대상에 넣으면 그 결정과 충돌.
+- 기각(보류): 범위 초과. burned month가 실제로 발생하는지는 #466 회고 본체(8월 2회차 이후) 실측 후 판단. 재발 시 별도 이슈로 승격.
+
+### B. 봇이 제안을 대신 생성·발송
+
+- 장점: 완전 결정론적 출력 연속성.
+- 단점: LLM 신호 생성 로직을 봇으로 이관 = P5b 발송 아키텍처(ADR-0040) 재설계, 범위 과대. ADR-0052 Alt B와 동일 이유.
+- 기각.
+
+### C. healthchecks.io dead-man 확장 (#577, ADR-0055)
+
+- #577 heartbeat는 5분 주기 프로세스/DB liveness 감시(인프라 레이어). "월 1회 특정 비즈니스 routine이 그 달에 돌았나"와는 층위가 다르고, dead-man 주기(월 1회)로는 grace 설정이 부적합.
+- 기각: 레이어 불일치. 직접 참조 모델은 `weeklyReviewFallback`(DB row 조회 + 알림)이 맞다. heartbeat는 보완 옵션일 뿐 drop-in 대상 아님.
+
+### D. 감지 시각 — 1일 늦게 vs 2일
+
+- 1일 늦은 시각(weekly 대칭, routine 09:30 + 몇 시간 뒤): routine 당일이라 앱 재시작 후 밀려 실행되는 케이스를 헛알림.
+- **2일 채택**: 하루 유예로 밀림을 흡수. 이미 `#574` 게이트 task(매월 2일)와도 리듬이 맞음.
+
+## Consequences
+
+### 장점
+
+- 그 달 routine이 아예 안 돈 경우(가장 흔한 조용한 실패)를 감지·알림 → 출력 연속성 확보(무증거 침묵 방지, 헌장 정합).
+- `weeklyReviewFallback` 코드·마이그레이션(093) 패턴 그대로 재사용 → 온보딩 비용 낮음, 일관성.
+
+### 단점 / 제약
+
+- burned month(클레임 후 크래시)와 후보 0건 정상 종료는 감지하지 못함 — row 의미론상 테이블만으로 구분 불가. **명시적 스코프 한계**이며 ADR-0053의 수용 결정과 정합.
+- 봇이 대신 발송하지 않으므로 누락 시 수동 재실행이 필요(연속성 보장은 "알림까지").
+- 2일 11시 이후로 routine이 밀려 실행되는 극저확률 케이스는 헛알림 가능 — 사용자가 수동 실행해도 `signal_suggest_runs` UNIQUE로 중복 차단되어 무해.
+
+### 후속 작업
+
+- [ ] 마이그 104 `signalSuggestFallback` 슬롯 + prod 적용
+- [ ] `src/cron/signal-suggest-fallback.ts` + `life-cron` SLOT_TASKS 등록
+- [ ] 테스트 (2일 가드 / row 유무 분기)
+- [ ] `docs/domains/insight.md` §45 본문
+- [ ] (8월 회고 #466) burned month 실측 여부 확인 → 대안 A 재검토 트리거
+
+---
+
+**참고 자료**
+
+- [ADR-0052](0052-weekly-insight-single-card-merge.md) — `weeklyReviewFallback`(발송 성공 기준, 알림만) 참조 모델
+- [ADR-0053](0053-signal-suggest-idempotency.md) — `signal_suggest_runs` 최초-클레임 의미론 / burned month 수용
+- [ADR-0040](0040-llm-signal-sql-validation-and-execution-isolation.md) — `monthly-signal-suggest` (P5b LLM 신호 제안)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -164,6 +164,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0055](0055-uptime-deadman-heartbeat.md) | 업타임 dead-man's-switch heartbeat — 봇 프로세스 5분 송신 + 외부 관측, GH Actions 폴링 2차망 강등 | Accepted | 2026-07-04 | infra, observability, reliability |
 | [0056](0056-signal-semantics-batch-correction.md) | 신호 의미론 일괄 교정 — 좀비 부활(schema drift) + done 재정의 + 자유지출 개명 + 결측 인프라 #574 편입 | Accepted | 2026-07-04 | insight, data, statistics, process |
 | [0057](0057-fortune-calls-ledger.md) | 일운 콜 장부 분리 — 서술형 반증 가능 콜(claim+criterion, 3단 판정)을 period_forecasts(무인 통계 채점)와 별도 경량 테이블로 | Accepted | 2026-07-05 | insight, data, process |
+| [0058](0058-signal-suggest-missing-fallback.md) | 월간 신호 제안 누락 fallback 알림 — signal_suggest_runs row-존재 감지(봇 daily 슬롯 + 월 2일 가드), 최초-클레임 의미론상 미실행만 확실 감지·알림만 | Accepted | 2026-07-08 | reliability, process, insight |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/design-notebook/metric-first-verification.md
+++ b/docs/design-notebook/metric-first-verification.md
@@ -684,3 +684,41 @@ P3([ADR-0035](../adr/0035-graded-confidence-exposure.md) 3-tier 노출)가 만�
 ### 회고
 
 [/build 머지 후 채움]
+
+---
+
+## 후속 — 월간 신호 제안 누락 fallback (#466, 2026-07-08, post-close)
+
+- 이슈: [#466](https://github.com/hyewon3938/slack-ai-agents/issues/466) (마스터 #434 Phase 6 follow-up 중 "routine 실패 fallback 경로" 하나)
+- 관련 ADR: [0058](../adr/0058-signal-suggest-missing-fallback.md)
+- 관련 계획서: `.claude/plans/466-signal-suggest-fallback.md`
+- 상태: 설계 완료
+
+`monthly-signal-suggest`(P5b, ADR-0040, repo 밖 앱 routine)가 그 달 아예 안 돌면 신호 제안이 조용히 누락되던 안전망 부재를 봇 사이드 fallback 슬롯으로 해소. `weeklyReviewFallback`(ADR-0052) 대칭 복제.
+
+**#466 본체(첫 가동 회고 — 후보 품질·승인률·거절률 분포)는 표본 1회(2026-07-01) 부족으로 8월 2회차 실행 이후로 연기**(사용자 2026-07-02 판단). 이번엔 표본과 무관한 fallback 경로만 처리.
+
+### 결정 요약
+
+- **감지 = `signal_suggest_runs` row-존재**(`SELECT EXISTS`). 월 2일 11:00 가드(daily 등록 + 내부 일자 가드). row 없으면 #insight 수동 실행 알림만.
+- **감지 의미론 비대칭이 핵심**: weekly는 row=발송 성공(연속성 우선), signal-suggest는 row=최초 클레임(중복 방지 우선, ADR-0053). 그래서 signal-suggest fallback은 "그 달 아예 안 돎"만 확실히 잡고, burned month(클레임 후 크래시)·후보 0건 정상은 구분 못 함 — 스코프 한계로 명시.
+
+### 의사결정 분기점
+
+- **감지 범위 — row 없음만 vs burned month까지**: burned month까지 잡으려면 `signal_suggest_runs`에 발송완료 컬럼 추가 or SKILL 계약 변경 필요. ADR-0053이 burned month를 "저손실 수용"으로 이미 결정 → 지금 뒤집으면 충돌. row 없음(=미실행)만 감지로 확정하고, burned month 실측 여부는 8월 회고로 미룸. 표본 무관 최소 안전망이라는 이번 작업 취지와도 일치.
+- **감지 시각 — 1일 늦게 vs 2일**: 1일은 routine 당일이라 앱 재시작 밀림을 헛알림. 2일 채택(하루 유예 흡수, #574 게이트 task와 리듬 일치).
+- **알림 vs 봇 대신 발송**: LLM 신호 생성은 봇 밖. ADR-0052 Alt B(반쪽 카드) 기각 계승 → 알림만.
+
+### 포기한 안 / 미룬 항목
+
+- burned month 감지(Alt A) → 8월 회고 실측 후.
+- healthchecks.io dead-man 확장(Alt C, #577) → 레이어 불일치(인프라 liveness vs 월 1회 비즈니스 routine)로 기각.
+- #466 이슈 stale 앵커 정합성(본문이 옛 pattern_metrics ADR을 링크) → /build에서 이슈 코멘트 1줄(선택), 코드 무관.
+
+### 기술적 의의
+
+같은 "repo 밖 routine 미발송 → 봇 fallback 알림" 패턴을 두 번째 적용하면서, **idempotency 클레임 시점 차이(발송 후 기록 vs 최초 클레임)가 fallback 감지 의미론을 어떻게 가르는지**를 스코프 한계로 정직하게 드러낸 사례. row 존재를 "정상"으로 오독하지 않도록 감지 대상을 "미실행"으로 한정. (어필 표현은 portfolio-candidates.)
+
+### 회고
+
+[/build 머지 후 채움]

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -2421,6 +2421,26 @@ db/migrations/  (마스터 #477 매트릭 중심 패턴 검증 — 2026-06)
 - 표시: `weekly-saju-review-v2` 월요 통합 카드가 지난주 판정 결과를 읽기 전용 2\~3줄로 표시.
 - routine 계약이 바뀌면 이 섹션을 갱신한다.
 
+### 45. 월간 신호 제안 누락 fallback 슬롯 (#466, ADR-0058)
+
+`monthly-signal-suggest`(월 1일 09:30 KST, repo 밖 Claude 앱 routine, §30·ADR-0040)가 그 달 실패하거나 앱이 안 켜져 아예 안 돌면 신호 제안이 조용히 누락된다. 봇 사이드에 `signal_suggest_runs`를 읽는 코드가 전무해 누락돼도 아무도 몰랐다. `weeklyReviewFallback`(§40, ADR-0052)과 대칭 구조의 봇 fallback 슬롯으로 해소.
+
+- **슬롯**: `signalSuggestFallback` — `notification_settings`에 daily 등록(마이그 104, 11:00), `signalSuggestFallbackTask`(`src/cron/signal-suggest-fallback.ts`) 내부에서 `getKSTDayOfMonth() !== 2` early return으로 **매월 2일만** 실행.
+- **감지**: `signal_suggest_runs`의 그 달 row 존재를 `SELECT EXISTS`로 확인. `month_start`는 SQL 안에서 `DATE_TRUNC('month', (NOW() AT TIME ZONE 'Asia/Seoul'))::date`로 계산 → routine 클레임 키(ADR-0053)와 동일.
+- **동작**: row 없으면 `#insight`에 "수동 실행해줘" 알림만 발송. 봇이 제안을 대신 생성·발송하지 않는다(LLM 신호 생성은 봇 능력 밖, ADR-0052 Alt B 기각 계승).
+
+**감지 의미론 차이 (weekly와 반대)** — 이게 핵심 제약이다:
+
+| | `saju_weekly_reviews`(§40) | `signal_suggest_runs`(§45) |
+|---|---|---|
+| row 기록 시점 | 발송 성공 후 | 최초 액션 클레임(발송 전, ADR-0053) |
+| row 없음 의미 | 미발송 | 그 달 routine이 **아예 안 돎** |
+
+즉 signal-suggest의 row는 발송 성공을 뜻하지 않는다. 그래서 **row 없음 = 미실행만 확실 감지**하고, burned month(클레임 직후 크래시로 row는 있는데 발송 0건)와 후보 0건 정상 종료는 row 의미론상 구분 불가 → 감지 대상 아님(스코프 한계, ADR-0053의 burned month 수용과 정합).
+
+- **2일 가드 근거**: 1일 정상 실행이면 2일엔 이미 row → no-op. 1일에 밀려 늦게 실행돼도 2일 체크 전 row가 생기면 헛알림 억제. `#574` 게이트 task(매월 2일)와도 리듬 일치.
+- **후속**: burned month 실측 여부는 #466 회고 본체(8월 2회차 실행 후)에서 판단 → 재발 시 ADR-0058 대안 A(발송완료 마킹) 재검토.
+
 ## 부록 — e-value 게이트 설계 노트 (S-f)
 
 > [ADR-0034](../adr/0034-evalue-construction-replay-test-martingale.md) 본문은 불변(Accepted). 이 부록은 운영·후속 판단을 위한 **경계 조건 메모**로, ADR 결정을 바꾸지 않는다.

--- a/docs/features.md
+++ b/docs/features.md
@@ -112,6 +112,7 @@
 | 월요일 09:00 | weeklyReport | 주간 인사이트 리포트 (Block Kit) |
 | 월요일 10:00 | weeklyReviewFallback | 주간 인사이트 미발송 시 수동 실행 알림(fallback, routine 실패 주만) (`#insight`, #542) |
 | 매월 1일 09:30 | (신호 제안) | LLM 신호 제안 — 새 측정 신호 자율 제안 승인 카드 (`#insight`, #477 P5b) |
+| 매월 2일 11:00 | signalSuggestFallback | 신호 제안 routine 미실행 월 수동 실행 알림(fallback, 그 달 미실행만 감지) (`#insight`, #466) |
 
 타임존: `Asia/Seoul` 고정. `pillar-level-distribution-review` 슬롯은 은퇴(마이그레이션 097 비활성).
 

--- a/src/cron/__tests__/signal-suggest-fallback.test.ts
+++ b/src/cron/__tests__/signal-suggest-fallback.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// signalSuggestFallbackTask(#466 ADR-0058) — monthly-signal-suggest 미실행 월 "수동 실행" 알림.
+// 핵심 회귀 가드: ① 매월 2일만 ② 클레임 row 있으면 no-op / 없으면 알림 1회
+//                ③ month_start는 SQL 내부 계산 → 조회 param은 [userId] 하나뿐(weekly의 [userId, today] 아님).
+
+let mockDay = 2; // 2 = 매월 2일
+const mockQuery = vi.fn();
+const mockPost = vi.fn();
+let mockMappings: Array<{
+  userId: number;
+  slackUserId: string;
+  lifeChannelId: string | null;
+  insightChannelId: string | null;
+}> = [];
+
+vi.mock('../../shared/db.js', () => ({
+  query: (...a: unknown[]) => mockQuery(...a),
+}));
+vi.mock('../../shared/slack.js', () => ({
+  postToChannel: (...a: unknown[]) => mockPost(...a),
+}));
+vi.mock('../../shared/kst.js', () => ({
+  getKSTDayOfMonth: () => mockDay,
+}));
+vi.mock('../../shared/user-resolver.js', () => ({
+  DEFAULT_USER_ID: 1,
+  queryAllUserMappings: () => Promise.resolve(mockMappings),
+}));
+
+const { signalSuggestFallbackTask } = await import('../signal-suggest-fallback.js');
+
+const app = { client: {} } as never;
+const config = { channelId: 'C_FALLBACK', llmClient: {} } as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDay = 2;
+  mockMappings = [];
+  delete process.env['INSIGHT_CHANNEL_ID'];
+});
+
+describe('signalSuggestFallbackTask — monthly-signal-suggest 미실행 알림 (#466)', () => {
+  it('매월 2일 아니면 no-op (쿼리·발송 없음)', async () => {
+    mockDay = 5;
+    await signalSuggestFallbackTask(app, config);
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('클레임 row 있으면 알림 안 보냄 (no-op)', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ exists: true }] });
+    await signalSuggestFallbackTask(app, config);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('클레임 row 없으면 수동 실행 알림 1회', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ exists: false }] });
+    await signalSuggestFallbackTask(app, config);
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    const [, channel, text] = mockPost.mock.calls[0] as [unknown, string, string];
+    expect(channel).toBe('C_FALLBACK'); // 매핑 없음 → config.channelId 폴백
+    expect(text).toContain('수동 실행');
+    expect(text).toContain('monthly-signal-suggest');
+  });
+
+  it('조회 param은 [userId] 하나 — month_start는 SQL 내부 DATE_TRUNC 계산', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ exists: false }] });
+    await signalSuggestFallbackTask(app, config);
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params).toEqual([1]); // [userId]만 — weekly의 [userId, today]와 다름
+  });
+
+  it('멀티유저 — 미실행 유저만 채널별 알림', async () => {
+    mockMappings = [
+      { userId: 1, slackUserId: 'U1', lifeChannelId: null, insightChannelId: 'C_INS_1' },
+      { userId: 2, slackUserId: 'U2', lifeChannelId: null, insightChannelId: 'C_INS_2' },
+    ];
+    // user1 실행됨, user2 미실행
+    mockQuery.mockImplementation((_sql: string, params: unknown[]) =>
+      Promise.resolve({ rows: [{ exists: (params as number[])[0] === 1 }] }),
+    );
+    await signalSuggestFallbackTask(app, config);
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    const [, channel] = mockPost.mock.calls[0] as [unknown, string, string];
+    expect(channel).toBe('C_INS_2');
+  });
+});

--- a/src/cron/life-cron.ts
+++ b/src/cron/life-cron.ts
@@ -48,6 +48,7 @@ import { weeklyReportTask } from './weekly-report.js';
 import { dailyPatternMatchingTask } from './daily-pattern-matching.js';
 import { diaryMetaExtractTask } from './diary-meta-extract.js';
 import { weeklyVerificationTask, weeklyReviewFallbackTask } from './weekly-verification.js';
+import { signalSuggestFallbackTask } from './signal-suggest-fallback.js';
 import { discoveryRecommendTask } from './discovery-recommend.js';
 import { periodFortuneTask } from './period-fortune.js';
 import { buildLifeContext } from '../shared/life-context.js';
@@ -731,6 +732,7 @@ const SLOT_TASKS: Record<string, CronTaskFn> = {
   diaryMetaExtract: diaryMetaExtractTask,
   weeklyVerification: weeklyVerificationTask,
   weeklyReviewFallback: weeklyReviewFallbackTask, // 월 10:00 — routine 미발송 시 수동 실행 알림 (#542 ADR-0052)
+  signalSuggestFallback: signalSuggestFallbackTask, // 월 2일 11:00 — monthly-signal-suggest 미실행 시 알림 (#466 ADR-0058)
   discoveryRecommend: discoveryRecommendTask, // 07:30 데일리 — 묶음 전부 패스 시 다음 best (#512 ADR-0047)
   periodFortune: periodFortuneTask, // 08:20 데일리 — 절기/입춘/대운 전환 시 주기 운세 카드 (#529 ADR-0050)
   // pillarLevelDistributionReview 은퇴(#508 ADR-0046) — 누적 시드 강도 밴드 위임으로 분포 리뷰 무의미.

--- a/src/cron/signal-suggest-fallback.ts
+++ b/src/cron/signal-suggest-fallback.ts
@@ -1,0 +1,71 @@
+/**
+ * 월간 신호 제안 누락 fallback 알림 cron — 매월 2일 11:00 KST (#466, ADR-0058) — 출력 연속성 보장.
+ *
+ * routine(monthly-signal-suggest, 월 1일 09:30, repo 밖 SKILL, #477 P5b/ADR-0040)이 그 달 실행되면
+ * 최초 액션에서 signal_suggest_runs에 (user_id, month_start=그 달 1일) 클레임 row가 남는다(ADR-0053).
+ * 2일에 그 row가 없으면(=그 달 routine이 아예 안 돎) "수동 실행해줘" 알림만 발송 —
+ * 봇이 제안을 대신 만들지 않는다(LLM 신호 생성은 봇 능력 밖, ADR-0052 Alt B 기각 계승).
+ *
+ * 주의: 이 row는 "최초 클레임"이라 발송 성공을 뜻하지 않는다(weekly의 발송-후 기록과 반대 의미론).
+ * 그래서 row 없음 = 그 달 미실행만 확실 감지. burned month(클레임 후 크래시)·후보 0건 정상 종료는
+ * 감지 대상이 아니다(row 의미론상 테이블만으로 구분 불가 — ADR-0058 스코프 한계, ADR-0053과 정합).
+ *
+ * 2일 가드: 1일 정상 실행이면 2일엔 이미 row → no-op. 1일에 앱이 꺼졌다 늦게 밀려 실행돼도
+ * 2일 체크 전 row가 생기면 no-op(헛알림 억제). 2일까지 row 없어야 진짜 누락으로 판정.
+ */
+
+import type { App } from '@slack/bolt';
+import { query } from '../shared/db.js';
+import { getKSTDayOfMonth } from '../shared/kst.js';
+import { postToChannel } from '../shared/slack.js';
+import { DEFAULT_USER_ID, queryAllUserMappings } from '../shared/user-resolver.js';
+import type { LifeCronConfig } from './life-cron.js';
+
+export const signalSuggestFallbackTask = async (
+  app: App,
+  config: LifeCronConfig,
+): Promise<void> => {
+  if (getKSTDayOfMonth() !== 2) return; // 매월 2일만 (매일 등록, 내부 가드)
+  const insightFallback = process.env['INSIGHT_CHANNEL_ID'] ?? config.channelId;
+
+  const notifyIfMissing = async (userId: number, channelId: string): Promise<void> => {
+    const res = await query<{ exists: boolean }>(
+      `SELECT EXISTS(
+         SELECT 1 FROM signal_suggest_runs
+         WHERE user_id = $1
+           AND month_start = DATE_TRUNC('month', (NOW() AT TIME ZONE 'Asia/Seoul'))::date
+       ) AS exists`,
+      [userId],
+    );
+    if (res.rows[0]?.exists) return; // 이번 달 실행됨 — no-op
+    await postToChannel(
+      app.client,
+      channelId,
+      '🔔 이번 달 신호 제안이 아직 안 왔어. 클로드 앱 routines에서 monthly-signal-suggest 수동 실행해줘.',
+    );
+    console.warn(`[SignalSuggestFallback] user=${userId} 미실행 — 수동 실행 알림 전송`);
+  };
+
+  const mappings = await queryAllUserMappings();
+  if (mappings.length === 0) {
+    if (!insightFallback) return;
+    try {
+      await notifyIfMissing(DEFAULT_USER_ID, insightFallback);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[SignalSuggestFallback] 폴백 실행 실패: ${msg}`);
+    }
+    return;
+  }
+
+  for (const mapping of mappings) {
+    const channelId = mapping.insightChannelId ?? insightFallback;
+    if (!channelId) continue;
+    try {
+      await notifyIfMissing(mapping.userId, channelId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[SignalSuggestFallback] user=${mapping.userId} 처리 실패: ${msg}`);
+    }
+  }
+};


### PR DESCRIPTION
## 관련 이슈
Refs #466 — 6개 검토 항목 중 **"routine 실패 fallback 경로"** 하나만 구현. 회고 본체(첫 가동 후보 품질·승인률·거절률 분포)는 표본 부족으로 8월 2회차 실행 후로 유지(이슈 open, 마일스톤 8월 연장).

## 변경 내용
- `monthly-signal-suggest` routine이 그 달 실행 안 되면 신호 제안이 조용히 누락되던 안전망 부재 해소
- 봇 daily 슬롯 `signalSuggestFallback`(매월 2일 11:00) — `signal_suggest_runs` row 존재를 확인해 미실행 월에만 `#insight`로 수동 실행 알림 발송 (알림만, 봇이 제안을 대신 생성하지 않음)
- `weeklyReviewFallback`(ADR-0052) 대칭 구조 재사용. 단 **감지 의미론 차이 명시**: signal-suggest row는 최초 클레임(ADR-0053)이라 그 달 미실행만 확실 감지 — burned month·후보 0건 정상 종료는 스코프 밖
- 마이그 104, ADR-0058

## 코드 리뷰 결과
- [x] 보안 감사 통과 (파라미터화 쿼리 `$1`, 하드코딩 크리덴셜 없음, 민감정보 로그 없음)
- [x] 타입 안전성 확인 (`tsc --noEmit` 통과, any 없음)
- [x] 컨벤션 점검 완료 (네이밍·파일 구조·외부 경계 try-catch)
- [x] 코드 품질 확인 (참조 패턴 대칭 복제, 단일 책임)

## 테스트
- [x] 매월 2일 아니면 no-op (쿼리·발송 없음)
- [x] 클레임 row 있으면 알림 안 보냄
- [x] row 없으면 수동 실행 알림 1회
- [x] 조회 param `[userId]`만 (month_start는 SQL 내부 `DATE_TRUNC` 계산)
- [x] 멀티유저 — 미실행 유저만 채널별 알림
- [x] 전체 스위트 989개 통과 (회귀 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)