### PR TITLE
chore(web): 화면 컴포넌트 반환 타입 규칙 완화 (#612)

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -38,4 +38,15 @@ export default [
       '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
+
+  // 화면 컴포넌트는 반환이 JSX 아니면 void라 반환 타입을 적어도 새 정보가 없다.
+  // 이 규칙이 웹에서 내는 경고의 대부분(376건 중 271건)이 여기서 나오는데,
+  // 그 탓에 정작 확인할 가치가 있는 널 단언 경고가 목록에 묻힌다.
+  // 데이터 쪽(.ts — 훅·repository·라우트 핸들러)은 반환 타입이 레이어 간 계약이라 유지한다.
+  {
+    files: ['**/*.tsx'],
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': 'off',
+    },
+  },
 ];


### PR DESCRIPTION
Closes #612

## 변경

`web/eslint.config.mjs`에 `.tsx` 한정 해제 블록을 추가했다. 설정 11줄이 전부이고 소스 코드는 건드리지 않았다.

```js
  {
    files: ['**/*.tsx'],
    rules: {
      '@typescript-eslint/explicit-function-return-type': 'off',
    },
  },
```

## 배경

#608에서 웹 lint를 복구한 뒤 error는 0이 됐지만 warning이 439건 남았다. 그중 376건이 이 규칙 하나에서 나오고, 271건은 반환이 JSX 아니면 void로 정해져 있는 화면 컴포넌트다.

건수가 문제가 아니라 신호 대 잡음비가 문제였다. 확인할 가치가 있는 경고가 형식적인 지적에 묻혀 아무도 목록을 읽지 않는 상태였고, 그러면 규칙을 켜둔 의미가 사라진다.

데이터 쪽(`.ts` — 훅 · repository · 라우트 핸들러)은 반환 타입이 레이어 간 계약이라 그대로 유지했다. 봇 설정은 변경 없다.

## 결과

| | 변경 전 | 변경 후 |
|---|---|---|
| error | 0 | 0 |
| warning | 439 | **168** |

남은 168건의 구성:

| 규칙 | 건수 |
|------|------|
| `explicit-function-return-type` (`.ts`) | 105 |
| `no-non-null-assertion` | 58 |
| `react-hooks/exhaustive-deps` | 3 |
| `no-console` | 2 |

이제 널 단언 58건이 목록에서 눈에 들어온다. 상위는 `calendar-utils.ts` 18건, `sleep/lib/queries.ts` 13건이다. 실제 정리 여부는 별건으로 판단한다.

## 검증

| 명령 | 결과 |
|------|------|
| `yarn --cwd web lint` | exit 0 — error 0 / warning 168 |
| `yarn --cwd web test` | 30 files / 359 tests passed |
| `yarn lint` (봇) | error 0 / warning 52 — 변화 없음 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)