### PR TITLE
fix(web): 결제수단 목록에서 계좌이체 제거

### DIFF
--- a/docs/domains/budget.md
+++ b/docs/domains/budget.md
@@ -383,7 +383,7 @@ runSettlementIfDue(userId, now)  ── 매일 실행
 ### 결제수단별 출금 시점 + 자금 기준일 (#615, ADR 0062)
 
 - **정의 1곳**: [billing/payment-methods.ts](../../web/src/features/budget/lib/billing/payment-methods.ts)가 결제수단 목록 · 출금 시점(`timing`) · 결제주기 시작일(`startDay`)을 함께 갖는다. `CARD_BILLING_CYCLES`는 여기서 파생된다
-- `timing = 'immediate'`(현금·계좌이체) → 쓰는 즉시 통장에서 나감 / `'deferred'`(카드) → 결제일에 나감
+- `timing = 'immediate'`(현금) → 쓰는 즉시 통장에서 나감 / `'deferred'`(카드·기타) → 결제일에 나감
 - 미등록 수단·`null`은 **보수적으로 `deferred`** — 즉시 출금으로 잘못 보면 기준선이 부풀기 때문
 - **예산 기준선 복원**(`readReflectedBudgetOutflow`): 다음을 **모두** 만족하는 지출만 되돌린다
   1. 즉시 출금 수단(`payment_method = ANY(즉시 출금 목록)`)

--- a/web/src/features/budget/lib/__tests__/ensure-fixed-cost-expenses.test.ts
+++ b/web/src/features/budget/lib/__tests__/ensure-fixed-cost-expenses.test.ts
@@ -175,14 +175,14 @@ describe('ensureFixedCostExpenses — 고정비 결제수단 (#615)', () => {
   it('즉시 출금 수단도 귀속 월 규칙은 동일 — 출금 시점만 다르다', async () => {
     mockQuery
       .mockResolvedValueOnce({
-        rows: [{ ...baseFC, name: 'c', day_of_month: 5, payment_method: '계좌이체' }],
+        rows: [{ ...baseFC, name: 'c', day_of_month: 5, payment_method: '현금' }],
       })
       .mockResolvedValueOnce({ rowCount: 1 });
 
     await ensureFixedCostExpenses(1, '2026-04');
 
     const params = mockQuery.mock.calls[1][1];
-    expect(params[7]).toEqual(['계좌이체']);
+    expect(params[7]).toEqual(['현금']);
     expect(params[6]).toEqual(['2026-04']);
   });
 });

--- a/web/src/features/budget/lib/billing/__tests__/payment-methods.test.ts
+++ b/web/src/features/budget/lib/billing/__tests__/payment-methods.test.ts
@@ -9,9 +9,8 @@ import {
 import { CARD_BILLING_CYCLES, getBillingMonthForExpense } from '../card-billing';
 
 describe('getWithdrawalTiming', () => {
-  it('현금·계좌이체는 즉시 출금', () => {
+  it('현금은 즉시 출금', () => {
     expect(getWithdrawalTiming('현금')).toBe('immediate');
-    expect(getWithdrawalTiming('계좌이체')).toBe('immediate');
   });
 
   it('카드는 후불', () => {
@@ -28,7 +27,12 @@ describe('getWithdrawalTiming', () => {
 
 describe('결제수단 목록', () => {
   it('IMMEDIATE_PAYMENT_METHODS는 즉시 출금 수단만 포함', () => {
-    expect([...IMMEDIATE_PAYMENT_METHODS].sort()).toEqual(['계좌이체', '현금']);
+    expect(IMMEDIATE_PAYMENT_METHODS).toEqual(['현금']);
+  });
+
+  it('은퇴한 수단은 미등록 취급 — 보수적으로 후불', () => {
+    expect(isKnownPaymentMethod('계좌이체')).toBe(false);
+    expect(getWithdrawalTiming('계좌이체')).toBe('deferred');
   });
 
   it('기본 결제수단은 등록된 수단', () => {

--- a/web/src/features/budget/lib/billing/payment-methods.ts
+++ b/web/src/features/budget/lib/billing/payment-methods.ts
@@ -1,6 +1,6 @@
 /** 출금 시점 — 통장에서 돈이 실제로 나가는 때 */
 export type WithdrawalTiming =
-  | 'immediate' // 기록 시점에 이미 나감 (현금·계좌이체)
+  | 'immediate' // 기록 시점에 이미 나감 (현금)
   | 'deferred'; // 결제주기 종료 후 카드사에 결제
 
 export interface PaymentMethodSpec {
@@ -13,7 +13,6 @@ export const PAYMENT_METHODS: Record<string, PaymentMethodSpec> = {
   현대카드: { timing: 'deferred', startDay: 15 },
   국민카드: { timing: 'deferred', startDay: 13 },
   현금: { timing: 'immediate' },
-  계좌이체: { timing: 'immediate' },
   기타: { timing: 'deferred' },
 };
 


### PR DESCRIPTION
## 배경

[#615](https://github.com/hyewon3938/slack-ai-agents/issues/615)에서 결제수단별 출금 시점 모델(ADR 0062)을 도입하면서 즉시 출금 수단으로 `현금`·`계좌이체` 두 가지를 등록했다. 실제 운용에서는 둘의 구분이 없어 `현금` 하나로 일원화한다.

## 변경

- `billing/payment-methods.ts`에서 `계좌이체` 항목 제거 → 즉시 출금 수단은 `현금`만
- 은퇴한 수단은 미등록 취급 → `getWithdrawalTiming`이 보수적으로 `deferred` 반환 (회귀 테스트 추가)
- 도메인 문서 출금 시점 설명 갱신

## 데이터 영향

프로덕션에 해당 수단으로 기록된 지출·고정비 행이 없음을 확인했다. 마이그레이션·백필 불필요.

## 검증

- web vitest 31 files / 397 tests pass
- `tsc --noEmit` clean
- eslint 변경 디렉터리 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)