### PR TITLE
ci: 웹 테스트를 CI 파이프라인에 편입 (#610)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,13 @@ jobs:
       - name: Build
         run: yarn build
 
-      # 웹은 Vercel이 빌드하지만 lint는 아무도 안 돌리던 상태였다.
-      # 여기서 검사해야 스크립트가 다시 죽어도 바로 드러난다.
+      # 웹은 Vercel이 빌드하지만 lint·test는 아무도 안 돌리던 상태였다.
+      # 여기서 검사해야 스크립트가 다시 죽거나 회귀가 나도 바로 드러난다.
       - name: Install (web)
         run: yarn --cwd web install --frozen-lockfile
 
       - name: Lint (web)
         run: yarn --cwd web lint
+
+      - name: Test (web)
+        run: yarn --cwd web test


### PR DESCRIPTION
Closes #610

## 변경

`.github/workflows/ci.yml`에 `Test (web)` 단계를 추가했다. 웹 의존성 설치는 lint 편입 때 만들어 둔 `Install (web)` 단계를 그대로 쓴다.

```yaml
      - name: Test (web)
        run: yarn --cwd web test
```

## 배경

웹 vitest 스위트(30 파일 / 359 테스트)가 CI에서 한 번도 실행되지 않았다. lint는 #608에서 편입했지만 테스트는 로컬 실행에만 의존하는 상태라, 웹 코드를 바꾸는 PR에서 회귀가 머지 시점까지 드러나지 않았다.

`web`의 test 스크립트는 `vitest run --passWithNoTests`라 watch 모드로 걸리지 않는다.

## 검증

| 명령 | 결과 |
|------|------|
| `yarn --cwd web test` | 30 files / 359 tests passed (1.36s) |

CI 실행 로그에 `Test (web)` 단계가 성공으로 남는지 이 PR에서 확인한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)