### PR TITLE
fix(web): 수면 기록 쓰기 500 — 파라미터 타입 추론 충돌 (#600)

### DIFF
--- a/docs/domains/sleep.md
+++ b/docs/domains/sleep.md
@@ -79,7 +79,7 @@ fast path 없음 — life 에이전트 LLM이 `modify_db`로 직접 INSERT/UPDAT
 
 - **폼**(`SleepRecordForm`): 날짜, 밤잠 구간(분할 수면 다중 세그먼트 add/remove), 중간기상, 낮잠, 특이사항 태그(고정 10종 칩), 메모.
 - **저장**(`save-day.ts` `saveSleepDay`): add = 구간별 `POST /api/sleep/records`(night/nap) + `POST /api/sleep/events`(중간기상), 태그·메모는 첫 구간에 탑재. edit = **제자리 재조정**(폼 행을 기존 레코드 id에 위치 매칭 → UPDATE, 넘치면 INSERT, 모자라는 기존 레코드만 **모든 upsert 성공 후 맨 마지막에** DELETE). 파괴적 삭제가 upsert 뒤에만 실행돼 편집 실패 시 데이터 손실이 없다 (초기 replace-day는 먼저 전부 삭제·재생성해 재생성 실패 시 데이터가 유실됨 — #598 수정).
-- **duration은 서버 SQL 계산** — `EXTRACT(EPOCH FROM (wake::time − bed::time + INTERVAL '24h'))/60 % 1440` (봇과 동일 규율, 자정 넘김 처리). 클라이언트 미전송.
+- **duration은 서버(TS) 계산** — `computeDurationMinutes`: `(wake − bed + 1440) mod 1440`, 자정 넘김 처리, 클라이언트 미전송. 초기엔 SQL 표현식이었으나 bedtime 파라미터가 `bedtime = $n`(text)·`$n::time`(time) 양쪽에 쓰여 pg "inconsistent types deduced" 500을 냈다 → TS 순수 함수로 이전해 파라미터 타입 충돌 제거 + 단위 테스트 가능화 (#600).
 - **API**: `POST /api/sleep/records` · `PATCH·DELETE /api/sleep/records/[id]` · `POST /api/sleep/events` · `DELETE /api/sleep/events/[id]`. 전부 requireAuth + user_id 스코프 + 검증(`validate-input.ts`: 날짜·시각 형식, sleep_type enum, 태그 화이트리스트, memo 길이).
 - 5단 쓰기 패턴(Form → hook mutation → API route → queries.ts → DB proxy) — 루틴/지출 도메인과 동일.
 

--- a/web/src/features/sleep/lib/__tests__/write-queries.test.ts
+++ b/web/src/features/sleep/lib/__tests__/write-queries.test.ts
@@ -8,6 +8,7 @@ vi.mock('@/lib/db', () => ({
 import { query, queryOne } from '@/lib/db';
 import type { QueryResult } from '@/lib/db';
 import {
+  computeDurationMinutes,
   createSleepRecord,
   updateSleepRecord,
   deleteSleepRecord,
@@ -17,9 +18,8 @@ import {
 
 // ─── 합성 픽스처 (실제 개인 데이터 아님) ───────────────────────────────
 // DB proxy는 fetch 기반이라 목킹 불가 → @/lib/db의 query/queryOne을 스텁하고
-// 생성된 SQL 조각(duration 공식·user_id 스코프)과 파라미터 배열 구성을 검증한다.
+// 생성된 SQL·파라미터 배열(user_id 스코프·서버 계산된 duration)을 검증한다.
 
-/** queryOne이 돌려줄 합성 행 (RETURNING 결과 대역, 내용은 assert에 안 씀) */
 const RECORD_ROW: Record<string, unknown> = {
   id: 1,
   date: '2026-07-11',
@@ -41,14 +41,12 @@ const EVENT_ROW: Record<string, unknown> = {
 const okDelete: QueryResult = { rows: [], rowCount: 1 };
 const noDelete: QueryResult = { rows: [], rowCount: 0 };
 
-/** queryOne 마지막 호출의 [sql, params] */
 function lastQueryOneCall(): [string, unknown[]] {
   const call = vi.mocked(queryOne).mock.calls.at(-1);
   if (!call) throw new Error('queryOne 미호출');
   return [call[0], (call[1] ?? []) as unknown[]];
 }
 
-/** query 마지막 호출의 [sql, params] */
 function lastQueryCall(): [string, unknown[]] {
   const call = vi.mocked(query).mock.calls.at(-1);
   if (!call) throw new Error('query 미호출');
@@ -59,8 +57,40 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-describe('createSleepRecord — INSERT SQL·파라미터·duration 공식', () => {
-  it('night(취침·기상 모두): user_id 선두 + duration 공식(자정 넘김·EXTRACT·% 1440)', async () => {
+// ─── duration 계산 (순수 함수) — #600 회귀 방어 ────────────────────────
+// 이 로직은 원래 SQL 표현식이었는데, bedtime 파라미터가 text(`bedtime = $n`)와
+// time(`$n::time`) 두 컨텍스트로 쓰여 "inconsistent types deduced for parameter"
+// 500을 냈다. TS 순수 함수로 옮겨 파라미터 타입 충돌을 제거하고, 여기서 직접 검증한다.
+describe('computeDurationMinutes — 서버 계산 (#600)', () => {
+  it('같은 날 구간: 23:30→07:30 = 480분', () => {
+    expect(computeDurationMinutes('23:30', '07:30')).toBe(480);
+  });
+
+  it('자정 넘김: 23:00→07:00 = 480분', () => {
+    expect(computeDurationMinutes('23:00', '07:00')).toBe(480);
+  });
+
+  it('새벽 취침(자정 이후): 02:50→10:30 = 460분 (실패 재현 케이스)', () => {
+    expect(computeDurationMinutes('02:50', '10:30')).toBe(460);
+  });
+
+  it('낮잠 짧은 구간: 13:00→13:30 = 30분', () => {
+    expect(computeDurationMinutes('13:00', '13:30')).toBe(30);
+  });
+
+  it('00:15→08:00 = 465분', () => {
+    expect(computeDurationMinutes('00:15', '08:00')).toBe(465);
+  });
+
+  it('한쪽이라도 null이면 null', () => {
+    expect(computeDurationMinutes(null, '07:00')).toBeNull();
+    expect(computeDurationMinutes('23:00', null)).toBeNull();
+    expect(computeDurationMinutes(null, null)).toBeNull();
+  });
+});
+
+describe('createSleepRecord — INSERT SQL·파라미터·서버 계산 duration', () => {
+  it('night(취침·기상 모두): user_id 선두 + duration은 계산된 정수 파라미터', async () => {
     vi.mocked(queryOne).mockResolvedValue(RECORD_ROW);
 
     const result = await createSleepRecord(7, {
@@ -77,29 +107,26 @@ describe('createSleepRecord — INSERT SQL·파라미터·duration 공식', () =
 
     const [sql, params] = lastQueryOneCall();
     expect(sql).toContain('INSERT INTO sleep_records');
-    // duration은 암산이 아니라 SQL에서 계산 — 공식 조각이 실제로 들어갔는지 고정
-    expect(sql).toContain('EXTRACT(EPOCH FROM');
-    expect(sql).toContain("INTERVAL '24h'");
-    expect(sql).toContain('% 1440');
-    // bedtime·wake_time 둘 다 있을 때만 계산하는 가드
-    expect(sql).toContain('$4 IS NOT NULL AND $5 IS NOT NULL');
-    // tags는 명시적 text[] 캐스팅
-    expect(sql).toContain('$6::text[]');
+    // duration은 파라미터($6)로 전달 — SQL time 캐스트 없음(파라미터 타입 충돌 방지 #600)
+    expect(sql).not.toContain('::time');
+    expect(sql).not.toContain('EXTRACT(EPOCH');
+    expect(sql).toContain('$7::text[]'); // tags는 명시적 text[] 캐스팅
 
-    // 파라미터 순서: user_id 선두(스코프), 이후 date·type·bed·wake·tags·memo
+    // user_id 선두 + date·type·bed·wake·**duration(계산값)**·tags·memo
     expect(params).toEqual([
       7,
       '2026-07-11',
       'night',
       '23:30',
       '07:30',
+      480,
       ['카페인'],
       '늦게 잠들었다',
     ]);
     expect(params[0]).toBe(7);
   });
 
-  it('nap: tags/memo 미지정 → tags 기본 [] + memo null 정규화', async () => {
+  it('nap: tags/memo 미지정 → tags 기본 [] + memo null, duration 계산', async () => {
     vi.mocked(queryOne).mockResolvedValue(RECORD_ROW);
 
     await createSleepRecord(7, {
@@ -111,10 +138,10 @@ describe('createSleepRecord — INSERT SQL·파라미터·duration 공식', () =
 
     const [sql, params] = lastQueryOneCall();
     expect(sql).toContain('INSERT INTO sleep_records');
-    expect(params).toEqual([7, '2026-07-11', 'nap', '13:00', '13:30', [], null]);
+    expect(params).toEqual([7, '2026-07-11', 'nap', '13:00', '13:30', 30, [], null]);
   });
 
-  it('bedtime·wake_time NULL(메모 전용 밤잠): null 파라미터가 그대로 전달, CASE가 duration NULL 처리', async () => {
+  it('bedtime·wake_time NULL(메모 전용 밤잠): duration은 null 파라미터', async () => {
     vi.mocked(queryOne).mockResolvedValue(RECORD_ROW);
 
     await createSleepRecord(7, {
@@ -125,17 +152,13 @@ describe('createSleepRecord — INSERT SQL·파라미터·duration 공식', () =
       memo: '시간 기억 안 남',
     });
 
-    const [sql, params] = lastQueryOneCall();
-    // duration은 CASE로 조건부 — 둘 다 NULL이면 SQL이 NULL 산출 (암산 아님)
-    expect(sql).toMatch(/CASE\s+WHEN .* IS NOT NULL AND .* IS NOT NULL/s);
-    expect(params[3]).toBeNull(); // bedtime
-    expect(params[4]).toBeNull(); // wake_time
-    expect(params).toEqual([7, '2026-07-11', 'night', null, null, [], '시간 기억 안 남']);
+    const [, params] = lastQueryOneCall();
+    expect(params).toEqual([7, '2026-07-11', 'night', null, null, null, [], '시간 기억 안 남']);
   });
 });
 
 describe('updateSleepRecord — UPDATE SQL·user_id 스코프·duration 재계산', () => {
-  it('전체 필드 교체 + duration 재계산($5/$6) + WHERE id·user_id', async () => {
+  it('전체 필드 교체 + duration 재계산(파라미터) + WHERE id·user_id', async () => {
     vi.mocked(queryOne).mockResolvedValue(RECORD_ROW);
 
     await updateSleepRecord(7, 42, {
@@ -150,14 +173,12 @@ describe('updateSleepRecord — UPDATE SQL·user_id 스코프·duration 재계�
     const [sql, params] = lastQueryOneCall();
     expect(sql).toContain('UPDATE sleep_records');
     expect(sql).toContain('WHERE id = $1 AND user_id = $2');
-    expect(sql).toContain("INTERVAL '24h'");
-    expect(sql).toContain('% 1440');
-    // update의 duration 재계산은 $5(bedtime)·$6(wake_time) 참조
-    expect(sql).toContain('$5 IS NOT NULL AND $6 IS NOT NULL');
-    expect(sql).toContain('$7::text[]');
+    expect(sql).not.toContain('::time');
+    expect(sql).toContain('duration_minutes = $7');
+    expect(sql).toContain('$8::text[]');
 
-    // id·user_id가 파라미터 선두(스코프), 이후 date·type·bed·wake·tags·memo
-    expect(params).toEqual([42, 7, '2026-07-12', 'night', '00:15', '08:00', [], null]);
+    // id·user_id 선두 + date·type·bed·wake·**duration(465)**·tags·memo
+    expect(params).toEqual([42, 7, '2026-07-12', 'night', '00:15', '08:00', 465, [], null]);
   });
 
   it('대상 없음(queryOne null) → null 반환', async () => {

--- a/web/src/features/sleep/lib/queries.ts
+++ b/web/src/features/sleep/lib/queries.ts
@@ -314,31 +314,37 @@ export function calculateDayOfWeekPattern(dailies: DailySleep[]): DayOfWeekPatte
 // ─── 수면 기록/이벤트 쓰기 (웹 대시보드 입력, #595) ───────────────────
 
 /**
- * duration_minutes 계산 SQL 조각 — 암산 금지, 봇과 동일하게 DB에서 계산.
- * bedtime·wake_time(TEXT 'HH:MM')이 둘 다 있을 때만 계산, 자정 넘김 보정.
- * (wake − bed + 24h)를 분으로 환산 후 1440 모듈러 → 0~1439분. 하나라도 NULL이면 NULL.
- * bed·wake 인자는 '$4' 같은 파라미터 참조(코드 상수, 사용자 입력 아님 → 인젝션 없음).
+ * duration_minutes 계산 — 서버(TS)에서 계산해 파라미터로 넘긴다.
+ * bedtime·wake_time('HH:MM')이 둘 다 있을 때만, 자정 넘김 보정: (wake − bed + 1440) mod 1440 → 0~1439분.
+ *
+ * SQL 표현식 대신 TS 계산인 이유(#600): bedtime을 `bedtime = $n`(text)과 `$n::time`(time) 양쪽에
+ * 쓰면 pg가 같은 파라미터를 두 타입으로 추론해 "inconsistent types deduced" 오류가 났다.
+ * TS 계산은 duration을 단순 정수 파라미터로 넘겨 타입 충돌을 원천 제거하고, 순수 함수라 단위 테스트도 된다.
  */
-function durationMinutesExpr(bed: string, wake: string): string {
-  return `CASE
-      WHEN ${bed} IS NOT NULL AND ${wake} IS NOT NULL
-        THEN (EXTRACT(EPOCH FROM (${wake}::time - ${bed}::time + INTERVAL '24h')) / 60)::int % 1440
-      ELSE NULL
-    END`;
+export function computeDurationMinutes(
+  bedtime: string | null,
+  wakeTime: string | null,
+): number | null {
+  if (!bedtime || !wakeTime) return null;
+  const toMinutes = (t: string): number => {
+    const [h, m] = t.split(':').map(Number);
+    return (h ?? 0) * 60 + (m ?? 0);
+  };
+  return (toMinutes(wakeTime) - toMinutes(bedtime) + 1440) % 1440;
 }
 
 /** sleep_records 쓰기 결과 컬럼 (SleepRecord 매핑) */
 const SLEEP_RECORD_RETURNING =
   'id, date::text, bedtime, wake_time, duration_minutes, sleep_type, memo, tags';
 
-/** 수면 기록 추가 (duration은 SQL에서 계산) */
+/** 수면 기록 추가 (duration은 서버에서 계산해 파라미터로 전달) */
 export async function createSleepRecord(
   userId: number,
   input: SleepRecordInput,
 ): Promise<SleepRecord> {
   const row = await queryOne<SleepRecord>(
     `INSERT INTO sleep_records (user_id, date, sleep_type, bedtime, wake_time, duration_minutes, tags, memo)
-     VALUES ($1, $2, $3, $4, $5, ${durationMinutesExpr('$4', '$5')}, $6::text[], $7)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::text[], $8)
      RETURNING ${SLEEP_RECORD_RETURNING}`,
     [
       userId,
@@ -346,6 +352,7 @@ export async function createSleepRecord(
       input.sleep_type,
       input.bedtime,
       input.wake_time,
+      computeDurationMinutes(input.bedtime, input.wake_time),
       input.tags ?? [],
       input.memo ?? null,
     ],
@@ -363,7 +370,7 @@ export async function updateSleepRecord(
   return queryOne<SleepRecord>(
     `UPDATE sleep_records
      SET date = $3, sleep_type = $4, bedtime = $5, wake_time = $6,
-         duration_minutes = ${durationMinutesExpr('$5', '$6')}, tags = $7::text[], memo = $8
+         duration_minutes = $7, tags = $8::text[], memo = $9
      WHERE id = $1 AND user_id = $2
      RETURNING ${SLEEP_RECORD_RETURNING}`,
     [
@@ -373,6 +380,7 @@ export async function updateSleepRecord(
       input.sleep_type,
       input.bedtime,
       input.wake_time,
+      computeDurationMinutes(input.bedtime, input.wake_time),
       input.tags ?? [],
       input.memo ?? null,
     ],


### PR DESCRIPTION
## 관련 이슈

Closes #600

## 근본 원인 (프로덕션 로그로 확정)

프록시 로그: `inconsistent types deduced for parameter $5`.

`createSleepRecord`/`updateSleepRecord`에서 bedtime 파라미터가 상충하는 두 타입 컨텍스트로 사용됨:
- `bedtime = $5` — TEXT 컬럼 값
- duration 계산식의 `$5::time` — TIME 캐스트

pg가 같은 파라미터를 text와 time 양쪽으로 추론하려다 충돌 → **bedtime/wake_time이 있는 모든 create/update가 500** (태그 유무 무관). 이게 #598에서 데이터 손실을 유발한 원래 create 실패의 정체이자, #598 수정 후 편집(단일 UPDATE)이 여전히 500 나던 원인.

단위 테스트가 DB를 목킹해 SQL '실행'을 검증하지 않아 누락됨.

## 수정

duration_minutes를 SQL 표현식 → **서버(TypeScript) 계산**(`computeDurationMinutes`)으로 이전:
- duration을 단순 정수 파라미터로 전달 → 파라미터 재사용/타입 충돌 원천 제거
- create/update SQL에서 `::time`·EXTRACT 제거
- 자정 넘김 처리 동일 `(wake − bed + 1440) mod 1440`
- 순수 함수라 단위 테스트로 커버 (SQL 버전이 못 잡던 지점)

## 코드 리뷰 결과

- [x] 근본 원인 프로덕션 로그로 확정 (추정 아님)
- [x] 타입 안전성 (웹 tsc 0)
- [x] 쓰기 경로에 `::time` 파라미터 캐스트 완전 제거 확인
- [x] 데이터 손실 방지(#598)는 이미 배포됨 — 이 수정은 실패 자체를 제거

## 테스트

- [x] computeDurationMinutes 단위 테스트 (자정 넘김·경계·null·실패 재현 02:50→10:30=460)
- [x] 웹 전체 341 테스트 통과
- [x] 웹 tsc 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)