### PR TITLE
fix(web): 고정비 결제수단 미설정 상태를 화면에 그대로 표시

### DIFF
--- a/db/migrations/110_fixed_cost_payment_method_backfill.sql
+++ b/db/migrations/110_fixed_cost_payment_method_backfill.sql
@@ -1,0 +1,10 @@
+-- 고정비 결제수단 미지정 행 백필 (#615 후속)
+--
+-- 109에서 fixed_costs.payment_method를 추가했지만 기존 행은 NULL로 남았다.
+-- 런타임은 NULL을 기본 결제수단으로 폴백하므로 동작은 같지만, 설정 화면이
+-- 폴백 값을 그대로 보여줘서 "미지정"과 "명시 지정"을 구분할 수 없었다.
+-- 저장값과 표시값을 일치시키기 위해 폴백과 같은 값으로 한 번 채운다.
+-- (기본 결제수단은 billing/payment-methods.ts의 DEFAULT_PAYMENT_METHOD와 같은 값)
+UPDATE fixed_costs
+SET payment_method = '현대카드'
+WHERE payment_method IS NULL;

--- a/docs/domains/budget.md
+++ b/docs/domains/budget.md
@@ -141,7 +141,7 @@ fixed_costs:
   active BOOLEAN,
   memo TEXT,
   created_at TIMESTAMPTZ,
-  payment_method TEXT                  -- 자동 기록에 쓰이는 결제수단. NULL이면 기본값 폴백 (마이그 109)
+  payment_method TEXT                  -- 자동 기록에 쓰이는 결제수단. NULL이면 기본값 폴백 (마이그 109, 기존 행은 110에서 백필)
 
 -- 자산
 -- #539: 비상금 제외 자산은 단일 '자금'(현금 유동자금)으로 통합 (마이그 092). balance=available_amount로 저장.

--- a/web/src/features/budget/components/budget-settings-page.tsx
+++ b/web/src/features/budget/components/budget-settings-page.tsx
@@ -150,9 +150,11 @@ function FixedCostItem({
           ) : (
             <span className="text-xs text-amber-500">결제일 미설정</span>
           )}
-          <span className="text-xs text-gray-400">
-            {cost.payment_method ?? DEFAULT_PAYMENT_METHOD}
-          </span>
+          {cost.payment_method ? (
+            <span className="text-xs text-gray-400">{cost.payment_method}</span>
+          ) : (
+            <span className="text-xs text-amber-500">결제수단 미설정</span>
+          )}
         </div>
       )}
     </div>

--- a/web/src/features/budget/lib/__tests__/update-expense.test.ts
+++ b/web/src/features/budget/lib/__tests__/update-expense.test.ts
@@ -49,11 +49,11 @@ describe('updateExpense — 단순 화이트리스트 UPDATE (#539, 자산 보�
   });
 
   it('amount만 변경 → 가드 SELECT 없이 단일 UPDATE', async () => {
-    mockQueryOne.mockResolvedValueOnce({ id: 686, amount: 167776 });
+    mockQueryOne.mockResolvedValueOnce({ id: 686, amount: 50_000 });
 
-    const result = await updateExpense(1, 686, { amount: 167776 });
+    const result = await updateExpense(1, 686, { amount: 50_000 });
 
-    expect(result).toEqual({ id: 686, amount: 167776 });
+    expect(result).toEqual({ id: 686, amount: 50_000 });
     // exclude 미변경 → 가드 SELECT 없음. UPDATE 한 번만.
     expect(queryOne).toHaveBeenCalledTimes(1);
     const sql = mockQueryOne.mock.calls[0]![0] as string;


### PR DESCRIPTION
## 배경

[#615](https://github.com/hyewon3938/slack-ai-agents/issues/615)에서 `fixed_costs.payment_method`를 도입했지만 기존 행은 미설정으로 남았다. 런타임은 미설정을 기본 결제수단으로 폴백하고 **설정 화면도 그 폴백 값을 그대로 표시**해서, 사용자 입장에서는 명시적으로 지정한 항목과 아직 지정하지 않은 항목을 구분할 방법이 없었다.

## 변경

- 설정 화면: 미설정이면 `결제수단 미설정`로 표시 (기존 `결제일 미설정` 표기와 동일한 패턴)
- 마이그레이션 110: 기존 미설정 행을 런타임 폴백과 **같은 값**으로 백필 → 저장값과 표시값 일치
- 런타임 폴백 자체는 유지 (이후 유입되는 미설정 행 방어)
- 테스트 픽스처 금액을 합성값으로 통일

## 검증

- web vitest 31 files / 397 tests pass
- `tsc --noEmit` clean, eslint 변경 파일 0 errors
- 마이그레이션은 봇 기동 시 적용 — 머지 후 프로덕션에서 미설정 행 0건 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)