### PR TITLE
feat(schedule): 일정 삭제 사유 수집 + 삭제 확인 UX 단일화 (#590)

### DIFF
--- a/db/migrations/106_schedule_delete_reason.sql
+++ b/db/migrations/106_schedule_delete_reason.sql
@@ -1,0 +1,185 @@
+-- 106: 일정 삭제 사유 수집 — tombstone 사유 컬럼 + 시드 신호 (#590, ADR-0060)
+-- 배경: 100(ADR-0054)이 삭제를 tombstone(change_type='deleted')으로 전 경로 캡처하지만 "왜"가 없음.
+--   삭제 사유는 일정 취소 행동을 해석하는 메타데이터 — 고정 어휘 5종 + 자유 텍스트로 수집해
+--   검증 파이프라인(P5a 발굴·주간 검증)의 입력으로 편입한다.
+-- 기록 규약(ADR-0060): tombstone 행 생성은 트리거 단일 계기 그대로(ADR-0054 불변).
+--   사유는 삭제 직후 앱(웹 DELETE API·에이전트 SQL)이 fill-NULL-only UPDATE로 1회 enrichment —
+--   append-only 로그에 허용하는 유일한 예외이며 트리거가 쓴 필드는 불변.
+-- 원칙: delete_reason_text는 사용자 원문 → 검증·발굴·제안 LLM 입력 금지(v2 헌장 ①).
+--   신호화는 delete_reason_category만. LLM 신호 SQL의 원문 컬럼 참조는 signal-sql-guard가 정적 차단.
+-- 구성:
+--   ① 스키마 — 사유 컬럼 2개 + CHECK 2개(어휘 고정, deleted 행 한정) + 테이블 COMMENT 갱신.
+--   ② 시드 신호 신설 — audit_cancel_changed_mind (변심 삭제 발생일, source='seed'라 승인 게이트 비대상).
+--   ③ schedule_fate view 재생성 — 말미에 delete_reason_category 노출(#574 코호트 레이어가 사유 슬라이스 가능).
+--   ④ 자기검증 DO 블록 — tombstone → enrichment → CHECK 거부 → fate 노출 확인 + 테스트 행 정리.
+--   ⑤ 정합 검증 DO 블록.
+-- 안전: 파일 전체가 단일 암묵 트랜잭션(migrate.ts) — 검증 DO 블록 RAISE 시 전체 롤백. 재실행 idempotent.
+--   105는 진행 중인 다른 브랜치가 선점 — 096 결번 전례대로 번호 갭 무해(러너는 파일명 순 미적용분 실행).
+
+-- ═══ ① 스키마 — 사유 컬럼 + CHECK + COMMENT ═══════════════
+ALTER TABLE schedule_changes ADD COLUMN IF NOT EXISTS delete_reason_category TEXT;
+ALTER TABLE schedule_changes ADD COLUMN IF NOT EXISTS delete_reason_text TEXT;
+
+COMMENT ON COLUMN schedule_changes.delete_reason_category IS
+  '삭제 사유 고정 어휘 (#590 ADR-0060): mistake(실수 생성)|changed_mind(변심·하기 싫음)|external(상대방·외부 사정)|rescheduled(다른 일정으로 대체)|other(기타). deleted 행 한정. 웹 delete-reasons.ts와 동기.';
+COMMENT ON COLUMN schedule_changes.delete_reason_text IS
+  '삭제 사유 자유 텍스트 (#590 ADR-0060). 사용자 원문이므로 검증·발굴·제안 LLM 입력 금지(v2 헌장 ①) — 신호화는 category만. deleted 행 한정.';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                  WHERE conrelid = 'schedule_changes'::regclass
+                    AND conname = 'schedule_changes_delete_reason_category_check') THEN
+    ALTER TABLE schedule_changes ADD CONSTRAINT schedule_changes_delete_reason_category_check
+      CHECK (delete_reason_category IS NULL
+             OR (change_type = 'deleted'
+                 AND delete_reason_category IN ('mistake','changed_mind','external','rescheduled','other')));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                  WHERE conrelid = 'schedule_changes'::regclass
+                    AND conname = 'schedule_changes_delete_reason_text_check') THEN
+    ALTER TABLE schedule_changes ADD CONSTRAINT schedule_changes_delete_reason_text_check
+      CHECK (delete_reason_text IS NULL OR change_type = 'deleted');
+  END IF;
+END $$;
+
+-- 기록 주체 규약 갱신 — 행 생성은 여전히 트리거 단일, 사유 enrichment 예외만 추가.
+COMMENT ON TABLE schedule_changes IS
+  '일정 변경 audit — append-only 로그(#572 ADR-0054). writer=DB 트리거 단일 계기(record_schedule_date_change / record_schedule_deletion). schedule_id FK 없음(users FK는 유지) — 일정 삭제 후에도 schedule_id·이력 유지. 웹·Slack 버튼·에이전트 SQL·수동 psql 전 경로가 단일 계기로 수렴. 예외(#590 ADR-0060): 삭제 tombstone의 delete_reason_* 2컬럼만 삭제 직후 앱(웹 API·에이전트 SQL)이 fill-NULL-only UPDATE로 1회 enrichment — 트리거 기록 필드는 불변.';
+
+-- ═══ ② 시드 신호 신설 — 변심 삭제 발생일 (100 §④ 패턴) ═══
+-- source='seed'라 signal-sql-guard(LLM 전용)·승인 게이트 비대상(086·100·101 전례).
+-- active 즉시 다음 월요일 P5a 발굴이 (시드×신호) 후보 여집합에 자동 편입.
+-- 존재-윈도우: audit 도메인 dataStart는 schedule_changes 최초 행 기준 — 사유 도입 전 구간(약 1주)은
+--   0으로 관측되는 좌단 아티팩트가 있으나 삭제는 희소 이벤트라 실질 영향 없음(ADR-0060 명시).
+INSERT INTO signal_defs (user_id, name, kind, sql_body, value_type, direction, threshold, domain, description, source, status)
+VALUES (1, 'audit_cancel_changed_mind', 'sql',
+  $sql$SELECT COUNT(*) FROM schedule_changes
+WHERE user_id=$1 AND change_type='deleted'
+  AND delete_reason_category='changed_mind'
+  AND DATE(changed_at AT TIME ZONE 'Asia/Seoul')=$2$sql$,
+  'continuous', 'above_abs', 1, 'audit',
+  '하기 싫어져서(변심) 일정을 삭제한 날 (삭제 사유 기록 기반)', 'seed', 'active')
+ON CONFLICT DO NOTHING;
+
+-- ═══ ③ schedule_fate view 재생성 — 사유 컬럼 노출 (#574 선행) ═══
+-- 100 §⑥ 정의 유지 + 말미에 delete_reason_category만 추가(CREATE OR REPLACE는 기존 컬럼
+-- 명·순서·타입 불변 + 신규 컬럼 끝 추가만 허용). 살아있는 일정 arm은 NULL.
+CREATE OR REPLACE VIEW schedule_fate AS
+WITH postpones AS (
+  -- (일정×하루) 순변위 미룸 일수 — 신호 SQL과 동일 의미론 (30분 유예 포함).
+  SELECT schedule_id, COUNT(*) AS net_postpone_days
+  FROM (
+    SELECT schedule_id, DATE(changed_at AT TIME ZONE 'Asia/Seoul') AS day,
+           (array_agg((before_value->>'date')::date ORDER BY changed_at ASC))[1]  AS first_b,
+           (array_agg((after_value->>'date')::date ORDER BY changed_at DESC))[1] AS last_a
+    FROM schedule_changes
+    WHERE change_type='date_changed'
+      AND before_value->>'date' IS NOT NULL AND after_value->>'date' IS NOT NULL
+      AND (schedule_created_at IS NULL OR changed_at > schedule_created_at + INTERVAL '30 minutes')
+    GROUP BY schedule_id, DATE(changed_at AT TIME ZONE 'Asia/Seoul')
+  ) g WHERE last_a > first_b GROUP BY schedule_id
+), tombstones AS (
+  SELECT schedule_id, user_id, schedule_created_at,
+         (before_value->>'category_id')::int AS category_id,
+         before_value->>'status' AS status_at_deletion,
+         changed_at AS deleted_at,
+         delete_reason_category
+  FROM schedule_changes WHERE change_type='deleted'
+)
+SELECT s.user_id, s.id AS schedule_id,
+       DATE(s.created_at AT TIME ZONE 'Asia/Seoul') AS cohort_date,
+       s.category_id, s.status AS final_status, false AS is_deleted,
+       NULL::timestamptz AS deleted_at,
+       COALESCE(p.net_postpone_days, 0) AS net_postpone_days,
+       NULL::text AS delete_reason_category
+FROM schedules s LEFT JOIN postpones p ON p.schedule_id = s.id
+UNION ALL
+SELECT t.user_id, t.schedule_id,
+       DATE(t.schedule_created_at AT TIME ZONE 'Asia/Seoul') AS cohort_date,
+       t.category_id, t.status_at_deletion AS final_status, true AS is_deleted,
+       t.deleted_at,
+       COALESCE(p.net_postpone_days, 0) AS net_postpone_days,
+       t.delete_reason_category
+FROM tombstones t LEFT JOIN postpones p ON p.schedule_id = t.schedule_id;
+
+COMMENT ON VIEW schedule_fate IS
+  '일정 단위 궤적 — 생성일(KST cohort_date) 코호트 추적 기반 (#572 ADR-0054, #574 선행). 살아있는 일정(schedules) + 삭제 일정(tombstone) 합집합으로 생존 편향 방지. net_postpone_days는 (일정×하루) 순변위 미룸 일수. delete_reason_category(#590 ADR-0060)로 삭제 사유 슬라이스 가능(살아있는 일정은 NULL). 코호트 신호 정의·성숙 기간·e-value 정합은 #574에서 설계.';
+
+-- ═══ ④ 자기검증 DO 블록 ═══════════════════════════════════
+-- 임시 일정 INSERT → DELETE(tombstone 트리거) → enrichment UPDATE(fill-NULL-only 규약 그대로) →
+-- 사유 저장 확인 → 무효 카테고리 UPDATE가 check_violation으로 거부되는지 확인 →
+-- schedule_fate에서 사유 노출 확인 → 테스트 audit 행 전부 DELETE 정리(남기면 그날 삭제 신호 오염).
+DO $$
+DECLARE
+  tmp_id INT; tomb_id INT; got_cat TEXT; got_text TEXT; fate_cat TEXT; guard_ok BOOLEAN := false;
+BEGIN
+  INSERT INTO schedules (user_id, title, date) VALUES (1, '__migration_106_selftest__', '2000-01-01')
+    RETURNING id INTO tmp_id;
+  DELETE FROM schedules WHERE id = tmp_id;
+  SELECT id INTO tomb_id FROM schedule_changes WHERE schedule_id = tmp_id AND change_type = 'deleted';
+  IF tomb_id IS NULL THEN RAISE EXCEPTION '[106④] 삭제 tombstone 미기록'; END IF;
+
+  UPDATE schedule_changes SET delete_reason_category = 'changed_mind', delete_reason_text = 'selftest'
+   WHERE id = tomb_id AND delete_reason_category IS NULL;
+  SELECT delete_reason_category, delete_reason_text INTO got_cat, got_text
+    FROM schedule_changes WHERE id = tomb_id;
+  IF got_cat IS DISTINCT FROM 'changed_mind' OR got_text IS DISTINCT FROM 'selftest' THEN
+    RAISE EXCEPTION '[106④] 사유 enrichment 실패 — category %, text %', got_cat, got_text;
+  END IF;
+
+  BEGIN
+    UPDATE schedule_changes SET delete_reason_category = 'bogus' WHERE id = tomb_id;
+    RAISE EXCEPTION '[106④] 무효 카테고리가 CHECK를 통과함';
+  EXCEPTION WHEN check_violation THEN
+    guard_ok := true;
+  END;
+  IF NOT guard_ok THEN RAISE EXCEPTION '[106④] CHECK 거부 검증 로직 오류'; END IF;
+
+  SELECT delete_reason_category INTO fate_cat
+    FROM schedule_fate WHERE schedule_id = tmp_id AND is_deleted;
+  IF fate_cat IS DISTINCT FROM 'changed_mind' THEN
+    RAISE EXCEPTION '[106④] schedule_fate 사유 컬럼 미노출 — %', fate_cat;
+  END IF;
+
+  DELETE FROM schedule_changes WHERE schedule_id = tmp_id;
+  RAISE NOTICE '[106④] 사유 컬럼·CHECK·fate 노출 자기검증 OK';
+END $$;
+
+-- ═══ ⑤ 정합 검증 DO 블록 (100 §⑦ 스타일) ═══════════════════
+DO $$
+DECLARE
+  col_cnt INT;
+  ck_cnt INT;
+  sig_cnt INT;
+  fate_col INT;
+BEGIN
+  SELECT count(*) INTO col_cnt FROM information_schema.columns
+   WHERE table_name = 'schedule_changes'
+     AND column_name IN ('delete_reason_category', 'delete_reason_text');
+  IF col_cnt <> 2 THEN
+    RAISE EXCEPTION '[106⑤] 사유 컬럼 수 이상 — % (기대 2)', col_cnt;
+  END IF;
+
+  SELECT count(*) INTO ck_cnt FROM pg_constraint
+   WHERE conrelid = 'schedule_changes'::regclass AND contype = 'c'
+     AND conname IN ('schedule_changes_delete_reason_category_check',
+                     'schedule_changes_delete_reason_text_check');
+  IF ck_cnt <> 2 THEN
+    RAISE EXCEPTION '[106⑤] CHECK 제약 수 이상 — % (기대 2)', ck_cnt;
+  END IF;
+
+  SELECT count(*) INTO sig_cnt FROM signal_defs
+   WHERE user_id = 1 AND name = 'audit_cancel_changed_mind' AND status = 'active';
+  IF sig_cnt <> 1 THEN
+    RAISE EXCEPTION '[106⑤] 시드 신호 active 수 이상 — % (기대 1)', sig_cnt;
+  END IF;
+
+  SELECT count(*) INTO fate_col FROM information_schema.columns
+   WHERE table_name = 'schedule_fate' AND column_name = 'delete_reason_category';
+  IF fate_col <> 1 THEN
+    RAISE EXCEPTION '[106⑤] schedule_fate 사유 컬럼 미노출';
+  END IF;
+
+  RAISE NOTICE '[106⑤] 정합 검증 완료 — 컬럼 2 / CHECK 2 / 신호 active 1 / view 컬럼 1';
+END $$;

--- a/docs/adr/0060-schedule-delete-reason-capture.md
+++ b/docs/adr/0060-schedule-delete-reason-capture.md
@@ -1,0 +1,113 @@
+# 0060. 일정 삭제 사유 수집 — tombstone 사유 컬럼 + fill-NULL-only enrichment
+
+- Status: Accepted
+- Date: 2026-07-10
+- Related: [#590](https://github.com/hyewon3938/slack-ai-agents/issues/590), [ADR-0054](0054-audit-net-displacement-and-trigger-writer.md)(전제 — 삭제 tombstone·기록 트리거 단일 계기), [ADR-0040](0040-llm-signal-sql-validation-and-execution-isolation.md)(신호 SQL 화이트리스트), [ADR-0044](0044-discovery-measurement-validity.md)(데이터-존재 윈도우)
+- Tags: data, ux, insight
+
+## Context
+
+두 계기가 겹쳤다.
+
+- **중복 confirm 버그**: 웹 캘린더 액션 메뉴에서 일정을 삭제하면 확인 confirm이 두 번 연속 뜬다 — 확인 로직이 컴포넌트(`action-menu.tsx`)와 훅(`use-schedules.ts` `handleDeleteById`) 양쪽에 중복 구현되어 있었다. 삭제 확인 UX를 어차피 단일 지점으로 재설계해야 한다.
+- **tombstone에 "왜"가 없음**: 삭제 tombstone(ADR-0054, 마이그레이션 100)은 삭제 사실과 삭제 시점 상태(`{date, status, category_id}`)만 남긴다. 같은 "삭제"라도 실수 교정과 마음이 바뀐 포기는 행동적으로 전혀 다른 사건인데 구분할 수 없다. 삭제 사유는 일정 취소 행동을 해석할 수 있는 메타데이터로, 패턴 검증 시스템의 입력 가치가 있다.
+
+제약 조건:
+
+- `schedule_changes`는 append-only 감사 로그이고, **행 생성은 DB 트리거 단일 계기**다(ADR-0054 — 이 원칙은 불변).
+- 웹은 DB Proxy 단일문 요청 계약이라, 트리거와 앱 코드 사이의 동일 트랜잭션 조율이 어렵다.
+
+## Decision
+
+### 1. 새 장부 없이 기존 tombstone에 사유 컬럼 2개 (마이그레이션 106)
+
+| 컬럼 | 정의 |
+|------|------|
+| `delete_reason_category TEXT` | 고정 어휘 5종 CHECK. deleted 행에서만 허용 |
+| `delete_reason_text TEXT` | 자유 텍스트 — `other`면 필수, 그 외 선택(수집 규약). deleted 행에서만 허용 |
+
+고정 어휘 5종:
+
+| 코드 | 의미 |
+|------|------|
+| `mistake` | 실수로 만든 일정 |
+| `changed_mind` | 하기 싫어짐·마음 바뀜 |
+| `external` | 상대방·외부 사정 |
+| `rescheduled` | 다른 일정으로 대체 |
+| `other` | 기타 (자유 텍스트 필수) |
+
+마이그레이션 번호는 106 — 105는 진행 중인 다른 브랜치가 선점했다(096 결번 전례처럼 번호 갭은 무해).
+
+### 2. 기록 주체 규약 — 행 생성은 트리거, 사유는 fill-NULL-only enrichment
+
+- tombstone **행 생성은 트리거 단일 계기를 유지**한다(ADR-0054 불변).
+- 사유는 삭제 직후 앱이 **UPDATE 1회로 enrichment**한다: `WHERE ... AND delete_reason_category IS NULL` — 사유가 NULL인 행만 1회 채울 수 있다(fill-NULL-only).
+- 이것이 append-only 감사 로그에 허용하는 **유일한 예외**다. 트리거가 쓴 필드(`change_type`·`before_value` 등)는 불변이고, 이미 채워진 사유의 덮어쓰기도 불가.
+
+### 3. 경로별 커버리지
+
+| 경로 | 수집 방식 |
+|------|----------|
+| 웹 삭제 | **삭제 사유 모달**(라디오 5종 + 기타 텍스트)이 유일한 확인 지점 — 중복 confirm 전부 제거. DELETE API body로 사유 전달 → API가 삭제 후 enrichment |
+| Slack 에이전트 자연어 | 프롬프트 지침으로 대화에서 사유를 받아 동일 UPDATE. 사용자가 안 주면 미기록으로 진행(수집 강제 없음) |
+| Slack 오버플로우 버튼 | **미기록(NULL)** — 빠른 액션 특성상 수용, 커버리지 한계로 명시 |
+
+### 4. 통계 연동
+
+1. **seed 신호 1종 신설** — `audit_cancel_changed_mind`: `delete_reason_category='changed_mind'`인 삭제의 일 카운트(KST). `domain='audit'`·`source='seed'`·`status='active'`(승인 게이트는 LLM 신호 전용이라 비대상 — 마이그 100·101 전례). 다음 월요일 주간 발굴(P5a)이 (시드×신호) 후보 여집합에 자동 편입한다.
+2. **P5b(LLM 신호 제안) 재료** — `schedule_changes`는 P5b 도입 시점부터 신호 SQL 테이블 화이트리스트(`SIGNAL_TABLE_WHITELIST`, ADR-0040)에 포함되어 있다. 사유 카테고리 컬럼이 생기면서 이 테이블 기반 신호 제안이 처음으로 의미 있는 재료를 얻는다.
+3. **`schedule_fate` view 확장** — view 끝에 `delete_reason_category` 컬럼 추가. #574 생성일 코호트 레이어가 사유별 슬라이스를 할 수 있다.
+
+### 5. 원문 비노출 — 카테고리만 신호화
+
+`delete_reason_text`(사용자 원문)는 검증·발굴·제안 어떤 LLM 입력에도 넣지 않고, 신호 SQL도 카테고리만 사용한다 — v2 헌장 ① 원문 비노출 유지(`diary_entries`를 화이트리스트에서 제외한 것과 같은 원칙). 화이트리스트는 테이블 단위 검사라 컬럼까지 못 막으므로, LLM 신호 SQL의 `delete_reason_text` 참조는 `signal-sql-guard.ts` BLOCKED_PATTERNS에 컬럼명을 추가해 **정적으로 차단**한다(프롬프트 지시 의존이 아닌 코드 레벨 강제).
+
+### 6. 존재-윈도우 주의 — 좌단 아티팩트
+
+삭제 이벤트 관측은 tombstone 도입(마이그레이션 100, 2026-07-04)부터, 사유는 본 건(마이그레이션 106, 2026-07-10)부터다. 그 사이 약 1주의 삭제는 사유가 NULL이라 `audit_cancel_changed_mind` 신호값이 0으로 관측되는 좌단 아티팩트가 있다. 삭제가 희소 이벤트라 실질 영향은 없지만 정직하게 명시해 둔다(ADR-0044 정신).
+
+## Alternatives considered
+
+### A. 별도 사유 장부 테이블
+
+- 장점: tombstone의 append-only 순수성을 그대로 유지
+- 단점: 트리거 tombstone과 같은 삭제 이벤트를 두 테이블에 이중 기록 — ADR-0054 "단일 계기" 원칙 훼손. 소비 시 JOIN 부담
+- 기각 이유: 같은 이벤트의 기록 계기가 둘로 갈라지는 구조 자체가 ADR-0054가 제거한 문제의 재도입
+
+### B. soft delete (`deleted_at` 컬럼)
+
+- 장점: 행이 살아 있으니 사유를 그 행에 그대로 쓰면 됨
+- 단점: LLM 자유 SQL을 포함한 **전 조회 경로**에 `deleted_at IS NULL` 필터 부담. 기존 "soft delete 안 씀" 프롬프트 원칙과 충돌
+- 기각 이유: 조회 경로 전체에 영구 비용을 지우는 대가가 사유 컬럼 2개의 가치를 크게 초과
+
+### C. 트리거 세션 변수 (`set_config`로 트리거가 사유까지 기록)
+
+- 장점: 기록 주체가 트리거 하나로 완결 — enrichment 예외 자체가 불필요
+- 단점: 웹 DB Proxy가 단일문 요청 계약이라 `set_config`와 DELETE의 동일 트랜잭션 보장이 복잡
+- 기각 이유: 인프라 계약을 흔드는 비용 대비 이득이 과함
+
+### D. tombstone 사유 컬럼 + fill-NULL-only enrichment (선택)
+
+- 장점: 새 테이블 0. 삭제 이벤트 기록은 여전히 트리거 단일 계기, 사유는 부가 enrichment로 역할이 명확히 분리
+- 단점: append-only 순수성에 예외 1개 — fill-NULL-only + 트리거 필드 불변으로 범위 최소화
+
+## Consequences
+
+### 장점
+
+- 중복 confirm 버그가 사유 모달 단일 지점화의 부산물로 해소 — 버그 수정과 데이터 수집이 한 재설계로 정렬
+- 일정 취소 행동의 해석 가능 메타데이터가 배포일부터 축적 — `changed_mind` 신호가 P5a 발굴 대상에 진입
+- 새 테이블 0 — 기존 audit 파이프라인(존재-윈도우·`schedule_fate` view) 위에 컬럼 2개로 얹힘
+
+### 단점 / 제약
+
+- Slack 오버플로우 버튼 경로는 미기록 — 채널 선택이 상황과 상관되면 결측이 랜덤이 아닐 수 있음(ADR-0054가 지적한 기록 경로 비대칭과 같은 계열의 한계, 규모는 작음)
+- 사유는 자기보고라 주관 — 고정 어휘 5종으로 최소한의 구조화만 강제
+- 사용자가 사유를 안 주면 NULL로 남는다(수집 강제 없음)
+- append-only 예외 1개 도입 — fill-NULL-only 조건과 트리거 필드 불변으로 범위를 최소화
+
+### 후속 작업
+
+- [ ] 마이그레이션 106 + 웹 사유 모달 + 에이전트 프롬프트 지침 + 신호 시드 구현·배포 (#590)
+- [ ] 사유 표본 축적 후(수개월) `changed_mind` 외 카테고리(`external`·`rescheduled`)의 신호화 여부 재평가
+- [ ] Slack 버튼 경로 미기록 수용 지속 여부 — 전체 삭제 중 버튼 경로 비중이 유의미해지면 재검토

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -165,6 +165,7 @@ docs/adr/NNNN-<kebab-case-제목>.md
 | [0056](0056-signal-semantics-batch-correction.md) | 신호 의미론 일괄 교정 — 좀비 부활(schema drift) + done 재정의 + 자유지출 개명 + 결측 인프라 #574 편입 | Accepted | 2026-07-04 | insight, data, statistics, process |
 | [0057](0057-fortune-calls-ledger.md) | 일운 콜 장부 분리 — 서술형 반증 가능 콜(claim+criterion, 3단 판정)을 period_forecasts(무인 통계 채점)와 별도 경량 테이블로 | Accepted | 2026-07-05 | insight, data, process |
 | [0058](0058-signal-suggest-missing-fallback.md) | 월간 신호 제안 누락 fallback 알림 — signal_suggest_runs row-존재 감지(봇 daily 슬롯 + 월 2일 가드), 최초-클레임 의미론상 미실행만 확실 감지·알림만 | Accepted | 2026-07-08 | reliability, process, insight |
+| [0060](0060-schedule-delete-reason-capture.md) | 일정 삭제 사유 수집 — tombstone 사유 컬럼 2개 + fill-NULL-only enrichment (행 생성은 트리거 불변, 웹 사유 모달 단일 확인 지점, 원문 비노출·카테고리만 신호화) | Accepted | 2026-07-10 | data, ux, insight |
 
 > **주**: ADR 0001\~0004는 2026-04-22 이후 소급 기록된 백필이다. 원본 판단 근거는 [docs/project-history.md](../project-history.md)와 관련 PR에 남아있으며, 각 ADR의 Date는 실제 판단이 내려진 시점을 사용했다.
 

--- a/docs/domains/insight.md
+++ b/docs/domains/insight.md
@@ -1762,7 +1762,7 @@ LLM이 새 측정 신호(`signal_defs`, `kind='sql'`, `source='llm'`)를 월간 
 
 **검증 게이트** ([signal-sql-guard.ts](../../src/shared/signal-sql-guard.ts) `validateSignalSql`, 통과 시 null·실패 시 한글 사유): self-contained(보안 경계를 한 파일에서 감사, 외부 리팩토링이 조용히 약화 못 하게). 빠른 실패 순서 — 길이 → 단일문 → SELECT/WITH → 블록패턴(`db-proxy.ts BLOCKED_PATTERNS` 정렬 + DML 전수 + `information_schema`/`pg_catalog`) → 플레이스홀더(`$1`/`$2`만) → 테이블 화이트리스트 → `user_id=$1` 스코프.
 
-- **테이블 화이트리스트(deny-by-default, `SIGNAL_TABLE_WHITELIST`)**: prod introspection으로 확정한 5개 신호 도메인의 행동 데이터 테이블 10개(`schedules`·`schedule_changes`·`routine_templates`·`routine_records`·`routine_inactive_periods`·`sleep_records`·`sleep_events`·`expenses`·`categories`·`diary_meta_tags`). 의도적 제외 — 재정(`assets`·`incomes`·`budget_*`·`fixed_cost*`, 도메인 밖+민감) / 시스템·메타(`signal_defs`·`pattern_links`·`users`·`custom_instructions`, 자기승인·변조·교차유저 차단) / 사주 내부·마스터 / `diary_entries`(원문, 헌장 ① — 일기는 메타 태그로만).
+- **테이블 화이트리스트(deny-by-default, `SIGNAL_TABLE_WHITELIST`)**: prod introspection으로 확정한 5개 신호 도메인의 행동 데이터 테이블 10개(`schedules`·`schedule_changes`·`routine_templates`·`routine_records`·`routine_inactive_periods`·`sleep_records`·`sleep_events`·`expenses`·`categories`·`diary_meta_tags`). 의도적 제외 — 재정(`assets`·`incomes`·`budget_*`·`fixed_cost*`, 도메인 밖+민감) / 시스템·메타(`signal_defs`·`pattern_links`·`users`·`custom_instructions`, 자기승인·변조·교차유저 차단) / 사주 내부·마스터 / `diary_entries`(원문, 헌장 ① — 일기는 메타 태그로만). 컬럼 단위 예외: `schedule_changes.delete_reason_text`(삭제 사유 원문, #590 ADR-0060)는 테이블은 허용하되 컬럼명을 블록패턴에 추가해 정적 차단(§46).
 - **오탐 방지(빌드 정련)**: 순진한 `FROM/JOIN` 추출은 `EXTRACT(EPOCH FROM …)` 내부 `FROM`과 CTE 이름을 테이블로 오인(prod 시드 신호에서 `min`·`rc` 오탐 실측). → `EXTRACT(…)` 제거 후 추출 + CTE 이름(`WITH x AS (…)`)은 화이트리스트 면제.
 
 **`source` 스레딩**: `SignalDef.source`·`SajuMetric.source`(`'seed'|'llm'`) 추가 → 두 loader(`verifyUserLinks`·`loadActiveSeeds`·`loadActiveSignals`) SELECT에 `source` + `computeSignalSeries`/`evaluateMetric`가 `source==='llm'`이면 격리 실행기로 분기. 단일 숫자 추출은 `extractFirstNumber` 공통 헬퍼.
@@ -2440,6 +2440,16 @@ db/migrations/  (마스터 #477 매트릭 중심 패턴 검증 — 2026-06)
 
 - **2일 가드 근거**: 1일 정상 실행이면 2일엔 이미 row → no-op. 1일에 밀려 늦게 실행돼도 2일 체크 전 row가 생기면 헛알림 억제. `#574` 게이트 task(매월 2일)와도 리듬 일치.
 - **후속**: burned month 실측 여부는 #466 회고 본체(8월 2회차 실행 후)에서 판단 → 재발 시 ADR-0058 대안 A(발송완료 마킹) 재검토.
+
+### 46. 일정 삭제 사유 신호화 (#590, ADR-0060)
+
+삭제 tombstone(§42, ADR-0054)에 사유 컬럼 2개가 추가됐다 — `delete_reason_category`(고정 어휘 5종: `mistake`·`changed_mind`·`external`·`rescheduled`·`other`) + `delete_reason_text`(자유 텍스트). 수집 UX·기록 규약(fill-NULL-only enrichment)·경로별 커버리지는 [schedule.md](schedule.md) 삭제 사유 섹션과 [ADR-0060](../adr/0060-schedule-delete-reason-capture.md) 참조. 인사이트 관점의 편입은 세 갈래:
+
+- **시드 신호 신설** — `audit_cancel_changed_mind`: `delete_reason_category='changed_mind'`인 삭제의 일 카운트(KST). `kind='sql'`·`value_type='continuous'`·`direction='above_abs'`·`threshold=1`·`domain='audit'`·`source='seed'`(LLM 가드·승인 게이트 비대상, 086·100·101 전례). 링크 없이 시작 → P5a 발굴이 자연 페어링. 카드 라벨 `변심 일정 취소`(`SIGNAL_LABEL_OVERRIDES`). 같은 "삭제"라도 실수 교정(`mistake`)은 노이즈라 제외하고 변심만 신호화 — 사유 구분이 없으면 만들 수 없던 신호다.
+- **P5b 재료** — `schedule_changes`는 화이트리스트에 이미 포함(§30). 사유 카테고리가 생기면서 이 테이블 기반 LLM 신호 제안이 처음으로 의미 있는 재료를 얻는다(`external`·`rescheduled` 등의 신호화는 표본 축적 후 P5b·수동 판단에 위임).
+- **`schedule_fate` 확장** — view 말미에 `delete_reason_category` 노출(살아있는 일정은 NULL). #574 생성일 코호트 레이어가 "미루다 변심으로 지운 일정" 같은 사유별 슬라이스를 얻는다.
+
+원문 비노출(헌장 ①): `delete_reason_text`는 검증·발굴·제안 어떤 LLM 입력에도 넣지 않는다. 화이트리스트가 테이블 단위 검사라 컬럼을 못 막으므로 [signal-sql-guard.ts](../../src/shared/signal-sql-guard.ts) `BLOCKED_PATTERNS`에 컬럼명 자체를 추가해 LLM 신호 SQL의 참조를 정적으로 차단했다. 존재-윈도우: audit 도메인 dataStart는 `schedule_changes` 최초 행(2026-07-04) 기준이라 사유 도입(마이그 106, 2026-07-10) 전 약 1주는 0으로 관측되는 좌단 아티팩트가 있다 — 삭제가 희소 이벤트라 실질 영향 없음(ADR-0060 명시).
 
 ## 부록 — e-value 게이트 설계 노트 (S-f)
 

--- a/docs/domains/schedule.md
+++ b/docs/domains/schedule.md
@@ -69,7 +69,7 @@ ORDER BY
 | GET | `/api/schedules?from=&to=` | 날짜 범위 일정 조회 (캘린더용) |
 | POST | `/api/schedules` | 일정 생성 |
 | PATCH | `/api/schedules/[id]` | 일정 수정 (부분 업데이트) |
-| DELETE | `/api/schedules/[id]` | 일정 삭제 |
+| DELETE | `/api/schedules/[id]` | 일정 삭제 (body로 사유 전달 — 삭제 후 tombstone enrichment) |
 | GET | `/api/categories` | 카테고리 목록 조회 |
 | POST | `/api/categories` | 카테고리 생성 |
 | PATCH | `/api/categories/[id]` | 카테고리 수정 |
@@ -91,6 +91,7 @@ features/schedule/
 │   ├── droppable-day.tsx       # 드롭 영역 (날짜 셀)
 │   ├── schedule-card.tsx       # 일정 카드 UI
 │   ├── schedule-form.tsx       # 일정 생성/수정 폼 (모달)
+│   ├── delete-reason-modal.tsx # 삭제 사유 선택 모달 (삭제 확인 단일 지점)
 │   ├── status-badge.tsx        # 상태 뱃지 컴포넌트
 │   ├── saju-pillar-label.tsx   # 사주 일주 라벨 (월/주 뷰 공용)
 │   └── action-menu.tsx         # 일정 컨텍스트 메뉴 (수정/삭제/미루기 등)
@@ -101,6 +102,7 @@ features/schedule/
     ├── types.ts                # ScheduleRow, ScheduleStatus, 정렬 함수
     ├── queries.ts              # 서버 사이드 DB 쿼리 (query, queryOne)
     ├── calendar-utils.ts       # 캘린더 유틸 (WEEK_START 등)
+    ├── delete-reasons.ts       # 삭제 사유 고정 어휘 5종 (코드·라벨, 마이그 106 CHECK와 동기)
     └── __tests__/              # 테스트
 ```
 
@@ -199,4 +201,33 @@ features/schedule/
 
 ### `schedule_fate` view — 생성일 코호트 추적 기반 (#574 선행)
 
-살아있는 일정 + 삭제 일정(tombstone) 합집합으로 일정 단위 궤적(생성일 코호트·카테고리·순미룸 일수·최종 상태/삭제)을 낸다. 한 번도 안 옮긴 채 완료된 일정도 포함해 생존 편향을 막는다. 가설·검증 레이어는 [#574](https://github.com/hyewon3938/slack-ai-agents/issues/574)에서 설계하고, 그 전에도 ad-hoc·주간 리뷰에서 소비 가능. 순변위 의미론·측정 정밀화 상세는 insight 도메인 [§42](insight.md) 참조.
+살아있는 일정 + 삭제 일정(tombstone) 합집합으로 일정 단위 궤적(생성일 코호트·카테고리·순미룸 일수·최종 상태/삭제)을 낸다. 한 번도 안 옮긴 채 완료된 일정도 포함해 생존 편향을 막는다. 가설·검증 레이어는 [#574](https://github.com/hyewon3938/slack-ai-agents/issues/574)에서 설계하고, 그 전에도 ad-hoc·주간 리뷰에서 소비 가능. 순변위 의미론·측정 정밀화 상세는 insight 도메인 [§42](insight.md) 참조. 마이그레이션 106부터 view 말미에 `delete_reason_category` 노출(살아있는 일정은 NULL) — 아래 삭제 사유 섹션 참조.
+
+### 삭제 사유 수집 (#590, ADR-0060)
+
+삭제 tombstone에 "왜 지웠는지"를 담는다. 마이그레이션 [106](../../db/migrations/106_schedule_delete_reason.sql), 설계 근거 [ADR-0060](../adr/0060-schedule-delete-reason-capture.md).
+
+**컬럼 2개** (둘 다 `change_type='deleted'` 행에서만 허용, CHECK 강제):
+
+- `delete_reason_category TEXT` — 고정 어휘 5종 CHECK. 웹 상수 [delete-reasons.ts](../../web/src/features/schedule/lib/delete-reasons.ts)와 동기.
+- `delete_reason_text TEXT` — 자유 텍스트. `other`면 필수, 그 외 선택(수집 규약). **사용자 원문이라 검증·발굴·제안 LLM 입력 금지**(v2 헌장 ①) — 신호화는 category만 (insight [§46](insight.md)).
+
+**사유 어휘 5종**:
+
+| 코드 | 라벨 | 의미 |
+|------|------|------|
+| `mistake` | 실수로 만든 일정 | 오기입·중복 생성 교정 (통계에선 노이즈로 취급) |
+| `changed_mind` | 하기 싫어졌거나 마음이 바뀜 | 내적 취소 — `audit_cancel_changed_mind` 신호의 대상 |
+| `external` | 상대방·외부 사정으로 취소됨 | 외생 취소 |
+| `rescheduled` | 다른 날짜·일정으로 대체함 | 삭제 후 재생성·대체 |
+| `other` | 기타 | 자유 텍스트 필수 |
+
+**기록 규약** — 행 생성은 트리거 단일 계기 그대로(ADR-0054 불변), 사유는 삭제 직후 앱이 **fill-NULL-only UPDATE 1회 enrichment** (`WHERE ... AND delete_reason_category IS NULL`, 최신 tombstone 대상). append-only 로그에 허용하는 유일한 예외이며 트리거가 쓴 필드는 불변.
+
+**경로별 커버리지**:
+
+| 경로 | 수집 방식 |
+|------|----------|
+| 웹 삭제 (액션 메뉴·수정 폼) | `DeleteReasonModal`(라디오 5종 + 텍스트)이 **유일한 삭제 확인 지점** — 기존 중복 confirm 제거. DELETE API body(`reason_category`/`reason_text`)로 전달 → API가 삭제 후 `recordDeleteReason` enrichment |
+| Slack 에이전트 자연어 | 프롬프트 지침([prompt.ts](../../src/agents/life/prompt.ts) 일정/백로그 규칙)으로 대화에서 사유 수집 후 동일 UPDATE. 사용자가 안 주면 미기록 진행 |
+| Slack 오버플로우 버튼 | 미기록(NULL) — 빠른 액션 특성상 수용, 한계로 명시 |

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,6 +9,7 @@
 ### 일정 관리 (`#life` 채널)
 
 - Slack 자연어로 일정 추가/조회/수정/삭제
+- 일정 삭제 사유 수집 — 웹은 사유 선택 모달(고정 5종 + 기타 텍스트), Slack은 대화 수집. tombstone enrichment로 축적, 변심 취소는 패턴 신호화 (#590, ADR-0060)
 - 카테고리 분류 (FK 기반, 2026-05-13 마이그레이션)
 - 밀린 일정 자동 감지 + 잔소리
 - 상세: [docs/domains/schedule.md](./domains/schedule.md)

--- a/src/agents/life/prompt.ts
+++ b/src/agents/life/prompt.ts
@@ -172,6 +172,9 @@ ORDER BY CASE WHEN COALESCE(c.type, p.type) = 'event' THEN 0 ELSE 1 END,
 - 백로그: date IS NULL인 일정. 표시 포맷 동일, 날짜 범위 없음.
 - **삭제: DELETE 실행.** "삭제", "지워", "없애" 요청은 DELETE FROM schedules로 처리. UPDATE status='cancelled' 금지 — soft delete 안 씀.
 - status='cancelled'는 사용자가 명시적으로 "취소"라고 말했을 때만 사용 (예: "그 약속 취소됐어"). 삭제와 취소는 다른 행동.
+- 삭제 사유 수집: 지우는 이유를 이미 말했으면 그대로 쓰고, 안 말했으면 삭제 전에 딱 한 번만 짧게 물어봐 (실수로 만든 건지, 하기 싫어진 건지, 사정이 생긴 건지). 대답 안 하거나 "그냥 지워"라고 하면 사유 없이 바로 삭제해.
+- 사유 기록: DELETE 직후 아래 UPDATE 실행. 카테고리 5종 — mistake(실수 생성) | changed_mind(변심·하기 싫음) | external(상대방·외부 사정) | rescheduled(다른 일정으로 대체) | other(기타).
+  UPDATE schedule_changes SET delete_reason_category='<카테고리>', delete_reason_text='<사용자가 말한 이유, 없으면 이 컬럼은 빼>' WHERE user_id = ${userId} AND schedule_id = <삭제한 일정 id> AND change_type='deleted' AND delete_reason_category IS NULL
 
 ## 수면 기록
 

--- a/src/shared/insight-labels.ts
+++ b/src/shared/insight-labels.ts
@@ -162,6 +162,8 @@ const SIGNAL_LABEL_OVERRIDES: Record<string, string> = {
   audit_date_postponed: '일정 미룸',
   audit_date_advanced: '일정 당김',
   audit_postponed_done: '미룬 일정 처리',
+  // #590 ADR-0060: 삭제 사유(changed_mind) 기반 — "하기 싫어져서 일정을 지운 날".
+  audit_cancel_changed_mind: '변심 일정 취소',
   expense_hospital_excl_installment: '병원비 지출(할부 제외)',
   schedule_tax_keyword: '세금 관련 일정',
   // #573 ADR-0056: category_id JOIN + status='done' 재정의 — "그 일정을 실제로 처리한 날".

--- a/src/shared/signal-sql-guard.ts
+++ b/src/shared/signal-sql-guard.ts
@@ -32,6 +32,8 @@ const MAX_SIGNAL_SQL_LENGTH = 2000;
 export const SIGNAL_TABLE_WHITELIST: ReadonlySet<string> = new Set([
   // schedule
   'schedules',
+  // schedule_changes의 delete_reason_text(사용자 원문, #590)는 헌장 ① 대상 —
+  // 화이트리스트는 테이블 단위라 BLOCKED_PATTERNS에서 컬럼명으로 정적 차단.
   'schedule_changes',
   // routine
   'routine_templates',
@@ -80,6 +82,8 @@ const BLOCKED_PATTERNS: readonly RegExp[] = [
   /\bpg_hba_file_rules\b/i,
   /\binformation_schema\b/i,
   /\bpg_catalog\b/i,
+  // 삭제 사유 원문 컬럼 (#590 ADR-0060) — 헌장 ①(원문 0). 신호화는 delete_reason_category만.
+  /\bdelete_reason_text\b/i,
 ];
 
 /** 주석·문자열 리터럴 제거 (db-proxy 등급 — 이스케이프된 '' 처리). */

--- a/web/src/app/api/schedules/[id]/route.ts
+++ b/web/src/app/api/schedules/[id]/route.ts
@@ -4,9 +4,11 @@ import {
   queryScheduleById,
   updateSchedule,
   deleteSchedule,
+  recordDeleteReason,
   validateCategoryOwnership,
 } from '@/features/schedule/lib/queries';
 import { isValidStatus } from '@/features/schedule/lib/types';
+import { isDeleteReasonCategory, type DeleteReason } from '@/features/schedule/lib/delete-reasons';
 import { validateFields } from '@/lib/validation';
 
 export const dynamic = 'force-dynamic';
@@ -79,7 +81,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
   }
 }
 
-export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const userId = await requireAuth();
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -87,10 +89,42 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
 
   try {
     const { id } = await params;
+
+    // 삭제 사유 (선택 body) — 카테고리는 고정 어휘, 텍스트는 길이 제한 (#590)
+    let reason: DeleteReason | null = null;
+    const body = (await request.json().catch(() => null)) as {
+      reason_category?: unknown;
+      reason_text?: unknown;
+    } | null;
+    if (body?.reason_category !== undefined) {
+      if (!isDeleteReasonCategory(body.reason_category)) {
+        return NextResponse.json({ error: '삭제 사유 값이 잘못됐어' }, { status: 400 });
+      }
+      const text =
+        typeof body.reason_text === 'string' && body.reason_text.trim()
+          ? body.reason_text.trim()
+          : null;
+      const lengthError = validateFields([[text ?? undefined, 'reason']]);
+      if (lengthError) {
+        return NextResponse.json({ error: lengthError }, { status: 400 });
+      }
+      reason = { category: body.reason_category, text };
+    }
+
     const deleted = await deleteSchedule(userId, Number(id));
     if (!deleted) {
       return NextResponse.json({ error: '일정을 찾을 수 없어' }, { status: 404 });
     }
+
+    if (reason) {
+      // 삭제는 이미 커밋됨 — 사유 기록 실패는 유실로만 처리하고 응답은 성공 유지
+      try {
+        await recordDeleteReason(userId, Number(id), reason.category, reason.text);
+      } catch (err) {
+        console.error('삭제 사유 기록 실패:', err);
+      }
+    }
+
     return NextResponse.json({ data: { id: Number(id) } });
   } catch {
     return NextResponse.json({ error: '일정 삭제 실패' }, { status: 500 });

--- a/web/src/app/schedules/calendar/page.tsx
+++ b/web/src/app/schedules/calendar/page.tsx
@@ -18,6 +18,7 @@ import { DndCalendar } from '@/features/schedule/components/dnd-calendar';
 import { BottomSheet } from '@/components/ui/bottom-sheet';
 import { Modal } from '@/components/ui/modal';
 import { ScheduleForm } from '@/features/schedule/components/schedule-form';
+import { DeleteReasonModal } from '@/features/schedule/components/delete-reason-modal';
 import type { CalendarView } from '@/features/schedule/components/calendar-header';
 
 function getInitialView(): CalendarView {
@@ -43,7 +44,15 @@ function getTitle(view: string, currentDate: Date): string {
 
 export default function CalendarPage() {
   return (
-    <Suspense fallback={<div className="flex-1 p-4"><div className="mx-auto max-w-3xl"><ListSkeleton rows={5} rowHeight="h-20" /></div></div>}>
+    <Suspense
+      fallback={
+        <div className="flex-1 p-4">
+          <div className="mx-auto max-w-3xl">
+            <ListSkeleton rows={5} rowHeight="h-20" />
+          </div>
+        </div>
+      }
+    >
       <CalendarContent />
     </Suspense>
   );
@@ -80,10 +89,12 @@ function CalendarContent() {
     handleEndDateChange,
     handleCreate,
     handleUpdate,
-    handleDelete,
     handlePostpone,
     handleMoveToBacklog,
-    handleDeleteById,
+    deleteTarget,
+    setDeleteTarget,
+    requestDelete,
+    confirmDelete,
     handleSelectDate,
     toggleCategory,
     toggleSubcategory,
@@ -150,8 +161,14 @@ function CalendarContent() {
         onDateChange={handleDateChange}
         onEndDateChange={handleEndDateChange}
       >
-        <div className={`md:flex md:flex-1 md:min-h-0 ${view === 'month' && selectedDate ? '' : 'md:flex-col'}`}>
-          <div className={view === 'month' && selectedDate ? 'flex-1' : 'md:flex md:flex-1 md:flex-col'}>
+        <div
+          className={`md:flex md:flex-1 md:min-h-0 ${view === 'month' && selectedDate ? '' : 'md:flex-col'}`}
+        >
+          <div
+            className={
+              view === 'month' && selectedDate ? 'flex-1' : 'md:flex md:flex-1 md:flex-col'
+            }
+          >
             {view === 'month' && (
               <MonthView
                 currentDate={currentDate}
@@ -175,7 +192,7 @@ function CalendarContent() {
                 onToggleImportant={handleToggleImportant}
                 onPostpone={handlePostpone}
                 onMoveToBacklog={handleMoveToBacklog}
-                onDelete={handleDeleteById}
+                onDelete={requestDelete}
               />
             )}
             {view === 'day' && (
@@ -188,7 +205,7 @@ function CalendarContent() {
                 onToggleImportant={handleToggleImportant}
                 onPostpone={handlePostpone}
                 onMoveToBacklog={handleMoveToBacklog}
-                onDelete={handleDeleteById}
+                onDelete={requestDelete}
               />
             )}
           </div>
@@ -254,12 +271,19 @@ function CalendarContent() {
             schedule={editingSchedule}
             categories={categories}
             onSubmit={handleUpdate}
-            onDelete={handleDelete}
+            onDelete={() => requestDelete(editingSchedule.id)}
             onClose={() => setEditingSchedule(null)}
             onDirtyChange={setFormDirty}
           />
         )}
       </Modal>
+
+      {/* 삭제 사유 모달 — 삭제 확인의 유일한 지점 (#590) */}
+      <DeleteReasonModal
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={confirmDelete}
+      />
     </>
   );
 }

--- a/web/src/features/schedule/components/action-menu.tsx
+++ b/web/src/features/schedule/components/action-menu.tsx
@@ -40,8 +40,10 @@ export function ActionMenu({
 
     const handleClickOutside = (e: MouseEvent) => {
       if (
-        menuRef.current && !menuRef.current.contains(e.target as Node) &&
-        buttonRef.current && !buttonRef.current.contains(e.target as Node)
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target as Node)
       ) {
         setOpen(false);
       }
@@ -114,7 +116,8 @@ export function ActionMenu({
               onClick={(e) => {
                 e.stopPropagation();
                 setOpen(false);
-                if (confirm('이 일정을 삭제할까?')) onDelete(scheduleId);
+                // 삭제 확인은 사유 모달(DeleteReasonModal) 단일 지점 — 여기에 confirm 추가 금지 (#590)
+                onDelete(scheduleId);
               }}
               className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-500 hover:bg-red-50"
             >

--- a/web/src/features/schedule/components/backlog-panel.tsx
+++ b/web/src/features/schedule/components/backlog-panel.tsx
@@ -6,6 +6,7 @@ import { getTodayISO } from '@/lib/kst';
 import { useBacklog } from '@/features/schedule/hooks/use-backlog';
 import { Modal } from '@/components/ui/modal';
 import { ScheduleForm } from '@/features/schedule/components/schedule-form';
+import { DeleteReasonModal } from '@/features/schedule/components/delete-reason-modal';
 import { StatusBadge } from '@/features/schedule/components/status-badge';
 
 export function BacklogPanel() {
@@ -21,7 +22,10 @@ export function BacklogPanel() {
     sortedCategories,
     handleAssignDate,
     handleUpdate,
-    handleDelete,
+    deleteTarget,
+    setDeleteTarget,
+    requestDelete,
+    confirmDelete,
     handleCreate,
   } = useBacklog();
 
@@ -105,7 +109,9 @@ export function BacklogPanel() {
                             <StatusBadge status={s.status} />
                           </div>
                           {s.memo && (
-                            <p className="mt-1 whitespace-pre-wrap text-xs text-gray-500">{s.memo}</p>
+                            <p className="mt-1 whitespace-pre-wrap text-xs text-gray-500">
+                              {s.memo}
+                            </p>
                           )}
                         </div>
 
@@ -126,7 +132,12 @@ export function BacklogPanel() {
       </div>
 
       {/* 생성 모달 */}
-      <Modal open={showCreateModal} onClose={() => setShowCreateModal(false)} onBeforeClose={handleBeforeClose} title="백로그 추가">
+      <Modal
+        open={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        onBeforeClose={handleBeforeClose}
+        title="백로그 추가"
+      >
         <ScheduleForm
           categories={categories}
           defaultDate={null}
@@ -148,12 +159,19 @@ export function BacklogPanel() {
             schedule={editingSchedule}
             categories={categories}
             onSubmit={handleUpdate}
-            onDelete={handleDelete}
+            onDelete={() => requestDelete(editingSchedule.id)}
             onClose={() => setEditingSchedule(null)}
             onDirtyChange={setFormDirty}
           />
         )}
       </Modal>
+
+      {/* 삭제 사유 모달 — 삭제 확인의 유일한 지점 (#590) */}
+      <DeleteReasonModal
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={confirmDelete}
+      />
 
       {/* 모바일 FAB */}
       <button

--- a/web/src/features/schedule/components/delete-reason-modal.tsx
+++ b/web/src/features/schedule/components/delete-reason-modal.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Modal } from '@/components/ui/modal';
+import {
+  DELETE_REASONS,
+  type DeleteReason,
+  type DeleteReasonCategory,
+} from '@/features/schedule/lib/delete-reasons';
+
+interface DeleteReasonModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** 사유와 함께 실제 삭제 실행. 삭제 확인은 이 모달이 유일한 지점 */
+  onConfirm: (reason: DeleteReason) => Promise<void>;
+}
+
+export function DeleteReasonModal({ open, onClose, onConfirm }: DeleteReasonModalProps) {
+  const [category, setCategory] = useState<DeleteReasonCategory | null>(null);
+  const [text, setText] = useState('');
+  const [deleting, setDeleting] = useState(false);
+
+  // 열릴 때마다 초기화
+  useEffect(() => {
+    if (open) {
+      setCategory(null);
+      setText('');
+      setDeleting(false);
+    }
+  }, [open]);
+
+  const needText = category === 'other';
+  const canSubmit = category !== null && (!needText || text.trim().length > 0) && !deleting;
+
+  const handleConfirm = async () => {
+    if (category === null || !canSubmit) return;
+    setDeleting(true);
+    try {
+      await onConfirm({ category, text: text.trim() || null });
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="일정 삭제">
+      <div className="space-y-4">
+        <p className="text-sm text-gray-600">왜 삭제하는지 남겨두면 나중에 패턴 분석에 쓰여.</p>
+
+        <div className="space-y-1.5">
+          {DELETE_REASONS.map((r) => (
+            <label
+              key={r.value}
+              className={`flex cursor-pointer items-center gap-2.5 rounded-lg border px-3 py-2.5 transition ${
+                category === r.value
+                  ? 'border-red-300 bg-red-50'
+                  : 'border-gray-200 hover:bg-gray-50'
+              }`}
+            >
+              <input
+                type="radio"
+                name="delete-reason"
+                value={r.value}
+                checked={category === r.value}
+                onChange={() => setCategory(r.value)}
+                className="h-4 w-4 border-gray-300 text-red-500 focus:ring-red-200"
+              />
+              <span className="text-sm text-gray-700">{r.label}</span>
+            </label>
+          ))}
+        </div>
+
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={2}
+          maxLength={300}
+          placeholder={needText ? '무슨 일인지 적어줘' : '덧붙일 메모 (선택)'}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        />
+
+        <div className="flex gap-2">
+          <div className="flex-1" />
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg px-4 py-2.5 text-sm font-medium text-gray-500 transition hover:bg-gray-100"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!canSubmit}
+            className="rounded-lg bg-red-500 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-red-600 disabled:opacity-50"
+          >
+            {deleting ? '삭제중...' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/features/schedule/components/schedule-form.tsx
+++ b/web/src/features/schedule/components/schedule-form.tsx
@@ -11,7 +11,8 @@ interface ScheduleFormProps {
   categories: CategoryRow[];
   defaultDate?: string | null;
   onSubmit: (data: Partial<ScheduleRow>) => Promise<void>;
-  onDelete?: () => Promise<void>;
+  // 실제 삭제가 아니라 삭제 사유 모달을 여는 트리거 (#590)
+  onDelete?: () => void;
   onClose: () => void;
   onDirtyChange?: (dirty: boolean) => void;
 }
@@ -335,11 +336,10 @@ export function ScheduleForm({
       {/* 버튼 */}
       <div className="flex gap-2">
         {onDelete && schedule && (
+          /* 삭제 확인은 사유 모달(DeleteReasonModal) 단일 지점 — 여기에 confirm 추가 금지 (#590) */
           <button
             type="button"
-            onClick={() => {
-              if (confirm('이 일정을 삭제할까?')) onDelete();
-            }}
+            onClick={() => onDelete()}
             className="rounded-lg px-4 py-2.5 text-sm font-medium text-red-500 transition hover:bg-red-50"
           >
             삭제

--- a/web/src/features/schedule/hooks/use-backlog.ts
+++ b/web/src/features/schedule/hooks/use-backlog.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { ScheduleRow } from '@/features/schedule/lib/types';
 import { getScheduleTopCategoryName } from '@/features/schedule/lib/types';
+import type { DeleteReason } from '@/features/schedule/lib/delete-reasons';
 import type { CategoryRow } from '@/lib/types';
 
 export function useBacklog() {
@@ -10,6 +11,8 @@ export function useBacklog() {
   const [categories, setCategories] = useState<CategoryRow[]>([]);
   const [editingSchedule, setEditingSchedule] = useState<ScheduleRow | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  // 삭제 사유 모달 대상 일정 id — null이면 모달 닫힘 (#590)
+  const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
 
   const fetchData = useCallback(async () => {
@@ -98,13 +101,24 @@ export function useBacklog() {
     }
   };
 
-  const handleDelete = async () => {
-    if (!editingSchedule) return;
+  /** 삭제 요청 — 사유 모달을 연다. 실제 삭제는 confirmDelete가 수행 */
+  const requestDelete = (id: number) => setDeleteTarget(id);
+
+  /** 사유 모달 확정 — 사유를 body에 담아 삭제 (API가 tombstone 사유 enrichment까지 수행) */
+  const confirmDelete = async (reason: DeleteReason) => {
+    if (deleteTarget === null) return;
     try {
-      const res = await fetch(`/api/schedules/${editingSchedule.id}`, { method: 'DELETE' });
+      const res = await fetch(`/api/schedules/${deleteTarget}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason_category: reason.category, reason_text: reason.text }),
+      });
       if (res.ok) {
-        setEditingSchedule(null);
+        if (editingSchedule?.id === deleteTarget) setEditingSchedule(null);
+        setDeleteTarget(null);
         await fetchData();
+      } else {
+        alert('일정 삭제에 실패했어');
       }
     } catch {
       alert('일정 삭제에 실패했어');
@@ -138,7 +152,10 @@ export function useBacklog() {
     sortedCategories,
     handleAssignDate,
     handleUpdate,
-    handleDelete,
+    deleteTarget,
+    setDeleteTarget,
+    requestDelete,
+    confirmDelete,
     handleCreate,
   };
 }

--- a/web/src/features/schedule/hooks/use-schedules.ts
+++ b/web/src/features/schedule/hooks/use-schedules.ts
@@ -16,6 +16,7 @@ import {
 } from 'date-fns';
 import type { ScheduleRow } from '@/features/schedule/lib/types';
 import { lookupCategory } from '@/features/schedule/lib/types';
+import type { DeleteReason } from '@/features/schedule/lib/delete-reasons';
 import type { CategoryRow } from '@/lib/types';
 import type { CalendarView } from '@/features/schedule/components/calendar-header';
 import { WEEK_START } from '@/features/schedule/lib/calendar-utils';
@@ -33,6 +34,8 @@ export function useSchedules(initialView?: CalendarView) {
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [editingSchedule, setEditingSchedule] = useState<ScheduleRow | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  // 삭제 사유 모달 대상 일정 id — null이면 모달 닫힘 (#590)
+  const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
   // 카테고리 필터: 최상위 id 기준
   const [selectedCategories, setSelectedCategories] = useState<Set<number>>(new Set());
   // 하위 카테고리 필터: child id 기준
@@ -237,15 +240,24 @@ export function useSchedules(initialView?: CalendarView) {
     }
   };
 
-  const handleDelete = async () => {
-    if (!editingSchedule) return;
+  /** 삭제 요청 — 사유 모달을 연다. 실제 삭제는 confirmDelete가 수행 */
+  const requestDelete = (id: number) => setDeleteTarget(id);
+
+  /** 사유 모달 확정 — 사유를 body에 담아 삭제 (API가 tombstone 사유 enrichment까지 수행) */
+  const confirmDelete = async (reason: DeleteReason) => {
+    if (deleteTarget === null) return;
     try {
-      const res = await fetch(`/api/schedules/${editingSchedule.id}`, {
+      const res = await fetch(`/api/schedules/${deleteTarget}`, {
         method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason_category: reason.category, reason_text: reason.text }),
       });
       if (res.ok) {
-        setEditingSchedule(null);
+        if (editingSchedule?.id === deleteTarget) setEditingSchedule(null);
+        setDeleteTarget(null);
         await fetchData();
+      } else {
+        alert('일정 삭제에 실패했어');
       }
     } catch {
       alert('일정 삭제에 실패했어');
@@ -338,16 +350,6 @@ export function useSchedules(initialView?: CalendarView) {
     }
   };
 
-  const handleDeleteById = async (id: number) => {
-    if (!confirm('이 일정을 삭제할까?')) return;
-    try {
-      const res = await fetch(`/api/schedules/${id}`, { method: 'DELETE' });
-      if (res.ok) await fetchData();
-    } catch {
-      alert('삭제에 실패했어');
-    }
-  };
-
   const handleSelectDate = (dateStr: string) => {
     setSelectedDate(dateStr === selectedDate ? null : dateStr);
   };
@@ -420,10 +422,12 @@ export function useSchedules(initialView?: CalendarView) {
     handleEndDateChange,
     handleCreate,
     handleUpdate,
-    handleDelete,
     handlePostpone,
     handleMoveToBacklog,
-    handleDeleteById,
+    deleteTarget,
+    setDeleteTarget,
+    requestDelete,
+    confirmDelete,
     handleSelectDate,
     toggleCategory,
     toggleSubcategory,

--- a/web/src/features/schedule/lib/__tests__/delete-reasons.test.ts
+++ b/web/src/features/schedule/lib/__tests__/delete-reasons.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { DELETE_REASONS, isDeleteReasonCategory } from '../delete-reasons';
+
+describe('DELETE_REASONS', () => {
+  it('고정 어휘 5종 — 마이그레이션 106 CHECK 제약과 동기', () => {
+    expect(DELETE_REASONS.map((r) => r.value)).toEqual([
+      'mistake',
+      'changed_mind',
+      'external',
+      'rescheduled',
+      'other',
+    ]);
+  });
+
+  it('value 중복 없음', () => {
+    const values = DELETE_REASONS.map((r) => r.value);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it('모든 항목에 한국어 라벨 존재', () => {
+    for (const r of DELETE_REASONS) {
+      expect(r.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('isDeleteReasonCategory', () => {
+  it('유효한 카테고리 코드 통과', () => {
+    expect(isDeleteReasonCategory('mistake')).toBe(true);
+    expect(isDeleteReasonCategory('changed_mind')).toBe(true);
+    expect(isDeleteReasonCategory('other')).toBe(true);
+  });
+
+  it('어휘 밖 값 거부', () => {
+    expect(isDeleteReasonCategory('bogus')).toBe(false);
+    expect(isDeleteReasonCategory('')).toBe(false);
+    expect(isDeleteReasonCategory('MISTAKE')).toBe(false);
+  });
+
+  it('문자열 아닌 값 거부', () => {
+    expect(isDeleteReasonCategory(null)).toBe(false);
+    expect(isDeleteReasonCategory(undefined)).toBe(false);
+    expect(isDeleteReasonCategory(1)).toBe(false);
+    expect(isDeleteReasonCategory({ value: 'mistake' })).toBe(false);
+  });
+});

--- a/web/src/features/schedule/lib/delete-reasons.ts
+++ b/web/src/features/schedule/lib/delete-reasons.ts
@@ -1,0 +1,21 @@
+/**
+ * 일정 삭제 사유 고정 어휘 (#590, ADR-0060).
+ * schedule_changes.delete_reason_category CHECK 제약(마이그레이션 106)과 동기 — 값 변경 시 마이그레이션도 함께.
+ */
+export const DELETE_REASONS = [
+  { value: 'mistake', label: '실수로 만든 일정' },
+  { value: 'changed_mind', label: '하기 싫어졌거나 마음이 바뀜' },
+  { value: 'external', label: '상대방·외부 사정으로 취소됨' },
+  { value: 'rescheduled', label: '다른 날짜·일정으로 대체함' },
+  { value: 'other', label: '기타' },
+] as const;
+
+export type DeleteReasonCategory = (typeof DELETE_REASONS)[number]['value'];
+
+export interface DeleteReason {
+  category: DeleteReasonCategory;
+  text: string | null;
+}
+
+export const isDeleteReasonCategory = (value: unknown): value is DeleteReasonCategory =>
+  typeof value === 'string' && DELETE_REASONS.some((r) => r.value === value);

--- a/web/src/features/schedule/lib/queries.ts
+++ b/web/src/features/schedule/lib/queries.ts
@@ -146,6 +146,28 @@ export const deleteSchedule = async (userId: number, id: number): Promise<boolea
   return result.rowCount !== null && result.rowCount > 0;
 };
 
+/**
+ * 삭제 tombstone 사유 enrichment (#590, ADR-0060).
+ * 행 생성은 DB 트리거 단일 계기(ADR-0054) — 앱은 삭제 직후 사유 필드만 fill-NULL-only로 1회 채운다.
+ * 같은 일정이 복구 후 재삭제될 수 있으므로 최신 tombstone만 대상.
+ */
+export const recordDeleteReason = async (
+  userId: number,
+  scheduleId: number,
+  category: string,
+  text: string | null,
+): Promise<void> => {
+  await query(
+    `UPDATE schedule_changes
+     SET delete_reason_category = $3, delete_reason_text = $4
+     WHERE user_id = $1 AND schedule_id = $2 AND change_type = 'deleted'
+       AND delete_reason_category IS NULL
+       AND id = (SELECT MAX(id) FROM schedule_changes
+                 WHERE user_id = $1 AND schedule_id = $2 AND change_type = 'deleted')`,
+    [userId, scheduleId, category, text],
+  );
+};
+
 // ─── 카테고리 ──────────────────────────────────────────
 
 export const queryCategories = async (userId: number): Promise<CategoryRow[]> =>

--- a/web/src/lib/validation.ts
+++ b/web/src/lib/validation.ts
@@ -4,6 +4,7 @@ export const MAX_LENGTHS = {
   name: 100,
   description: 200,
   memo: 500,
+  reason: 300,
   category: 50,
   color: 7,
   paymentMethod: 50,


### PR DESCRIPTION
## 요약

- 캘린더 액션 메뉴에서 일정 삭제 시 확인 창이 두 번 연속 뜨던 문제 해소 — 컴포넌트/훅 양쪽에 중복 구현돼 있던 confirm을 모두 제거하고, **삭제 사유 선택 모달을 유일한 확인 지점**으로 도입
- 일정 삭제 시 "왜 지우는지"를 수집해 감사 로그 tombstone에 축적 — 고정 사유 5종 라디오 + 기타(자유 텍스트), 매번 타이핑 없이 클릭 한 번으로 기록
- 삭제 사유를 패턴 검증 시스템에 편입 — 변심 취소 시드 신호 신설, `schedule_fate` view 사유 컬럼, 사유 원문 텍스트는 통계 파이프라인에서 정적 차단

## 변경

### 웹

- `DeleteReasonModal` 신규 (라디오 5종 + 조건부 필수 텍스트) — 액션 메뉴·수정 폼 두 삭제 경로가 모두 이 모달로 수렴
- `use-schedules`/`use-backlog`: `requestDelete`(모달 열기) / `confirmDelete`(사유 포함 DELETE)로 재구성, 훅 내부 confirm 제거
- DELETE API: body로 사유 수신(고정 어휘 검증 + 길이 제한) → 삭제 후 tombstone enrichment(`recordDeleteReason`, fill-NULL-only)

### 봇/DB

- 마이그레이션 106: `schedule_changes` 사유 컬럼 2개 + CHECK 2개(어휘 고정·deleted 행 한정), 시드 신호 `audit_cancel_changed_mind`, `schedule_fate` 말미 사유 컬럼, 자기검증 DO 블록 2개
- life 에이전트 프롬프트: 자연어 삭제 요청 시 사유 수집·기록 지침
- `signal-sql-guard`: LLM 신호 SQL의 사유 원문 컬럼 참조를 블록 패턴으로 정적 차단 (신호화는 카테고리만)

### 문서

- ADR-0060 (기록 규약 fill-NULL-only enrichment, 대안 3종 비교, 존재-윈도우 좌단 아티팩트 명시)
- domains/schedule.md 삭제 사유 섹션 / domains/insight.md §46 / features.md / adr README 인덱스

## 검증

- 타입체크·전체 테스트 통과 — 봇 989개 / 웹 292개 (신규 사유 어휘 테스트 6개 포함)
- 웹 프로덕션 빌드 통과
- 마이그레이션 106: 운영 스키마 사본(스키마 전용 덤프)을 로컬 일회용 postgres 17에 올려 **2회 실행** — 자기검증 NOTICE 2종 통과, 멱등성 확인, 테스트 행 정리 확인

## 배포 주의

- 마이그레이션 번호는 106 — 105는 진행 중인 다른 브랜치가 선점 (096 결번 전례대로 러너는 파일명 순 미적용분만 실행하므로 번호 갭 무해)
- Slack 오버플로우 버튼 삭제 경로는 사유 미기록(NULL) — ADR-0060에 커버리지 한계로 명시

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)
