### PR TITLE
fix(web): lint 스크립트 복구 및 CI 편입 (#608)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,11 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      # 웹은 Vercel이 빌드하지만 lint는 아무도 안 돌리던 상태였다.
+      # 여기서 검사해야 스크립트가 다시 죽어도 바로 드러난다.
+      - name: Install (web)
+        run: yarn --cwd web install --frozen-lockfile
+
+      - name: Lint (web)
+        run: yarn --cwd web lint

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,0 +1,41 @@
+import reactHooks from 'eslint-plugin-react-hooks';
+import rootConfig from '../eslint.config.mjs';
+
+// 웹 대시보드 전용 ESLint 설정.
+// 규칙의 단일 출처는 루트 설정이고, 여기서는 웹에만 해당하는 차이만 얹는다.
+// (typescript-eslint 등 루트 설정이 import하는 패키지는 루트 node_modules에서 해석된다)
+export default [
+  ...rootConfig,
+
+  {
+    ignores: ['.next/', 'next-env.d.ts'],
+  },
+
+  // React 훅 규칙. 훅 호출 순서 위반은 실제 버그라 error,
+  // 의존성 배열은 의도적으로 비우는 경우가 있어 warn.
+  {
+    files: ['**/*.{ts,tsx}'],
+    plugins: { 'react-hooks': reactHooks },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+
+  // non-null 단언은 봇에선 error지만 웹에선 warn으로 둔다.
+  // 웹 코드에 이미 널리 퍼져 있어 지금 일괄 제거하면 이 PR 범위를 벗어나고,
+  // 되레 런타임 동작을 바꿀 위험이 있다. 새로 쓰지 말라는 신호로 남긴다.
+  {
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+    },
+  },
+
+  // 테스트는 픽스처가 존재한다는 전제 위에서 단언하는 게 정상이라 아예 끈다.
+  {
+    files: ['**/__tests__/**', '**/*.test.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+];

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint src",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
@@ -28,6 +28,8 @@
     "@types/pg": "^8.18.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "eslint": "^10.0.2",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.1",
     "typescript": "^5.9.3",

--- a/web/src/app/schedules/calendar/page.tsx
+++ b/web/src/app/schedules/calendar/page.tsx
@@ -157,7 +157,6 @@ function CalendarContent() {
 
       <DndCalendar
         schedules={filteredSchedules}
-        categories={categories}
         onDateChange={handleDateChange}
         onEndDateChange={handleEndDateChange}
       >

--- a/web/src/components/ui/color-picker.tsx
+++ b/web/src/components/ui/color-picker.tsx
@@ -33,14 +33,17 @@ function hexToHsl(hex: string): [number, number, number] {
   if (max === min) return [0, 0, Math.round(l * 100)];
   const d = max - min;
   const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-  let h = 0;
+  let h: number;
   if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
   else if (max === g) h = ((b - r) / d + 2) / 6;
   else h = ((r - g) / d + 4) / 6;
   return [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)];
 }
 
-const PRESET_LIST = Object.entries(PRESET_COLORS).filter(([k]) => k !== 'gray') as [string, string][];
+const PRESET_LIST = Object.entries(PRESET_COLORS).filter(([k]) => k !== 'gray') as [
+  string,
+  string,
+][];
 
 export function ColorPicker({ value, onChange, previewLabel }: ColorPickerProps) {
   const [open, setOpen] = useState(false);
@@ -128,32 +131,37 @@ function TagPreview({ label, colorKey }: { label: string; colorKey: string }) {
   );
 }
 
-function HslGradient({ hex, previewLabel, onApply }: { hex: string; previewLabel?: string; onApply: (hex: string) => void }) {
+function HslGradient({
+  hex,
+  previewLabel,
+  onApply,
+}: {
+  hex: string;
+  previewLabel?: string;
+  onApply: (hex: string) => void;
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [hue, setHue] = useState(() => hexToHsl(hex)[0]);
   const [preview, setPreview] = useState(hex);
   const dragging = useRef(false);
 
-  const drawCanvas = useCallback(
-    (h: number) => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return;
-      const w = canvas.width;
-      const hCanvas = canvas.height;
+  const drawCanvas = useCallback((h: number) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const w = canvas.width;
+    const hCanvas = canvas.height;
 
-      for (let x = 0; x < w; x++) {
-        for (let y = 0; y < hCanvas; y++) {
-          const s = (x / w) * 100;
-          const l = 100 - (y / hCanvas) * 100;
-          ctx.fillStyle = `hsl(${h}, ${s}%, ${l}%)`;
-          ctx.fillRect(x, y, 1, 1);
-        }
+    for (let x = 0; x < w; x++) {
+      for (let y = 0; y < hCanvas; y++) {
+        const s = (x / w) * 100;
+        const l = 100 - (y / hCanvas) * 100;
+        ctx.fillStyle = `hsl(${h}, ${s}%, ${l}%)`;
+        ctx.fillRect(x, y, 1, 1);
       }
-    },
-    [],
-  );
+    }
+  }, []);
 
   useEffect(() => {
     drawCanvas(hue);

--- a/web/src/features/budget/components/budget-settings-page.tsx
+++ b/web/src/features/budget/components/budget-settings-page.tsx
@@ -585,7 +585,6 @@ function TargetDateCard({
     if (savedTarget && /^\d{4}-\d{2}$/.test(savedTarget)) {
       void fetchPreview(savedTarget);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [savedTarget]);
 
   const fetchPreview = async (target: string) => {

--- a/web/src/features/budget/components/planned-expense-list.tsx
+++ b/web/src/features/budget/components/planned-expense-list.tsx
@@ -34,8 +34,9 @@ export function PlannedExpenseList({ yearMonth, refreshTrigger }: PlannedExpense
   }, [yearMonth]);
 
   // yearMonth 변경 또는 지출 변경(refreshTrigger) 시 예정지출 목록 리프레시
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { void fetchItems(); }, [fetchItems, refreshTrigger]);
+  useEffect(() => {
+    void fetchItems();
+  }, [fetchItems, refreshTrigger]);
 
   const handleAdd = async () => {
     const amount = parseInt(amountInput.replace(/,/g, ''), 10);
@@ -189,14 +190,14 @@ export function PlannedExpenseList({ yearMonth, refreshTrigger }: PlannedExpense
                     <div className="mt-1 flex justify-between text-[10px] text-gray-400">
                       <span>사용 {formatAmount(used)}</span>
                       <span className={isOver ? 'text-red-500' : ''}>
-                        {isOver ? `${formatAmount(Math.abs(remaining))} 초과` : `${formatAmount(remaining)} 남음`}
+                        {isOver
+                          ? `${formatAmount(Math.abs(remaining))} 초과`
+                          : `${formatAmount(remaining)} 남음`}
                       </span>
                     </div>
                   </>
                 )}
-                {used === 0 && (
-                  <div className="text-[10px] text-gray-400">아직 사용 내역 없음</div>
-                )}
+                {used === 0 && <div className="text-[10px] text-gray-400">아직 사용 내역 없음</div>}
               </button>
             );
           })}

--- a/web/src/features/budget/lib/__tests__/ensure-fixed-cost-expenses.test.ts
+++ b/web/src/features/budget/lib/__tests__/ensure-fixed-cost-expenses.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 vi.mock('@/lib/db', () => ({
   query: vi.fn(),
@@ -13,8 +13,9 @@ import { query, queryOne } from '@/lib/db';
 import { getTodayISO } from '@/lib/kst';
 import { ensureFixedCostExpenses } from '../queries';
 
-// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
-type Any = any;
+// vi.mocked()는 실제 시그니처(QueryResult)를 요구해서 부분 목 객체를 넘길 수 없다.
+// 목 핸들을 여기서 한 번만 느슨하게 잡고, 각 케이스에서는 캐스팅 없이 쓴다.
+const mockQuery = query as unknown as Mock;
 
 const baseFC = {
   id: 1,
@@ -34,7 +35,7 @@ describe('ensureFixedCostExpenses', () => {
   });
 
   it('활성 고정비 없음 → 0 반환, INSERT 호출 안 됨', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
     expect(query).toHaveBeenCalledTimes(1); // SELECT만
@@ -42,18 +43,18 @@ describe('ensureFixedCostExpenses', () => {
   });
 
   it('day_of_month 없는 고정비는 skip', async () => {
-    vi.mocked(query).mockResolvedValueOnce({
+    mockQuery.mockResolvedValueOnce({
       rows: [{ ...baseFC, name: 'no-day', day_of_month: null }],
-    } as Any);
+    });
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
     expect(query).toHaveBeenCalledTimes(1);
   });
 
   it('active=false 고정비는 skip', async () => {
-    vi.mocked(query).mockResolvedValueOnce({
+    mockQuery.mockResolvedValueOnce({
       rows: [{ ...baseFC, name: 'inactive', day_of_month: 10, active: false }],
-    } as Any);
+    });
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
     expect(query).toHaveBeenCalledTimes(1);
@@ -61,38 +62,38 @@ describe('ensureFixedCostExpenses', () => {
 
   it('결제일이 오늘 이후 → skip (아직 안 지났음)', async () => {
     vi.mocked(getTodayISO).mockReturnValue('2026-04-10');
-    vi.mocked(query).mockResolvedValueOnce({
+    mockQuery.mockResolvedValueOnce({
       rows: [{ ...baseFC, name: 'future', day_of_month: 12 }],
-    } as Any);
+    });
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
     expect(query).toHaveBeenCalledTimes(1);
   });
 
   it('이미 같은 날짜에 기록된 고정비는 skip (idempotent)', async () => {
-    vi.mocked(query)
+    mockQuery
       .mockResolvedValueOnce({
         rows: [{ ...baseFC, name: 'netflix', day_of_month: 10 }],
-      } as Any)
-      .mockResolvedValueOnce({ rowCount: 0 } as Any); // NOT EXISTS가 전부 필터
+      })
+      .mockResolvedValueOnce({ rowCount: 0 }); // NOT EXISTS가 전부 필터
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(0);
     expect(query).toHaveBeenCalledTimes(2);
-    const insertCall = vi.mocked(query).mock.calls[1];
+    const insertCall = mockQuery.mock.calls[1];
     expect(insertCall[0]).toMatch(/NOT EXISTS/);
   });
 
   it('결제일 16일 이상 → 전월로 기록 (결제주기 반영)', async () => {
     vi.mocked(getTodayISO).mockReturnValue('2026-04-10');
-    vi.mocked(query)
+    mockQuery
       .mockResolvedValueOnce({
         rows: [{ ...baseFC, name: 'rent', day_of_month: 20 }],
-      } as Any)
-      .mockResolvedValueOnce({ rowCount: 1 } as Any);
+      })
+      .mockResolvedValueOnce({ rowCount: 1 });
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(1);
     // INSERT 파라미터의 date 배열이 '2026-03-20' 을 포함 (전월로 이동)
-    const params = vi.mocked(query).mock.calls[1][1] as Any[];
+    const params = mockQuery.mock.calls[1][1];
     expect(params[0]).toBe(1); // userId
     expect(params[1]).toEqual(['2026-03-20']); // date 배열
     expect(params[4]).toEqual(['rent']); // description 배열
@@ -100,14 +101,14 @@ describe('ensureFixedCostExpenses', () => {
 
   it('INSERT 시 exclude_from_budget=true + source=fixed 로 저장', async () => {
     vi.mocked(getTodayISO).mockReturnValue('2026-04-15');
-    vi.mocked(query)
+    mockQuery
       .mockResolvedValueOnce({
         rows: [{ ...baseFC, name: '건보', day_of_month: 5 }],
-      } as Any)
-      .mockResolvedValueOnce({ rowCount: 1 } as Any);
+      })
+      .mockResolvedValueOnce({ rowCount: 1 });
 
     await ensureFixedCostExpenses(1, '2026-04');
-    const insertCall = vi.mocked(query).mock.calls[1];
+    const insertCall = mockQuery.mock.calls[1];
     expect(insertCall[0]).toMatch(/INSERT INTO expenses/);
     expect(insertCall[0]).toMatch(/'fixed'/);
     expect(insertCall[0]).toMatch(/true/); // exclude_from_budget 리터럴
@@ -115,7 +116,7 @@ describe('ensureFixedCostExpenses', () => {
 
   it('여러 고정비 혼합 — created count 정확', async () => {
     vi.mocked(getTodayISO).mockReturnValue('2026-04-15');
-    vi.mocked(query)
+    mockQuery
       .mockResolvedValueOnce({
         rows: [
           { ...baseFC, id: 1, name: 'a', day_of_month: 5 }, // 2026-04-05 ← 기록 대상
@@ -123,13 +124,13 @@ describe('ensureFixedCostExpenses', () => {
           { ...baseFC, id: 3, name: 'c', day_of_month: 25, active: false }, // skip
           { ...baseFC, id: 4, name: 'd', day_of_month: 18 }, // 2026-03-18 ← 이미 존재
         ],
-      } as Any)
-      .mockResolvedValueOnce({ rowCount: 1 } as Any); // NOT EXISTS로 d는 필터, a만 INSERT
+      })
+      .mockResolvedValueOnce({ rowCount: 1 }); // NOT EXISTS로 d는 필터, a만 INSERT
 
     const count = await ensureFixedCostExpenses(1, '2026-04');
     expect(count).toBe(1);
     // INSERT 대상 후보는 a, d (필터 통과) — 배열 길이 2
-    const params = vi.mocked(query).mock.calls[1][1] as Any[];
+    const params = mockQuery.mock.calls[1][1];
     expect(params[1]).toHaveLength(2);
   });
 });

--- a/web/src/features/budget/lib/__tests__/query-month-summary.test.ts
+++ b/web/src/features/budget/lib/__tests__/query-month-summary.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 vi.mock('@/lib/db', () => ({
   query: vi.fn(),
@@ -13,24 +13,26 @@ import { query, queryOne } from '@/lib/db';
 import { readFlexibleSpent } from '../repository/expenses-repo';
 import { queryMonthSummary } from '../queries';
 
-// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
-type Any = any;
+// vi.mocked()는 실제 시그니처(QueryResult)를 요구해서 부분 목 객체를 넘길 수 없다.
+// 목 핸들을 여기서 한 번만 느슨하게 잡고, 각 케이스에서는 캐스팅 없이 쓴다.
+const mockQuery = query as unknown as Mock;
+const mockQueryOne = queryOne as unknown as Mock;
 
 // queryMonthSummary가 발행하는 query() 호출 순서 (queryOne은 별도 mock):
 //   [0] total, [1] byCategory, [2] queryFixedCosts,
 //   [3] installmentTotal, [4] incomeTotal, [5] queryPlannedExpenses
 // queryOne 호출: [0] variableTotal
 function primeQueries(opts?: { installmentTotal?: string; variableTotal?: string }) {
-  vi.mocked(query)
-    .mockResolvedValueOnce({ rows: [{ total: '100000' }] } as Any) // total
-    .mockResolvedValueOnce({ rows: [] } as Any) // byCategory
-    .mockResolvedValueOnce({ rows: [] } as Any) // queryFixedCosts
-    .mockResolvedValueOnce({ rows: [{ total: opts?.installmentTotal ?? '0' }] } as Any) // installment
-    .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any) // income
-    .mockResolvedValueOnce({ rows: [] } as Any); // planned
-  vi.mocked(queryOne).mockResolvedValueOnce({
+  mockQuery
+    .mockResolvedValueOnce({ rows: [{ total: '100000' }] }) // total
+    .mockResolvedValueOnce({ rows: [] }) // byCategory
+    .mockResolvedValueOnce({ rows: [] }) // queryFixedCosts
+    .mockResolvedValueOnce({ rows: [{ total: opts?.installmentTotal ?? '0' }] }) // installment
+    .mockResolvedValueOnce({ rows: [{ total: '0' }] }) // income
+    .mockResolvedValueOnce({ rows: [] }); // planned
+  mockQueryOne.mockResolvedValueOnce({
     total: opts?.variableTotal ?? '0',
-  } as Any);
+  });
   vi.mocked(readFlexibleSpent).mockResolvedValueOnce(0);
 }
 
@@ -45,7 +47,7 @@ describe('queryMonthSummary — 할부 exclude 플래그 정합성 (#549)', () =
     await queryMonthSummary(1, '2026-04');
 
     // query 호출 [3]이 할부 합계 (is_installment=true, exclude 필터 없음)
-    const installmentSql = vi.mocked(query).mock.calls[3]![0] as string;
+    const installmentSql = mockQuery.mock.calls[3]![0] as string;
     expect(installmentSql).toMatch(/is_installment\s*=\s*true/i);
     expect(installmentSql).not.toMatch(/exclude_from_budget/i);
   });
@@ -55,7 +57,7 @@ describe('queryMonthSummary — 할부 exclude 플래그 정합성 (#549)', () =
 
     await queryMonthSummary(1, '2026-04');
 
-    const variableSql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+    const variableSql = mockQueryOne.mock.calls[0]![0] as string;
     expect(variableSql).toMatch(/is_installment\s*=\s*false/i);
     expect(variableSql).toMatch(/exclude_from_budget\s*=\s*false/i);
   });

--- a/web/src/features/budget/lib/__tests__/update-expense.test.ts
+++ b/web/src/features/budget/lib/__tests__/update-expense.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 vi.mock('@/lib/db', () => ({
   query: vi.fn(),
@@ -8,8 +8,9 @@ vi.mock('@/lib/db', () => ({
 import { query, queryOne } from '@/lib/db';
 import { updateExpense, FIXED_SOURCE_EXCLUDE_LOCKED } from '../queries';
 
-// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
-type Any = any;
+// vi.mocked()는 실제 시그니처(QueryResult)를 요구해서 부분 목 객체를 넘길 수 없다.
+// 목 핸들을 여기서 한 번만 느슨하게 잡고, 각 케이스에서는 캐스팅 없이 쓴다.
+const mockQueryOne = queryOne as unknown as Mock;
 
 describe('updateExpense — source=fixed 행 exclude_from_budget 가드', () => {
   beforeEach(() => {
@@ -17,7 +18,7 @@ describe('updateExpense — source=fixed 행 exclude_from_budget 가드', () => 
   });
 
   it("source='fixed' 행 + exclude_from_budget 변경 → 에러 throw, UPDATE 미실행", async () => {
-    vi.mocked(queryOne).mockResolvedValueOnce({ source: 'fixed' } as Any);
+    mockQueryOne.mockResolvedValueOnce({ source: 'fixed' });
 
     await expect(updateExpense(1, 686, { exclude_from_budget: true })).rejects.toThrow(
       FIXED_SOURCE_EXCLUDE_LOCKED,
@@ -29,15 +30,15 @@ describe('updateExpense — source=fixed 행 exclude_from_budget 가드', () => 
   });
 
   it("source='manual' 행 + exclude_from_budget 변경 → 가드 통과 후 단일 UPDATE", async () => {
-    vi.mocked(queryOne)
-      .mockResolvedValueOnce({ source: 'manual' } as Any) // 가드 SELECT
-      .mockResolvedValueOnce({ id: 100, exclude_from_budget: true } as Any); // UPDATE RETURNING
+    mockQueryOne
+      .mockResolvedValueOnce({ source: 'manual' }) // 가드 SELECT
+      .mockResolvedValueOnce({ id: 100, exclude_from_budget: true }); // UPDATE RETURNING
 
     const result = await updateExpense(1, 100, { exclude_from_budget: true });
 
     expect(result).toEqual({ id: 100, exclude_from_budget: true });
     expect(queryOne).toHaveBeenCalledTimes(2);
-    const updateSql = vi.mocked(queryOne).mock.calls[1]![0] as string;
+    const updateSql = mockQueryOne.mock.calls[1]![0] as string;
     expect(updateSql).toMatch(/UPDATE\s+expenses\s+SET/i);
   });
 });
@@ -48,19 +49,19 @@ describe('updateExpense — 단순 화이트리스트 UPDATE (#539, 자산 보�
   });
 
   it('amount만 변경 → 가드 SELECT 없이 단일 UPDATE', async () => {
-    vi.mocked(queryOne).mockResolvedValueOnce({ id: 686, amount: 167776 } as Any);
+    mockQueryOne.mockResolvedValueOnce({ id: 686, amount: 167776 });
 
     const result = await updateExpense(1, 686, { amount: 167776 });
 
     expect(result).toEqual({ id: 686, amount: 167776 });
     // exclude 미변경 → 가드 SELECT 없음. UPDATE 한 번만.
     expect(queryOne).toHaveBeenCalledTimes(1);
-    const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+    const sql = mockQueryOne.mock.calls[0]![0] as string;
     expect(sql).toMatch(/UPDATE\s+expenses\s+SET\s+amount/i);
   });
 
   it('할부 회차 amount 변경 → 그룹 동기화·자산 보정 query() 없이 단일 행 UPDATE만', async () => {
-    vi.mocked(queryOne).mockResolvedValueOnce({ id: 100, amount: 50000 } as Any);
+    mockQueryOne.mockResolvedValueOnce({ id: 100, amount: 50000 });
 
     await updateExpense(1, 100, { amount: 50000 });
 
@@ -70,25 +71,25 @@ describe('updateExpense — 단순 화이트리스트 UPDATE (#539, 자산 보�
   });
 
   it('허용되지 않는 컬럼만 → SELECT(현재 행 반환), UPDATE 미실행', async () => {
-    vi.mocked(queryOne).mockResolvedValueOnce({ id: 1, amount: 100 } as Any);
+    mockQueryOne.mockResolvedValueOnce({ id: 1, amount: 100 });
 
     const result = await updateExpense(1, 1, { unknown_col: 'x' });
 
     expect(result).toEqual({ id: 1, amount: 100 });
     expect(queryOne).toHaveBeenCalledTimes(1);
-    const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+    const sql = mockQueryOne.mock.calls[0]![0] as string;
     expect(sql).toMatch(/SELECT/i);
     expect(sql).not.toMatch(/UPDATE/i);
   });
 
   it('distribute_to_runway는 화이트리스트에서 제외 → 단독 전달 시 UPDATE 미실행', async () => {
-    vi.mocked(queryOne).mockResolvedValueOnce({ id: 5 } as Any);
+    mockQueryOne.mockResolvedValueOnce({ id: 5 });
 
     await updateExpense(1, 5, { distribute_to_runway: false });
 
     // 유효 키 0개 → queryExpense(SELECT)만
     expect(queryOne).toHaveBeenCalledTimes(1);
-    const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+    const sql = mockQueryOne.mock.calls[0]![0] as string;
     expect(sql).toMatch(/SELECT/i);
     expect(sql).not.toMatch(/UPDATE/i);
   });

--- a/web/src/features/budget/lib/repository/__tests__/assets-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/assets-repo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 vi.mock('@/lib/db', () => ({
   query: vi.fn(),
@@ -7,11 +7,12 @@ vi.mock('@/lib/db', () => ({
 import { query } from '@/lib/db';
 import { applyAssetDeduction, applyAssetIncrease, getDefaultAssetId } from '../assets-repo';
 
-// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
-type Any = any;
+// vi.mocked()는 실제 시그니처(QueryResult)를 요구해서 부분 목 객체를 넘길 수 없다.
+// 목 핸들을 여기서 한 번만 느슨하게 잡고, 각 케이스에서는 캐스팅 없이 쓴다.
+const mockQuery = query as unknown as Mock;
 
 function mockCandidates(rows: Array<{ id: number; available_amount: number }>) {
-  vi.mocked(query).mockResolvedValueOnce({ rows } as Any);
+  mockQuery.mockResolvedValueOnce({ rows });
 }
 
 describe('applyAssetDeduction — cascading 차감', () => {
@@ -30,7 +31,7 @@ describe('applyAssetDeduction — cascading 차감', () => {
       { id: 10, available_amount: 100_000 },
       { id: 20, available_amount: 50_000 },
     ]);
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE
 
     const result = await applyAssetDeduction(1, 30_000);
 
@@ -43,8 +44,8 @@ describe('applyAssetDeduction — cascading 차감', () => {
       { id: 10, available_amount: 50_000 }, // default
       { id: 20, available_amount: 100_000 }, // fallback 후보
     ]);
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE 1
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE 2
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE 1
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE 2
 
     const result = await applyAssetDeduction(1, 70_000);
 
@@ -59,8 +60,8 @@ describe('applyAssetDeduction — cascading 차감', () => {
       { id: 10, available_amount: 10_000 },
       { id: 20, available_amount: 5_000 }, // last = 마이너스 통장
     ]);
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const result = await applyAssetDeduction(1, 50_000);
 
@@ -77,8 +78,8 @@ describe('applyAssetDeduction — cascading 차감', () => {
       { id: 20, available_amount: -5_000 }, // 음수 - skip 대상이지만 last면 음수 허용
       { id: 30, available_amount: 50_000 }, // last
     ]);
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const result = await applyAssetDeduction(1, 130_000);
 
@@ -110,8 +111,8 @@ describe('applyAssetIncrease — default 자산 증액', () => {
   });
 
   it('default 자산 있으면 거기에 증액', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ id: 42 }] } as Any); // getDefaultAssetId
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 42 }] }); // getDefaultAssetId
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE
 
     const result = await applyAssetIncrease(1, 100_000);
 
@@ -119,9 +120,9 @@ describe('applyAssetIncrease — default 자산 증액', () => {
   });
 
   it('default 없으면 is_emergency=false 첫 자산으로 fallback', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // getDefaultAssetId → null
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ id: 7 }] } as Any); // fallback
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // UPDATE
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // getDefaultAssetId → null
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 7 }] }); // fallback
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE
 
     const result = await applyAssetIncrease(1, 50_000);
 
@@ -129,8 +130,8 @@ describe('applyAssetIncrease — default 자산 증액', () => {
   });
 
   it('default도 fallback도 없으면 빈 배열 (DB 변동 없음)', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // getDefaultAssetId → null
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any); // fallback → null
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // getDefaultAssetId → null
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // fallback → null
 
     const result = await applyAssetIncrease(1, 50_000);
 
@@ -145,13 +146,13 @@ describe('getDefaultAssetId', () => {
   });
 
   it('is_default=true 자산 있으면 ID 반환', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ id: 99 }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 99 }] });
     const id = await getDefaultAssetId(1);
     expect(id).toBe(99);
   });
 
   it('없으면 null', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const id = await getDefaultAssetId(1);
     expect(id).toBeNull();
   });

--- a/web/src/features/budget/lib/repository/__tests__/category-limits-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/category-limits-repo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 vi.mock('@/lib/db', () => ({
   query: vi.fn(),
@@ -14,8 +14,10 @@ import {
   deleteCategoryLimit,
 } from '../category-limits-repo';
 
-// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
-type Any = any;
+// vi.mocked()는 실제 시그니처(QueryResult)를 요구해서 부분 목 객체를 넘길 수 없다.
+// 목 핸들을 여기서 한 번만 느슨하게 잡고, 각 케이스에서는 캐스팅 없이 쓴다.
+const mockQuery = query as unknown as Mock;
+const mockQueryOne = queryOne as unknown as Mock;
 
 describe('category-limits-repo', () => {
   beforeEach(() => {
@@ -24,13 +26,13 @@ describe('category-limits-repo', () => {
 
   describe('readCategoryLimitsWithUsage', () => {
     it('used_count는 expenses COUNT 결과를 그대로 반환', async () => {
-      vi.mocked(query).mockResolvedValueOnce({
+      mockQuery.mockResolvedValueOnce({
         rows: [
           { id: 1, category: '카페', target_count: 5, used_count: 2 },
           { id: 2, category: '배달음식', target_count: 4, used_count: 5 },
         ],
         rowCount: 2,
-      } as Any);
+      });
 
       const result = await readCategoryLimitsWithUsage(1, '2026-05');
 
@@ -38,7 +40,7 @@ describe('category-limits-repo', () => {
         { id: 1, category: '카페', target_count: 5, used_count: 2 },
         { id: 2, category: '배달음식', target_count: 4, used_count: 5 },
       ]);
-      const sql = vi.mocked(query).mock.calls[0]![0] as string;
+      const sql = mockQuery.mock.calls[0]![0] as string;
       expect(sql).toMatch(/SELECT/i);
       expect(sql).toMatch(/COUNT/i);
       expect(sql).toMatch(/billing_month/);
@@ -46,11 +48,11 @@ describe('category-limits-repo', () => {
       // 예산 미포함(exclude_from_budget=true) 건은 카운트 제외
       expect(sql).toMatch(/COALESCE\(e\.exclude_from_budget, false\) = false/);
       // userId, billingMonth 파라미터 전달 확인
-      expect(vi.mocked(query).mock.calls[0]![1]).toEqual([1, '2026-05']);
+      expect(mockQuery.mock.calls[0]![1]).toEqual([1, '2026-05']);
     });
 
     it('비어있는 경우 빈 배열 반환', async () => {
-      vi.mocked(query).mockResolvedValueOnce({ rows: [], rowCount: 0 } as Any);
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
       const result = await readCategoryLimitsWithUsage(1, '2026-05');
       expect(result).toEqual([]);
     });
@@ -58,7 +60,7 @@ describe('category-limits-repo', () => {
 
   describe('readCategoryLimits', () => {
     it('user의 모든 한도 반환', async () => {
-      vi.mocked(query).mockResolvedValueOnce({
+      mockQuery.mockResolvedValueOnce({
         rows: [
           {
             id: 1,
@@ -70,7 +72,7 @@ describe('category-limits-repo', () => {
           },
         ],
         rowCount: 1,
-      } as Any);
+      });
 
       const result = await readCategoryLimits(1);
       expect(result).toHaveLength(1);
@@ -80,27 +82,27 @@ describe('category-limits-repo', () => {
 
   describe('createCategoryLimit', () => {
     it('INSERT 후 row 반환', async () => {
-      vi.mocked(queryOne).mockResolvedValueOnce({
+      mockQueryOne.mockResolvedValueOnce({
         id: 1,
         user_id: 1,
         category: '카페',
         target_count: 5,
         created_at: '2026-05-14',
         updated_at: '2026-05-14',
-      } as Any);
+      });
 
       const result = await createCategoryLimit(1, { category: '카페', target_count: 5 });
 
       expect(result.id).toBe(1);
       expect(result.category).toBe('카페');
       expect(result.target_count).toBe(5);
-      const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+      const sql = mockQueryOne.mock.calls[0]![0] as string;
       expect(sql).toMatch(/INSERT INTO category_limits/i);
-      expect(vi.mocked(queryOne).mock.calls[0]![1]).toEqual([1, '카페', 5]);
+      expect(mockQueryOne.mock.calls[0]![1]).toEqual([1, '카페', 5]);
     });
 
     it('INSERT가 row를 반환하지 않으면 throw', async () => {
-      vi.mocked(queryOne).mockResolvedValueOnce(null);
+      mockQueryOne.mockResolvedValueOnce(null);
 
       await expect(createCategoryLimit(1, { category: '카페', target_count: 5 })).rejects.toThrow(
         /INSERT returned no rows/,
@@ -116,24 +118,24 @@ describe('category-limits-repo', () => {
     });
 
     it('target_count 있으면 UPDATE 호출 + row 반환', async () => {
-      vi.mocked(queryOne).mockResolvedValueOnce({
+      mockQueryOne.mockResolvedValueOnce({
         id: 1,
         user_id: 1,
         category: '카페',
         target_count: 10,
-      } as Any);
+      });
 
       const result = await updateCategoryLimit(1, 1, { target_count: 10 });
 
       expect(result?.target_count).toBe(10);
-      const sql = vi.mocked(queryOne).mock.calls[0]![0] as string;
+      const sql = mockQueryOne.mock.calls[0]![0] as string;
       expect(sql).toMatch(/UPDATE category_limits/i);
       expect(sql).toMatch(/WHERE id = \$2 AND user_id = \$1/i);
-      expect(vi.mocked(queryOne).mock.calls[0]![1]).toEqual([1, 1, 10]);
+      expect(mockQueryOne.mock.calls[0]![1]).toEqual([1, 1, 10]);
     });
 
     it('user_id 불일치 시 null 반환 (RETURNING 없음)', async () => {
-      vi.mocked(queryOne).mockResolvedValueOnce(null);
+      mockQueryOne.mockResolvedValueOnce(null);
       const result = await updateCategoryLimit(99, 1, { target_count: 10 });
       expect(result).toBeNull();
     });
@@ -141,19 +143,19 @@ describe('category-limits-repo', () => {
 
   describe('deleteCategoryLimit', () => {
     it('rowCount > 0이면 true', async () => {
-      vi.mocked(query).mockResolvedValueOnce({ rows: [], rowCount: 1 } as Any);
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
       const result = await deleteCategoryLimit(1, 1);
       expect(result).toBe(true);
     });
 
     it('rowCount 0이면 false (user_id 불일치 등)', async () => {
-      vi.mocked(query).mockResolvedValueOnce({ rows: [], rowCount: 0 } as Any);
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
       const result = await deleteCategoryLimit(1, 999);
       expect(result).toBe(false);
     });
 
     it('rowCount null이면 false', async () => {
-      vi.mocked(query).mockResolvedValueOnce({ rows: [], rowCount: null } as Any);
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: null });
       const result = await deleteCategoryLimit(1, 1);
       expect(result).toBe(false);
     });

--- a/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/expenses-repo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 vi.mock('@/lib/db', () => ({
   query: vi.fn(),
@@ -14,8 +14,9 @@ import {
   readTotalCycleSpent,
 } from '../expenses-repo';
 
-// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
-type Any = any;
+// vi.mocked()는 실제 시그니처(QueryResult)를 요구해서 부분 목 객체를 넘길 수 없다.
+// 목 핸들을 여기서 한 번만 느슨하게 잡고, 각 케이스에서는 캐스팅 없이 쓴다.
+const mockQuery = query as unknown as Mock;
 
 describe('readFlexibleSpent', () => {
   beforeEach(() => {
@@ -23,33 +24,33 @@ describe('readFlexibleSpent', () => {
   });
 
   it('planned_expense_id IS NULL 조건이 SQL에 포함되어야 함', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '50000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '50000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
     expect(query).toHaveBeenCalledTimes(2);
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
   });
 
   it('예정지출 연결 건이 자유지출 합계에 포함되지 않아야 함 (direct만 합산)', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '30000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '30000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     const result = await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
     expect(result).toBe(30000);
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
   });
 
   it('plannedOverflow 가산: direct 30000 + overflow 5000 = 35000', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '30000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '5000' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '30000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '5000' }] });
 
     const result = await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
@@ -57,39 +58,39 @@ describe('readFlexibleSpent', () => {
   });
 
   it('기본 필터 조건: expense 타입, exclude_from_budget=false', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/exclude_from_budget\s*=\s*false/i);
     expect(sql).toMatch(/type.*expense/i);
   });
 
   it('할부는 전부 제외 — is_installment=false만, installment_num 조건 없음 (#539)', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/is_installment\s*=\s*false/i);
     // 1회차 특례 제거 — installment_num 조건이 더 이상 없어야 함
     expect(sql).not.toMatch(/installment_num/i);
   });
 
   it('billing_month / date 범위 필터가 SQL에 포함되어야 함', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readFlexibleSpent(1, '2026-03-16', '2026-04-15');
 
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
-    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    const params = mockQuery.mock.calls[0]![1] as unknown[];
     expect(sql).toMatch(/billing_month\s*=\s*\$2/i);
     expect(sql).toMatch(/date\s*<=\s*\$3/i);
     expect(params).toEqual([1, '2026-03-16', '2026-04-15']);
@@ -102,64 +103,64 @@ describe('readTodayFlexSpent', () => {
   });
 
   it('planned_expense_id IS NULL 조건이 SQL에 포함되어야 함', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '15000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '15000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
     expect(query).toHaveBeenCalledTimes(3);
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
   });
 
   it('예정지출 연결 건이 오늘 자유지출에 포함되지 않아야 함 (direct만)', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '10000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '10000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
     expect(result).toBe(10000);
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/planned_expense_id\s+IS\s+NULL/i);
   });
 
   it('직접 쿼리는 비할부만 — params [userId, today] (billing_month는 overflow에만 전달)', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
-    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    const params = mockQuery.mock.calls[0]![1] as unknown[];
     expect(sql).toMatch(/is_installment\s*=\s*false/i);
     expect(sql).not.toMatch(/installment_num/i);
     expect(params).toEqual([1, '2026-04-10']);
   });
 
   it('할부는 전부 제외 (1회차 특례 없음)', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/is_installment\s*=\s*false/i);
     expect(sql).not.toMatch(/installment_num/i);
   });
 
   it('일 단위 overflow: today 10000 - yesterday 0 → 10000 가산', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '5000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '10000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '5000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '10000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
@@ -167,10 +168,10 @@ describe('readTodayFlexSpent', () => {
   });
 
   it('이미 초과 상태에서 추가 지출: today 15000 - yesterday 10000 → 5000 가산', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '15000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '10000' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '15000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '10000' }] });
 
     const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
@@ -178,10 +179,10 @@ describe('readTodayFlexSpent', () => {
   });
 
   it('아직 미달이면 0 가산: today 0 - yesterday 0', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '8000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '8000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
@@ -189,10 +190,10 @@ describe('readTodayFlexSpent', () => {
   });
 
   it('환불·조정으로 today < yesterday: 음수 방어 → 0 가산', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '3000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '5000' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '8000' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '3000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '5000' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '8000' }] });
 
     const result = await readTodayFlexSpent(1, '2026-04-10', '2026-04');
 
@@ -200,15 +201,15 @@ describe('readTodayFlexSpent', () => {
   });
 
   it('어제 날짜를 정확히 -1일로 계산해 readPlannedOverflow에 전달', async () => {
-    vi.mocked(query)
-      .mockResolvedValueOnce({ rows: [{ total: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any)
-      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readTodayFlexSpent(1, '2026-04-01', '2026-04');
 
-    const todayParams = vi.mocked(query).mock.calls[1]![1] as unknown[];
-    const yesterdayParams = vi.mocked(query).mock.calls[2]![1] as unknown[];
+    const todayParams = mockQuery.mock.calls[1]![1] as unknown[];
+    const yesterdayParams = mockQuery.mock.calls[2]![1] as unknown[];
     expect(todayParams).toEqual([1, '2026-04', '2026-04-01']);
     expect(yesterdayParams).toEqual([1, '2026-04', '2026-03-31']);
   });
@@ -220,7 +221,7 @@ describe('readPlannedOverflow', () => {
   });
 
   it('예정지출 합계가 예산 미달이면 0', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     const result = await readPlannedOverflow(1, '2026-04', '2026-04-15');
 
@@ -228,7 +229,7 @@ describe('readPlannedOverflow', () => {
   });
 
   it('예정지출 초과분만 합산', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '15000' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ overflow: '15000' }] });
 
     const result = await readPlannedOverflow(1, '2026-04', '2026-04-15');
 
@@ -236,29 +237,29 @@ describe('readPlannedOverflow', () => {
   });
 
   it('GREATEST(used - budget, 0) 산식이 SQL에 포함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readPlannedOverflow(1, '2026-04', '2026-04-15');
 
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/GREATEST\s*\(\s*used\s*-\s*budget\s*,\s*0\s*\)/i);
   });
 
   it('billing_month / date 필터 파라미터 전달', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readPlannedOverflow(1, '2026-04', '2026-04-15');
 
-    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    const params = mockQuery.mock.calls[0]![1] as unknown[];
     expect(params).toEqual([1, '2026-04', '2026-04-15']);
   });
 
   it('user_id 필터가 LEFT JOIN 안에도 명시되어야 함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ overflow: '0' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ overflow: '0' }] });
 
     await readPlannedOverflow(1, '2026-04', '2026-04-15');
 
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/e\.user_id\s*=\s*p\.user_id/i);
   });
 });
@@ -269,13 +270,13 @@ describe('readTotalCycleSpent (#539)', () => {
   });
 
   it('billing_month의 모든 type=expense 합 — 할부·고정비·예정 포함 (exclude 필터 없음)', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '1234567' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '1234567' }] });
 
     const result = await readTotalCycleSpent(1, '2026-04');
 
     expect(result).toBe(1234567);
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
-    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    const params = mockQuery.mock.calls[0]![1] as unknown[];
     expect(sql).toMatch(/billing_month\s*=\s*\$2/i);
     expect(sql).toMatch(/type.*expense/i);
     // 전체 결제분이라 exclude_from_budget·is_installment·planned 필터가 없어야 함
@@ -286,7 +287,7 @@ describe('readTotalCycleSpent (#539)', () => {
   });
 
   it('행 없음 → 0', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     expect(await readTotalCycleSpent(1, '2026-04')).toBe(0);
   });
 });
@@ -297,13 +298,13 @@ describe('readExcludedSpent (#549)', () => {
   });
 
   it('제외 지출은 일반(비할부) 지출만 — is_installment=false 필터 포함', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ total: '20000' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '20000' }] });
 
     const result = await readExcludedSpent(1, '2026-04');
 
     expect(result).toBe(20000);
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
-    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    const params = mockQuery.mock.calls[0]![1] as unknown[];
     // 할부는 묶인 돈으로 따로 집계되므로 제외 지출에서 빠져야 함
     expect(sql).toMatch(/is_installment\s*=\s*false/i);
     expect(sql).toMatch(/exclude_from_budget\s*=\s*true/i);
@@ -313,7 +314,7 @@ describe('readExcludedSpent (#549)', () => {
   });
 
   it('행 없음 → 0', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     expect(await readExcludedSpent(1, '2026-04')).toBe(0);
   });
 });
@@ -324,25 +325,25 @@ describe('readAvgVariableMonthly (#552)', () => {
   });
 
   it('완결된 결제주기 범위 [current-N, current)를 파라미터로 전달', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ avg_monthly: '0' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ avg_monthly: '0' }] });
 
     // current='2026-07', months=3 → windowStart='2026-04', upper bound(exclusive)='2026-07'
     await readAvgVariableMonthly(1, 3, '2026-07');
 
-    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    const params = mockQuery.mock.calls[0]![1] as unknown[];
     expect(params).toEqual([1, '2026-04', '2026-07']);
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     // 진행 중 주기는 제외 (< current), 하한은 포함 (>= windowStart)
     expect(sql).toMatch(/billing_month\s*>=\s*\$2/i);
     expect(sql).toMatch(/billing_month\s*<\s*\$3/i);
   });
 
   it('할부·예정연결 제외 + billing_month 단위 집계 (이중 계상 방지)', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ avg_monthly: '0' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ avg_monthly: '0' }] });
 
     await readAvgVariableMonthly(1, 3, '2026-07');
 
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     // 할부 회차는 예측 시 락 맵으로 따로 burn → 평균에서 제외
     expect(sql).toMatch(/is_installment\s*=\s*false/i);
     // 예정지출 연결분도 예측에서 planned로 따로 반영 → 제외
@@ -356,12 +357,12 @@ describe('readAvgVariableMonthly (#552)', () => {
   });
 
   it('AVG 결과를 반올림해 반환', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ avg_monthly: '123456.7' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ avg_monthly: '123456.7' }] });
     expect(await readAvgVariableMonthly(1, 3, '2026-07')).toBe(123457);
   });
 
   it('행 없음 → 0', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     expect(await readAvgVariableMonthly(1, 3, '2026-07')).toBe(0);
   });
 });

--- a/web/src/features/budget/lib/repository/__tests__/installments-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/installments-repo.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 vi.mock('@/lib/db', () => ({ query: vi.fn() }));
 
 import { query } from '@/lib/db';
 import { readInstallmentLockByMonth } from '../installments-repo';
 
-// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
-type Any = any;
+// vi.mocked()는 실제 시그니처(QueryResult)를 요구해서 부분 목 객체를 넘길 수 없다.
+// 목 핸들을 여기서 한 번만 느슨하게 잡고, 각 케이스에서는 캐스팅 없이 쓴다.
+const mockQuery = query as unknown as Mock;
 
 describe('readInstallmentLockByMonth (#539)', () => {
   beforeEach(() => {
@@ -14,12 +15,12 @@ describe('readInstallmentLockByMonth (#539)', () => {
   });
 
   it('창 안 billing_month별 합을 Map으로 반환', async () => {
-    vi.mocked(query).mockResolvedValueOnce({
+    mockQuery.mockResolvedValueOnce({
       rows: [
         { billing_month: '2026-04', total: 30000 },
         { billing_month: '2026-05', total: 30000 },
       ],
-    } as Any);
+    });
 
     const result = await readInstallmentLockByMonth(1, '2026-04', '2026-06');
 
@@ -30,12 +31,12 @@ describe('readInstallmentLockByMonth (#539)', () => {
   });
 
   it('SQL: is_installment=true + type=expense + billing_month BETWEEN, 건별 토글/exclude 필터 없음', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     await readInstallmentLockByMonth(1, '2026-04', '2026-08');
 
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
-    const params = vi.mocked(query).mock.calls[0]![1] as unknown[];
+    const sql = mockQuery.mock.calls[0]![0] as string;
+    const params = mockQuery.mock.calls[0]![1] as unknown[];
     expect(sql).toMatch(/is_installment\s*=\s*true/i);
     expect(sql).toMatch(/billing_month\s+BETWEEN\s+\$2\s+AND\s+\$3/i);
     expect(sql).toMatch(/GROUP BY billing_month/i);
@@ -46,7 +47,7 @@ describe('readInstallmentLockByMonth (#539)', () => {
   });
 
   it('빈 결과 → 빈 Map', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const result = await readInstallmentLockByMonth(1, '2026-04', '2026-04');
     expect(result.size).toBe(0);
   });

--- a/web/src/features/budget/lib/repository/__tests__/settings-repo.test.ts
+++ b/web/src/features/budget/lib/repository/__tests__/settings-repo.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 vi.mock('@/lib/db', () => ({ query: vi.fn() }));
 
 import { query } from '@/lib/db';
 import { readTargetMonth, upsertTargetDate } from '../settings-repo';
 
-// biome-ignore lint/suspicious/noExplicitAny: test mock convenience
-type Any = any;
+// vi.mocked()는 실제 시그니처(QueryResult)를 요구해서 부분 목 객체를 넘길 수 없다.
+// 목 핸들을 여기서 한 번만 느슨하게 잡고, 각 케이스에서는 캐스팅 없이 쓴다.
+const mockQuery = query as unknown as Mock;
 
 const USER = 1;
 
@@ -16,17 +17,17 @@ describe('readTargetMonth', () => {
   });
 
   it('저장된 target_date 반환', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ target_date: '2026-08' }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ target_date: '2026-08' }] });
     expect(await readTargetMonth(USER)).toBe('2026-08');
   });
 
   it('행 없으면 null', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     expect(await readTargetMonth(USER)).toBeNull();
   });
 
   it('target_date가 null이면 null', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [{ target_date: null }] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [{ target_date: null }] });
     expect(await readTargetMonth(USER)).toBeNull();
   });
 });
@@ -37,22 +38,22 @@ describe('upsertTargetDate (#539 — 단순 upsert, 자산 보정 없음)', () =
   });
 
   it('ON CONFLICT upsert 한 번만 — 영향 분석·자산 보정 호출 없음', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     await upsertTargetDate(USER, '2026-09');
 
     expect(query).toHaveBeenCalledTimes(1);
-    const sql = vi.mocked(query).mock.calls[0]![0] as string;
+    const sql = mockQuery.mock.calls[0]![0] as string;
     expect(sql).toMatch(/INSERT INTO budget_settings/i);
     expect(sql).toMatch(/ON CONFLICT/i);
-    expect(vi.mocked(query).mock.calls[0]![1]).toEqual([USER, '2026-09']);
+    expect(mockQuery.mock.calls[0]![1]).toEqual([USER, '2026-09']);
   });
 
   it('null 저장 가능 (목표 해제)', async () => {
-    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as Any);
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     await upsertTargetDate(USER, null);
 
-    expect(vi.mocked(query).mock.calls[0]![1]).toEqual([USER, null]);
+    expect(mockQuery.mock.calls[0]![1]).toEqual([USER, null]);
   });
 });

--- a/web/src/features/schedule/components/dnd-calendar.tsx
+++ b/web/src/features/schedule/components/dnd-calendar.tsx
@@ -12,7 +12,6 @@ import {
   type DragEndEvent,
 } from '@dnd-kit/core';
 import type { ScheduleRow } from '@/features/schedule/lib/types';
-import type { CategoryRow } from '@/lib/types';
 
 type DragType = 'move' | 'resize-left' | 'resize-right';
 
@@ -26,8 +25,7 @@ function parseDragId(id: string | number): { type: DragType; scheduleId: number 
     const prefix = match[1];
     const scheduleId = Number(match[2]);
     const type: DragType =
-      prefix === 'resize-r-' ? 'resize-right' :
-      prefix === 'resize-' ? 'resize-left' : 'move';
+      prefix === 'resize-r-' ? 'resize-right' : prefix === 'resize-' ? 'resize-left' : 'move';
     return { type, scheduleId };
   }
 
@@ -39,7 +37,6 @@ function parseDragId(id: string | number): { type: DragType; scheduleId: number 
 interface DndCalendarProps {
   children: React.ReactNode;
   schedules: ScheduleRow[];
-  categories: CategoryRow[];
   onDateChange: (id: number, newDate: string) => void;
   onEndDateChange?: (id: number, endDate: string | null) => void;
 }
@@ -47,7 +44,6 @@ interface DndCalendarProps {
 export function DndCalendar({
   children,
   schedules,
-  categories,
   onDateChange,
   onEndDateChange,
 }: DndCalendarProps) {
@@ -133,9 +129,7 @@ export function DndCalendar({
             const durationMs =
               new Date(endDate + 'T12:00:00').getTime() -
               new Date(scheduleDate + 'T12:00:00').getTime();
-            const newEndStr = new Date(
-              new Date(targetDate + 'T12:00:00').getTime() + durationMs,
-            )
+            const newEndStr = new Date(new Date(targetDate + 'T12:00:00').getTime() + durationMs)
               .toISOString()
               .slice(0, 10);
             onDateChange(scheduleId, targetDate);

--- a/web/src/features/schedule/components/month-view.tsx
+++ b/web/src/features/schedule/components/month-view.tsx
@@ -19,7 +19,6 @@ import {
   WEEK_START,
   type WeekSpan,
 } from '@/features/schedule/lib/calendar-utils';
-import { ScheduleCard } from './schedule-card';
 import { DroppableDay } from './droppable-day';
 import { DraggableCard } from './draggable-card';
 import { SajuPillarLabel } from './saju-pillar-label';

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7,6 +7,145 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
+"@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
+
+"@babel/core@^7.24.4":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/generator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.7.tgz#cca0b8827e6bcf3ba176788e7f3b180ad6db2fa3"
+  integrity sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==
+  dependencies:
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
+"@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
+  dependencies:
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
+
+"@babel/helper-module-imports@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
+  integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/helper-module-transforms@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz#b062747a5997ba138637201328bbff77960574ae"
+  integrity sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
+
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
+
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
+  dependencies:
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/parser@^7.24.4", "@babel/parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
+  integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
+"@babel/template@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/traverse@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.7.tgz#c47b07a41b95da0907d026b5dd894d98de7d2f2d"
+  integrity sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    debug "^4.3.1"
+
+"@babel/types@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
+  integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+
 "@dnd-kit/accessibility@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
@@ -190,6 +329,85 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz#0eaf705c941a218a43dba8e09f1df1d6cd2f1f17"
   integrity sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==
 
+"@eslint-community/eslint-utils@^4.8.0":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz#8911bd72b2c3640a543609e0400b8c4d2e7e7cb6"
+  integrity sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
+"@eslint-community/regexpp@^4.12.2":
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
+  integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
+
+"@eslint/config-array@^0.23.5":
+  version "0.23.5"
+  resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.23.5.tgz#56e86d243049195d8acc0c06a1b3dfdc3fa3de95"
+  integrity sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==
+  dependencies:
+    "@eslint/object-schema" "^3.0.5"
+    debug "^4.3.1"
+    minimatch "^10.2.4"
+
+"@eslint/config-helpers@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@eslint/config-helpers/-/config-helpers-0.7.0.tgz#09ee4aa07b73f059ec2d4c74bf4b2ff02b322377"
+  integrity sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==
+  dependencies:
+    "@eslint/core" "^1.2.1"
+
+"@eslint/core@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-1.2.1.tgz#c1da7cd1b82fa8787f98b5629fb811848a1b63ce"
+  integrity sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==
+  dependencies:
+    "@types/json-schema" "^7.0.15"
+
+"@eslint/object-schema@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-3.0.5.tgz#88e9bf4d11d2b19c082e78ebe7ce88724a5eb091"
+  integrity sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==
+
+"@eslint/plugin-kit@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz#4b0962f3f2c7ce8bc98b3ecfe34525c09d2cb729"
+  integrity sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==
+  dependencies:
+    "@eslint/core" "^1.2.1"
+    levn "^0.4.1"
+
+"@humanfs/core@^0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.2.tgz#a8272ca03b2acf492670222b2320b6c421bfde60"
+  integrity sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==
+  dependencies:
+    "@humanfs/types" "^0.15.0"
+
+"@humanfs/node@^0.16.6":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@humanfs/node/-/node-0.16.8.tgz#8f800cccc13f4f8cd3116e2d9c0a94939da3e3ed"
+  integrity sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==
+  dependencies:
+    "@humanfs/core" "^0.19.2"
+    "@humanfs/types" "^0.15.0"
+    "@humanwhocodes/retry" "^0.4.0"
+
+"@humanfs/types@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@humanfs/types/-/types-0.15.0.tgz#f2a09f62012390b2bff3fc6fb248ddec8c09a090"
+  integrity sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==
+
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
+
+"@humanwhocodes/retry@^0.4.0", "@humanwhocodes/retry@^0.4.2":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
+  integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
+
 "@img/colour@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.1.0.tgz#b0c2c2fa661adf75effd6b4964497cd80010bb9d"
@@ -337,7 +555,7 @@
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz#a81ffb00e69267cd0a1d626eaedb8a8430b2b2f8"
   integrity sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==
 
-"@jridgewell/gen-mapping@^0.3.5":
+"@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
   integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
@@ -363,7 +581,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.24":
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
@@ -691,10 +909,25 @@
   resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
+"@types/esrecurse@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/esrecurse/-/esrecurse-4.3.1.tgz#6f636af962fbe6191b830bd676ba5986926bccec"
+  integrity sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==
+
 "@types/estree@1.0.8", "@types/estree@^1.0.0":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/estree@^1.0.6", "@types/estree@^1.0.8":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
+
+"@types/json-schema@^7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
 "@types/node@*", "@types/node@^25.4.0":
   version "25.4.0"
@@ -782,20 +1015,73 @@
     "@vitest/pretty-format" "4.0.18"
     tinyrainbow "^3.0.3"
 
+acorn-jsx@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn@^8.16.0:
+  version "8.17.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
+  integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
+
+ajv@^6.14.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
+baseline-browser-mapping@^2.10.44:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz#3da1a877a8be2ec06495123ce994b43af58cc55e"
+  integrity sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==
 
 baseline-browser-mapping@^2.8.3:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz#5b09935025bf8a80e29130251e337c6a7fc8cbb9"
   integrity sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==
 
+brace-expansion@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
+  dependencies:
+    balanced-match "^4.0.2"
+
+browserslist@^4.24.0:
+  version "4.28.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.7.tgz#409046517fccd2e51cdc20f077454b7141184028"
+  integrity sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==
+  dependencies:
+    baseline-browser-mapping "^2.10.44"
+    caniuse-lite "^1.0.30001806"
+    electron-to-chromium "^1.5.393"
+    node-releases "^2.0.51"
+    update-browserslist-db "^1.2.3"
+
 caniuse-lite@^1.0.30001579:
   version "1.0.30001777"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz#028f21e4b2718d138b55e692583e6810ccf60691"
   integrity sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==
+
+caniuse-lite@^1.0.30001806:
+  version "1.0.30001806"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz#1bc8e502b723fa393455dfbedd5ccec0c29bb74e"
+  integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
 
 chai@^6.2.1:
   version "6.2.2"
@@ -807,10 +1093,24 @@ client-only@0.0.1:
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
 cookie@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
+
+cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 csstype@^3.2.2:
   version "3.2.3"
@@ -822,10 +1122,27 @@ date-fns@^4.1.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
   integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
+debug@^4.1.0, debug@^4.3.1, debug@^4.3.2:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
+deep-is@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
 detect-libc@^2.0.3, detect-libc@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+electron-to-chromium@^1.5.393:
+  version "1.5.396"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz#4aa96428486c8d1c9c8aeb205b2d6e04928ca046"
+  integrity sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==
 
 enhanced-resolve@^5.19.0:
   version "5.20.0"
@@ -872,6 +1189,111 @@ esbuild@^0.27.0:
     "@esbuild/win32-ia32" "0.27.3"
     "@esbuild/win32-x64" "0.27.3"
 
+escalade@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+eslint-plugin-react-hooks@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz#e6742cad75d970c0a3f30d7d3fa80a4784f55927"
+  integrity sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==
+  dependencies:
+    "@babel/core" "^7.24.4"
+    "@babel/parser" "^7.24.4"
+    hermes-parser "^0.25.1"
+    zod "^3.25.0 || ^4.0.0"
+    zod-validation-error "^3.5.0 || ^4.0.0"
+
+eslint-scope@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-9.1.2.tgz#b9de6ace2fab1cff24d2e58d85b74c8fcea39802"
+  integrity sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==
+  dependencies:
+    "@types/esrecurse" "^4.3.1"
+    "@types/estree" "^1.0.8"
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
+eslint-visitor-keys@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
+  integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
+
+eslint@^10.0.2:
+  version "10.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-10.8.0.tgz#e6d19907a3f090a53a022261ba34c5ff6d04908b"
+  integrity sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.8.0"
+    "@eslint-community/regexpp" "^4.12.2"
+    "@eslint/config-array" "^0.23.5"
+    "@eslint/config-helpers" "^0.7.0"
+    "@eslint/core" "^1.2.1"
+    "@eslint/plugin-kit" "^0.7.2"
+    "@humanfs/node" "^0.16.6"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@humanwhocodes/retry" "^0.4.2"
+    "@types/estree" "^1.0.6"
+    ajv "^6.14.0"
+    cross-spawn "^7.0.6"
+    debug "^4.3.2"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^9.1.2"
+    eslint-visitor-keys "^5.0.1"
+    espree "^11.2.0"
+    esquery "^1.7.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^8.0.0"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    ignore "^5.2.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    minimatch "^10.2.5"
+    natural-compare "^1.4.0"
+    optionator "^0.9.3"
+
+espree@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-11.2.0.tgz#01d5e47dc332aaba3059008362454a8cc34ccaa5"
+  integrity sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==
+  dependencies:
+    acorn "^8.16.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^5.0.1"
+
+esquery@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.7.0.tgz#08d048f261f0ddedb5bae95f46809463d9c9496d"
+  integrity sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==
+  dependencies:
+    estraverse "^5.1.0"
+
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
 estree-walker@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
@@ -879,25 +1301,107 @@ estree-walker@^3.0.3:
   dependencies:
     "@types/estree" "^1.0.0"
 
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
 expect-type@^1.2.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
   integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
+
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+file-entry-cache@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
+  integrity sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==
+  dependencies:
+    flat-cache "^4.0.0"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
+flat-cache@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-4.0.1.tgz#0ece39fcb14ee012f4b0410bd33dd9c1f011127c"
+  integrity sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==
+  dependencies:
+    flatted "^3.2.9"
+    keyv "^4.5.4"
+
+flatted@^3.2.9:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.3.tgz#be5c21e943b2d7a328bb23795ae28c98f0103a9e"
+  integrity sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
+gensync@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+glob-parent@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+hermes-estree@0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.25.1.tgz#6aeec17d1983b4eabf69721f3aa3eb705b17f480"
+  integrity sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==
+
+hermes-parser@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.25.1.tgz#5be0e487b2090886c62bd8a11724cd766d5f54d1"
+  integrity sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==
+  dependencies:
+    hermes-estree "0.25.1"
+
+ignore@^5.2.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 iron-session@^8.0.4:
   version "8.0.4"
@@ -913,10 +1417,72 @@ iron-webcrypto@^1.2.1:
   resolved "https://registry.yarnpkg.com/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz#aa60ff2aa10550630f4c0b11fd2442becdb35a6f"
   integrity sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==
 
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-glob@^4.0.0, is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
 jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.1.tgz#178ef2fc9a1a594248c20627cd820187a4d78d92"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
+
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+jsesc@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
+  integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
+
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+keyv@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
+
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
 
 lightningcss-android-arm64@1.31.1:
   version "1.31.1"
@@ -992,6 +1558,20 @@ lightningcss@1.31.1:
     lightningcss-win32-arm64-msvc "1.31.1"
     lightningcss-win32-x64-msvc "1.31.1"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 magic-string@^0.30.21:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
@@ -999,10 +1579,27 @@ magic-string@^0.30.21:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
+minimatch@^10.2.4, minimatch@^10.2.5:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  dependencies:
+    brace-expansion "^5.0.5"
+
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 nanoid@^3.3.11, nanoid@^3.3.6:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 next@^16.1.6:
   version "16.1.6"
@@ -1026,10 +1623,51 @@ next@^16.1.6:
     "@next/swc-win32-x64-msvc" "16.1.6"
     sharp "^0.34.4"
 
+node-releases@^2.0.51:
+  version "2.0.51"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.51.tgz#cdc08433577f5b32ad01694481726e22eeb54aef"
+  integrity sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==
+
 obug@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
   integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
+
+optionator@^0.9.3:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
+  integrity sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.5"
+
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 pathe@^2.0.3:
   version "2.0.3"
@@ -1142,6 +1780,16 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+punycode@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
 react-dom@^19.2.4:
   version "19.2.4"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
@@ -1193,6 +1841,11 @@ scheduler@^0.27.0:
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
 semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
@@ -1231,6 +1884,18 @@ sharp@^0.34.4:
     "@img/sharp-win32-arm64" "0.34.5"
     "@img/sharp-win32-ia32" "0.34.5"
     "@img/sharp-win32-x64" "0.34.5"
+
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 siginfo@^2.0.0:
   version "2.0.0"
@@ -1302,6 +1967,13 @@ tslib@^2.0.0, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
 typescript@^5.9.3:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
@@ -1316,6 +1988,21 @@ undici-types@~7.18.0:
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
+
+update-browserslist-db@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
+  integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
+  dependencies:
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
+
+uri-js@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
 
 "vite@^6.0.0 || ^7.0.0":
   version "7.3.1"
@@ -1357,6 +2044,13 @@ vitest@^4.0.18:
     vite "^6.0.0 || ^7.0.0"
     why-is-node-running "^2.3.0"
 
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
 why-is-node-running@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
@@ -1365,7 +2059,32 @@ why-is-node-running@^2.3.0:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
+word-wrap@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+
 xtend@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+"zod-validation-error@^3.5.0 || ^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-4.0.2.tgz#bc605eba49ce0fcd598c127fee1c236be3f22918"
+  integrity sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==
+
+"zod@^3.25.0 || ^4.0.0":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
Closes #608

## 문제

`web/package.json`의 `lint`가 Next 16에서 제거된 `next lint`를 호출한다. 실행하면 검사가 아니라 "`lint`라는 디렉터리가 없다"는 에러가 난다. 웹 첫 커밋부터 이 상태였고, CI는 봇 코드만 검사해서 드러나지 않았다.

정리하면 웹 코드는 지금까지 정적 검사를 통과한 적이 없다. 이번에 실제로 돌려 보니 error 180개가 나왔다.

## 변경

### 웹 전용 ESLint 설정 (`web/eslint.config.mjs`)

규칙의 단일 출처는 루트 설정으로 두고, 웹에만 해당하는 차이만 얹었다.

- **React 훅 규칙 활성화** — 호출 순서 위반(`rules-of-hooks`)은 실제 버그라 error, 의존성 배열(`exhaustive-deps`)은 의도적으로 비우는 경우가 있어 warn. 지금까지는 플러그인이 없어서 코드에 남아 있던 `eslint-disable` 주석이 "그런 규칙 없음" 에러를 내고 있었다
- **non-null 단언은 웹에서 warn** — 봇에서는 error 유지. 웹 소스에 이미 널리 퍼져 있어 지금 일괄 제거하면 도구 복구와 섞이고 런타임 동작을 바꿀 위험이 있다. 새로 쓰지 말라는 신호로 남긴다
- **테스트에서는 끔** — 픽스처가 존재한다는 전제 위에서 단언하는 게 정상

### 실제 위반 정리

- **테스트 목의 `any` 우회 통로 제거** (8개 파일). `vi.mocked(query)`가 실제 시그니처(`QueryResult`)를 요구해서 부분 목 객체를 넘기려면 캐스팅이 필요했고, 그래서 `type Any = any`를 두고 113곳에서 `as Any`를 붙이고 있었다. 파일당 목 핸들 하나(`query as unknown as Mock`)로 대체하니 캐스팅이 전부 사라졌다 — 대부분 삭제 diff
- 미사용 prop `categories`(전달만 하고 쓰지 않던 것), 미사용 import, 항상 덮어써지는 초기 대입 정리
- 규칙이 아무것도 보고하지 않는 죽은 `eslint-disable` 주석 2개 제거

### CI

웹 lint 단계 추가. 스크립트가 다시 죽으면 PR에서 바로 드러난다.

## 남긴 것

warning 439개(반환 타입 명시 376, non-null 단언 58, 훅 의존성 3 등)는 그대로 뒀다. 수백 곳에 퍼져 있어 이번 PR에 넣으면 도구 복구가 묻히고, non-null 단언 제거는 런타임 동작을 바꿀 수 있다. 봇도 warning 52개를 같은 성격으로 안고 간다.

## 검증

- `yarn --cwd web lint` — **exit 0** (0 error / 439 warning). 이 저장소에서 처음 통과
- `yarn --cwd web build` / `yarn --cwd web test` (359 통과) / `npx tsc --noEmit -p web/tsconfig.json`
- `yarn lint` (0 error) / `yarn build` / `yarn test` (1010 통과)
- `yarn --cwd web install --frozen-lockfile` — CI 단계 그대로 로컬 확인

컴포넌트 3개는 prettier 훅이 같이 정리한 포맷 변경이 섞여 있다(동작 변화 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)