### PR TITLE
chore: 에디터 포맷 훅을 전역 설정으로 일원화

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,5 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "FILE=$(cat - | jq -r '.tool_input.file_path // empty' 2>/dev/null); if [ -z \"$FILE\" ]; then exit 0; fi; if echo \"$FILE\" | grep -qE '\\.(ts|mjs|json)$'; then cd \"$CLAUDE_PROJECT_DIR\" && npx prettier --write \"$FILE\" 2>/dev/null; fi; if echo \"$FILE\" | grep -qE '\\.(ts|mjs)$'; then npx eslint --fix \"$FILE\" 2>/dev/null; fi; exit 0",
-            "timeout": 10
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## 변경 내용
- 프로젝트 설정의 에디터 포맷 자동화 훅 제거 — 전역 설정과 중복 실행되던 것을 일원화 (파일 편집당 도구 실행 횟수 절반)
- 커밋 전 검사 훅은 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)