### PR TITLE
fix(web): 예산 제외 기본 카테고리의 할부 지출 등록 실패 해소

### DIFF
--- a/docs/domains/budget.md
+++ b/docs/domains/budget.md
@@ -406,6 +406,7 @@ runSettlementIfDue(userId, now)  ── 매일 실행
 - `assets.is_emergency=true` → `readDistributableAssetBalance` 에서 제외 (예산 분배 밖 '최후의 보루')
 - `expenses.exclude_from_budget=true` → 자유 예산 계산 대상 아님 (별도 `excluded_spent`로 집계). 할부는 `is_installment` 필터로 이미 flex에서 빠지므로 exclude와 무관 (#539)
 - **할부 × exclude 조합 금지**(#549, 마이그 095): 할부는 예외 없이 묶인 돈이라 `exclude_from_budget=true`가 될 수 없다. 기존 할부 exclude 행은 정규화하고 CHECK 제약(`expenses_installment_not_excluded`)으로 재발 차단. `queryMonthSummary`의 할부 합계는 exclude 필터 없이 락 집합과 동일하게, `readExcludedSpent`는 비할부 지출로 한정
+  - 입력 경로 강제(#620): 예산 제외가 기본인 카테고리(`BUDGET_EXCLUDED_CATEGORIES`)를 할부로 고르면 두 값이 충돌해 INSERT가 막혔다. 지출 추가 폼은 할부 선택 시 예산 토글을 감추고(수정 모달과 동일 규칙), `createInstallmentExpenses`는 `exclude_from_budget` 파라미터 자체를 받지 않고 false로 고정한다
 - 고정비 자동 기록은 현재 **항상** `exclude_from_budget=true`로 저장 (정책 재검토 대상)
 - Vercel cron 드리프트 보정: 발화 시각에서 1시간 버퍼 차감 후 KST 날짜 결정
 

--- a/web/src/app/api/expenses/route.ts
+++ b/web/src/app/api/expenses/route.ts
@@ -119,6 +119,8 @@ export async function POST(request: Request) {
       typeof body.exclude_from_budget === 'boolean' ? body.exclude_from_budget : false;
 
     // 할부 처리 (카드 2~12개월)
+    // 예산 제외 카테고리(리커밋 사업 등)를 할부로 넣으면 클라이언트가 exclude 토글 값을 실어 보내는데,
+    // 할부 행은 예외 없이 묶인 돈이라 그 조합을 저장할 수 없다 (#549). 여기서 값을 넘기지 않는다.
     const installmentMonths = body.installment_months ?? 1;
     if (installmentMonths >= 2 && installmentMonths <= 12) {
       const data = await createInstallmentExpenses(userId, {
@@ -130,7 +132,6 @@ export async function POST(request: Request) {
         payment_method: body.payment_method,
         memo: body.memo,
         type: entryType,
-        exclude_from_budget: excludeFromBudget,
       });
       return NextResponse.json({ data }, { status: 201 });
     }

--- a/web/src/features/budget/components/expense-form.tsx
+++ b/web/src/features/budget/components/expense-form.tsx
@@ -84,6 +84,14 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
     if (getWithdrawalTiming(method) === 'immediate') setInstallmentMonths(1);
   };
 
+  // 할부 회차는 예외 없이 묶인 돈이라 예산 제외가 성립하지 않는다 (#549). 예산 제외가 기본인
+  // 카테고리(리커밋 사업 등)를 할부로 고르면 두 값이 충돌해 저장 자체가 막히므로, 할부일 때는
+  // 토글을 감추고 제외 값도 보내지 않는다. 수정 모달도 같은 규칙으로 토글을 감춘다.
+  const isInstallment =
+    entryType === 'expense' &&
+    getWithdrawalTiming(paymentMethod) === 'deferred' &&
+    installmentMonths >= 2;
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -106,7 +114,7 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
           entryType === 'expense' && getWithdrawalTiming(paymentMethod) === 'deferred'
             ? installmentMonths
             : undefined,
-        exclude_from_budget: entryType === 'expense' ? excludeFromBudget : false,
+        exclude_from_budget: entryType === 'expense' && !isInstallment ? excludeFromBudget : false,
         distribute_to_budget: entryType === 'income' ? distributeToBudget : false,
       });
       setAmountStr('');
@@ -283,32 +291,38 @@ export function ExpenseForm({ onAdd, yearMonth }: ExpenseFormProps) {
             </p>
           )}
 
-          {/* 예산 포함/제외 토글 */}
-          <div>
-            <label className="mb-1 block text-xs text-gray-500">예산</label>
-            <div className="flex rounded-lg border border-gray-200 p-0.5">
-              <button
-                type="button"
-                onClick={() => setExcludeFromBudget(false)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                  !excludeFromBudget
-                    ? 'bg-blue-600 text-white'
-                    : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                포함
-              </button>
-              <button
-                type="button"
-                onClick={() => setExcludeFromBudget(true)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                  excludeFromBudget ? 'bg-gray-500 text-white' : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                제외
-              </button>
+          {/* 예산 포함/제외 토글 — 일반 지출만 (할부는 항상 묶인 돈, #549) */}
+          {!isInstallment ? (
+            <div>
+              <label className="mb-1 block text-xs text-gray-500">예산</label>
+              <div className="flex rounded-lg border border-gray-200 p-0.5">
+                <button
+                  type="button"
+                  onClick={() => setExcludeFromBudget(false)}
+                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
+                    !excludeFromBudget
+                      ? 'bg-blue-600 text-white'
+                      : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  포함
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setExcludeFromBudget(true)}
+                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
+                    excludeFromBudget
+                      ? 'bg-gray-500 text-white'
+                      : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  제외
+                </button>
+              </div>
             </div>
-          </div>
+          ) : (
+            <p className="pb-1 text-[10px] text-gray-400">할부는 예산에 항상 묶인 돈으로 포함</p>
+          )}
         </div>
       )}
 

--- a/web/src/features/budget/lib/__tests__/create-installment-expenses.test.ts
+++ b/web/src/features/budget/lib/__tests__/create-installment-expenses.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  query: vi.fn(),
+  queryOne: vi.fn(),
+}));
+
+import { queryOne } from '@/lib/db';
+import { createInstallmentExpenses } from '../queries';
+
+// vi.mocked()는 실제 시그니처(QueryResult)를 요구해서 부분 목 객체를 넘길 수 없다.
+const mockQueryOne = queryOne as unknown as Mock;
+
+/** INSERT 파라미터 배열에서 exclude_from_budget 자리($12) 값을 꺼낸다. */
+function excludeParamOf(callIndex: number): unknown {
+  const params = mockQueryOne.mock.calls[callIndex][1] as unknown[];
+  return params[11];
+}
+
+describe('createInstallmentExpenses — 할부 × 예산 제외 조합 차단 (#549)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockQueryOne.mockResolvedValue({ id: 1 });
+  });
+
+  it('예산 제외가 기본인 카테고리도 회차 전부 exclude_from_budget=false로 저장', async () => {
+    await createInstallmentExpenses(1, {
+      date: '2026-08-01',
+      totalAmount: 300000,
+      months: 3,
+      category: '리커밋 사업',
+      payment_method: '현대카드',
+    });
+
+    // DB CHECK(expenses_installment_not_excluded)에 걸리는 조합이 한 회차도 나가면 안 된다
+    expect(mockQueryOne).toHaveBeenCalledTimes(3);
+    expect([excludeParamOf(0), excludeParamOf(1), excludeParamOf(2)]).toEqual([
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it('회차 금액은 끝전을 마지막 회차가 흡수해 총액과 일치', async () => {
+    await createInstallmentExpenses(1, {
+      date: '2026-08-01',
+      totalAmount: 100000,
+      months: 3,
+      category: '쇼핑',
+      payment_method: '현대카드',
+    });
+
+    const amounts = mockQueryOne.mock.calls.map((c) => (c[1] as unknown[])[2] as number);
+    expect(amounts).toEqual([33333, 33333, 33334]);
+    expect(amounts.reduce((a, b) => a + b, 0)).toBe(100000);
+  });
+});

--- a/web/src/features/budget/lib/queries.ts
+++ b/web/src/features/budget/lib/queries.ts
@@ -152,14 +152,15 @@ export async function createInstallmentExpenses(
     payment_method?: string;
     memo?: string | null;
     type?: 'expense' | 'income';
-    exclude_from_budget?: boolean;
   },
 ): Promise<ExpenseRow> {
   const monthlyAmount = Math.round(data.totalAmount / data.months);
   // 끝전 보정: 마지막 회차에서 나머지 흡수
   const lastMonthAmount = data.totalAmount - monthlyAmount * (data.months - 1);
   const groupId = crypto.randomUUID();
-  const excludeFromBudget = data.exclude_from_budget ?? false;
+  // 할부는 예외 없이 묶인 돈 — exclude_from_budget=true 조합은 존재할 수 없다 (#549, 마이그 095의
+  // CHECK 제약). 호출부가 제외 토글 값을 넘길 수 없도록 파라미터 자체를 두지 않고 false로 고정한다.
+  const excludeFromBudget = false;
 
   // 할부 회차는 등록 시점에 자산을 차감하지 않는다 (#539, ADR 0051).
   // 목표 기간 창 안 회차는 묶인 돈(reservation)으로 라이브 계산되고, 실제 자금 차감은


### PR DESCRIPTION
## 배경

예산 제외가 기본으로 켜지는 카테고리를 할부로 등록하면 저장이 되지 않고 실패 메시지만 반복됐다.

원인은 입력 폼과 데이터 계약의 불일치다. 폼은 카테고리를 고르는 순간 예산 제외 토글을 자동으로 켜는데, 할부 회차는 예외 없이 묶인 돈으로 취급하는 규칙(#539)이 있어 두 값이 함께 저장될 수 없다. 그 조합은 #549에서 DB 제약으로 이미 차단해 둔 상태라, 요청이 데이터 계층에서 튕기면서 일반 실패 응답으로만 표면화됐다.

## 변경

- **입력 폼**: 할부를 선택하면 예산 포함/제외 토글을 감추고 안내 문구로 대체한다. 수정 모달이 이미 쓰던 규칙과 동일하게 맞춘 것.
- **데이터 계층**: 할부 생성 함수가 예산 제외 값을 파라미터로 받지 않도록 시그니처에서 제거하고 내부에서 고정한다. 호출부가 다시 값을 실어 보내면 타입 에러로 잡히므로 같은 경로의 재발이 컴파일 단계에서 막힌다.
- **API**: 할부 분기에서 제외 값을 넘기지 않는다.
- 회차 전부가 올바른 값으로 저장되는지, 회차 금액 합이 총액과 맞는지 확인하는 회귀 테스트 추가.
- 도메인 문서에 입력 경로 강제 규칙 기록.

## 검증

- 웹 테스트 399개 통과
- 타입체크·린트·포맷 통과
